### PR TITLE
[pulsar-zookeeper-utils] Fix Updating Rack Info Dynamically

### DIFF
--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.zookeeper;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -78,12 +80,14 @@ public class ZkBookieRackAffinityMappingTest {
         ClientConfiguration bkClientConf1 = new ClientConfiguration();
         bkClientConf1.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache("test", localZkc, 30) {
         });
+        assertNull(bkClientConf1.getProperty(ZkBookieRackAffinityMapping.ZK_DATA_CACHE_BK_RACK_CONF_INSTANCE));
         mapping1.setConf(bkClientConf1);
         List<String> racks1 = mapping1
                 .resolve(Lists.newArrayList(BOOKIE1.getHostName(), BOOKIE2.getHostName(), BOOKIE3.getHostName()));
         assertEquals(racks1.get(0), "/rack0");
         assertEquals(racks1.get(1), "/rack1");
         assertEquals(racks1.get(2), null);
+        assertNotNull(bkClientConf1.getProperty(ZkBookieRackAffinityMapping.ZK_DATA_CACHE_BK_RACK_CONF_INSTANCE));
 
         // Case 2: ZkServers and ZkTimeout are given (ZKCache will be constructed in
         // ZkBookieRackAffinityMapping#setConf)


### PR DESCRIPTION
### Motivation
When the value of "/bookies" in ZooKeeper is changed, Brokers are notified of the change.
After the notification to Brokers, only one of the two BookKeeper clients that Brokers have seems to reflect the change.

**Two BookKeeper clients that Brokers have**
- https://github.com/apache/pulsar/blob/ac0c6e41f0ebe3c900bb31e41c8d40b3f60b19df/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java#L81
- https://github.com/apache/pulsar/blob/102fa9de03509b86e47f58ab8e1c0dde2095da3b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java#L105

The client of `BookkeeperSchemaStorage` don't seems to reflect the change.
The cause is that `ZkBookieRackAffinityMapping#onUpdate` don't run.

I confirmed that I change ZkBookieRackAffinityMapping instances to use same `ZooKeeperDataCache` and `ZkBookieRackAffinityMapping#onUpdate` works.

### Modification
- Set the argument of `ZkBookieRackAffinityMapping#setConf` to `bookieMappingCache`
- Move `updateRacksWithHost()`