### PR TITLE
[bot-cherry-pick][website] Fix the Pulsar website build issue

### DIFF
--- a/site2/website/data/connectors.js
+++ b/site2/website/data/connectors.js
@@ -136,7 +136,7 @@ module.exports = [
         longName: 'NSQ source',
         type: 'Source',
         link: 'https://nsq.io/',
-    }
+    },
     {
         name: 'rabbitmq',
         longName: 'RabbitMQ source and sink',


### PR DESCRIPTION
### Motivation
The whole Pulsar website could not be built correctly with some syntax errors.
Found the error here https://github.com/apache/pulsar/runs/1483341061?check_suite_focus=true

### Modifications
Fix the syntax error.

(cherry picked from commit dc2596f2fc7b644a411a6ffc8f04724bf79cf86b)
