### PR TITLE
[Transaction] Transaction buffer in memory implementation.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -129,6 +129,20 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
         return false;
     }
 
+    public static PositionImpl convertStringToPosition(String positionString) {
+        if (positionString == null) {
+            throw new NullPointerException();
+        } else {
+            String[] strings = positionString.split(":");
+            if (strings.length != 2) {
+                throw new IndexOutOfBoundsException();
+            }
+            long ledgerId = Long.parseLong(strings[0]);
+            long entryId = Long.parseLong(strings[1]);
+            return PositionImpl.get(ledgerId, entryId);
+        }
+    }
+
     public boolean hasAckSet() {
         return ackSet != null;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferReplayCallback.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferReplayCallback.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer;
+
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+
+/**
+ * The callback of transaction buffer replay the transaction entry.
+ */
+public interface TransactionBufferReplayCallback {
+
+    /**
+     * Topic transaction buffer replay complete callback for transaction metadata store.
+     */
+    void replayComplete();
+
+    /**
+     * Handle metadata entry.
+     *
+     * @param position the transaction operation position
+     * @param messageMetadata the metadata entry
+     */
+    void handleMetadataEntry(Position position, MessageMetadata messageMetadata);
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -18,15 +18,14 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import static org.apache.pulsar.common.protocol.Markers.isTxnMarker;
 import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
@@ -52,8 +51,6 @@ import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.SpscArrayQueue;
-
-import static org.apache.pulsar.common.protocol.Markers.isTxnMarker;
 
 /**
  * Transaction buffer based on normal persistent topic.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -178,7 +178,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     log.error("Topic : [{}] Position : [{}], transaction buffer " +
                             "sync replay position fail!", topic.getName(), position);
                 }
-                countToSyncPosition.addAndGet(defaultCountToSyncPosition);
+                countToSyncPosition.addAndGet(-defaultCountToSyncPosition);
             }
         });
         return completableFuture;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -19,31 +19,128 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferReader;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBufferReplayCallback;
 import org.apache.pulsar.broker.transaction.buffer.TransactionMeta;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarMarkers;
+import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
+import org.jctools.queues.MessagePassingQueue;
+import org.jctools.queues.SpscArrayQueue;
+
+import static org.apache.pulsar.common.protocol.Markers.isTxnMarker;
 
 /**
  * Transaction buffer based on normal persistent topic.
  */
 @Slf4j
-public class TopicTransactionBuffer implements TransactionBuffer {
+public class TopicTransactionBuffer extends TopicTransactionBufferState implements TransactionBuffer {
 
     private final PersistentTopic topic;
 
-    public TopicTransactionBuffer(PersistentTopic topic) {
+    private final SpscArrayQueue<Entry> entryQueue;
+
+    private final ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>> txnBufferCache = new ConcurrentOpenHashMap<>();
+
+    //this is for transaction buffer replay start position
+    //this will be stored in managed ledger properties and every 10000 will sync to zk by default.
+    private final ConcurrentSkipListSet<PositionImpl> positionsSort = new ConcurrentSkipListSet<>();
+
+    private final ManagedCursor cursor;
+
+    //this is for replay
+    private final PositionImpl lastConfirmedEntry;
+    //this if for replay
+    private PositionImpl currentLoadPosition;
+
+    private final AtomicInteger countToSyncPosition = new AtomicInteger(0);
+
+    private final static String TXN_ON_GOING_POSITION_SUFFIX = "-txnOnGoingPosition";
+
+    private final String txnOnGoingPositionName;
+
+    //TODO this can config
+    private int defaultCountToSyncPosition = 10000;
+
+    public TopicTransactionBuffer(PersistentTopic topic) throws ManagedLedgerException {
+        super(State.None);
+        this.entryQueue = new SpscArrayQueue<>(2000);
         this.topic = topic;
+        ManagedLedger managedLedger = topic.getManagedLedger();
+        this.lastConfirmedEntry = (PositionImpl) managedLedger.getLastConfirmedEntry();
+        this.txnOnGoingPositionName = topic.getName() + TXN_ON_GOING_POSITION_SUFFIX;
+        String positionString = managedLedger.getProperties().get(txnOnGoingPositionName);
+        if (positionString == null) {
+            this.currentLoadPosition = PositionImpl.earliest;
+        } else {
+            PositionImpl position = PositionImpl.earliest;
+            try {
+                position = PositionImpl.convertStringToPosition(positionString);
+            } catch (Exception e) {
+                log.error("Topic : [{}] transaction buffer get replay start position error!", topic.getName());
+            }
+            this.currentLoadPosition = position;
+        }
+        this.cursor = managedLedger.newNonDurableCursor(currentLoadPosition);
+
+        new Thread(() -> new TopicTransactionBufferReplayer(new TransactionBufferReplayCallback() {
+
+            @Override
+            public void replayComplete() {
+                if (!changeToReadyState()) {
+                    log.error("Managed ledger transaction metadata store change state error when replay complete");
+                }
+            }
+
+            @Override
+            public void handleMetadataEntry(Position position, MessageMetadata messageMetadata) {
+                if (!messageMetadata.hasTxnidMostBits() || !messageMetadata.hasTxnidLeastBits()) {
+                    return;
+                }
+                TxnID txnID = new TxnID(messageMetadata.getTxnidMostBits(),
+                        messageMetadata.getTxnidLeastBits());
+                if (isTxnMarker(messageMetadata)) {
+                    ConcurrentOpenHashSet<PositionImpl> positions = txnBufferCache.remove(txnID);
+                    positionsSort.removeAll(positions.values());
+                } else {
+                    ConcurrentOpenHashSet<PositionImpl> positions =
+                            txnBufferCache.computeIfAbsent(txnID, (v) -> new ConcurrentOpenHashSet<>());
+                    positions.add((PositionImpl) position);
+                    positionsSort.add((PositionImpl) position);
+                }
+            }
+        }).start()).start();
+    }
+
+    //TODO numberOfEntriesToRead can config
+    private void readAsync(int numberOfEntriesToRead,
+                           AsyncCallbacks.ReadEntriesCallback readEntriesCallback) {
+        cursor.asyncReadEntries(numberOfEntriesToRead, readEntriesCallback, System.nanoTime());
     }
 
     @Override
@@ -53,6 +150,11 @@ public class TopicTransactionBuffer implements TransactionBuffer {
 
     @Override
     public CompletableFuture<Position> appendBufferToTxn(TxnID txnId, long sequenceId, ByteBuf buffer) {
+        if (!checkIfReady()) {
+            return FutureUtil.failedFuture(
+                    new ServiceUnitNotReadyException("Topic : " + topic.getName()
+                            +  " transaction buffer haven't finish replay!"));
+        }
         CompletableFuture<Position> completableFuture = new CompletableFuture<>();
         topic.publishMessage(buffer, (e, ledgerId, entryId) -> {
             if (e != null) {
@@ -60,7 +162,24 @@ public class TopicTransactionBuffer implements TransactionBuffer {
                 completableFuture.completeExceptionally(e);
                 return;
             }
-            completableFuture.complete(PositionImpl.get(ledgerId, entryId));
+            ConcurrentOpenHashSet<PositionImpl> positions =
+                    txnBufferCache.computeIfAbsent(txnId, (v) -> new ConcurrentOpenHashSet<>());
+            PositionImpl position = PositionImpl.get(ledgerId, entryId);
+            positions.add(position);
+            positionsSort.add(position);
+            completableFuture.complete(position);
+            if (countToSyncPosition.incrementAndGet() == defaultCountToSyncPosition) {
+                try {
+                    PositionImpl syncPosition = positionsSort.pollFirst();
+                    if (syncPosition != null) {
+                        topic.getManagedLedger().setProperty(txnOnGoingPositionName, syncPosition.toString());
+                    }
+                } catch (ManagedLedgerException | InterruptedException exception) {
+                    log.error("Topic : [{}] Position : [{}], transaction buffer " +
+                            "sync replay position fail!", topic.getName(), position);
+                }
+                countToSyncPosition.addAndGet(defaultCountToSyncPosition);
+            }
         });
         return completableFuture;
     }
@@ -69,53 +188,88 @@ public class TopicTransactionBuffer implements TransactionBuffer {
     public CompletableFuture<TransactionBufferReader> openTransactionBufferReader(TxnID txnID, long startSequenceId) {
         return null;
     }
+
     @Override
     public CompletableFuture<Void> commitTxn(TxnID txnID, List<MessageIdData> sendMessageIdList) {
+        if (!checkIfReady()) {
+            return FutureUtil.failedFuture(
+                    new ServiceUnitNotReadyException("Topic : " + topic.getName()
+                            +  " transaction buffer haven't finish replay!"));
+        }
         if (log.isDebugEnabled()) {
             log.debug("Transaction {} commit on topic {}.", txnID.toString(), topic.getName());
         }
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-
-        ByteBuf commitMarker = Markers.newTxnCommitMarker(-1L, txnID.getMostSigBits(),
-                txnID.getLeastSigBits(), getMessageIdDataList(sendMessageIdList));
-        topic.publishMessage(commitMarker, (e, ledgerId, entryId) -> {
-            if (e != null) {
-                log.error("Failed to commit for txn {}", txnID, e);
-                completableFuture.completeExceptionally(e);
-                return;
-            }
+        ConcurrentOpenHashSet<PositionImpl> positions = txnBufferCache.get(txnID);
+        if (positions != null) {
+            ByteBuf commitMarker = Markers.newTxnCommitMarker(-1L, txnID.getMostSigBits(),
+                    txnID.getLeastSigBits(), convertPositionToMessageIdData(positions.values()));
+            topic.publishMessage(commitMarker, (e, ledgerId, entryId) -> {
+                if (e != null) {
+                    log.error("Failed to commit for txn {}", txnID, e);
+                    completableFuture.completeExceptionally(e);
+                    return;
+                }
+                txnBufferCache.remove(txnID);
+                completableFuture.complete(null);
+                positionsSort.removeAll(positions.values());
+            });
+        } else {
             completableFuture.complete(null);
-        });
+        }
         return completableFuture;
     }
 
     @Override
     public CompletableFuture<Void> abortTxn(TxnID txnID, List<MessageIdData> sendMessageIdList) {
+        if (!checkIfReady()) {
+            return FutureUtil.failedFuture(
+                    new ServiceUnitNotReadyException("Topic : " + topic.getName()
+                            +  " transaction buffer haven't finish replay!"));
+        }
         if (log.isDebugEnabled()) {
             log.debug("Transaction {} abort on topic {}.", txnID.toString(), topic.getName());
         }
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-
-        ByteBuf abortMarker = Markers.newTxnAbortMarker(
-                -1L, txnID.getMostSigBits(), txnID.getLeastSigBits(), getMessageIdDataList(sendMessageIdList));
-        topic.publishMessage(abortMarker, (e, ledgerId, entryId) -> {
-            if (e != null) {
-                log.error("Failed to abort for txn {}", txnID, e);
-                completableFuture.completeExceptionally(e);
-                return;
-            }
+        ConcurrentOpenHashSet<PositionImpl> positions = txnBufferCache.get(txnID);
+        if (positions != null) {
+            ByteBuf abortMarker = Markers.newTxnAbortMarker(
+                    -1L, txnID.getMostSigBits(),
+                    txnID.getLeastSigBits(), convertPositionToMessageIdData(positions.values()));
+            topic.publishMessage(abortMarker, (e, ledgerId, entryId) -> {
+                if (e != null) {
+                    log.error("Failed to abort for txn {}", txnID, e);
+                    completableFuture.completeExceptionally(e);
+                    return;
+                }
+                txnBufferCache.remove(txnID);
+                completableFuture.complete(null);
+                positionsSort.removeAll(positions.values());
+            });
+        } else {
             completableFuture.complete(null);
-        });
+        }
         return completableFuture;
     }
 
-    private List<PulsarMarkers.MessageIdData> getMessageIdDataList(List<MessageIdData> sendMessageIdList) {
+    private static List<PulsarMarkers.MessageIdData> getMessageIdDataList(List<MessageIdData> sendMessageIdList) {
         List<PulsarMarkers.MessageIdData> messageIdDataList = new ArrayList<>(sendMessageIdList.size());
         for (MessageIdData msgIdData : sendMessageIdList) {
             messageIdDataList.add(
                     PulsarMarkers.MessageIdData.newBuilder()
                             .setLedgerId(msgIdData.getLedgerId())
                             .setEntryId(msgIdData.getEntryId()).build());
+        }
+        return messageIdDataList;
+    }
+
+    private static List<PulsarMarkers.MessageIdData> convertPositionToMessageIdData(List<PositionImpl> positions) {
+        List<PulsarMarkers.MessageIdData> messageIdDataList = new ArrayList<>(positions.size());
+        for (PositionImpl position : positions) {
+            messageIdDataList.add(
+                    PulsarMarkers.MessageIdData.newBuilder()
+                            .setLedgerId(position.getLedgerId())
+                            .setEntryId(position.getEntryId()).build());
         }
         return messageIdDataList;
     }
@@ -128,5 +282,78 @@ public class TopicTransactionBuffer implements TransactionBuffer {
     @Override
     public CompletableFuture<Void> closeAsync() {
         return null;
+    }
+
+    class TopicTransactionBufferReplayer {
+
+        private final TopicTransactionBuffer.FillEntryQueueCallback fillEntryQueueCallback;
+        private final TransactionBufferReplayCallback transactionBufferReplayCallback;
+
+        TopicTransactionBufferReplayer(TransactionBufferReplayCallback transactionBufferReplayCallback) {
+            this.fillEntryQueueCallback = new TopicTransactionBuffer.FillEntryQueueCallback();
+            this.transactionBufferReplayCallback = transactionBufferReplayCallback;
+        }
+
+        public void start() {
+            changeToInitializingState();
+            if (((PositionImpl) cursor.getMarkDeletedPosition()).compareTo(lastConfirmedEntry) == 0) {
+                this.transactionBufferReplayCallback.replayComplete();
+                return;
+            }
+            while (lastConfirmedEntry.compareTo(currentLoadPosition) > 0) {
+                fillEntryQueueCallback.fillQueue();
+                Entry entry = entryQueue.poll();
+                if (entry != null) {
+                    ByteBuf buffer = entry.getDataBuffer();
+                    currentLoadPosition = PositionImpl.get(entry.getLedgerId(), entry.getEntryId());
+                    MessageMetadata messageMetadata = Commands.parseMessageMetadata(buffer);;
+                    transactionBufferReplayCallback.handleMetadataEntry(entry.getPosition(), messageMetadata);
+                    entry.release();
+                    messageMetadata.recycle();
+                } else {
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        //no-op
+                    }
+                }
+            }
+            transactionBufferReplayCallback.replayComplete();
+        }
+    }
+
+    class FillEntryQueueCallback implements AsyncCallbacks.ReadEntriesCallback {
+
+        private final AtomicLong outstandingReadsRequests = new AtomicLong(0);
+
+        void fillQueue() {
+            if (entryQueue.size() < entryQueue.capacity() && outstandingReadsRequests.get() == 0) {
+                if (cursor.hasMoreEntries()) {
+                    outstandingReadsRequests.incrementAndGet();
+                    readAsync(100, this);
+                }
+            }
+        }
+
+        @Override
+        public void readEntriesComplete(List<Entry> entries, Object ctx) {
+            entryQueue.fill(new MessagePassingQueue.Supplier<Entry>() {
+                private int i = 0;
+                @Override
+                public Entry get() {
+                    Entry entry = entries.get(i);
+                    i++;
+                    return entry;
+                }
+            }, entries.size());
+
+            outstandingReadsRequests.decrementAndGet();
+        }
+
+        @Override
+        public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+            log.error("Transaction log init fail error!", exception);
+            outstandingReadsRequests.decrementAndGet();
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferProvider.java
@@ -18,14 +18,13 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A provider that provides topic implementations of {@link TransactionBuffer}.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferState.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferState.java
@@ -1,0 +1,71 @@
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * The implement of transaction buffer state.
+ */
+public abstract class TopicTransactionBufferState {
+
+    /**
+     * The state of the transactionMetadataStore {@link TopicTransactionBufferState}.
+     */
+    public enum State {
+        None,
+        Initializing,
+        Ready,
+        Close
+    }
+
+    private static final AtomicReferenceFieldUpdater<TopicTransactionBufferState, State> STATE_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(TopicTransactionBufferState.class, State.class, "state");
+
+    @SuppressWarnings("unused")
+    private volatile State state = null;
+
+    public TopicTransactionBufferState(State state) {
+        STATE_UPDATER.set(this, state);
+
+    }
+
+    protected boolean changeToReadyState() {
+        return (STATE_UPDATER.compareAndSet(this, State.Initializing, State.Ready));
+    }
+
+    protected boolean changeToInitializingState() {
+        return STATE_UPDATER.compareAndSet(this, State.None, State.Initializing);
+    }
+
+    protected boolean changeToCloseState() {
+        return (STATE_UPDATER.compareAndSet(this, State.Ready, State.Close)
+                || STATE_UPDATER.compareAndSet(this, State.None, State.Close)
+                || STATE_UPDATER.compareAndSet(this, State.Initializing, State.Close));
+    }
+
+    protected boolean checkIfReady() {
+        return STATE_UPDATER.get(this) == State.Ready;
+    }
+
+    public State getState() {
+        return STATE_UPDATER.get(this);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferInMemoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferInMemoryTest.java
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBuffer;
+import org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBufferState;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
+import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TransactionBufferInMemoryTest extends BrokerTestBase {
+
+    private final static String TOPIC = "persistent://prop/ns-abc/test";
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        ServiceConfiguration configuration = getDefaultConf();
+        configuration.setTransactionCoordinatorEnabled(true);
+        super.baseSetup(configuration);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testTransactionBufferCommitAndAbort() throws Exception {
+        admin.topics().createNonPartitionedTopicAsync(TOPIC);
+        admin.topics().createSubscription(TOPIC, "test", MessageId.earliest);
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        TopicTransactionBuffer topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+        TxnID txnID1 = new TxnID(1, 1);
+        TxnID txnID2 = new TxnID(2, 2);
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 1,Unpooled.buffer()).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 1,Unpooled.buffer()).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 1,Unpooled.buffer()).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1,Unpooled.buffer()).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1,Unpooled.buffer()).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1,Unpooled.buffer()).get();
+
+        Field field = TopicTransactionBuffer.class.getDeclaredField("txnBufferCache");
+        field.setAccessible(true);
+        ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>> txnBufferCache =
+                (ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>>) field.get(topicTransactionBuffer);
+        assertTrue(txnBufferCache.containsKey(txnID1));
+        assertTrue(txnBufferCache.containsKey(txnID2));
+        field = TopicTransactionBuffer.class.getDeclaredField("positionsSort");
+        field.setAccessible(true);
+
+        ConcurrentSkipListSet<PositionImpl> positionsSort =
+                (ConcurrentSkipListSet<PositionImpl>) field.get(topicTransactionBuffer);
+
+        assertTrue(positionsSort.containsAll(txnBufferCache.get(txnID1).values()));
+        assertTrue(positionsSort.containsAll(txnBufferCache.get(txnID2).values()));
+
+        ConcurrentSkipListSet<PositionImpl> comparePositionsSort = new ConcurrentSkipListSet<>();
+        comparePositionsSort.addAll(txnBufferCache.get(txnID2).values());
+        comparePositionsSort.addAll(txnBufferCache.get(txnID1).values());
+
+        assertEquals(comparePositionsSort.first(), comparePositionsSort.first());
+
+        ConcurrentOpenHashSet<PositionImpl> txn1Positions = txnBufferCache.get(txnID1);
+        ConcurrentOpenHashSet<PositionImpl> txn2Positions = txnBufferCache.get(txnID2);
+        topicTransactionBuffer.commitTxn(txnID1, null).get();
+
+        assertFalse(txnBufferCache.containsKey(txnID1));
+        assertTrue(txnBufferCache.containsKey(txnID2));
+
+        assertEquals(txn1Positions.size(), 3);
+        assertEquals(txn2Positions.size(), 3);
+        for (int i = 0; i < txn1Positions.size(); i++) {
+            assertFalse(positionsSort.contains(txn1Positions.values().get(i)));
+            assertTrue(positionsSort.contains(txn2Positions.values().get(i)));
+        }
+
+        topicTransactionBuffer.abortTxn(txnID2, null).get();
+        assertFalse(txnBufferCache.containsKey(txnID2));
+
+        for (int i = 0; i < txn1Positions.size(); i++) {
+            assertFalse(positionsSort.contains(txn2Positions.values().get(i)));
+        }
+    }
+
+    @Test
+    public void testTransactionBufferReplay() throws Exception {
+
+        admin.topics().createNonPartitionedTopicAsync(TOPIC);
+        admin.topics().createSubscription(TOPIC, "test", MessageId.earliest);
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        TopicTransactionBuffer topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+
+        TxnID txnID1 = new TxnID(1, 1);
+        TxnID txnID2 = new TxnID(2, 2);
+
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 1, getTxnMetadataByteBuf(1, 1)).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 2, getTxnMetadataByteBuf(1, 1)).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID1, 3, getTxnMetadataByteBuf(1, 1)).get();
+
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1, getTxnMetadataByteBuf(2, 2)).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1, getTxnMetadataByteBuf(2, 2)).get();
+        topicTransactionBuffer.appendBufferToTxn(txnID2, 1, getTxnMetadataByteBuf(2, 2)).get();
+
+        //test replay
+        admin.topics().unload(TOPIC);
+
+        topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+
+        Field field = TopicTransactionBuffer.class.getDeclaredField("txnBufferCache");
+        field.setAccessible(true);
+        ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>> txnBufferCache =
+                (ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>>) field.get(topicTransactionBuffer);
+        assertTrue(txnBufferCache.containsKey(txnID1));
+        assertTrue(txnBufferCache.containsKey(txnID2));
+        field = TopicTransactionBuffer.class.getDeclaredField("positionsSort");
+        field.setAccessible(true);
+
+        ConcurrentSkipListSet<PositionImpl> positionsSort =
+                (ConcurrentSkipListSet<PositionImpl>) field.get(topicTransactionBuffer);
+
+        assertTrue(positionsSort.containsAll(txnBufferCache.get(txnID1).values()));
+        assertTrue(positionsSort.containsAll(txnBufferCache.get(txnID2).values()));
+
+        ConcurrentSkipListSet<PositionImpl> comparePositionsSort = new ConcurrentSkipListSet<>();
+        comparePositionsSort.addAll(txnBufferCache.get(txnID2).values());
+        comparePositionsSort.addAll(txnBufferCache.get(txnID1).values());
+
+        assertEquals(comparePositionsSort.first(), comparePositionsSort.first());
+
+
+        ConcurrentOpenHashSet<PositionImpl> txn1Positions = txnBufferCache.get(txnID1);
+        ConcurrentOpenHashSet<PositionImpl> txn2Positions = txnBufferCache.get(txnID2);
+
+        //test commit replay
+        topicTransactionBuffer.commitTxn(txnID1, null).get();
+
+        admin.topics().unload(TOPIC);
+
+        topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+
+        field = TopicTransactionBuffer.class.getDeclaredField("txnBufferCache");
+        field.setAccessible(true);
+        txnBufferCache =
+                (ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>>) field.get(topicTransactionBuffer);
+
+        field = TopicTransactionBuffer.class.getDeclaredField("positionsSort");
+        field.setAccessible(true);
+
+        positionsSort = (ConcurrentSkipListSet<PositionImpl>) field.get(topicTransactionBuffer);
+
+
+        assertFalse(txnBufferCache.containsKey(txnID1));
+        assertTrue(txnBufferCache.containsKey(txnID2));
+
+        assertEquals(txn1Positions.size(), 3);
+        assertEquals(txn2Positions.size(), 3);
+        for (int i = 0; i < txn1Positions.size(); i++) {
+            assertFalse(positionsSort.contains(txn1Positions.values().get(i)));
+            assertTrue(positionsSort.contains(txn2Positions.values().get(i)));
+        }
+
+        topicTransactionBuffer.abortTxn(txnID2, null).get();
+
+        //test offload
+        admin.topics().unload(TOPIC);
+
+        topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+        field = TopicTransactionBuffer.class.getDeclaredField("positionsSort");
+        field.setAccessible(true);
+
+        positionsSort = (ConcurrentSkipListSet<PositionImpl>) field.get(topicTransactionBuffer);
+
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+
+        field = TopicTransactionBuffer.class.getDeclaredField("txnBufferCache");
+        field.setAccessible(true);
+        txnBufferCache =
+                (ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>>) field.get(topicTransactionBuffer);
+
+        assertFalse(txnBufferCache.containsKey(txnID2));
+
+        for (int i = 0; i < txn1Positions.size(); i++) {
+            assertFalse(positionsSort.contains(txn2Positions.values().get(i)));
+        }
+    }
+
+    @Test
+    public void testReplayIndex() throws Exception {
+
+        admin.topics().createNonPartitionedTopicAsync(TOPIC);
+        admin.topics().createSubscription(TOPIC, "test", MessageId.earliest);
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        TopicTransactionBuffer topicTransactionBuffer =
+                (TopicTransactionBuffer) topic.getTransactionBuffer(true).get();
+        for (int i = 0; i < 3; i++) {
+            Thread.sleep(100);
+            if (topicTransactionBuffer.getState() == TopicTransactionBufferState.State.Ready) {
+                break;
+            }
+        }
+
+        TxnID txnID1 = new TxnID(1, 1);
+        TxnID txnID2 = new TxnID(2, 2);
+
+        for (int i = 0; i < 5000; i++) {
+            topicTransactionBuffer.appendBufferToTxn(txnID1, 1, getTxnMetadataByteBuf(1, 1)).get();
+        }
+
+        topicTransactionBuffer.commitTxn(txnID1, null).get();
+
+        PositionImpl position = null;
+        for (int i = 0; i < 5001; i++) {
+            if (i == 0) {
+                position = (PositionImpl) topicTransactionBuffer
+                        .appendBufferToTxn(txnID2, 1, getTxnMetadataByteBuf(2, 2)).get();
+            } else {
+                topicTransactionBuffer.appendBufferToTxn(txnID2, 1, getTxnMetadataByteBuf(2, 2)).get();
+            }
+        }
+        PositionImpl storePosition = PositionImpl.convertStringToPosition(topic.getManagedLedger()
+                .getProperties().get(topic.getName() + "-txnOnGoingPosition"));
+        assertEquals(storePosition, position);
+
+        //unload check the replay index
+        admin.topics().unload(TOPIC);
+        topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(TopicName.get(TOPIC).toString(), true).get().get();
+        storePosition = PositionImpl.convertStringToPosition(topic.getManagedLedger()
+                .getProperties().get(topic.getName() + "-txnOnGoingPosition"));
+        assertEquals(storePosition, position);
+
+    }
+
+    private ByteBuf getTxnMetadataByteBuf(long txnIdMostBits, long txnIdLeastBits) throws IOException {
+        MessageMetadata.Builder builder = MessageMetadata.newBuilder();
+        builder.setPublishTime(System.currentTimeMillis());
+        builder.setSequenceId(1);
+        builder.setProducerName("test");
+        builder.setTxnidLeastBits(txnIdLeastBits);
+        builder.setTxnidMostBits(txnIdMostBits);
+        MessageMetadata messageMetadata = builder.build();
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeInt(messageMetadata.getSerializedSize());
+        ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(byteBuf);
+        messageMetadata.writeTo(outStream);
+        outStream.recycle();
+        return byteBuf;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -144,6 +144,18 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         Transaction txn1 = getTxn();
         Transaction txn2 = getTxn();
+        //TODO in order to wait buffer replay, and the transaction buffer will not send repeat, it can remove
+        Transaction txn3 = getTxn();
+        for (int i = 0; i < 10; i++) {
+            producer.newMessage(txn3).value(("Hello Txn - " + -i).getBytes(UTF_8)).send();
+        }
+
+        txn3.commit().get();
+
+        Message<byte[]> messageToWaitReplay = consumer.receive();
+        while (messageToWaitReplay != null) {
+            messageToWaitReplay = consumer.receive(2, TimeUnit.SECONDS);
+        }
 
         int txn1MessageCnt = 0;
         int txn2MessageCnt = 0;
@@ -356,6 +368,19 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .create();
 
         Transaction txn = getTxn();
+        //TODO in order to wait buffer replay, and the transaction buffer will not send repeat, it can remove
+        Transaction txn1 = getTxn();
+        for (int i = 0; i < 10; i++) {
+            producer.newMessage(txn1).value(("Hello Txn - " + -i).getBytes(UTF_8)).send();
+        }
+
+        txn1.commit().get();
+
+        Message<byte[]> messageToWaitReplay = consumer.receive();
+        while (messageToWaitReplay != null) {
+            consumer.acknowledge(messageToWaitReplay);
+            messageToWaitReplay = consumer.receive(2, TimeUnit.SECONDS);
+        }
 
         int messageCnt = 10;
         for (int i = 0; i < messageCnt; i++) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
@@ -272,6 +272,12 @@ public class Markers {
                && msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE;
     }
 
+    public static boolean isTxnMarker(MessageMetadata msgMetadata) {
+        return msgMetadata != null
+                && msgMetadata.hasMarkerType() && (msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE
+                || msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE);
+    }
+
     public static ByteBuf newTxnAbortMarker(long sequenceId, long txnMostBits,
                                             long txnLeastBits, List<MessageIdData> messageIdDataList) {
         return newTxnMarker(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/transaction/TransactionTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/transaction/TransactionTest.java
@@ -84,6 +84,7 @@ public class TransactionTest extends TransactionTestBase {
         Producer<TransferOperation> transferProducer = pulsarClient
                 .newProducer(Schema.JSON(TransferOperation.class))
                 .topic(transferTopic)
+                .sendTimeout(0, TimeUnit.SECONDS)
                 .create();
         log.info("transfer producer create finished");
 
@@ -120,18 +121,13 @@ public class TransactionTest extends TransactionTestBase {
                 .withTransactionTimeout(5, TimeUnit.MINUTES)
                 .build().get();
         for (int i = 0; i < 10; i++) {
-            transferProducer.newMessage(txn).value(new TransferOperation()).send();
             balanceUpdateProducer.newMessage(txn).value(new BalanceUpdate()).send();
         }
 
         txn.commit().get();
 
-        Message<TransferOperation> transferMessageToWaitReplay = transferConsumer.receive();
         Message<BalanceUpdate> balanceUpdateMessageToWaitReplay = balanceUpdateConsumer.receive();
-
-        while (transferMessageToWaitReplay != null) {
-            transferMessageToWaitReplay = transferConsumer.receive(2, TimeUnit.SECONDS);
-        }
+        
         while (balanceUpdateMessageToWaitReplay != null) {
             balanceUpdateMessageToWaitReplay = balanceUpdateConsumer.receive(2, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
## Motivation
now we transaction abort or commit transaction depend on client send all messageId, but TC time out can abort this TXN, because it won't carry the messageId, so we should defend the <txn, List<MessagId>> in transaction buffer to handle the tc send abort. 
if we implement it, client will not need to send commit with messageId.
## implement
1. When we send the first txn message, the topic will load the transaction buffer and then the buffer will replay this message
2. we will open a no durable cursor.
3. the no durable cursor start position from managedLedger properties, when the txn message send every 10000(can config) it will modify the position in managedLedger.
3. if the managedLedger properties get this is null, we will start in Position.earliest.
4. we defend a struct 
```
ConcurrentOpenHashMap<TxnID, ConcurrentOpenHashSet<PositionImpl>> txnBufferCache
```
This is for positions which txn send.
when we append the txn message to the topic log complete, we will add the position into it.
commit and abort will remove it
5. we defend a struct
```
private final ConcurrentSkipListSet<PositionImpl> positionsSort = new ConcurrentSkipListSet<>();
```
This is for replay index when every 10000 txn message send finish, we can pollFirst, it is the minimum position on going transaction.
when we append the txn message to the topic log complete, we will add the position into it.
commit and abort will remove it
6. we add the state for transaction buffer, when the buffer haven't replay finish, client cant send txn message to broker.


### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

