### PR TITLE
Add cmd flag of retain key ordering

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -267,6 +267,8 @@ public class CmdFunctions extends CmdBase {
         protected Boolean DEPRECATED_retainOrdering;
         @Parameter(names = "--retain-ordering", description = "Function consumes and processes messages in order")
         protected Boolean retainOrdering;
+        @Parameter(names = "--retain-key-ordering", description = "Function consumes and processes messages in key order")
+        protected Boolean retainKeyOrdering;
         @Parameter(names = "--batch-builder", description = "BatcherBuilder provides two types of batch construction methods, DEFAULT and KEY_BASED. The default value is: DEFAULT")
         protected String batchBuilder;
         @Parameter(names = "--forward-source-message-property", description = "Forwarding input message's properties to output topic when processing")
@@ -427,6 +429,10 @@ public class CmdFunctions extends CmdBase {
 
             if (null != retainOrdering) {
                 functionConfig.setRetainOrdering(retainOrdering);
+            }
+
+            if (null != retainKeyOrdering) {
+                functionConfig.setRetainKeyOrdering(retainKeyOrdering);
             }
 
             if (isNotBlank(batchBuilder)) {

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -460,6 +460,7 @@ Options
 |`--fqfn`|The Fully Qualified Function Name (FQFN) for the function||
 |`--max-message-retries`|How many times should we try to process a message before giving up||
 |`--retain-ordering`|Function consumes and processes messages in order||
+|`--retain-key-ordering`|Function consumes and processes messages in key order||
 |`--timeout-ms`|The message timeout in milliseconds||
 |`--tls-allow-insecure`|Allow insecure tls connection|false|
 |`--tls-trust-cert-path`|The tls trust cert file path||
@@ -509,6 +510,7 @@ Options
 |`--fqfn`|The Fully Qualified Function Name (FQFN) for the function||
 |`--max-message-retries`|How many times should we try to process a message before giving up||
 |`--retain-ordering`|Function consumes and processes messages in order||
+|`--retain-key-ordering`|Function consumes and processes messages in key order||
 |`--timeout-ms`|The message timeout in milliseconds||
 |`--producer-config`| The custom producer configuration (as a JSON string) | |
 
@@ -573,6 +575,7 @@ Options
 |`--fqfn`|The Fully Qualified Function Name (FQFN) for the function||
 |`--max-message-retries`|How many times should we try to process a message before giving up||
 |`--retain-ordering`|Function consumes and processes messages in order||
+|`--retain-key-ordering`|Function consumes and processes messages in key order||
 |`--timeout-ms`|The message timeout in milliseconds||
 |`--producer-config`| The custom producer configuration (as a JSON string) | |
 


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #6527 

### Motivation

We already support `key_shared` mode on Pulsar Functions in #7647, However, this option is not exposed in the command line parameters, so users currently cannot use this function.

### Modifications

In this pull request, we expose this cmd flag of `--retain-key-ordering` and add the docs for this.

### Verifying this change

The original test can cover this option, so, in this change, no relevant code is added


### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
