### PR TITLE
fix force delete namespace did not delete all topics of the namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -411,9 +411,12 @@ public abstract class NamespacesBase extends AdminResource {
             // firstly remove all topics including system topics
             if (!topics.isEmpty()) {
                 for (String topic : topics) {
-                    pulsar().getBrokerService().getTopicIfExists(topic).whenComplete((topicOptional, ex) -> {
-                        topicOptional.ifPresent(tp -> futures.add(tp.deleteForcefully()));
-                    });
+                    try {
+                        futures.add(pulsar().getAdminClient().topics().deleteAsync(topic, true));
+                    } catch (Exception e) {
+                        log.error("[{}] Failed to force delete topic {}", clientAppId(), topic, e);
+                        asyncResponse.resume(new RestException(e));
+                    }
                 }
             }
             // forcefully delete namespace bundles

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -1085,7 +1085,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     /**
      * Verifies that deleteNamespace cleans up policies(global,local), bundle cache and bundle ownership
-     *
+
      * @throws Exception
      */
     @Test
@@ -1112,6 +1112,35 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // returns full bundle if policies not present
         assertEquals("0x00000000_0xffffffff", bundle2.getBundleRange());
 
+    }
+
+    /**
+     * Verifies that force deleteNamespace delete all topics in the namespace
+     * @throws Exception
+     */
+    @Test
+    public void testForceDeleteNamespace() throws Exception {
+        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String topic = namespace + "/topic";
+
+        admin.namespaces().createNamespace(namespace, 100);
+
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        List<String> topicList = admin.topics().getList(namespace);
+        assertFalse(topicList.isEmpty());
+
+        try {
+            admin.namespaces().deleteNamespace(namespace, false);
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            // Expected: Cannot delete non empty namespace
+        }
+
+        admin.namespaces().deleteNamespace(namespace, true);
+        admin.namespaces().createNamespace(namespace, 100);
+        topicList = admin.topics().getList(namespace);
+        assertTrue(topicList.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
We found a issue that when force deleting a namespace, only topics owned by the broker were deleted, topics owned by other brokers were not deleted. 
The force delete namespace feature was added in #7993 .

### Modifications
Use admin client to delete the topic, which could delete all topics include those owned by other brokers.

