### PR TITLE
Pulsar IO: Make Source topic Schema information available to downstream Sinks

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -503,7 +503,7 @@ public class PulsarFunctionLocalRunTest {
                 .withPojo(AvroTestObject.class).build());
         //use AVRO schema
         admin.schemas().createSchema(sourceTopic, schema.getSchemaInfo());
-        // please note that in this testthe sink topic schema is different from the schema of the source topic
+        // please note that in this test the sink topic schema is different from the schema of the source topic
 
         //produce message to sourceTopic
         Producer<AvroTestObject> producer = pulsarClient.newProducer(schema).topic(sourceTopic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -219,7 +219,7 @@ public class PulsarFunctionLocalRunTest {
         propAdmin.getAdminRoles().add("superUser");
         propAdmin.setAllowedClusters(Sets.newHashSet(Lists.newArrayList(CLUSTER)));
         admin.tenants().updateTenant(tenant, propAdmin);
-        
+
         // setting up simple web sever to test submitting function via URL
         fileServer = HttpServer.create(new InetSocketAddress(0), 0);
         fileServer.createContext("/pulsar-io-data-generator.nar", he -> {
@@ -503,6 +503,7 @@ public class PulsarFunctionLocalRunTest {
                 .withPojo(AvroTestObject.class).build());
         //use AVRO schema
         admin.schemas().createSchema(sourceTopic, schema.getSchemaInfo());
+        // please note that in this testthe sink topic schema is different from the schema of the source topic
 
         //produce message to sourceTopic
         Producer<AvroTestObject> producer = pulsarClient.newProducer(schema).topic(sourceTopic).create();

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -217,15 +217,15 @@ public class PulsarSink<T> implements Sink<T> {
 
         @Override
         public TypedMessageBuilder<T> newMessage(Record<T> record) {
-            if (record.getSchema() != null) {
+            if (schema != null) {
                 return getProducer(record
                         .getDestinationTopic()
-                        .orElse(pulsarSinkConfig.getTopic()), record.getSchema())
-                        .newMessage(record.getSchema());
+                        .orElse(pulsarSinkConfig.getTopic()), schema)
+                        .newMessage(schema);
             } else {
                 return getProducer(record
                         .getDestinationTopic()
-                        .orElse(pulsarSinkConfig.getTopic()), record.getSchema())
+                        .orElse(pulsarSinkConfig.getTopic()), schema)
                         .newMessage();
             }
         }
@@ -269,10 +269,10 @@ public class PulsarSink<T> implements Sink<T> {
                     String.format("%s-%s",record.getDestinationTopic().orElse(pulsarSinkConfig.getTopic()), record.getPartitionId().get()),
                     record.getPartitionId().get(),
                     record.getDestinationTopic().orElse(pulsarSinkConfig.getTopic()),
-                    record.getSchema()
+                    schema
             );
-            if (record.getSchema() != null) {
-                return producer.newMessage(record.getSchema());
+            if (schema != null) {
+                return producer.newMessage(schema);
             } else {
                 return producer.newMessage();
             }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
@@ -28,6 +28,7 @@ import lombok.ToString;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 
@@ -41,6 +42,7 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
     private final int partition;
 
     private final Message<T> message;
+    private final Schema<T> schema;
 
     private final Runnable failFunction;
     private final Runnable ackFunction;
@@ -72,6 +74,11 @@ public class PulsarRecord<T> implements RecordWithEncryptionContext<T> {
     @Override
     public T getValue() {
         return message.getValue();
+    }
+
+    @Override
+    public Schema<T> getSchema() {
+        return schema;
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -29,9 +29,11 @@ import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -127,9 +129,14 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
 
     @Override
     public void received(Consumer<T> consumer, Message<T> message) {
-
+        Schema<T> schema = null;
+        if (message instanceof MessageImpl) {
+            MessageImpl impl = (MessageImpl) message;
+            schema = impl.getSchema();
+        }
         Record<T> record = PulsarRecord.<T>builder()
                 .message(message)
+                .schema(schema)
                 .topicName(message.getTopicName())
                 .ackFunction(() -> {
                     if (pulsarSourceConfig

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.client.api.*;

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -118,6 +118,7 @@ public class PulsarSinkTest {
         Producer producer = mock(Producer.class);
         doReturn(producer).when(producerBuilder).create();
         doReturn(typedMessageBuilder).when(producer).newMessage();
+        doReturn(typedMessageBuilder).when(producer).newMessage(any(Schema.class));
 
         doReturn(producerBuilder).when(pulsarClient).newProducer();
         doReturn(producerBuilder).when(pulsarClient).newProducer(any());


### PR DESCRIPTION
## Changes:
- extract original Schema from the message read from the topic
- expose the schema into the PulsarRecord implementation
- add unit test
- in PulsarSink detect the fact that the source record is directly from a PulsarSource and drop the schema (there was already a check about the fact that the source record is a PulsarRecord, so this patch is not adding a new shortcircuit)
- little refactor in PulsarSink in order to make it clear that we are working with SinkRecord (casts were already present in the code, and it would not have worked without SinkRecord, so we are only tidying it up)

### Motivation
Pulsar sinks cannot access the original Schema of the Message they are consuming,
this is because currently PulsarSource does not publish the Schema information to downstream processing.

### Modifications
Try to retrieve Schema information from the Message and push it down to the Record.

### Verifying this change
- [X] Make sure that the change passes the CI checks.
- [X] This change added tests and can be verified as follows:
- added unit test
- tested manually with Pulsar Standalone 
- there are existing unit and integration tests that are touching this change (in fact I had to iterate a few times)

### Does this pull request potentially affect one of the following parts: yes
with this change Pulsar function users and especially Pulsar I/O Sinks will be able to inspect the original schema in case the processing starts from a Pulsar topic (PulsarSource)

