### PR TITLE
[Doc]--update message TTL for namespace contents

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -436,6 +436,34 @@ admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
+#### Remove message-ttl
+
+Remove a message TTL of the configured namespace.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+
+```
+$ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
+```
+
+```
+100
+```
+
+<!--REST API-->
+
+```
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}
+```
+
+<!--Java-->
+
+```java
+admin.namespaces().removeNamespaceMessageTTL(namespace)
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 #### Split bundle
 
 Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. 

--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -315,3 +315,24 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 
+### Remove the TTL configuration for a namespace
+
+#### pulsar-admin
+
+Use the [`remove-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces-remove-message-ttl) subcommand and specify a namespace.
+
+##### Example
+
+```shell
+$ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
+```
+
+#### REST API
+
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL}
+
+#### Java
+
+```java
+admin.namespaces().removeNamespaceMessageTTL(namespace)
+```

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -848,6 +848,7 @@ Subcommands
 * `set-persistence`
 * `get-message-ttl`
 * `set-message-ttl`
+* `remove-message-ttl`
 * `get-anti-affinity-group`
 * `set-anti-affinity-group`
 * `get-anti-affinity-namespaces`
@@ -1166,7 +1167,16 @@ $ pulsar-admin namespaces set-message-ttl tenant/namespace options
 Options
 |Flag|Description|Default|
 |----|---|---|
-|`-ttl`, `--messageTTL`|Message TTL in seconds|0|
+|`-ttl`, `--messageTTL`|Message TTL in seconds|3600s|
+
+### `remove-message-ttl`
+Remove the message TTL for a namespace.
+
+Usage
+```bash
+$ pulsar-admin namespaces remove-message-ttl tenant/namespace
+```
+
 
 ### `get-anti-affinity-group`
 Get Anti-affinity group name for a namespace

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
@@ -415,6 +415,33 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 
+#### Remove message-ttl
+
+Remove a message TTL of the configured namespace.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+
+```
+$ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
+```
+
+```
+100
+```
+
+<!--REST API-->
+
+```
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}
+```
+
+<!--Java-->
+
+```java
+admin.namespaces().removeNamespaceMessageTTL(namespace)
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 #### split bundle
 

--- a/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
@@ -289,3 +289,24 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
 
+### Remove the TTL configuration for a namespace
+
+#### pulsar-admin
+
+Use the [`remove-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces-remove-message-ttl) subcommand and specify a namespace.
+
+##### Example
+
+```shell
+$ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
+```
+
+#### REST API
+
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL}
+
+#### Java
+
+```java
+admin.namespaces().removeNamespaceMessageTTL(namespace)
+```

--- a/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
@@ -846,6 +846,7 @@ Subcommands
 * `set-persistence`
 * `get-message-ttl`
 * `set-message-ttl`
+* `remove-message-ttl`
 * `get-anti-affinity-group`
 * `set-anti-affinity-group`
 * `get-anti-affinity-namespaces`
@@ -1164,7 +1165,15 @@ $ pulsar-admin namespaces set-message-ttl tenant/namespace options
 Options
 |Flag|Description|Default|
 |----|---|---|
-|`-ttl`, `--messageTTL`|Message TTL in seconds|0|
+|`-ttl`, `--messageTTL`|Message TTL in seconds|3600s|
+
+### `remove-message-ttl`
+Remove the message TTL for a namespace.
+
+Usage
+```bash
+$ pulsar-admin namespaces remove-message-ttl tenant/namespace
+```
 
 ### `get-anti-affinity-group`
 Get Anti-affinity group name for a namespace


### PR DESCRIPTION


Fixes #1735

### Motivation

Codes for message TTL for namespace is updated. Therefore, update the docs accordingly.

### Modifications
Update the following docs: 

- Admin API for Namespace
- Cookbook: Message retention and expiry
- reference: pulsar-admin

Affected releases:

- master
- 2.6.2
