### PR TITLE
[CI] Fix broken "build (macos-latest)" in "CI - Build - Multiple - OS"

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -17,14 +17,16 @@
 # under the License.
 #
 
-name: CI - Build - Multiple - OS
+name: CI - Build - MacOS
 on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
+    paths-ignore: ['site2/**', 'deployment/**']
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -33,10 +35,7 @@ jobs:
 
   build:
     name:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: macos-latest
     timeout-minutes: 120
 
     steps:
@@ -51,26 +50,19 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
-      - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+      - name: Cache Maven dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/pulsar
+            !~/.m2/.gradle-enterprise
+          key: ${{ runner.os }}-maven-dependencies-${{ hashFiles('**/pom.xml') }}
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: build package
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn clean install -DskipTests


### PR DESCRIPTION
Fixes #8711

- replace ci-build-multi-os.yaml with specific build for MacOS
  - the current build is broken since container actions aren't available on macos runner
    - error msg was `Error: Container action is only supported on Linux`
  - it's better to handle only macos build in this workflow. Other workflows will cover the builds on Linux.
