### PR TITLE
[bot-cherry-pick]Add oauth2 client wrapper for python

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Authentication.h
+++ b/pulsar-client-cpp/include/pulsar/Authentication.h
@@ -249,6 +249,7 @@ typedef std::shared_ptr<CachedToken> CachedTokenPtr;
  *   "client_secret": "on1uJ...k6F6R",
  *   "audience": "https://broker.example.com"
  *  ```
+ *  If passed in as std::string, it should be in Json format.
  */
 class PULSAR_PUBLIC AuthOauth2 : public Authentication {
    public:

--- a/pulsar-client-cpp/include/pulsar/c/authentication.h
+++ b/pulsar-client-cpp/include/pulsar/c/authentication.h
@@ -41,6 +41,8 @@ PULSAR_PUBLIC pulsar_authentication_t *pulsar_authentication_token_create_with_s
 
 PULSAR_PUBLIC pulsar_authentication_t *pulsar_authentication_athenz_create(const char *authParamsString);
 
+PULSAR_PUBLIC pulsar_authentication_t *pulsar_authentication_oauth2_create(const char *authParamsString);
+
 PULSAR_PUBLIC void pulsar_authentication_free(pulsar_authentication_t *authentication);
 
 #ifdef __cplusplus

--- a/pulsar-client-cpp/lib/c/c_Authentication.cc
+++ b/pulsar-client-cpp/lib/c/c_Authentication.cc
@@ -66,3 +66,9 @@ pulsar_authentication_t *pulsar_authentication_token_create_with_supplier(token_
     authentication->auth = pulsar::AuthToken::create(std::bind(&tokenSupplierWrapper, tokenSupplier, ctx));
     return authentication;
 }
+
+pulsar_authentication_t *pulsar_authentication_oauth2_create(const char *authParamsString) {
+    pulsar_authentication_t *authentication = new pulsar_authentication_t;
+    authentication->auth = pulsar::AuthOauth2::create(authParamsString);
+    return authentication;
+}

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -325,6 +325,20 @@ class AuthenticationAthenz(Authentication):
         _check_type(str, auth_params_string, 'auth_params_string')
         self.auth = _pulsar.AuthenticationAthenz(auth_params_string)
 
+class AuthenticationOauth2(Authentication):
+    """
+    Oauth2 Authentication implementation
+    """
+    def __init__(self, auth_params_string):
+        """
+        Create the Oauth2 authentication provider instance.
+
+        **Args**
+
+        * `auth_params_string`: JSON encoded configuration for Oauth2 client
+        """
+        _check_type(str, auth_params_string, 'auth_params_string')
+        self.auth = _pulsar.AuthenticationOauth2(auth_params_string)
 
 class Client:
     """
@@ -358,7 +372,7 @@ class Client:
 
         * `authentication`:
           Set the authentication provider to be used with the broker. For example:
-          `AuthenticationTls` or `AuthenticationAthenz`
+          `AuthenticationTls`, AuthenticaionToken, `AuthenticationAthenz`or `AuthenticationOauth2`
         * `operation_timeout_seconds`:
           Set timeout on client operations (subscribe, create producer, close,
           unsubscribe).

--- a/pulsar-client-cpp/python/src/authentication.cc
+++ b/pulsar-client-cpp/python/src/authentication.cc
@@ -92,6 +92,13 @@ struct AuthenticationAthenzWrapper : public AuthenticationWrapper {
     }
 };
 
+struct AuthenticationOauth2Wrapper : public AuthenticationWrapper {
+    AuthenticationOauth2Wrapper(const std::string& authParamsString) :
+            AuthenticationWrapper() {
+        this->auth = AuthOauth2::create(authParamsString);
+    }
+};
+
 void export_authentication() {
     using namespace boost::python;
 
@@ -107,6 +114,10 @@ void export_authentication() {
             ;
 
     class_<AuthenticationAthenzWrapper, bases<AuthenticationWrapper> >("AuthenticationAthenz",
+                                                                       init<const std::string&>())
+            ;
+
+    class_<AuthenticationOauth2Wrapper, bases<AuthenticationWrapper> >("AuthenticationOauth2",
                                                                        init<const std::string&>())
             ;
 }


### PR DESCRIPTION
Motivation
There was already cpp oauth2 client provided, this or tries to provide a wrapper around it for Python client.

Modifications
add wrapper on cpp to support python client oauth2.

(cherry picked from commit 58704f9e82750bf2613131eccbe9fca4c530ec3c)
