### PR TITLE
exclude ahc.properties for license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1170,6 +1170,7 @@ flexible messaging model and an intuitive client API.</description>
                 <exclude>**/src/main/java/org/apache/bookkeeper/mledger/util/AbstractCASReferenceCounted.java</exclude>
                 <exclude>**/ByteBufCodedInputStream.java</exclude>
                 <exclude>**/ByteBufCodedOutputStream.java</exclude>
+                <exclude>**/ahc.properties</exclude>
                 <exclude>bin/proto/*</exclude>
                 <exclude>conf/schema_example.conf</exclude>
                 <exclude>data/**</exclude>


### PR DESCRIPTION
### Motivation

license-maven-plugin check fail for ahc.properties, maybe related with license-maven-plugin update in #8706 
![licenseCheck](https://user-images.githubusercontent.com/65590138/100595150-81dd9d80-3335-11eb-8539-3dd07f982442.PNG)


### Modifications

Add ahc.properties to exclude list of license-maven-plugin
