### PR TITLE
Fix the test HealthCheckTest.testBookKeeperDown

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
@@ -108,7 +108,7 @@ public class HealthCheckTest {
     @Test
     public void testBookKeeperDown() throws Exception {
         for (BKContainer b : pulsarCluster.getBookies()) {
-            b.execCmd("pkill", "-STOP", "-f", "BookieServer");
+            b.execCmd("pkill", "-STOP", "-f", "Main");
         }
         assertHealthcheckFailure();
     }


### PR DESCRIPTION
---

Fixes #8790

*Motivation*

The test HealthCheckTest.testBookKeeperDown always failed.
That because of we have a change in the `bin/pulsar bookie`. #8065
changed the main class name so the bookie process name change to
the `MAIN` not `BookieServer`.
