### PR TITLE
[build] Configure Google Error Prone static code analysis tool for Pulsar maven build

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -17,6 +17,9 @@
 # under the License.
 #
 
-## This file is to fix the conflict with jackson error like this:
-##    com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of ...
-lombok.anyConstructor.addConstructorProperties=true
+# this is the top level Lombok configuration file
+# see https://projectlombok.org/features/configuration for reference
+
+config.stopBubbling = true
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,10 @@ flexible messaging model and an intuitive client API.</description>
     <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.1.3</spotbugs-maven-plugin.version>
     <spotbugs.version>4.2.0</spotbugs.version>
+    <errorprone.version>2.4.0</errorprone.version>
+    <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
+    <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
+
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -1105,6 +1109,13 @@ flexible messaging model and an intuitive client API.</description>
           <optimize>true</optimize>
           <!-- workaround https://issues.apache.org/jira/browse/MCOMPILER-205 -->
           <useIncrementalCompilation>false</useIncrementalCompilation>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>
@@ -1726,6 +1737,126 @@ flexible messaging model and an intuitive client API.</description>
       </modules>
     </profile>
 
+    <!--
+         Configure Google Error Prone static code analyser, http://errorprone.info
+
+         consists of 3 maven profiles: errorprone, errorprone-jdk8 and errorprone-jdk11
+
+         usage:
+         activate profiles "errorprone" and either "errorprone-jdk8" or "errorprone-jdk11"
+         depending on the JVM version
+
+         It is required to add "lombok.addJavaxGeneratedAnnotation = true" to lombok.config
+         temporarily before running the analysis.
+
+         usage example:
+         echo lombok.addJavaxGeneratedAnnotation=true >> lombok.config
+         mvn -Perrorprone,errorprone-jdk11,main compile
+
+         Revisiting warnings and errors is possible in IntelliJ after activating
+         errorprone, errorprone-jdk11 and main in "Maven->Profiles" and choosing
+         "Build->Rebuild Project"
+         Compiling all Pulsar projects in IntelliJ requires some manual tweaks to get the
+         shaded projects to pass compilation. In some cases, it's better to mark the project
+         ignored in IntelliJ by right clicking the project in IntelliJ's maven view and
+         choosing "Ignore Projects". After "Reload All Maven Projects" and a rebuild, it might
+         be possible to proceed compiling the remaining projects.
+    -->
+    <profile>
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <meminitial>128m</meminitial>
+              <maxmem>1024m</maxmem>
+              <optimize>false</optimize>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xlint:-options</arg>
+                <!-- configure Error Prone . Disable some checks that crash the compiler or are annoying -->
+                <!-- the following argument must be kept on one line when building with JDK8 -->
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -XepDisableWarningsInGeneratedCode -Xep:UnusedVariable:OFF -Xep:FallThrough:OFF -Xep:OverrideThrowableToString:OFF -Xep:UnusedMethod:OFF -Xep:StringSplitter:OFF -Xep:CanonicalDuration:OFF ${errorprone.arguments.jdk11}</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+                <path>
+                  <groupId>org.mockito</groupId>
+                  <artifactId>mockito-errorprone</artifactId>
+                  <version>${mockito.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- running errorprone on JDK 8 requires special javac configuration -->
+    <profile>
+      <id>errorprone-jdk8</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>
+                  -J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>javac</artifactId>
+                  <version>${errorprone.javac.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>errorprone-jdk11</id>
+      <dependencies>
+        <!-- required on JDK9+ when there is "lombok.addJavaxGeneratedAnnotation = true" in lombok.config -->
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+      </dependencies>
+      <properties>
+        <!-- pass the additional properties to -Xplugin:ErrorProne argument defined in errorprone profile -->
+        <!-- change configuration of slf4j checks to be more permissive -->
+        <errorprone.arguments.jdk11>-Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:WARN -Xep:Slf4jSignOnlyFormat:WARN -Xep:Slf4jFormatShouldBeConst:WARN -Xep:Slf4jLoggerShouldBePrivate:WARN -Xep:Slf4jLoggerShouldBeNonStatic:OFF</errorprone.arguments.jdk11>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths combine.children="append">
+                <!-- add https://github.com/KengoTODA/errorprone-slf4j Error Prone plugin -->
+                <!-- detects slf4j misusage. Doesn't run on Java 8, so this is why it's in the errorprone-jdk11 profile -->
+                <path>
+                  <groupId>jp.skypencil.errorprone.slf4j</groupId>
+                  <artifactId>errorprone-slf4j</artifactId>
+                  <version>${errorprone-slf4j.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <repositories>


### PR DESCRIPTION
### Motivation

Google's [Error Prone static code analysis tool](https://errorprone.info/) can detect typical programming mistakes (for more info see https://errorprone.info/). This PR adds configuration to Pulsar maven build so that Error Prone static code analysis
can be run for the Pulsar code base. This additional configuration is not active by default and requires activating `errorprone` and `errorprone-jdk8` or `errorprone-jdk11` maven profiles in addition to `main` or `core-modules` profile for running the analysis.

### Modifications

- add a separate maven profile for running errorprone analysis
  it is not active by default

- Add top-level `lombok.config file` for configuring Lombok.
  This file doesn't contain any other settings that
  marks it as the top most config file with `config.stopBubbling = true`
  (see https://projectlombok.org/features/configuration for reference)

- Before running the Error Prone analysis, it's necessary to
  manually configure Lombok to add `@javax.annotation.Generated("lombok")`
  annotation on all fields, methods, and types that are generated.
  This makes Error Prone skip the analysis for Lombok generated code.
  - this setting cannot be enabled by default since JDK9+ doesn't include
    the `javax.annotation.Generated` annotation by default and adding the
    required dependency will change the classpath dependency resolution results.
  - There is an open issue to support lombok.Generated annotion in
    ErrorProne, https://github.com/google/error-prone/issues/1863

- example usage:
  Configure Lombok to add Generated annotations
  `echo "lombok.addJavaxGeneratedAnnotation = true" >> lombok.config`
  then,
  on JDK8
  `mvn -Perrorprone,errorprone-jdk8,core-modules compile`
  on JDK11+
  `mvn -Perrorprone,errorprone-jdk11,core-modules compile`

  - usability is better when used together with IntelliJ
    since one can click on the error message to navigate
    to the code location

- also add configuration for Error Prone SLF4J plugin
  https://github.com/KengoTODA/errorprone-slf4j
  which helps detect misusage of SLF4J API