### PR TITLE
[WebSocket] Fix the initial sequence id error

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -64,7 +64,6 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
 
     protected boolean checkAuth(ServletUpgradeResponse response) {
         String authRole = "<none>";
-        AuthenticationDataSource authenticationData = new AuthenticationDataHttps(request);
         if (service.isAuthenticationEnabled()) {
             try {
                 authRole = service.getAuthenticationService().authenticateHttpRequest(request);
@@ -85,6 +84,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         }
 
         if (service.isAuthorizationEnabled()) {
+            AuthenticationDataSource authenticationData = new AuthenticationDataHttps(request);
             try {
                 if (!isAuthorized(authRole, authenticationData)) {
                     log.warn("[{}:{}] WebSocket Client [{}] is not authorized on topic {}", request.getRemoteAddr(),

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -330,7 +330,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         numBytesDelivered.add(msgSize);
     }
 
-    private ConsumerBuilder<byte[]> getConsumerConfiguration(PulsarClient client) {
+    protected ConsumerBuilder<byte[]> getConsumerConfiguration(PulsarClient client) {
         ConsumerBuilder<byte[]> builder = client.newConsumer();
 
         if (queryParams.containsKey("ackTimeoutMillis")) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -298,7 +298,7 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         }
 
         if (queryParams.containsKey("initialSequenceId")) {
-            builder.initialSequenceId(Long.parseLong("initialSequenceId"));
+            builder.initialSequenceId(Long.parseLong(queryParams.get("initialSequenceId")));
         }
 
         if (queryParams.containsKey("hashingScheme")) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -285,7 +285,7 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         MSG_PUBLISHED_COUNTER_UPDATER.getAndIncrement(this);
     }
 
-    private ProducerBuilder<byte[]> getProducerBuilder(PulsarClient client) {
+    public ProducerBuilder<byte[]> getProducerBuilder(PulsarClient client) {
         ProducerBuilder<byte[]> builder = client.newProducer()
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.SinglePartition);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -285,7 +285,7 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         MSG_PUBLISHED_COUNTER_UPDATER.getAndIncrement(this);
     }
 
-    public ProducerBuilder<byte[]> getProducerBuilder(PulsarClient client) {
+    protected ProducerBuilder<byte[]> getProducerBuilder(PulsarClient client) {
         ProducerBuilder<byte[]> builder = client.newProducer()
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.SinglePartition);

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -18,7 +18,14 @@
  */
 package org.apache.pulsar.websocket;
 
+import lombok.Getter;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.ProducerBuilderImpl;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.naming.TopicName;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.junit.Assert;
@@ -26,12 +33,20 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class AbstractWebSocketHandlerTest {
@@ -171,4 +186,93 @@ public class AbstractWebSocketHandlerTest {
 
     }
 
+    class MockedServletUpgradeResponse extends ServletUpgradeResponse {
+
+        @Getter
+        private int statusCode;
+        @Getter
+        private String message;
+
+        public MockedServletUpgradeResponse(HttpServletResponse response) {
+            super(response);
+        }
+
+        public void sendError(int statusCode, String message) {
+            this.statusCode = statusCode;
+            this.message = message;
+        }
+    }
+
+    class MockedProducerHandler extends ProducerHandler {
+
+        public MockedProducerHandler(WebSocketService service, HttpServletRequest request, ServletUpgradeResponse response) {
+            super(service, request, response);
+        }
+
+        public void clearQueryParams() {
+            queryParams.clear();
+        }
+
+        public void putQueryParam(String key, String value) {
+            queryParams.put(key, value);
+        }
+    }
+
+    @Test
+    public void producerBuilderTest() throws IOException {
+        String producerV2 = "/ws/v2/producer/persistent/my-property/my-ns/my-topic";
+        // the params are all different with the default value
+        Map<String, String[]> queryParams = new HashMap<String, String>(){{
+            put("producerName", "my-producer");
+            put("initialSequenceId", "1");
+            put("hashingScheme", "Murmur3_32Hash");
+            put("sendTimeoutMillis", "30001");
+            put("batchingEnabled", "false");
+            put("batchingMaxMessages", "1001");
+            put("maxPendingMessages", "1001");
+            put("batchingMaxPublishDelay", "2");
+            put("messageRoutingMode", "RoundRobinPartition");
+            put("compressionType", "LZ4");
+        }}.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> new String[]{ entry.getValue() }));
+
+        httpServletRequest = mock(HttpServletRequest.class);
+        when(httpServletRequest.getRequestURI()).thenReturn(producerV2);
+        when(httpServletRequest.getParameterMap()).thenReturn(queryParams);
+
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .operationTimeout(1, TimeUnit.SECONDS)
+                .build();
+        WebSocketService service = mock(WebSocketService.class);
+        when(service.isAuthenticationEnabled()).thenReturn(false);
+        when(service.isAuthorizationEnabled()).thenReturn(false);
+        when(service.getPulsarClient()).thenReturn(client);
+
+        MockedServletUpgradeResponse response = new MockedServletUpgradeResponse(null);
+
+        MockedProducerHandler producerHandler = new MockedProducerHandler(service, httpServletRequest, response);
+        assertEquals(response.getStatusCode(), 500);
+        assertTrue(response.getMessage().contains("Connection refused"));
+
+        ProducerConfigurationData conf = ((ProducerBuilderImpl<byte[]>) producerHandler.getProducerBuilder(client)).getConf();
+        assertEquals(conf.getProducerName(), "my-producer");
+        assertEquals(conf.getInitialSequenceId().longValue(), 1L);
+        assertEquals(conf.getHashingScheme(), HashingScheme.Murmur3_32Hash);
+        assertEquals(conf.getSendTimeoutMs(), 30001);
+        assertFalse(conf.isBatchingEnabled() );
+        assertEquals(conf.getBatchingMaxMessages(), 1001);
+        assertEquals(conf.getMaxPendingMessages(), 1001);
+        assertEquals(conf.getMessageRoutingMode(), MessageRoutingMode.RoundRobinPartition);
+        assertEquals(conf.getCompressionType(), CompressionType.LZ4);
+
+        producerHandler.clearQueryParams();
+        conf = ((ProducerBuilderImpl<byte[]>) producerHandler.getProducerBuilder(client)).getConf();
+        // The default message routing mode is SinglePartition, which is different with ProducerBuilder
+        assertEquals(conf.getMessageRoutingMode(), MessageRoutingMode.SinglePartition);
+
+        producerHandler.putQueryParam("messageRoutingMode", "CustomPartition");
+        conf = ((ProducerBuilderImpl<byte[]>) producerHandler.getProducerBuilder(client)).getConf();
+        // ProducerHandler doesn't support CustomPartition
+        assertEquals(conf.getMessageRoutingMode(), MessageRoutingMode.SinglePartition);
+    }
 }


### PR DESCRIPTION
### Motivation

The WebSocket `ProducerHandler` parse a wrong string so the client's query param `initialSequenceId` will always fail.

### Modifications

- Parse the real `initialSequenceId` value.
- Add unit tests to ensure that all params from the WebSocket url can be converted to the right config.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `AbstractWebSocketHandlerTest#producerBuilderTest`
- `AbstractWebSocketHandlerTest#consumerBuilderTest`