### PR TITLE
Delete explicit claim for log configuration file position in surefire…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1102,7 +1102,6 @@ flexible messaging model and an intuitive client API.</description>
             -Dpulsar.allocator.pooled=false
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false
-            -Dlog4j.configurationFile=log4j2.xml
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>
           <forkCount>${testForkCount}</forkCount>


### PR DESCRIPTION
As this page https://logging.apache.org/log4j/2.x/manual/configuration.html said, 
If we define `log4j.configurationFile` explicitly, it will become the highest priority to configure log related properties, that means any log configuration file in any module will be disabled, that will be the only active configuration file no matter we run some class or test some class in this project.

But we may need different configuration file for different module, and different configuration files in main directories and test directories.

For example, I may want to put a `log4j2-test.xml` in `src/test/resources` with loglevel `debug`, which only effective when I execute `mvn test`, but `-Dlog4j.configurationFile=log4j2.xml` make it impossible.

With `-Dlog4j.configurationFile=log4j2.xml` removed, `log4j2.xml` is still the default configuration file for a module if there is no other configuration file in corresponding modules, So I think it's OK to remove a explicit define.