### PR TITLE
[website] Resolve a blank page of schema

### DIFF
--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -122,7 +122,6 @@
       "admin-api-namespaces",
       "admin-api-permissions",
       "admin-api-topics",
-      "admin-api-schemas",
       "admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_docs/version-2.1.0-incubating/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/concepts-schema-registry.md
@@ -79,4 +79,4 @@ For usage instructions, see the documentation for your preferred client library:
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.3.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.3.0/concepts-schema-registry.md
@@ -81,4 +81,4 @@ For usage instructions, see the documentation for your preferred client library:
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.3.1/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.3.1/concepts-schema-registry.md
@@ -81,4 +81,4 @@ For usage instructions, see the documentation for your preferred client library:
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.3.2/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.3.2/concepts-schema-registry.md
@@ -81,4 +81,4 @@ For usage instructions, see the documentation for your preferred client library:
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.0/concepts-schema-registry.md
@@ -117,4 +117,4 @@ The following example shows how to define an Avro schema using the `GenericSchem
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.1/concepts-schema-registry.md
@@ -117,4 +117,4 @@ The following example shows how to define an Avro schema using the `GenericSchem
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.4.2/concepts-schema-registry.md
@@ -115,4 +115,4 @@ The following example shows how to define an Avro schema using the `GenericSchem
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-schema-registry.md
@@ -103,4 +103,4 @@ The following example shows how to define an Avro schema using the `GenericSchem
 
 ## Managing Schemas
 
-You can use Pulsar's [admin tools](admin-api-schemas.md) for managing schemas for topics.
+You can use Pulsar admin tools to manage schemas for topics.

--- a/site2/website/versioned_sidebars/version-2.5.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.5.0-sidebars.json
@@ -105,7 +105,6 @@
       "version-2.5.0-admin-api-non-persistent-topics",
       "version-2.5.0-admin-api-partitioned-topics",
       "version-2.5.0-admin-api-non-partitioned-topics",
-      "version-2.5.0-admin-api-schemas",
       "version-2.5.0-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.5.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.5.1-sidebars.json
@@ -106,7 +106,6 @@
       "version-2.5.1-admin-api-non-persistent-topics",
       "version-2.5.1-admin-api-partitioned-topics",
       "version-2.5.1-admin-api-non-partitioned-topics",
-      "version-2.5.1-admin-api-schemas",
       "version-2.5.1-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.5.2-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.5.2-sidebars.json
@@ -106,7 +106,6 @@
       "version-2.5.2-admin-api-non-persistent-topics",
       "version-2.5.2-admin-api-partitioned-topics",
       "version-2.5.2-admin-api-non-partitioned-topics",
-      "version-2.5.2-admin-api-schemas",
       "version-2.5.2-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.6.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.6.0-sidebars.json
@@ -112,7 +112,6 @@
       "version-2.6.0-admin-api-non-persistent-topics",
       "version-2.6.0-admin-api-partitioned-topics",
       "version-2.6.0-admin-api-non-partitioned-topics",
-      "version-2.6.0-admin-api-schemas",
       "version-2.6.0-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.6.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.6.1-sidebars.json
@@ -114,7 +114,6 @@
       "version-2.6.1-admin-api-non-persistent-topics",
       "version-2.6.1-admin-api-partitioned-topics",
       "version-2.6.1-admin-api-non-partitioned-topics",
-      "version-2.6.1-admin-api-schemas",
       "version-2.6.1-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.6.2-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.6.2-sidebars.json
@@ -114,7 +114,6 @@
       "version-2.6.2-admin-api-non-persistent-topics",
       "version-2.6.2-admin-api-partitioned-topics",
       "version-2.6.2-admin-api-non-partitioned-topics",
-      "version-2.6.2-admin-api-schemas",
       "version-2.6.2-admin-api-functions"
     ],
     "Adaptors": [

--- a/site2/website/versioned_sidebars/version-2.7.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.7.0-sidebars.json
@@ -121,7 +121,6 @@
       "version-2.7.0-admin-api-namespaces",
       "version-2.7.0-admin-api-permissions",
       "version-2.7.0-admin-api-topics",
-      "version-2.7.0-admin-api-schemas",
       "version-2.7.0-admin-api-functions"
     ],
     "Adaptors": [


### PR DESCRIPTION
### Motivation
The "Manage Schema" content is merged into "Pulsar Schema" section, yet there are some links to it, and the blank content is still in the sidebar file. The changes was applied since 2.5.0.

### Modifications
- Resolve the link issues.
- Fix the sidebar since 2.5.0.