### PR TITLE
Fix: Close functions initial metadata reader

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
@@ -97,9 +97,9 @@ public class FunctionMetaDataManager implements AutoCloseable {
      * We create a new reader
      */
     public synchronized void initialize() {
-        try {
+        try (Reader reader = FunctionMetaDataTopicTailer.createReader(
+          workerConfig, pulsarClient.newReader(), MessageId.earliest)){
             // read all existing messages
-            Reader reader = FunctionMetaDataTopicTailer.createReader(workerConfig, pulsarClient.newReader(), MessageId.earliest);
             while (reader.hasMessageAvailable()) {
                 processMetaDataTopicMessage(reader.readNext());
             }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -227,12 +227,11 @@ public class FunctionRuntimeManager implements AutoCloseable{
      * @return the message id of the message processed during init phase
      */
     public MessageId initialize() {
-        try {
-            Reader<byte[]> reader = WorkerUtils.createReader(
-                    workerService.getClient().newReader(),
-                    workerConfig.getWorkerId() + "-function-assignment-initialize",
-                    workerConfig.getFunctionAssignmentTopic(),
-                    MessageId.earliest);
+        try (Reader<byte[]> reader = WorkerUtils.createReader (
+          workerService.getClient().newReader(),
+          workerConfig.getWorkerId() + "-function-assignment-initialize",
+          workerConfig.getFunctionAssignmentTopic(),
+          MessageId.earliest)) {
 
             // start init phase
             this.isInitializePhase = true;
@@ -246,8 +245,6 @@ public class FunctionRuntimeManager implements AutoCloseable{
             }
             // init phase is done
             this.isInitializePhase = false;
-            // close reader
-            reader.close();
             // realize existing assignments
             Map<String, Assignment> assignmentMap = workerIdToAssignments.get(this.workerConfig.getWorkerId());
             if (assignmentMap != null) {


### PR DESCRIPTION

### Motivation

The reader used to read the metadata topic during worker service initialization is not closed.

