### PR TITLE
[WebSocket] Add spotbugs plugin for websocket module

### DIFF
--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -129,6 +129,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs-maven-plugin.version}</version>
         <configuration>
           <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
         </configuration>

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -129,6 +129,9 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>check</id>

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -123,4 +123,22 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -32,7 +32,10 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
@@ -83,8 +86,8 @@ public class ProducerHandler extends AbstractWebSocketHandler {
     private static final AtomicLongFieldUpdater<ProducerHandler> MSG_PUBLISHED_COUNTER_UPDATER =
             AtomicLongFieldUpdater.newUpdater(ProducerHandler.class, "msgPublishedCounter");
 
-    public static final long[] ENTRY_LATENCY_BUCKETS_USEC = { 500, 1_000, 5_000, 10_000, 20_000, 50_000, 100_000,
-            200_000, 1000_000 };
+    public static final List<Long> ENTRY_LATENCY_BUCKETS_USEC = Collections.unmodifiableList(Arrays.asList(
+            500L, 1_000L, 5_000L, 10_000L, 20_000L, 50_000L, 100_000L, 200_000L, 1000_000L));
 
     public ProducerHandler(WebSocketService service, HttpServletRequest request, ServletUpgradeResponse response) {
         super(service, request, response);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
@@ -27,7 +27,7 @@ public class WebSocketConsumerServlet extends WebSocketServlet {
     public static final String SERVLET_PATH = "/ws/consumer";
     public static final String SERVLET_PATH_V2 = "/ws/v2/consumer";
 
-    WebSocketService service;
+    private final transient WebSocketService service;
 
     public WebSocketConsumerServlet(WebSocketService service) {
         super();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
@@ -27,7 +27,7 @@ public class WebSocketProducerServlet extends WebSocketServlet {
     public static final String SERVLET_PATH = "/ws/producer";
     public static final String SERVLET_PATH_V2 = "/ws/v2/producer";
 
-    private final WebSocketService service;
+    private final transient WebSocketService service;
 
     public WebSocketProducerServlet(WebSocketService service) {
         this.service = service;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
@@ -22,12 +22,12 @@ import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
 public class WebSocketReaderServlet extends WebSocketServlet {
-    private static final long serialVersionUID = 1L;
+    private static final transient long serialVersionUID = 1L;
 
     public static final String SERVLET_PATH = "/ws/reader";
     public static final String SERVLET_PATH_V2 = "/ws/v2/reader";
 
-    WebSocketService service;
+    private final transient WebSocketService service;
 
     public WebSocketReaderServlet(WebSocketService service) {
         super();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -76,7 +76,6 @@ public class WebSocketService implements Closeable {
     private ServiceConfiguration config;
     private ConfigurationCacheService configurationCacheService;
 
-    @Setter
     private ClusterData localCluster;
     private final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<ProducerHandler>> topicProducerMap;
     private final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<ConsumerHandler>> topicConsumerMap;
@@ -175,6 +174,10 @@ public class WebSocketService implements Closeable {
             pulsarClient = createClientInstance(localCluster);
         }
         return pulsarClient;
+    }
+
+    public synchronized void setLocalCluster(ClusterData clusterData) {
+        this.localCluster = clusterData;
     }
 
     private PulsarClient createClientInstance(ClusterData clusterData) throws IOException {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
@@ -155,8 +155,9 @@ public class ProxyStats {
             dMetrics.put("ns_byte_deliver_rate", numberOfBytesDelivered);
             dMetrics.put("ns_msg_ack_rate", numberOfMsgsAcked);
             for (int i = 0; i < latencyBuckets.length; i++) {
-                final String latencyBucket = i >= ENTRY_LATENCY_BUCKETS_USEC.length
-                        ? ENTRY_LATENCY_BUCKETS_USEC[ENTRY_LATENCY_BUCKETS_USEC.length-1] + "_higher" : Long.toString(ENTRY_LATENCY_BUCKETS_USEC[i]);
+                final String latencyBucket = i >= ENTRY_LATENCY_BUCKETS_USEC.size()
+                        ? ENTRY_LATENCY_BUCKETS_USEC.get(ENTRY_LATENCY_BUCKETS_USEC.size() - 1) + "_higher"
+                        : Long.toString(ENTRY_LATENCY_BUCKETS_USEC.get(i));
                 dMetrics.put("ns_msg_publish_latency_" + latencyBucket, latencyBuckets[i]);
             }
             return dMetrics;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/StatsBuckets.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/StatsBuckets.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.websocket.stats;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -35,6 +36,10 @@ public class StatsBuckets {
     private final long[] values;
     private long count = 0;
     private long sum = 0;
+
+    public StatsBuckets(List<Long> boundaries) {
+        this(boundaries.stream().mapToLong(l -> l).toArray());
+    }
 
     public StatsBuckets(long... boundaries) {
         checkArgument(boundaries.length > 0);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/StatsBuckets.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/StatsBuckets.java
@@ -90,7 +90,7 @@ public class StatsBuckets {
     }
 
     public long[] getBuckets() {
-        return values;
+        return values.clone();
     }
 
     public long getCount() {

--- a/pulsar-websocket/src/main/resources/findbugsExclude.xml
+++ b/pulsar-websocket/src/main/resources/findbugsExclude.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindBugsFilter>
+  <!-- these public fields may be used in other modules -->
+  <Match>
+    <Class name="org.apache.pulsar.websocket.data.ConsumerMessage"/>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.websocket.stats.ProxyTopicStat$ConsumerStats"/>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.websocket.stats.ProxyTopicStat$ProducerStats"/>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
### Motivation

Add spotbugs plugin for WebSocket module.

### Modifications

There're 20 potential bugs after adding the plugin to check. Here're the modifications to fix:
- MS_MUTABLE_ARRAY: Change the public static array `ENTRY_LATENCY_BUCKETS_USEC` to an unmodifiableList.
- SE_BAD_FIELD: Make the `service` field of Servlet classes `transient` to avoid being serialized.
- URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD: Ignore these errors because it's just an encapsulation issue and some fields are used in other modules or existed clients.
- IS2_INCONSISTENT_SYNC: Add `synchronized` keyword to the setter of `localCluster` to make all access synchronized.
- EI_EXPOSE_REP: Return a clone of array as a snapshot.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.