### PR TITLE
8704-improve env config handling

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -47,16 +47,30 @@ for conf_filename in conf_files:
         if not line or line.startswith('#'):
             continue
 
-        k,v = line.split('=', 1)
-        keys[k] = len(lines) - 1
+        try:
+            k,v = line.split('=', 1)
+            keys[k] = len(lines) - 1
+        except:
+            print("[%s] skip Processing %s" % (conf_filename, line))
 
     # Update values from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k]
+        v = os.environ[k].strip()
+
+        # Quote the value if it contains a space.
+        if v.find(" ") >= 0:
+            v = '\"%s\"' % v
+
+        # Hide the value in logs if is password.
+        if "password" in k:
+            displayValue = "********"
+        else:
+            displayValue = v
+
         if k.startswith(PF_ENV_PREFIX):
             k = k[len(PF_ENV_PREFIX):]
         if k in keys:
-            print('[%s] Applying config %s = %s' % (conf_filename, k, v))
+            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
             idx = keys[k]
             lines[idx] = '%s=%s\n' % (k, v)
 
@@ -66,16 +80,29 @@ for conf_filename in conf_files:
         v = os.environ[k]
         if not k.startswith(PF_ENV_PREFIX):
             continue
+
+        # Quote the value if it contains a space.
+        if v.find(" ") >= 0:
+            v = '\"%s\"' % v
+
+        # Hide the value in logs if is password.
+        if "password" in k:
+            displayValue = "********"
+        else:
+            displayValue = v
+
         k = k[len(PF_ENV_PREFIX):]
         if k not in keys:
-            print('[%s] Adding config %s = %s' % (conf_filename, k, v))
+            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
             lines.append('%s=%s\n' % (k, v))
         else:
-            print('[%s] Updating config %s = %s' %(conf_filename, k, v))
+            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
             lines[keys[k]] = '%s=%s\n' % (k, v)
+
 
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')
     for line in lines:
         f.write(line)
     f.close()
+


### PR DESCRIPTION
Fixes #8704

There are three issues addressed in this PR.

1) script files that contain lines other than comments and value
assignments cause the script to abort not re-writing the file at all.
These lines should be tolerated if they cannot be parsed as value
assignments and flow through to the edited results.

2) Redaction of passwords in environment variables. Environment
variables with a name containing password will automatically be
redacted and not printed in the log messages.

3) values that contain spaces as in many java args that contain
stringed together options like "-Xmx ... -Xmn ..." are read from the
environment without the quotes. These quotes need to be added back
when writing back to the shell script to ensure that these values are
processed as a group.

