### PR TITLE
PrometheusMetrics on binaries built from the source tarball

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -565,7 +565,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             }
 
             Matcher matcher = pattern.matcher(line);
-            assertTrue(matcher.matches());
+            assertTrue(matcher.matches(), "line " + line + " does not match pattern " + pattern);
             String name = matcher.group(1);
 
             Metric m = new Metric();

--- a/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
+++ b/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
@@ -70,6 +70,11 @@ public class PulsarVersion {
     public static String getGitSha() {
         String commit = "${git.commit.id}";
         String dirtyString = "${git.dirty}";
+        if (commit.contains("git.commit.id")){
+            // this case may happen if you are building the sources
+            // out of the git repository
+            commit = "";
+        }
         if (dirtyString == null || Boolean.valueOf(dirtyString)) {
             return commit + "(dirty)";
         } else {


### PR DESCRIPTION
When you run the tests from the sources in the source release tarball there is no git reference and we are publishing on the metrics a placeholder.

`pulsar_version_info{cluster="test",version="2.7.0",commit="${git.commit.id}"} `

I noticed the problem because PrometheusMetricsTest.java is failing on 2.7.0 sources

The fix is to detect this fact an publish only an empty string.
The change affects PulsarVersion, that in turn is used in Prometheus metrics endpoint