### PR TITLE
Expose the receiver queue size to client consumer stats

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Serializable;
+import java.util.Map;
+
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -101,4 +103,16 @@ public interface ConsumerStats extends Serializable {
      * @return Total number of message acknowledgments failures on this consumer
      */
     long getTotalAcksFailed();
+
+    /**
+     * Get the size of receiver queue.
+     * @return
+     */
+    Integer getMsgNumInReceiverQueue();
+
+    /**
+     * Get the receiver queue size of sub-consumers.
+     * @return
+     */
+    Map<Long, Integer> getMsgNumInSubReceiverQueue();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.pulsar.client.api.ConsumerStats;
@@ -113,6 +114,16 @@ public class ConsumerStatsDisabled implements ConsumerStatsRecorder {
     @Override
     public long getTotalAcksFailed() {
         return 0;
+    }
+
+    @Override
+    public Integer getMsgNumInReceiverQueue() {
+        return null;
+    }
+
+    @Override
+    public Map<Long, Integer> getMsgNumInSubReceiverQueue() {
+        return null;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -20,10 +20,14 @@ package org.apache.pulsar.client.impl;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
 
+import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -42,7 +46,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     private static final long serialVersionUID = 1L;
     private TimerTask stat;
     private Timeout statTimeout;
-    private ConsumerImpl<?> consumer;
+    private Consumer<?> consumer;
     private PulsarClientImpl pulsarClient;
     private long oldTime;
     private long statsIntervalSeconds;
@@ -65,6 +69,11 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     private static final DecimalFormat THROUGHPUT_FORMAT = new DecimalFormat("0.00");
 
     public ConsumerStatsRecorderImpl() {
+        this(null);
+    }
+
+    public ConsumerStatsRecorderImpl(Consumer<?> consumer) {
+        this.consumer = consumer;
         numMsgsReceived = new LongAdder();
         numBytesReceived = new LongAdder();
         numReceiveFailed = new LongAdder();
@@ -80,7 +89,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     }
 
     public ConsumerStatsRecorderImpl(PulsarClientImpl pulsarClient, ConsumerConfigurationData<?> conf,
-            ConsumerImpl<?> consumer) {
+            Consumer<?> consumer) {
         this.pulsarClient = pulsarClient;
         this.consumer = consumer;
         this.statsIntervalSeconds = pulsarClient.getConfiguration().getStatsIntervalSeconds();
@@ -112,9 +121,10 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         }
 
         stat = (timeout) -> {
-            if (timeout.isCancelled()) {
+            if (timeout.isCancelled() || !(consumer instanceof ConsumerImpl)) {
                 return;
             }
+            ConsumerImpl<?> consumerImpl = (ConsumerImpl<?>) consumer;
             try {
                 long now = System.nanoTime();
                 double elapsed = (now - oldTime) / 1e9;
@@ -135,7 +145,6 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
 
                 receivedMsgsRate = currentNumMsgsReceived / elapsed;
                 receivedBytesRate = currentNumBytesReceived / elapsed;
-
                 if ((currentNumMsgsReceived | currentNumBytesReceived | currentNumReceiveFailed | currentNumAcksSent
                         | currentNumAcksFailed) != 0) {
                     log.info(
@@ -143,15 +152,15 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                                     + "Consume throughput received: {} msgs/s --- {} Mbit/s --- "
                                     + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- batch messages: {} ---"
                                     + "Failed acks: {}",
-                            consumer.getTopic(), consumer.getSubscription(), consumer.consumerName,
-                            consumer.incomingMessages.size(), THROUGHPUT_FORMAT.format(receivedMsgsRate),
+                            consumerImpl.getTopic(), consumerImpl.getSubscription(), consumerImpl.consumerName,
+                            consumerImpl.incomingMessages.size(), THROUGHPUT_FORMAT.format(receivedMsgsRate),
                             THROUGHPUT_FORMAT.format(receivedBytesRate * 8 / 1024 / 1024),
                             THROUGHPUT_FORMAT.format(currentNumAcksSent / elapsed), currentNumReceiveFailed,
                             currentNumBatchReceiveFailed, currentNumAcksFailed);
                 }
             } catch (Exception e) {
-                log.error("[{}] [{}] [{}]: {}", consumer.getTopic(), consumer.subscription, consumer.consumerName,
-                        e.getMessage());
+                log.error("[{}] [{}] [{}]: {}", consumerImpl.getTopic(), consumerImpl.subscription
+                        , consumerImpl.consumerName, e.getMessage());
             } finally {
                 // schedule the next stat info
                 statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);
@@ -230,22 +239,47 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         totalAcksFailed.add(stats.getTotalAcksFailed());
     }
 
+    @Override
+    public Integer getMsgNumInReceiverQueue() {
+        if (consumer instanceof ConsumerBase) {
+            return ((ConsumerBase<?>) consumer).incomingMessages.size();
+        }
+        return null;
+    }
+
+    @Override
+    public Map<Long, Integer> getMsgNumInSubReceiverQueue() {
+        if (consumer instanceof MultiTopicsConsumerImpl) {
+            List<ConsumerImpl<?>> consumerList = ((MultiTopicsConsumerImpl) consumer).getConsumers();
+            return consumerList.stream().collect(
+                    Collectors.toMap((consumerImpl) -> consumerImpl.consumerId
+                            , (consumerImpl) -> consumerImpl.incomingMessages.size())
+            );
+        }
+        return null;
+    }
+
+    @Override
     public long getNumMsgsReceived() {
         return numMsgsReceived.longValue();
     }
 
+    @Override
     public long getNumBytesReceived() {
         return numBytesReceived.longValue();
     }
 
+    @Override
     public long getNumAcksSent() {
         return numAcksSent.longValue();
     }
 
+    @Override
     public long getNumAcksFailed() {
         return numAcksFailed.longValue();
     }
 
+    @Override
     public long getNumReceiveFailed() {
         return numReceiveFailed.longValue();
     }
@@ -255,14 +289,17 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         return numBatchReceiveFailed.longValue();
     }
 
+    @Override
     public long getTotalMsgsReceived() {
         return totalMsgsReceived.longValue();
     }
 
+    @Override
     public long getTotalBytesReceived() {
         return totalBytesReceived.longValue();
     }
 
+    @Override
     public long getTotalReceivedFailed() {
         return totalReceiveFailed.longValue();
     }
@@ -272,10 +309,12 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         return totalBatchReceiveFailed.longValue();
     }
 
+    @Override
     public long getTotalAcksSent() {
         return totalAcksSent.longValue();
     }
 
+    @Override
     public long getTotalAcksFailed() {
         return totalAcksFailed.longValue();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -157,7 +157,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
 
         this.internalConfig = getInternalConsumerConfig();
-        this.stats = client.getConfiguration().getStatsIntervalSeconds() > 0 ? new ConsumerStatsRecorderImpl() : null;
+        this.stats = client.getConfiguration().getStatsIntervalSeconds() > 0 ? new ConsumerStatsRecorderImpl(this) : null;
 
         // start track and auto subscribe partition increasement
         if (conf.isAutoUpdatePartitions()) {


### PR DESCRIPTION
Fixes #8650
### Motivation
Currently, we log the receiver queue size. But we don't expose the receiver queue size to the client consumer stats. We should expose it.

### Modifications
add API for `ConsumerStats.java`

### Verifying this change
SimpleProducerConsumerTest#testGetStats
SimpleProducerConsumerTest#testGetStatsForPartitionedTopic