### PR TITLE
[Issue 8338][Function Worker] Splitting the authentication logic of function worker and client

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -61,6 +61,7 @@ pulsarWebServiceUrl: http://localhost:8080
 ############################################
 # security settings for pulsar broker client
 ############################################
+brokerClientAuthenticationEnabled: false
 # The path to trusted certificates used by the Pulsar client to authenticate with Pulsar brokers
 # brokerClientTrustCertsFilePath:
 # the authentication plugin to be used by the pulsar client used in worker service

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -274,6 +274,18 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     )
     private long instanceLivenessCheckFreqMs;
     @FieldContext(
+            category = CATEGORY_CLIENT_SECURITY,
+            doc = "Whether to enable the broker client authentication used by function workers to talk to brokers"
+    )
+    private Boolean brokerClientAuthenticationEnabled = null;
+    public boolean isBrokerClientAuthenticationEnabled() {
+        if (brokerClientAuthenticationEnabled != null) {
+            return brokerClientAuthenticationEnabled;
+        } else {
+            return authenticationEnabled;
+        }
+    }
+    @FieldContext(
         category = CATEGORY_CLIENT_SECURITY,
         doc = "The authentication plugin used by function workers to talk to brokers"
     )

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -133,7 +133,8 @@ public class WorkerService {
                     ? workerConfig.getFunctionWebServiceUrl()
                     : workerConfig.getWorkerWebAddress();
 
-            if (workerConfig.isAuthenticationEnabled()) {
+             // using isBrokerClientAuthenticationEnabled instead of isAuthenticationEnabled in function-worker
+            if (workerConfig.isBrokerClientAuthenticationEnabled()) {
                 // for compatible, if user do not define brokerClientTrustCertsFilePath, we will use tlsTrustCertsFilePath,
                 // otherwise we will use brokerClientTrustCertsFilePath
                 final String pulsarClientTlsTrustCertsFilePath;
@@ -142,7 +143,6 @@ public class WorkerService {
                 } else {
                     pulsarClientTlsTrustCertsFilePath = workerConfig.getTlsTrustCertsFilePath();
                 }
-
                 this.brokerAdmin = WorkerUtils.getPulsarAdminClient(workerConfig.getPulsarWebServiceUrl(),
                     workerConfig.getBrokerClientAuthenticationPlugin(), workerConfig.getBrokerClientAuthenticationParameters(),
                     pulsarClientTlsTrustCertsFilePath, workerConfig.isTlsAllowInsecureConnection(),


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fixes #8338 

### Motivation

>In some scenarios, users use their own function-worker to connect to an existing pulsar cluster. Their own function-worker and pulsar cluster have different authentication methods, In the following code, when both function-worker and client have enabled the authentication and authorization services, the authentication and authorization can take effect. A better way is to separate them. function-worker can enable and disable the authentication service, and the broker-client can also enable and disable the authentication service according to the configuration.

### Modifications

Add a configuration called `brokerClientAuthenticationEnabled` in the configuration file, which is disabled by default. It is used to control whether the broker-client of function-worker enable or disable the authentication.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
