### PR TITLE
Issue 8882: GenericJsonReader converts the null value to string "null"

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -90,6 +90,8 @@ public class GenericJsonRecord extends VersionedGenericRecord {
             } catch (IOException e) {
                 return fn.asText();
             }
+        } else if (fn.isNull()) {
+            return null;
         } else {
             return fn.asText();
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecordTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecordTest.java
@@ -25,11 +25,24 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.pulsar.client.api.schema.Field;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
 public class GenericJsonRecordTest {
+
+    @Test
+    public void decodeNullValue() throws Exception{
+        byte[] json = "{\"somefield\":null}".getBytes(UTF_8);
+        GenericJsonRecord record
+                = new GenericJsonReader(Collections.singletonList(new Field("somefield", 0)))
+                        .read(json, 0, json.length);
+        assertTrue(record.getJsonNode().get("somefield").isNull());
+        assertNull(record.getField("somefield"));
+    }
+
 
     @Test
     public void decodeLongField() throws Exception{


### PR DESCRIPTION
Describe the bug
It looks like GenericJsonReader is not handling correctly null values

Expected behavior
The null value is not converted to a string, but it is still a null value

Changes
- Handle correctly null values
- add test case

Additional context
The problem affects Pulsar Functions/Pulsar IO

Fixes #8882 