### PR TITLE
[build] specify maven-antrun-plugin version and migrate to use newer syntax

### DIFF
--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -89,9 +89,9 @@
                 <id>create-conf-dir</id>
                 <phase>compile</phase>
                 <configuration>
-                  <tasks>
+                  <target>
                     <mkdir dir="target/conf"/>
-                  </tasks>
+                  </target>
                 </configuration>
                 <goals>
                   <goal>run</goal>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -94,11 +94,11 @@
                 </goals>
                 <configuration>
                   <skip>${skipCopyPythonClients}</skip>
-                  <tasks>
+                  <target>
                     <echo>copy python wheel file</echo>
                     <mkdir dir="${basedir}/target/python-client"/>
                     <copydir src="${basedir}/../../pulsar-client-cpp/python/wheelhouse" dest="${basedir}/target/python-client"/>
-                  </tasks>
+                  </target>
                 </configuration>
               </execution>
               <execution>
@@ -109,11 +109,11 @@
                 </goals>
                 <configuration>
                   <skip>${skipCopyCppClient}</skip>
-                  <tasks>
+                  <target>
                     <echo>copy cpp client deb file</echo>
                     <mkdir dir="${basedir}/target/cpp-client"/>
                     <copydir src="${basedir}/../../pulsar-client-cpp/pkg/deb/BUILD/DEB" dest="${basedir}/target/cpp-client"/>
-                  </tasks>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@ flexible messaging model and an intuitive client API.</description>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin>3.2.4</maven-shade-plugin>
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+    <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <maven-archiver.version>2.5</maven-archiver.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>
@@ -1376,6 +1377,10 @@ flexible messaging model and an intuitive client API.</description>
           <configuration>
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${maven-antrun-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -252,7 +252,7 @@
       <artifactId>swagger-annotations</artifactId>
     </dependency>
 
-     <dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>
@@ -402,12 +402,14 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>copy test examples package</echo>
                 <mkdir dir="${basedir}/src/test/resources"/>
-                <copy file="${basedir}/../pulsar-functions/java-examples/target/pulsar-functions-api-examples.jar" tofile="${basedir}/src/test/resources/pulsar-functions-api-examples.jar"/>
-                <copy file="${basedir}/../pulsar-io/data-generator/target/pulsar-io-data-generator-${project.version}.nar" tofile="${basedir}/src/test/resources/pulsar-io-data-generator.nar"/>
-              </tasks>
+                <copy file="${basedir}/../pulsar-functions/java-examples/target/pulsar-functions-api-examples.jar"
+                      tofile="${basedir}/src/test/resources/pulsar-functions-api-examples.jar"/>
+                <copy file="${basedir}/../pulsar-io/data-generator/target/pulsar-io-data-generator-${project.version}.nar"
+                      tofile="${basedir}/src/test/resources/pulsar-io-data-generator.nar"/>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -96,9 +96,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="${basedir}/pom.xml" tofile="${basedir}/src/test/resources/dummy.nar"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -186,7 +186,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>building python instance</echo>
                 <mkdir dir="${basedir}/target/python-instance"/>
                 <copydir src="${basedir}/src/main/python" dest="${basedir}/target/python-instance"/>
@@ -195,7 +195,7 @@
                          dest="${basedir}/target/python-instance/pulsar"/>
                 <mkdir dir="${basedir}/target/python-instance/tests"/>
                 <copydir src="${basedir}/src/test/python" dest="${basedir}/target/python-instance/tests"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -94,7 +94,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>copy test config files</echo>
                 <mkdir dir="${basedir}/src/test/resources"/>
                 <copy todir="${basedir}/src/test/resources/">
@@ -102,7 +102,7 @@
                     <include name="*.yml"/>
                   </fileset>
                 </copy>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -165,13 +165,15 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <echo>copy test sink package</echo>
                 <mkdir dir="${basedir}/src/test/resources"/>
-                <copy file="${basedir}/../../pulsar-io/cassandra/target/pulsar-io-cassandra-${project.version}.nar" tofile="${basedir}/src/test/resources/pulsar-io-cassandra.nar"/>
+                <copy file="${basedir}/../../pulsar-io/cassandra/target/pulsar-io-cassandra-${project.version}.nar"
+                      tofile="${basedir}/src/test/resources/pulsar-io-cassandra.nar"/>
                 <echo>copy test source package</echo>
                 <mkdir dir="${basedir}/src/test/resources"/>
-                <copy file="${basedir}/../../pulsar-io/twitter/target/pulsar-io-twitter-${project.version}.nar" tofile="${basedir}/src/test/resources/pulsar-io-twitter.nar"/>
+                <copy file="${basedir}/../../pulsar-io/twitter/target/pulsar-io-twitter-${project.version}.nar"
+                      tofile="${basedir}/src/test/resources/pulsar-io-twitter.nar"/>
                 <echo>copy test config files</echo>
                 <mkdir dir="${basedir}/src/test/resources"/>
                 <copy todir="${basedir}/src/test/resources/">
@@ -179,7 +181,7 @@
                     <include name="*.yml"/>
                   </fileset>
                 </copy>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### Motivation

Keep maintaining the maven build. The build was using the deprecated syntax for maven antrun plugin configuration.
`tasks` should be replaced with `target` for maven-antrun-plugin 3.0.0 version.
https://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks
"For version 3.0.0, this parameter is only defined to break the build if you use it!"

