### PR TITLE
Add package management bookkeeper storage jar into the distribution package

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -68,6 +68,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-package-bookkeeper-storage</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.objenesis</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -66,6 +66,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-package-bookkeeper-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/pulsar-package-management/bookkeeper-storage/pom.xml
+++ b/pulsar-package-management/bookkeeper-storage/pom.xml
@@ -29,7 +29,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>bookkeeper-storage</artifactId>
+    <artifactId>pulsar-package-bookkeeper-storage</artifactId>
     <name>Apache Pulsar :: Package Management :: BookKeeper Storage</name>
 
     <dependencies>


### PR DESCRIPTION
---

Master Issue: #8676

*Motivation*

Currently, the package management bookkeeper storage jar is not in the distribution
package so the service can not find the storage class to start up.

*Modifications*

- Add pulsar-package-bookkeeper-storage.jar to the distribution module
