### PR TITLE
[pulsar-broker] validate namespace isolation policy regex before updating

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -398,6 +398,35 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             LOG.warn("TEST FAILED [{}]", e.getMessage());
             throw e;
         }
+
+        // validate regex: invlid regex for primary and seconday
+        NamespaceIsolationData nsRegexPolicy = new NamespaceIsolationData();
+        nsRegexPolicy.namespaces = new ArrayList<String>();
+        nsRegexPolicy.namespaces.add("other/use/other.*");
+        nsRegexPolicy.primary = new ArrayList<String>();
+        nsRegexPolicy.primary.add("prod1-broker[45-46].messaging.use.example.com");
+        nsRegexPolicy.auto_failover_policy = new AutoFailoverPolicyData();
+        nsRegexPolicy.auto_failover_policy.policy_type = AutoFailoverPolicyType.min_available;
+        nsRegexPolicy.auto_failover_policy.parameters = new HashMap<String, String>();
+        nsRegexPolicy.auto_failover_policy.parameters.put("min_limit", "1");
+        nsRegexPolicy.auto_failover_policy.parameters.put("usage_threshold", "100");
+        try {
+            admin.clusters().createNamespaceIsolationPolicy("test", "invalid_primary", nsRegexPolicy);
+            fail("should have failed with invalid regex");
+        }catch (PulsarAdminException e) {
+            //Ok
+        }
+
+        nsRegexPolicy.primary.add("prod1-broker[4-5].messaging.use.example.com");
+        nsRegexPolicy.secondary = new ArrayList<String>();
+        nsRegexPolicy.secondary.add("prod1-broker[45-46].messaging.use.example.com");
+        try {
+            admin.clusters().createNamespaceIsolationPolicy("test", "invalid_primary", nsRegexPolicy);
+            fail("should have failed with invalid regex");
+        } catch (PulsarAdminException e) {
+            // Ok
+        }
+
     }
 
     @Test

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationData.java
@@ -24,6 +24,10 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * The data of namespace isolation configuration.
@@ -83,8 +87,23 @@ public class NamespaceIsolationData {
 
     public void validate() {
         checkArgument(namespaces != null && !namespaces.isEmpty() && primary != null && !primary.isEmpty()
-                && secondary != null && auto_failover_policy != null);
+                && validateRegex(primary) && secondary != null && validateRegex(secondary) && auto_failover_policy != null);
         auto_failover_policy.validate();
+    }
+
+    private boolean validateRegex(List<String> policies) {
+        if (policies != null && !policies.isEmpty()) {
+            policies.forEach((policy) -> {
+                try {
+                    if (StringUtils.isNotBlank(policy)) {
+                        Pattern.compile(policy);
+                    }
+                } catch (PatternSyntaxException exception) {
+                    throw new IllegalArgumentException("invalid policy regex " + policy);
+                }
+            });
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Right now, the broker stores ns-isolation policy regex without validating which will cause failure at runtime. So, perform fast fail validation and validate policy before storing instead of failing at runtime with invalid policy regex.

```
23:14:56.710 [pulsar-1-11] WARN  o.a.p.b.l.i.SimpleResourceAllocationPolicies - isPrimaryForAnyNamespace: [{}]
java.util.regex.PatternSyntaxException: Illegal character range near index 16
test-broker1[45-46].uswest.com.*
                 ^
        at java.util.regex.Pattern.error(Pattern.java:1955) ~[na:1.8.0_131]
        at java.util.regex.Pattern.range(Pattern.java:2655) ~[na:1.8.0_131]
        at java.util.regex.Pattern.clazz(Pattern.java:2562) ~[na:1.8.0_131]
        at java.util.regex.Pattern.sequence(Pattern.java:2063) ~[na:1.8.0_131]
        at java.util.regex.Pattern.expr(Pattern.java:1996) ~[na:1.8.0_131]
        at java.util.regex.Pattern.compile(Pattern.java:1696) ~[na:1.8.0_131]
        at java.util.regex.Pattern.<init>(Pattern.java:1351) ~[na:1.8.0_131]
        at java.util.regex.Pattern.compile(Pattern.java:1028) ~[na:1.8.0_131]
        at java.util.regex.Pattern.matches(Pattern.java:1133) ~[na:1.8.0_131]
        at java.lang.String.matches(String.java:2121) ~[na:1.8.0_131]
        at org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicyImpl.matchesBrokerRegex(NamespaceIsolationPolicyImpl.java:104)
```