### PR TITLE
Add timeout to hasMessageAvailable to leader election process in Pulsar Functions

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionAssignmentTailer.java
@@ -145,7 +145,7 @@ public class FunctionAssignmentTailer implements AutoCloseable {
                 try {
                     Message<byte[]> msg = reader.readNext(1, TimeUnit.SECONDS);
                     if (msg == null) {
-                        if (exitOnEndOfTopic && !reader.hasMessageAvailable()) {
+                        if (exitOnEndOfTopic && !reader.hasMessageAvailableAsync().get(10, TimeUnit.SECONDS)) {
                             break;
                         }
                     } else {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailer.java
@@ -67,7 +67,7 @@ public class FunctionMetaDataTopicTailer
             try {
                 Message<byte[]> msg = reader.readNext(1, TimeUnit.SECONDS);
                 if (msg == null) {
-                    if (exitOnEndOfTopic && !reader.hasMessageAvailable()) {
+                    if (exitOnEndOfTopic && !reader.hasMessageAvailableAsync().get(10, TimeUnit.SECONDS)) {
                         break;
                     }
                 } else {


### PR DESCRIPTION
### Motivation

The API "hasMessageAvailable" stalls sometimes which leads to the leader initialization process in Pulsar Functions to stall and not complete.  

### Modifications

Add a timeout so that a leader does not get stuck
