### PR TITLE
[CI] Fix maven install failure caused by spotbugs check

### DIFF
--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStream.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStream.java
@@ -84,27 +84,6 @@ class DLOutputStream {
             .thenCompose(this::writeAsync);
     }
 
-    /**
-     * Write a ByteBuf data to the distribute log.
-     *
-     * @param data the data we need to write
-     * @return
-     */
-    private CompletableFuture<DLOutputStream> writeAsync(ByteBuf data) {
-        synchronized (this) {
-            offset += data.readableBytes();
-            LogRecord record = new LogRecord(offset, data);
-            log.info("execute write to the dlog " + offset);
-            return writer.write(record).whenComplete((dlsn, throwable) -> {
-                if (throwable != null) {
-                    throwable.printStackTrace();
-                } else {
-                    log.info("DLSN is {} {}", dlsn.toString(), offset);
-                }
-            }).thenApply(ignore -> this);
-        }
-    }
-
     private CompletableFuture<DLOutputStream> writeAsync(List<LogRecord> records) {
         return writer.writeBulk(records).thenApply(ignore -> this);
     }


### PR DESCRIPTION
### Motivation

[#8784](https://github.com/apache/pulsar/pull/8784) introduced spotbugs plugin for pulsar-package-management module and its submodules. However, [#8744](https://github.com/apache/pulsar/pull/8744) cannot pass the spotsbug check but all CI passed because it's an earlier PR that didn't include the spotbugs commit.

Therefore, all PRs that rebased to the latest commit fail with all the CI checks. This PR is to fix it.

### Modifications

Remove the private `DLOutputStream#writeAsync` method that is never used.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
