### PR TITLE
[build] Fix issue in maven build that recompiles all classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1092,6 +1092,8 @@ flexible messaging model and an intuitive client API.</description>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <optimize>true</optimize>
+          <!-- workaround https://issues.apache.org/jira/browse/MCOMPILER-205 -->
+          <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
### Motivation

Maven has a bug that recompiles all classes on every build invocation.
The PR has a workaround for the maven bug https://issues.apache.org/jira/browse/MCOMPILER-205 .