### PR TITLE
[logging] Upgrade Log4j2 version to 2.14.0 and replace legacy log4j dependency

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -43,17 +43,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.10.0</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.10.0</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.10.0</version>
+      <version>2.14.0</version>
     </dependency>
   </dependencies>
 

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -95,8 +95,8 @@
     </dependency>
 
     <dependency>
-      <artifactId>log4j</artifactId>
-      <groupId>log4j</groupId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
     <dependency>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -388,11 +388,11 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - log4j-log4j-1.2.17.jar
-    - org.apache.logging.log4j-log4j-api-2.10.0.jar
-    - org.apache.logging.log4j-log4j-core-2.10.0.jar
-    - org.apache.logging.log4j-log4j-slf4j-impl-2.10.0.jar
-    - org.apache.logging.log4j-log4j-web-2.10.0.jar
+    - org.apache.logging.log4j-log4j-api-2.14.0.jar
+    - org.apache.logging.log4j-log4j-core-2.14.0.jar
+    - org.apache.logging.log4j-log4j-slf4j-impl-2.14.0.jar
+    - org.apache.logging.log4j-log4j-web-2.14.0.jar
+    - org.apache.logging.log4j-log4j-1.2-api-2.14.0.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.12.0.jar

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -97,8 +97,8 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.10.0</log4j2.version>
+    <log4j2.version>2.14.0</log4j2.version>
     <bouncycastle.version>1.66</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.11.1</jackson.version>
@@ -534,40 +534,10 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
+        <artifactId>log4j-bom</artifactId>
         <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-web</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <type>test-jar</type>
-        <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <type>test-jar</type>
-        <version>${log4j2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

Upgrade to most recent Log4j2 version to keep it updated. Replace legacy log4j dependency with API facade for legacy API

### Modifications

- Upgrade Log4j2 version to 2.14.0

- replace legacy log4j dependency with log4j-1.2-api

- import Log4j2's BOM into Pulsar's dependency management instead of
  defining versions separately for each Log4j2 library

- distribution/server/pom.xml included log4j:log4j dependency.
  - replace with org.apache.logging.log4j:log4j-1.2-api to
    keep supporting the legacy logging api in the case something
    depends on it
