### PR TITLE
[Transaction] Add the batch size in transaction ack command.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1171,5 +1171,5 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 ### --- Transaction config variables --- ###
 
 # Enable transaction coordinator in broker
-transactionCoordinatorEnabled=true
+transactionCoordinatorEnabled=false
 transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1849,7 +1849,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TRANSACTION,
             doc = "Enable transaction coordinator in broker"
     )
-    private boolean transactionCoordinatorEnabled = true;
+    private boolean transactionCoordinatorEnabled = false;
 
     @FieldContext(
         category = CATEGORY_TRANSACTION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -319,7 +319,9 @@ public class PulsarStandalone implements AutoCloseable {
                                    });
         broker.start();
 
-        broker.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        if (config.isTransactionCoordinatorEnabled()) {
+            broker.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        }
 
         final String cluster = config.getClusterName();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -399,7 +399,7 @@ public class Consumer {
     //this method is for individual ack carry the transaction
     private CompletableFuture<Void> individualAckWithTransaction(CommandAck ack) {
         // Individual ack
-        List<MutablePair<PositionImpl, Long>> positionsAcked = new ArrayList<>();
+        List<MutablePair<PositionImpl, Integer>> positionsAcked = new ArrayList<>();
 
         if (!isTransactionEnabled()) {
             return FutureUtil.failedFuture(
@@ -419,7 +419,7 @@ public class Consumer {
             if (msgId.hasBatchIndex()) {
                 positionsAcked.add(new MutablePair<>(position, msgId.getBatchSize()));
             } else {
-                positionsAcked.add(new MutablePair<>(position, 0L));
+                positionsAcked.add(new MutablePair<>(position, 0));
             }
 
             checkCanRemovePendingAcksAndHandle(position, msgId);
@@ -465,7 +465,7 @@ public class Consumer {
     private CompletableFuture<Void> transactionIndividualAcknowledge(
             long txnidMostBits,
             long txnidLeastBits,
-            List<MutablePair<PositionImpl, Long>> positionList) {
+            List<MutablePair<PositionImpl, Integer>> positionList) {
         if (subscription instanceof PersistentSubscription) {
             TxnID txnID = new TxnID(txnidMostBits, txnidLeastBits);
             return ((PersistentSubscription) subscription).transactionIndividualAcknowledge(txnID, positionList);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -467,7 +467,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
                 return;
             }
 
-            if (messagesToRedeliver.size() > 0) {
+            if (messagesToRedeliver != null && messagesToRedeliver.size() > 0) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule replay of {} messages", name, messagesToRedeliver.size());
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -388,7 +388,7 @@ public class PersistentSubscription implements Subscription {
     }
 
     public CompletableFuture<Void> transactionIndividualAcknowledge(TxnID txnId,
-                                                                    List<MutablePair<PositionImpl, Long>> positions) {
+                                                                    List<MutablePair<PositionImpl, Integer>> positions) {
         return pendingAckHandle.individualAcknowledgeMessage(txnId, positions);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -103,7 +103,7 @@ public interface PendingAckHandle {
      *
      * @param position {@link Position} which position need to sync and carry it batch size
      */
-    void syncBatchPositionAckSetForTransaction(MutablePair<PositionImpl, Long> position);
+    void syncBatchPositionAckSetForTransaction(PositionImpl position);
 
     /**
      * Judge the all ack set point have acked by normal ack and transaction pending ack.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -54,7 +54,7 @@ public interface PendingAckHandle {
      * @throws NotAllowedException if Use this method incorrectly eg. not use
      * PositionImpl or cumulative ack with a list of positions.
      */
-    CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID, List<MutablePair<PositionImpl, Long>> positions);
+    CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID, List<MutablePair<PositionImpl, Integer>> positions);
 
     /**
      * Acknowledge message(s) for an ongoing transaction.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.pendingack.impl;
+
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandle;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.util.FutureUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The disabled implementation of {@link PendingAckHandle}.
+ */
+public class PendingAckHandleDisabled implements PendingAckHandle {
+
+    @Override
+    public CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID,
+                                                                List<MutablePair<PositionImpl, Long>> positions) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer) {
+        return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
+    }
+
+    @Override
+    public void syncBatchPositionAckSetForTransaction(PositionImpl position) {
+        //no operation
+    }
+
+    @Override
+    public boolean checkIsCanDeleteConsumerPendingAck(PositionImpl position) {
+        return false;
+    }
+
+    @Override
+    public void clearIndividualPosition(Position position) {
+        //no operation
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -38,7 +38,7 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
 
     @Override
     public CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID,
-                                                                List<MutablePair<PositionImpl, Long>> positions) {
+                                                                List<MutablePair<PositionImpl, Integer>> positions) {
         return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -81,7 +81,7 @@ public class PendingAckHandleImpl implements PendingAckHandle {
      *     <p>
      *         If it does not exits the map, the position will be added to the map.
      */
-    private Map<PositionImpl, MutablePair<PositionImpl, Long>> individualAckPositions;
+    private Map<PositionImpl, MutablePair<PositionImpl, Integer>> individualAckPositions;
 
     /**
      * The map is for transaction with position witch was cumulative acked by this transaction.
@@ -103,7 +103,7 @@ public class PendingAckHandleImpl implements PendingAckHandle {
 
     @Override
     public synchronized CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID,
-                                                                List<MutablePair<PositionImpl, Long>> positions) {
+                                                                List<MutablePair<PositionImpl, Integer>> positions) {
         if (txnID == null) {
             return FutureUtil.failedFuture(new NotAllowedException("TransactionID can not be null."));
         }
@@ -111,8 +111,8 @@ public class PendingAckHandleImpl implements PendingAckHandle {
             return FutureUtil.failedFuture(new NotAllowedException("Positions can not be null."));
         }
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        for (int i = 0; i < positions.size(); i++) {
-            PositionImpl position = positions.get(i).left;
+        for (MutablePair<PositionImpl, Integer> positionIntegerMutablePair : positions) {
+            PositionImpl position = positionIntegerMutablePair.left;
 
             // If try to ack message already acked by committed transaction or normal acknowledge, throw exception.
             if (((ManagedCursorImpl) persistentSubscription.getCursor())
@@ -127,10 +127,10 @@ public class PendingAckHandleImpl implements PendingAckHandle {
                 //in order to jude the bit set is over lap, so set the covering the batch size bit to 1,
                 // should know the two bit set don't have the same point is 0
                 BitSetRecyclable bitSetRecyclable = BitSetRecyclable.valueOf(position.getAckSet());
-                if (positions.get(i).right.intValue() > bitSetRecyclable.size()) {
-                    bitSetRecyclable.set(positions.get(i).right.intValue());
+                if (positionIntegerMutablePair.right > bitSetRecyclable.size()) {
+                    bitSetRecyclable.set(positionIntegerMutablePair.right);
                 }
-                bitSetRecyclable.set(positions.get(i).right.intValue(), bitSetRecyclable.size());
+                bitSetRecyclable.set(positionIntegerMutablePair.right, bitSetRecyclable.size());
                 long[] ackSetOverlap = bitSetRecyclable.toLongArray();
                 bitSetRecyclable.recycle();
                 if (isAckSetOverlap(ackSetOverlap,
@@ -185,7 +185,7 @@ public class PendingAckHandleImpl implements PendingAckHandle {
                 if (!individualAckPositions.containsKey(position)) {
                     this.individualAckPositions.put(position, positions.get(i));
                 } else {
-                    MutablePair<PositionImpl, Long> positionPair = this.individualAckPositions.get(position);
+                    MutablePair<PositionImpl, Integer> positionPair = this.individualAckPositions.get(position);
                     positionPair.setRight(positions.get(i).right);
                     andAckSet(positionPair.getLeft(), position);
                 }
@@ -290,7 +290,7 @@ public class PendingAckHandleImpl implements PendingAckHandle {
                 for (Entry<PositionImpl, PositionImpl> entry : pendingAckMessageForCurrentTxn.entrySet()) {
                     if (entry.getValue().hasAckSet() && individualAckPositions.containsKey(entry.getValue())) {
                         BitSetRecyclable thisBitSet = BitSetRecyclable.valueOf(entry.getValue().getAckSet());
-                        thisBitSet.flip(0, individualAckPositions.get(entry.getValue()).right.intValue());
+                        thisBitSet.flip(0, individualAckPositions.get(entry.getValue()).right);
                         BitSetRecyclable otherBitSet =
                                 BitSetRecyclable.valueOf(individualAckPositions.get(entry.getValue()).left.getAckSet());
                         otherBitSet.or(thisBitSet);
@@ -317,7 +317,7 @@ public class PendingAckHandleImpl implements PendingAckHandle {
         //sync don't carry the batch size
         //when one position is ack by transaction the batch size is for `and` operation.
         if (!individualAckPositions.containsKey(position)) {
-            this.individualAckPositions.put(position, new MutablePair<>(position, 0L));
+            this.individualAckPositions.put(position, new MutablePair<>(position, 0));
         } else {
             andAckSet(this.individualAckPositions.get(position).left, position);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -85,7 +85,7 @@ public abstract class MockedPulsarServiceBaseTest {
     protected MockZooKeeper mockZooKeeper;
     protected NonClosableMockBookKeeper mockBookKeeper;
     protected boolean isTcpLookup = false;
-    protected final String configClusterName = "test";
+    protected static final String configClusterName = "test";
 
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private ExecutorService bkExecutor;
@@ -95,22 +95,7 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected final void resetConfig() {
-        this.conf = new ServiceConfiguration();
-        this.conf.setAdvertisedAddress("localhost");
-        this.conf.setClusterName(configClusterName);
-        this.conf.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
-        this.conf.setManagedLedgerCacheSizeMB(8);
-        this.conf.setActiveConsumerFailoverDelayTimeMillis(0);
-        this.conf.setDefaultNumberOfNamespaceBundles(1);
-        this.conf.setZookeeperServers("localhost:2181");
-        this.conf.setConfigurationStoreServers("localhost:3181");
-        this.conf.setAllowAutoTopicCreationType("non-partitioned");
-        this.conf.setBrokerServicePort(Optional.of(0));
-        this.conf.setBrokerServicePortTls(Optional.of(0));
-        this.conf.setWebServicePort(Optional.of(0));
-        this.conf.setWebServicePortTls(Optional.of(0));
-        this.conf.setBookkeeperClientExposeStatsToPrometheus(true);
-        this.conf.setNumExecutorThreadPoolSize(5);
+        this.conf = getDefaultConf();
     }
 
     protected final void internalSetup() throws Exception {
@@ -120,6 +105,11 @@ public abstract class MockedPulsarServiceBaseTest {
             lookupUrl = new URI(pulsar.getBrokerServiceUrl());
         }
         pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+    }
+
+    protected final void internalSetup(ServiceConfiguration serviceConfiguration) throws Exception {
+        this.conf = serviceConfiguration;
+        internalSetup();
     }
 
     protected final void internalSetup(boolean isPreciseDispatcherFlowControl) throws Exception {
@@ -401,6 +391,26 @@ public abstract class MockedPulsarServiceBaseTest {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(classObj, fieldValue);
+    }
+
+    protected static ServiceConfiguration getDefaultConf() {
+        ServiceConfiguration configuration = new ServiceConfiguration();
+        configuration.setAdvertisedAddress("localhost");
+        configuration.setClusterName(configClusterName);
+        configuration.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
+        configuration.setManagedLedgerCacheSizeMB(8);
+        configuration.setActiveConsumerFailoverDelayTimeMillis(0);
+        configuration.setDefaultNumberOfNamespaceBundles(1);
+        configuration.setZookeeperServers("localhost:2181");
+        configuration.setConfigurationStoreServers("localhost:3181");
+        configuration.setAllowAutoTopicCreationType("non-partitioned");
+        configuration.setBrokerServicePort(Optional.of(0));
+        configuration.setBrokerServicePortTls(Optional.of(0));
+        configuration.setWebServicePort(Optional.of(0));
+        configuration.setWebServicePortTls(Optional.of(0));
+        configuration.setBookkeeperClientExposeStatsToPrometheus(true);
+        configuration.setNumExecutorThreadPoolSize(5);
+        return configuration;
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -38,6 +39,15 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
 
     public void baseSetup() throws Exception {
         super.internalSetup();
+        baseSetupCommon();
+    }
+
+    public void baseSetup(ServiceConfiguration serviceConfiguration) throws Exception {
+        super.internalSetup(serviceConfiguration);
+        baseSetupCommon();
+    }
+
+    private void baseSetupCommon() throws Exception {
         admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
         admin.tenants().createTenant("prop",
                 new TenantInfo(Sets.newHashSet("appid1"), Sets.newHashSet("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
@@ -40,7 +41,9 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        super.baseSetup();
+        ServiceConfiguration configuration = getDefaultConf();
+        configuration.setTransactionCoordinatorEnabled(true);
+        super.baseSetup(configuration);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -111,6 +111,7 @@ public class PersistentSubscriptionTest {
         executor = Executors.newSingleThreadExecutor();
 
         ServiceConfiguration svcConfig = spy(new ServiceConfiguration());
+        svcConfig.setTransactionCoordinatorEnabled(true);
         pulsarMock = spy(new PulsarService(svcConfig));
         doReturn(svcConfig).when(pulsarMock).getConfiguration();
         doReturn(mock(Compactor.class)).when(pulsarMock).getCompactor();
@@ -184,10 +185,10 @@ public class PersistentSubscriptionTest {
             return null;
         }).when(cursorMock).asyncDelete(any(List.class), any(AsyncCallbacks.DeleteCallback.class), any());
 
-        List<MutablePair<PositionImpl, Long>> positionsPair = new ArrayList<>();
-        positionsPair.add(new MutablePair(new PositionImpl(1, 1), 0));
-        positionsPair.add(new MutablePair(new PositionImpl(1, 3), 0));
-        positionsPair.add(new MutablePair(new PositionImpl(1, 5), 0));
+        List<MutablePair<PositionImpl, Integer>> positionsPair = new ArrayList<>();
+        positionsPair.add(new MutablePair<>(new PositionImpl(1, 1), 0));
+        positionsPair.add(new MutablePair<>(new PositionImpl(1, 3), 0));
+        positionsPair.add(new MutablePair<>(new PositionImpl(1, 5), 0));
 
         doAnswer((invocationOnMock) -> {
             assertTrue(Arrays.deepEquals(((List)invocationOnMock.getArguments()[0]).toArray(),
@@ -222,10 +223,10 @@ public class PersistentSubscriptionTest {
 
     @Test
     public void testCanAcknowledgeAndAbortForTransaction() throws BrokerServiceException, InterruptedException {
-        List<MutablePair<PositionImpl, Long>> positionsPair = new ArrayList<>();
-        positionsPair.add(new MutablePair(new PositionImpl(2, 1), 0));
-        positionsPair.add(new MutablePair(new PositionImpl(2, 3), 0));
-        positionsPair.add(new MutablePair(new PositionImpl(2, 5), 0));
+        List<MutablePair<PositionImpl, Integer>> positionsPair = new ArrayList<>();
+        positionsPair.add(new MutablePair<>(new PositionImpl(2, 1), 0));
+        positionsPair.add(new MutablePair<>(new PositionImpl(2, 3), 0));
+        positionsPair.add(new MutablePair<>(new PositionImpl(2, 5), 0));
 
         doAnswer((invocationOnMock) -> {
             ((AsyncCallbacks.DeleteCallback) invocationOnMock.getArguments()[1])

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -115,6 +115,7 @@ public class TransactionTestBase {
             conf.setAdvertisedAddress("localhost");
             conf.setWebServicePort(Optional.of(0));
             conf.setWebServicePortTls(Optional.of(0));
+            conf.setTransactionCoordinatorEnabled(true);
             serviceConfigurationList.add(conf);
 
             PulsarService pulsar = spy(new PulsarService(conf));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
@@ -70,6 +70,7 @@ public class TransactionMetaStoreTestBase {
             config.setDefaultNumberOfNamespaceBundles(1);
             config.setLoadBalancerEnabled(false);
             config.setAcknowledgmentAtBatchIndexLevelEnabled(true);
+            config.setTransactionCoordinatorEnabled(true);
             configurations[i] = config;
 
             pulsarServices[i] = Mockito.spy(new PulsarService(config));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
@@ -90,6 +90,12 @@ public class ConsumerAckResponseTest extends ProducerConsumerBase {
             Assert.assertTrue(e.getCause() instanceof PulsarClientException.NotAllowedException);
         }
         Message<Integer> message = consumer.receive();
-        consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
+
+        try {
+            consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
+            fail();
+        } catch (ExecutionException e) {
+            Assert.assertTrue(e.getCause() instanceof PulsarClientException.NotAllowedException);
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -243,18 +243,28 @@ public class TransactionEndToEndTest extends TransactionTestBase {
     }
 
     @Test
-    public void txnAckTestNoBatchAndSharedSub() throws Exception {
+    public void txnIndividualAckTestNoBatchAndSharedSub() throws Exception {
         txnAckTest(false, 1, SubscriptionType.Shared);
     }
 
     @Test
-    public void txnAckTestBatchAndSharedSub() throws Exception {
+    public void txnIndividualAckTestBatchAndSharedSub() throws Exception {
         txnAckTest(true, 200, SubscriptionType.Shared);
     }
 
+    @Test
+    public void txnIndividualAckTestNoBatchAndFailoverSub() throws Exception {
+        txnAckTest(false, 1, SubscriptionType.Failover);
+    }
 
-    private void txnAckTest(boolean batchEnable, int maxBatchSize,
-                         SubscriptionType subscriptionType) throws Exception {
+    //TODO: will not remove messageId in Failover unackMessageTracker, we should think about the redeliver problem
+    @Test
+    public void txnIndividualAckTestBatchAndFailoverSub() throws Exception {
+        txnAckTest(true, 200, SubscriptionType.Failover);
+    }
+
+
+    private void txnAckTest(boolean batchEnable, int maxBatchSize, SubscriptionType subscriptionType) throws Exception {
         String normalTopic = NAMESPACE1 + "/normal-topic";
 
         @Cleanup
@@ -263,7 +273,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .subscriptionName("test")
                 .enableBatchIndexAcknowledgment(true)
                 .subscriptionType(subscriptionType)
-                .ackTimeout(2, TimeUnit.SECONDS)
                 .subscribe();
 
         @Cleanup
@@ -289,7 +298,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 log.info("receive msgId: {}, count : {}", message.getMessageId(), i);
                 consumer.acknowledgeAsync(message.getMessageId(), txn).get();
             }
-            Thread.sleep(2000L);
 
             // the messages are pending ack state and can't be received
             Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -257,14 +257,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         txnAckTest(false, 1, SubscriptionType.Failover);
     }
 
-    //TODO: will not remove messageId in Failover unackMessageTracker, we should think about the redeliver problem
     @Test
     public void txnIndividualAckTestBatchAndFailoverSub() throws Exception {
         txnAckTest(true, 200, SubscriptionType.Failover);
     }
 
-
-    private void txnAckTest(boolean batchEnable, int maxBatchSize, SubscriptionType subscriptionType) throws Exception {
+    private void txnAckTest(boolean batchEnable, int maxBatchSize,
+                         SubscriptionType subscriptionType) throws Exception {
         String normalTopic = NAMESPACE1 + "/normal-topic";
 
         @Cleanup

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -1159,6 +1159,10 @@ public final class PulsarApi {
     java.util.List<java.lang.Long> getAckSetList();
     int getAckSetCount();
     long getAckSet(int index);
+    
+    // optional int32 batch_size = 6;
+    boolean hasBatchSize();
+    int getBatchSize();
   }
   public static final class MessageIdData extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -1249,12 +1253,23 @@ public final class PulsarApi {
       return ackSet_.get(index);
     }
     
+    // optional int32 batch_size = 6;
+    public static final int BATCH_SIZE_FIELD_NUMBER = 6;
+    private int batchSize_;
+    public boolean hasBatchSize() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    public int getBatchSize() {
+      return batchSize_;
+    }
+    
     private void initFields() {
       ledgerId_ = 0L;
       entryId_ = 0L;
       partition_ = -1;
       batchIndex_ = -1;
       ackSet_ = java.util.Collections.emptyList();;
+      batchSize_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1296,6 +1311,9 @@ public final class PulsarApi {
       for (int i = 0; i < ackSet_.size(); i++) {
         output.writeInt64(5, ackSet_.get(i));
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeInt32(6, batchSize_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -1328,6 +1346,10 @@ public final class PulsarApi {
         }
         size += dataSize;
         size += 1 * getAckSetList().size();
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeInt32Size(6, batchSize_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -1452,6 +1474,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000008);
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        batchSize_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
       
@@ -1506,6 +1530,10 @@ public final class PulsarApi {
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.ackSet_ = ackSet_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.batchSize_ = batchSize_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -1533,6 +1561,9 @@ public final class PulsarApi {
             ackSet_.addAll(other.ackSet_);
           }
           
+        }
+        if (other.hasBatchSize()) {
+          setBatchSize(other.getBatchSize());
         }
         return this;
       }
@@ -1603,6 +1634,11 @@ public final class PulsarApi {
                 addAckSet(input.readInt64());
               }
               input.popLimit(limit);
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              batchSize_ = input.readInt32();
               break;
             }
           }
@@ -1736,6 +1772,27 @@ public final class PulsarApi {
       public Builder clearAckSet() {
         ackSet_ = java.util.Collections.emptyList();;
         bitField0_ = (bitField0_ & ~0x00000010);
+        
+        return this;
+      }
+      
+      // optional int32 batch_size = 6;
+      private int batchSize_ ;
+      public boolean hasBatchSize() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      public int getBatchSize() {
+        return batchSize_;
+      }
+      public Builder setBatchSize(int value) {
+        bitField0_ |= 0x00000020;
+        batchSize_ = value;
+        
+        return this;
+      }
+      public Builder clearBatchSize() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        batchSize_ = 0;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1143,12 +1143,13 @@ public class Commands {
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties) {
-        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError, properties, -1, -1, -1);
+        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
+                properties, -1L, -1L, -1L, -1);
     }
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
                                  ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
-                                 long txnIdMostBits, long requestId) {
+                                 long txnIdMostBits, long requestId, int batchSize) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
         ackBuilder.setConsumerId(consumerId);
         ackBuilder.setAckType(ackType);
@@ -1158,6 +1159,10 @@ public class Commands {
         if (ackSet != null) {
             messageIdDataBuilder.addAllAckSet(SafeCollectionUtils.longArrayToList(ackSet.toLongArray()));
             ackSet.recycle();
+        }
+
+        if (batchSize >= 0) {
+            messageIdDataBuilder.setBatchSize(batchSize);
         }
         MessageIdData messageIdData = messageIdDataBuilder.build();
         ackBuilder.addMessageId(messageIdData);
@@ -1186,6 +1191,13 @@ public class Commands {
         messageIdDataBuilder.recycle();
         messageIdData.recycle();
         return res;
+    }
+
+    public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, BitSetRecyclable ackSet, AckType ackType,
+                                 ValidationError validationError, Map<String, Long> properties, long txnIdLeastBits,
+                                 long txnIdMostBits, long requestId) {
+        return newAck(consumerId, ledgerId, entryId, ackSet, ackType, validationError,
+                properties, txnIdLeastBits, txnIdMostBits, requestId, -1);
     }
 
     public static ByteBuf newAckResponse(long requestId, ServerError error, String errorMsg, long consumerId) {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -60,6 +60,7 @@ message MessageIdData {
     optional int32 partition = 3 [default = -1];
     optional int32 batch_index = 4 [default = -1];
     repeated int64 ack_set = 5;
+    optional int32 batch_size = 6;
 }
 
 message KeyValue {


### PR DESCRIPTION
## Motivation
Now in Failover sub we ack with transaction will not get the batch size from consumer pendingAcks, so we should ack request carry the batch size.

## implement
We ack with transaction will carry the bath size for individual ack delete the consumer pendingAcks.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (yes)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

