### PR TITLE
[client] Fix warn log on the producer side when duplicate message is dropped

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -367,8 +367,8 @@ public class ClientCnx extends PulsarHandler {
         }
 
         if (ledgerId == -1 && entryId == -1) {
-            log.warn("[{}] Message has been dropped for non-persistent topic producer-id {}-{}", ctx.channel(),
-                    producerId, sequenceId);
+            log.warn("{} Message with sequence-id {} published by producer {} has been dropped", ctx.channel(),
+                    sequenceId, producerId);
         }
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
If sending a message with a duplicate sequence ID to a persistent topic for which message deduplication is enabled, the following warning log is output on the producer side.
```
[[id: 0xa48ed1f4, L:/127.0.0.1:60058 - R:localhost/127.0.0.1:6650]] Message has been dropped for non-persistent topic producer-id 0-3
```

This message is not appropriate because in this case the topic is not non-persistent but persistent, so I fixed it.