### PR TITLE
include failureaccess in shaded JAR

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -71,6 +71,7 @@
               <artifactSet>
                 <includes>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.guava:failureaccess</include>
                   <include>org.apache.jclouds:*</include>
                   <include>org.apache.jclouds.api:*</include>
                   <include>org.apache.jclouds.common:*</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -115,6 +115,7 @@
                   <include>com.typesafe.netty:netty-reactive-streams</include>
                   <include>org.javassist:javassist</include>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.guava:failureaccess</include>
                   <include>com.google.code.gson:gson</include>
                   <include>com.fasterxml.jackson.core</include>
                   <include>com.fasterxml.jackson.module</include>


### PR DESCRIPTION
### Motivation

after #8538, some code using pulsar-client threw `NoClassDefFoundError` and didn't work.
using Guava ≥ 27.0 requires `com.google.guava:failureaccess` to be included in shaded JAR.

### Modifications

include `com.google.guava:failureaccess` in pulsar-client-shaded.