### PR TITLE
[docs][issue-8853]Add version number for doc endpoint

### DIFF
--- a/site2/docs/admin-api-brokers.md
+++ b/site2/docs/admin-api-brokers.md
@@ -38,7 +38,7 @@ broker1.use.org.com:8080
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -71,7 +71,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -102,7 +102,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -124,7 +124,7 @@ brokerShutdownTimeoutMs
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -147,7 +147,7 @@ brokerShutdownTimeoutMs:100
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-brokers.md
+++ b/site2/docs/admin-api-brokers.md
@@ -38,7 +38,7 @@ broker1.use.org.com:8080
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -71,7 +71,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -102,7 +102,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -124,7 +124,7 @@ brokerShutdownTimeoutMs
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -147,7 +147,7 @@ brokerShutdownTimeoutMs:100
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-clusters.md
+++ b/site2/docs/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -105,7 +105,7 @@ $ pulsar-admin clusters get cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -131,7 +131,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -161,7 +161,7 @@ $ pulsar-admin clusters delete cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -187,7 +187,7 @@ cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -211,7 +211,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-clusters.md
+++ b/site2/docs/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -105,7 +105,7 @@ $ pulsar-admin clusters get cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -131,7 +131,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -161,7 +161,7 @@ $ pulsar-admin clusters delete cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -187,7 +187,7 @@ cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -211,7 +211,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-functions.md
+++ b/site2/docs/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -89,7 +89,7 @@ $ pulsar-admin functions update \
 
 <!--REST Admin API-->
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -126,7 +126,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -155,7 +155,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -185,7 +185,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -214,7 +214,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -244,7 +244,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -273,7 +273,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -301,7 +301,7 @@ $ pulsar-admin functions list \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -330,7 +330,7 @@ $ pulsar-admin functions delete \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -359,7 +359,7 @@ $ pulsar-admin functions get \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -388,7 +388,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -417,7 +417,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -446,7 +446,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -475,7 +475,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -506,7 +506,7 @@ $ pulsar-admin functions trigger \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -536,7 +536,7 @@ $ pulsar-admin functions putstate \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -568,7 +568,7 @@ $ pulsar-admin functions querystate \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 <!--Java Admin CLI-->
 

--- a/site2/docs/admin-api-functions.md
+++ b/site2/docs/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -89,7 +89,7 @@ $ pulsar-admin functions update \
 
 <!--REST Admin API-->
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -126,7 +126,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -155,7 +155,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -185,7 +185,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -214,7 +214,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -244,7 +244,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -273,7 +273,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -301,7 +301,7 @@ $ pulsar-admin functions list \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -330,7 +330,7 @@ $ pulsar-admin functions delete \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -359,7 +359,7 @@ $ pulsar-admin functions get \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -388,7 +388,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -417,7 +417,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -446,7 +446,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -475,7 +475,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -506,7 +506,7 @@ $ pulsar-admin functions trigger \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -536,7 +536,7 @@ $ pulsar-admin functions putstate \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -568,7 +568,7 @@ $ pulsar-admin functions querystate \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 <!--Java Admin CLI-->
 

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -74,7 +74,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -100,7 +100,7 @@ test-tenant/ns2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -124,7 +124,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -150,7 +150,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -178,7 +178,7 @@ cl2
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -216,7 +216,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -249,7 +249,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -277,7 +277,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -315,7 +315,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -348,7 +348,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -378,7 +378,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -407,7 +407,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -437,7 +437,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -465,7 +465,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -493,7 +493,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -524,7 +524,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -552,7 +552,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation?version=[[pulsar:version_number]]/clearNamespaceBundleBacklogForSubscription}
 ```
 
 <!--Java-->
@@ -582,7 +582,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -613,7 +613,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -652,7 +652,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -684,7 +684,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -716,7 +716,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -748,7 +748,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -780,7 +780,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -812,7 +812,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -838,7 +838,7 @@ $ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -863,7 +863,7 @@ $ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/ns1 --
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 ```json
@@ -893,7 +893,7 @@ $ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -925,7 +925,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 <!--REST-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -74,7 +74,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -100,7 +100,7 @@ test-tenant/ns2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -124,7 +124,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -150,7 +150,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -178,7 +178,7 @@ cl2
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -216,7 +216,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -249,7 +249,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -277,7 +277,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -315,7 +315,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -348,7 +348,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -378,7 +378,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -407,7 +407,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -437,7 +437,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -465,7 +465,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -493,7 +493,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -524,7 +524,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -552,7 +552,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBundleBacklogForSubscription}
 ```
 
 <!--Java-->
@@ -582,7 +582,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -613,7 +613,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -652,7 +652,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -684,7 +684,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -716,7 +716,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -748,7 +748,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -780,7 +780,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -812,7 +812,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -838,7 +838,7 @@ $ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -863,7 +863,7 @@ $ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/ns1 --
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
 ```
 
 ```json
@@ -893,7 +893,7 @@ $ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -925,7 +925,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 <!--REST-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 <!--Java-->

--- a/site2/docs/admin-api-permissions.md
+++ b/site2/docs/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -85,7 +85,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -110,7 +110,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 

--- a/site2/docs/admin-api-permissions.md
+++ b/site2/docs/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -85,7 +85,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -110,7 +110,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 

--- a/site2/docs/admin-api-tenants.md
+++ b/site2/docs/admin-api-tenants.md
@@ -28,7 +28,7 @@ my-tenant-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants}
+{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -61,7 +61,7 @@ $ pulsar-admin tenants create my-tenant \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/functions/{tenant}
+{@inject: endpoint|POST|/admin/v2/functions/{tenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -95,7 +95,7 @@ $ pulsar-admin tenants get my-tenant
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant}
+{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -120,7 +120,7 @@ $ pulsar-admin tenants delete my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -144,7 +144,7 @@ $ pulsar-admin tenants update my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-tenants.md
+++ b/site2/docs/admin-api-tenants.md
@@ -28,7 +28,7 @@ my-tenant-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -61,7 +61,7 @@ $ pulsar-admin tenants create my-tenant \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/functions/{tenant?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/createTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -95,7 +95,7 @@ $ pulsar-admin tenants get my-tenant
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -120,7 +120,7 @@ $ pulsar-admin tenants delete my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -144,7 +144,7 @@ $ pulsar-admin tenants update my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -570,7 +570,7 @@ $ pulsar-admin topics reset-cursor \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation?version=((pulsar:version_number))/resetCursor}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -20,7 +20,7 @@ Whether it is persistent or non-persistent topic, you can obtain the topic resou
 
 > **Note**    
 > In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.     
-> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 ### List of topics
 
@@ -35,7 +35,7 @@ $ pulsar-admin topics list \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -57,7 +57,7 @@ $ pulsar-admin topics grant-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -88,7 +88,7 @@ $ pulsar-admin topics permissions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -117,7 +117,7 @@ $ pulsar-admin topics revoke-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -140,7 +140,7 @@ $ pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -161,7 +161,7 @@ $ pulsar-admin topics unload \
 ```
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -313,7 +313,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -445,7 +445,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -471,7 +471,7 @@ msg-payload
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=((pulsar:version_number))/peekNthMessage}
 
 <!--Java-->
 ```java
@@ -496,7 +496,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -521,7 +521,7 @@ $ pulsar-admin topics skip \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -546,7 +546,7 @@ $ pulsar-admin topics skip-all \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -570,7 +570,7 @@ $ pulsar-admin topics reset-cursor \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation?version=((pulsar:version_number))/resetCursor}
 
 <!--Java-->
 ```java
@@ -596,7 +596,7 @@ $ pulsar-admin topics lookup \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -620,7 +620,7 @@ $ pulsar-admin topics bundle-range \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -644,7 +644,7 @@ $ pulsar-admin topics subscriptions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -667,7 +667,7 @@ $ pulsar-admin topics unsubscribe \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -689,7 +689,7 @@ pulsar-admin topics last-message-id topic-name
 ```
 
 <!--REST API-->
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId}
+{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=((pulsar:version_number))}
 
 <!--Java-->
 ```Java
@@ -722,7 +722,7 @@ $ bin/pulsar-admin topics create \
 > When you create a non-partitioned topic with the suffix '-partition-' followed by numeric value like 'xyz-topic-partition-x' for the topic name, if a partitioned topic with same suffix 'xyz-topic-partition-y' exists, then the numeric value(x) for the non-partitioned topic must be larger than the number of partitions(y) of the partitioned topic. Otherwise, you cannot create such a non-partitioned topic. 
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -742,7 +742,7 @@ $ bin/pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -763,7 +763,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -818,7 +818,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -853,7 +853,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 > If a non-partitioned topic with the suffix '-partition-' followed by a numeric value like 'xyz-topic-partition-10', you can not create a partitioned topic with name 'xyz-topic', because the partitions of the partitioned topic could override the existing non-partitioned topic. To create such partitioned topic, you have to delete that non-partitioned topic first.
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -878,7 +878,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -909,7 +909,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -936,7 +936,7 @@ $ pulsar-admin topics update-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -956,7 +956,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -976,7 +976,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -1052,7 +1052,7 @@ $ pulsar-admin topics partitioned-stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -1112,7 +1112,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -20,7 +20,7 @@ Whether it is persistent or non-persistent topic, you can obtain the topic resou
 
 > **Note**    
 > In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.     
-> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 ### List of topics
 
@@ -35,7 +35,7 @@ $ pulsar-admin topics list \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -57,7 +57,7 @@ $ pulsar-admin topics grant-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -88,7 +88,7 @@ $ pulsar-admin topics permissions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -117,7 +117,7 @@ $ pulsar-admin topics revoke-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -140,7 +140,7 @@ $ pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -161,7 +161,7 @@ $ pulsar-admin topics unload \
 ```
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -313,7 +313,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -445,7 +445,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -471,7 +471,7 @@ msg-payload
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=((pulsar:version_number))/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=[[pulsar:version_number]]/peekNthMessage}
 
 <!--Java-->
 ```java
@@ -496,7 +496,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -521,7 +521,7 @@ $ pulsar-admin topics skip \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -546,7 +546,7 @@ $ pulsar-admin topics skip-all \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -570,7 +570,7 @@ $ pulsar-admin topics reset-cursor \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -596,7 +596,7 @@ $ pulsar-admin topics lookup \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -620,7 +620,7 @@ $ pulsar-admin topics bundle-range \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -644,7 +644,7 @@ $ pulsar-admin topics subscriptions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -667,7 +667,7 @@ $ pulsar-admin topics unsubscribe \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -689,7 +689,7 @@ pulsar-admin topics last-message-id topic-name
 ```
 
 <!--REST API-->
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=((pulsar:version_number))}
+{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```Java
@@ -722,7 +722,7 @@ $ bin/pulsar-admin topics create \
 > When you create a non-partitioned topic with the suffix '-partition-' followed by numeric value like 'xyz-topic-partition-x' for the topic name, if a partitioned topic with same suffix 'xyz-topic-partition-y' exists, then the numeric value(x) for the non-partitioned topic must be larger than the number of partitions(y) of the partitioned topic. Otherwise, you cannot create such a non-partitioned topic. 
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -742,7 +742,7 @@ $ bin/pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -763,7 +763,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -818,7 +818,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -853,7 +853,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 > If a non-partitioned topic with the suffix '-partition-' followed by a numeric value like 'xyz-topic-partition-10', you can not create a partitioned topic with name 'xyz-topic', because the partitions of the partitioned topic could override the existing non-partitioned topic. To create such partitioned topic, you have to delete that non-partitioned topic first.
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -878,7 +878,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -909,7 +909,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -936,7 +936,7 @@ $ pulsar-admin topics update-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -956,7 +956,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -976,7 +976,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -1052,7 +1052,7 @@ $ pulsar-admin topics partitioned-stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -1112,7 +1112,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java

--- a/site2/docs/administration-zk-bk.md
+++ b/site2/docs/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/docs/administration-zk-bk.md
+++ b/site2/docs/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -104,7 +104,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 > **Note**  
 > To disable the retention policy, you need to set both the size and time limit to `0`. Set either size or time limit to `0` is invalid. 
@@ -139,7 +139,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -191,7 +191,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -222,7 +222,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -243,7 +243,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -284,7 +284,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -307,7 +307,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -329,7 +329,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -104,7 +104,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 > **Note**  
 > To disable the retention policy, you need to set both the size and time limit to `0`. Set either size or time limit to `0` is invalid. 
@@ -139,7 +139,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -191,7 +191,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -222,7 +222,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -243,7 +243,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -284,7 +284,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -307,7 +307,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -329,7 +329,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/docs/io-use.md
+++ b/site2/docs/io-use.md
@@ -182,7 +182,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -259,7 +259,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -342,11 +342,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -370,11 +370,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -450,7 +450,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -547,7 +547,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -641,7 +641,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -686,7 +686,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -737,11 +737,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -819,11 +819,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -905,7 +905,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -986,7 +986,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1075,11 +1075,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1157,11 +1157,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1245,11 +1245,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1327,11 +1327,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1415,7 +1415,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1469,7 +1469,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/docs/io-use.md
+++ b/site2/docs/io-use.md
@@ -182,7 +182,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -259,7 +259,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -342,11 +342,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -370,11 +370,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -450,7 +450,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -547,7 +547,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -641,7 +641,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -686,7 +686,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -737,11 +737,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -819,11 +819,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -905,7 +905,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -986,7 +986,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1075,11 +1075,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1157,11 +1157,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1245,11 +1245,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1327,11 +1327,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1415,7 +1415,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1469,7 +1469,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/docs/schema-manage.md
+++ b/site2/docs/schema-manage.md
@@ -266,7 +266,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchem?version=((pulsar:version_number))a}
 
 The post payload is in JSON format.
 
@@ -398,7 +398,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchem?version=((pulsar:version_number))a}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -542,7 +542,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchem?version=((pulsar:version_number))a}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -704,7 +704,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=((pulsar:version_number))} 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/docs/schema-manage.md
+++ b/site2/docs/schema-manage.md
@@ -266,7 +266,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchem?version=((pulsar:version_number))a}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchem?version=[[pulsar:version_number]]a}
 
 The post payload is in JSON format.
 
@@ -398,7 +398,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchem?version=((pulsar:version_number))a}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchem?version=[[pulsar:version_number]]a}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -542,7 +542,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchem?version=((pulsar:version_number))a}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchem?version=[[pulsar:version_number]]a}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -704,7 +704,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=((pulsar:version_number))} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]} 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -141,7 +141,7 @@ const from = [
   /\/api\/client/g,
   /\/api\/admin/g,
 
-  /\(\(pulsar:version_number\)\)/g,
+  /\[\[pulsar:version_number\]\]/g,
 ];
 
 const options = {

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -140,6 +140,8 @@ const from = [
   /\/api\/pulsar-functions/g,
   /\/api\/client/g,
   /\/api\/admin/g,
+
+  /\(\(pulsar:version_number\)\)/g,
 ];
 
 const options = {
@@ -174,7 +176,8 @@ const options = {
     clientVersionUrl(`${latestVersion}`, "cpp"),
     clientVersionUrl(`${latestVersion}`, "pulsar-functions"),
     clientVersionUrl(`${latestVersion}`, "client"),
-    clientVersionUrl(`${latestVersion}`, "admin")
+    clientVersionUrl(`${latestVersion}`, "admin"),
+    `${latestVersion}`
   ],
   dry: false
 };
@@ -218,7 +221,8 @@ for (v of versions) {
       clientVersionUrl(`${v}`, "cpp"),
       clientVersionUrl(`${v}`, "pulsar-functions"),
       clientVersionUrl(`${v}`, "client"),
-      clientVersionUrl(`${v}`, "admin")
+      clientVersionUrl(`${v}`, "admin"),
+      `${v}`,
     ],
     dry: false
   };

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -35,12 +35,13 @@ const createVariableInjectionPlugin = variables => {
         if (keyparts[0] == 'endpoint') {
             const restApiVersion = keyparts[2].split('/')[2]
             const suffix = keyparts[keyparts.length - 1]
+            restUrl = ''
             if (suffix.indexOf('?version') >= 0) {
-              keyparts[keyparts.length - 1] += '&apiVersion=' + restApiVersion
+              restUrl = keyparts[keyparts.length - 1] + '&apiVersion=' + restApiVersion
             } else {
-              keyparts[keyparts.length - 1] += 'version=master&apiVersion=' + restApiVersion
+              restUrl = keyparts[keyparts.length - 1] + 'version=master&apiVersion=' + restApiVersion
             }
-            return renderEndpoint(initializedPlugin, restApiUrl + "#", keyparts);
+            return renderEndpoint(initializedPlugin, restApiUrl + "#", keyparts, restUrl);
         }
       }
       return initializedPlugin.render(variables[key])
@@ -67,8 +68,8 @@ const renderUrl = (initializedPlugin, baseUrl, keyparts) => {
     return rendered_content;
 };
 
-const renderEndpoint = (initializedPlugin, baseUrl, keyparts) => {
-    content = '[<b>' + keyparts[1] + '</b> <i>' + keyparts[2] + '</i>](' + baseUrl + keyparts[3] + ')';
+const renderEndpoint = (initializedPlugin, baseUrl, keyparts, restUrl) => {
+    content = '[<b>' + keyparts[1] + '</b> <i>' + keyparts[2] + '</i>](' + baseUrl + restUrl + ')';
     rendered_content = initializedPlugin.render(content);
     rendered_content = rendered_content.replace('<p>', '');
     rendered_content = rendered_content.replace('</p>', '');

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -33,8 +33,13 @@ const createVariableInjectionPlugin = variables => {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
         if (keyparts[0] == 'endpoint') {
-            console.log(key)
-            console.log(keyparts)
+            const restApiVersion = keyparts[2].split('/')[2]
+            const suffix = keyparts[keyparts.length - 1]
+            if (suffix.indexOf('?version') >= 0) {
+              keyparts[keyparts.length - 1] += '&apiVersion=' + restApiVersion
+            } else {
+              keyparts[keyparts.length - 1] += 'version=master&apiVersion=' + restApiVersion
+            }
             return renderEndpoint(initializedPlugin, restApiUrl + "#", keyparts);
         }
       }

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -33,6 +33,8 @@ const createVariableInjectionPlugin = variables => {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
         if (keyparts[0] == 'endpoint') {
+            console.log(key)
+            console.log(keyparts)
             return renderEndpoint(initializedPlugin, restApiUrl + "#", keyparts);
         }
       }
@@ -70,10 +72,10 @@ const renderEndpoint = (initializedPlugin, baseUrl, keyparts) => {
 
 const url = 'https://pulsar.incubator.apache.org';
 const javadocUrl = url + '/api';
-const restApiUrl = url + '/en' + "/admin-rest-api";
-const functionsApiUrl = url + '/en' + "/functions-rest-api";
-const sourceApiUrl = url + '/en' + "/source-rest-api";
-const sinkApiUrl = url + '/en' + "/sink-rest-api";
+const restApiUrl = url + "/admin-rest-api";
+const functionsApiUrl = url + "/functions-rest-api";
+const sourceApiUrl = url + "/source-rest-api";
+const sinkApiUrl = url + "/sink-rest-api";
 const githubUrl = 'https://github.com/apache/incubator-pulsar';
 const baseUrl = '/';
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/admin-api-namespaces.md
@@ -174,7 +174,7 @@ cl2
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/replication
+GET /admin/v2/namespaces/:tenant/:namespace/replication
 ```
 
 ###### Java
@@ -208,7 +208,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/backlogQuota
+POST /admin/v2/namespaces/:tenant/:namespace/backlogQuota
 ```
 
 ###### Java
@@ -239,7 +239,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap
+GET /admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap
 ```
 
 ###### Java
@@ -265,7 +265,7 @@ N/A
 ###### REST
 
 ```
-DELETE /admin/v2/namespaces/{tenant}/{namespace}/backlogQuota
+DELETE /admin/v2/namespaces/:tenant/:namespace/backlogQuota
 ```
 
 ###### Java
@@ -299,7 +299,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/persistence
+POST /admin/v2/namespaces/:tenant/:namespace/persistence
 ```
 
 ###### Java
@@ -331,7 +331,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/persistence
+GET /admin/v2/namespaces/:tenant/:namespace/persistence
 ```
 
 ###### Java
@@ -358,7 +358,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/v2/namespaces/{tenant}/{namespace}/unload
+PUT /admin/v2/namespaces/:tenant/:namespace/unload
 ```
 
 ###### Java
@@ -385,7 +385,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/messageTTL
+POST /admin/v2/namespaces/:tenant/:namespace/messageTTL
 ```
 
 ###### Java
@@ -412,7 +412,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/messageTTL
+GET /admin/v2/namespaces/:tenant/:namespace/messageTTL
 ```
 
 ###### Java
@@ -439,7 +439,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split
+PUT /admin/v2/namespaces/:tenant/:namespace/{bundle}/split
 ```
 
 ###### Java
@@ -466,7 +466,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/clearBacklog
+POST /admin/v2/namespaces/:tenant/:namespace/clearBacklog
 ```
 
 ###### Java
@@ -493,7 +493,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog
+POST /admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog
 ```
 
 ###### Java
@@ -520,7 +520,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/retention
+POST /admin/v2/namespaces/:tenant/:namespace/retention
 ```
 
 ###### Java
@@ -550,7 +550,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/retention
+GET /admin/v2/namespaces/:tenant/:namespace/retention
 ```
 
 ###### Java
@@ -578,7 +578,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-POST /admin/v2/namespaces/{tenant}/{namespace}/dispatchRate
+POST /admin/v2/namespaces/:tenant/:namespace/dispatchRate
 ```
 
 ###### Java
@@ -608,7 +608,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-GET /admin/v2/namespaces/{tenant}/{namespace}/dispatchRate
+GET /admin/v2/namespaces/:tenant/:namespace/dispatchRate
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.3.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.3.0/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation?version=((pulsar:version_number))/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation?version=[[pulsar:version_number]]/setNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation?version=((pulsar:version_number))/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation?version=[[pulsar:version_number]]/getNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation?version=[[pulsar:version_number]]/clearNamespaceBacklogForSubscription}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation?version=[[pulsar:version_number]]/clearNamespaceBundleBacklogForSubscription}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -633,7 +633,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.3.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.3.0/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation?version=((pulsar:version_number))/setNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation?version=((pulsar:version_number))/getNamespaceReplicationClusters}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBacklogForSubscription}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation?version=((pulsar:version_number))/clearNamespaceBundleBacklogForSubscription}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -633,7 +633,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.3.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.3.0/admin-api-partitioned-topics.md
@@ -35,7 +35,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -63,7 +63,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -97,7 +97,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -129,7 +129,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -173,7 +173,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -261,7 +261,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -348,7 +348,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.3.0/admin-api-partitioned-topics.md
@@ -35,7 +35,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -63,7 +63,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -97,7 +97,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -129,7 +129,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -173,7 +173,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -261,7 +261,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -348,7 +348,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
@@ -271,7 +271,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -307,7 +307,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
@@ -271,7 +271,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -307,7 +307,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.3.0/cookbooks-retention-expiry.md
@@ -78,7 +78,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -109,7 +109,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -159,7 +159,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -190,7 +190,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -211,7 +211,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -252,7 +252,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -275,7 +275,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.3.0/cookbooks-retention-expiry.md
@@ -78,7 +78,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -109,7 +109,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -159,7 +159,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -190,7 +190,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -211,7 +211,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -252,7 +252,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -275,7 +275,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.3.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -189,7 +189,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -219,7 +219,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -244,7 +244,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.3.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -189,7 +189,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -219,7 +219,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -244,7 +244,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.3.2/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.3.2/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -631,7 +631,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -661,7 +661,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -689,7 +689,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -719,7 +719,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -749,7 +749,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.3.2/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.3.2/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -631,7 +631,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -661,7 +661,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -689,7 +689,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -719,7 +719,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -749,7 +749,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.3.2/admin-api-schemas.md
+++ b/site2/website/versioned_docs/version-2.3.2/admin-api-schemas.md
@@ -46,7 +46,7 @@ An example of the schema definition file can be found at {@inject: github:Schema
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+{@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 ### Get Schema
 
@@ -78,11 +78,11 @@ $ pulsar-admin schemas get <topic-name> --version <version>
 
 Retrieve the latest version of the schema:
 
-{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Retrieve the schema of a given version:
 
-{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 ### Delete Schema
 
@@ -96,4 +96,4 @@ $ pulsar-admin schemas delete <topic-name>
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}
+{@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=((pulsar:version_number))}

--- a/site2/website/versioned_docs/version-2.3.2/admin-api-schemas.md
+++ b/site2/website/versioned_docs/version-2.3.2/admin-api-schemas.md
@@ -46,7 +46,7 @@ An example of the schema definition file can be found at {@inject: github:Schema
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 ### Get Schema
 
@@ -78,11 +78,11 @@ $ pulsar-admin schemas get <topic-name> --version <version>
 
 Retrieve the latest version of the schema:
 
-{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Retrieve the schema of a given version:
 
-{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 ### Delete Schema
 
@@ -96,4 +96,4 @@ $ pulsar-admin schemas delete <topic-name>
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}

--- a/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
@@ -277,7 +277,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -313,7 +313,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
@@ -277,7 +277,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -313,7 +313,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/start?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/trigger?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-partitioned-topics.md
@@ -45,7 +45,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -83,7 +83,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -117,7 +117,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -149,7 +149,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -171,7 +171,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -193,7 +193,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.4.1/admin-api-partitioned-topics.md
@@ -45,7 +45,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -83,7 +83,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -117,7 +117,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -149,7 +149,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -171,7 +171,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -193,7 +193,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.1/io-use.md
+++ b/site2/website/versioned_docs/version-2.4.1/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](reference-connector-admin.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](reference-connector-admin.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](reference-connector-admin.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](reference-connector-admin.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](reference-connector-admin.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](reference-connector-admin.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](reference-connector-admin.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](reference-connector-admin.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](reference-connector-admin.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](reference-connector-admin.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](reference-connector-admin.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](reference-connector-admin.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](reference-connector-admin.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](reference-connector-admin.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](reference-connector-admin.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](reference-connector-admin.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](reference-connector-admin.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](reference-connector-admin.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.4.1/io-use.md
+++ b/site2/website/versioned_docs/version-2.4.1/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](reference-connector-admin.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](reference-connector-admin.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](reference-connector-admin.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](reference-connector-admin.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](reference-connector-admin.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](reference-connector-admin.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](reference-connector-admin.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](reference-connector-admin.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](reference-connector-admin.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](reference-connector-admin.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](reference-connector-admin.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](reference-connector-admin.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](reference-connector-admin.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](reference-connector-admin.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](reference-connector-admin.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](reference-connector-admin.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](reference-connector-admin.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](reference-connector-admin.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.4.1/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.4.1/schema-manage.md
@@ -244,7 +244,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -376,7 +376,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -520,7 +520,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -682,7 +682,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.4.1/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.4.1/schema-manage.md
@@ -244,7 +244,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -376,7 +376,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -520,7 +520,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -682,7 +682,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/start?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/trigger?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-partitioned-topics.md
@@ -45,7 +45,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -83,7 +83,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -117,7 +117,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -149,7 +149,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -171,7 +171,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -193,7 +193,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.4.2/admin-api-partitioned-topics.md
@@ -45,7 +45,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -83,7 +83,7 @@ $ bin/pulsar-admin topics create persistent://my-tenant/my-namespace/my-topic
 
 #### REST API
 
-{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -117,7 +117,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -149,7 +149,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -171,7 +171,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -193,7 +193,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.4.2/io-use.md
+++ b/site2/website/versioned_docs/version-2.4.2/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](reference-connector-admin.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](reference-connector-admin.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](reference-connector-admin.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](reference-connector-admin.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](reference-connector-admin.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](reference-connector-admin.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](reference-connector-admin.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](reference-connector-admin.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](reference-connector-admin.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](reference-connector-admin.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](reference-connector-admin.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](reference-connector-admin.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](reference-connector-admin.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](reference-connector-admin.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](reference-connector-admin.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](reference-connector-admin.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](reference-connector-admin.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](reference-connector-admin.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.4.2/io-use.md
+++ b/site2/website/versioned_docs/version-2.4.2/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](reference-connector-admin.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](reference-connector-admin.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](reference-connector-admin.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](reference-connector-admin.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](reference-connector-admin.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](reference-connector-admin.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](reference-connector-admin.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](reference-connector-admin.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](reference-connector-admin.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](reference-connector-admin.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](reference-connector-admin.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](reference-connector-admin.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](reference-connector-admin.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](reference-connector-admin.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](reference-connector-admin.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](reference-connector-admin.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](reference-connector-admin.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](reference-connector-admin.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.4.2/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.4.2/schema-manage.md
@@ -244,7 +244,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -376,7 +376,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -520,7 +520,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -682,7 +682,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.4.2/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.4.2/schema-manage.md
@@ -244,7 +244,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -376,7 +376,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -520,7 +520,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -682,7 +682,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -280,7 +280,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -367,7 +367,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -280,7 +280,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -367,7 +367,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -308,7 +308,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -424,7 +424,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -452,7 +452,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 #### Java
 
@@ -478,7 +478,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -504,7 +504,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -531,7 +531,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -558,7 +558,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -583,7 +583,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -608,7 +608,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -632,7 +632,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.0/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -308,7 +308,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -424,7 +424,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -452,7 +452,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -478,7 +478,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -504,7 +504,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -531,7 +531,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -558,7 +558,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -583,7 +583,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -608,7 +608,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -632,7 +632,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
@@ -269,7 +269,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}?version=((pulsar:version_number))
 
 #### Java
 
@@ -305,7 +305,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}?version=((pulsar:version_number))
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
@@ -269,7 +269,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -305,7 +305,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.5.0/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.5.0/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-use.md
@@ -184,7 +184,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -261,7 +261,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -344,11 +344,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -372,11 +372,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -452,7 +452,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -549,7 +549,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -643,7 +643,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -688,7 +688,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -739,11 +739,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -821,11 +821,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -907,7 +907,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -988,7 +988,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1077,11 +1077,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1159,11 +1159,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1247,11 +1247,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1329,11 +1329,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1417,7 +1417,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1471,7 +1471,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.5.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-use.md
@@ -184,7 +184,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -261,7 +261,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -344,11 +344,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -372,11 +372,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -452,7 +452,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -549,7 +549,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -643,7 +643,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -688,7 +688,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -739,11 +739,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -821,11 +821,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -907,7 +907,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -988,7 +988,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1077,11 +1077,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1159,11 +1159,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1247,11 +1247,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1329,11 +1329,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1417,7 +1417,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1471,7 +1471,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.5.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.5.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.5.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.5.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation?version=((pulsar:version_number))/updatePartitionedTopic}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation?version=((pulsar:version_number))/deletePartitionedTopic}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation?version=((pulsar:version_number))/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation?version=[[pulsar:version_number]]/updatePartitionedTopic}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation?version=((pulsar:version_number))/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation?version=[[pulsar:version_number]]/deletePartitionedTopic}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -490,7 +490,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -516,7 +516,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -543,7 +543,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -570,7 +570,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -595,7 +595,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -620,7 +620,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.1/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.1/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 #### Java
 
@@ -490,7 +490,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -516,7 +516,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -543,7 +543,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -570,7 +570,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -595,7 +595,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -620,7 +620,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation?version=((pulsar:version_number))/createNonPartitionedTopic}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation?version=((pulsar:version_number))/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation?version=[[pulsar:version_number]]/createNonPartitionedTopic}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -490,7 +490,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -516,7 +516,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -543,7 +543,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -570,7 +570,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -595,7 +595,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -620,7 +620,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.5.2/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.5.2/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 #### Java
 
@@ -490,7 +490,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -516,7 +516,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -543,7 +543,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -570,7 +570,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -595,7 +595,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -620,7 +620,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -631,7 +631,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -661,7 +661,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -689,7 +689,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -719,7 +719,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -749,7 +749,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -572,7 +572,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -602,7 +602,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -631,7 +631,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -661,7 +661,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -689,7 +689,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -719,7 +719,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -749,7 +749,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.0/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.0/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.0/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.6.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -579,7 +579,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -609,7 +609,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -638,7 +638,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -668,7 +668,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -696,7 +696,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -726,7 +726,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -756,7 +756,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -544,7 +544,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -579,7 +579,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -609,7 +609,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -638,7 +638,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -668,7 +668,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -696,7 +696,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -726,7 +726,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -756,7 +756,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=((pulsar:version_number))/peekNthMessage}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.1/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=((pulsar:version_number))/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation?version=[[pulsar:version_number]]/peekNthMessage}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.1/cookbooks-retention-expiry.md
@@ -117,7 +117,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -149,7 +149,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -232,7 +232,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -253,7 +253,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -317,7 +317,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.1/cookbooks-retention-expiry.md
@@ -117,7 +117,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -149,7 +149,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -232,7 +232,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -253,7 +253,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -317,7 +317,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.1/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.1/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.1/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.1/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation?version=((pulsar:version_number))/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation?version=[[pulsar:version_number]]/getSchema}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation?version=((pulsar:version_number))/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation?version=[[pulsar:version_number]]/deleteSchema} 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.6.1/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.1/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation?version=((pulsar:version_number))/getSchema}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation?version=((pulsar:version_number))/deleteSchema} 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -69,7 +69,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -98,7 +98,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
 
 #### Java
 
@@ -140,7 +140,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=[[pulsar:version_number]]}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-clusters.md
@@ -34,7 +34,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -103,7 +103,7 @@ $ pulsar-admin clusters get cluster-1
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -127,7 +127,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 #### REST
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -155,7 +155,7 @@ $ pulsar-admin clusters delete cluster-1
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
 
 #### Java
 
@@ -179,7 +179,7 @@ cluster-2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
 
 ###### Java
 
@@ -201,7 +201,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-functions.md
@@ -46,7 +46,7 @@ $ pulsar-admin functions create \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -87,7 +87,7 @@ $ pulsar-admin functions update \
 
 #### REST Admin API
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -122,7 +122,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -149,7 +149,7 @@ $ pulsar-admin functions start \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -177,7 +177,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -204,7 +204,7 @@ $ pulsar-admin functions stop \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -232,7 +232,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -259,7 +259,7 @@ $ pulsar-admin functions restart \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -285,7 +285,7 @@ $ pulsar-admin functions list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -312,7 +312,7 @@ $ pulsar-admin functions delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -339,7 +339,7 @@ $ pulsar-admin functions get \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -367,7 +367,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -394,7 +394,7 @@ $ pulsar-admin functions status \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -422,7 +422,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -449,7 +449,7 @@ $ pulsar-admin functions stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -479,7 +479,7 @@ $ pulsar-admin functions trigger \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions putstate \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin API
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions querystate \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 #### Java Admin CLI
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -541,7 +541,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -571,7 +571,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -606,7 +606,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -636,7 +636,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -665,7 +665,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -695,7 +695,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -723,7 +723,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -753,7 +753,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 ###### Java
@@ -783,7 +783,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-namespaces.md
@@ -29,7 +29,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -72,7 +72,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=((pulsar:version_number))}
 
 #### Java
 
@@ -96,7 +96,7 @@ test-tenant/ns2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=((pulsar:version_number))}
 
 #### Java
 
@@ -119,7 +119,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 #### REST
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=((pulsar:version_number))}
 
 #### Java
 
@@ -142,7 +142,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -168,7 +168,7 @@ cl2
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -202,7 +202,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -233,7 +233,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -259,7 +259,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -293,7 +293,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -325,7 +325,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -352,7 +352,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -379,7 +379,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -406,7 +406,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -433,7 +433,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -460,7 +460,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -487,7 +487,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -514,7 +514,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -541,7 +541,7 @@ N/A
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -571,7 +571,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -606,7 +606,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -636,7 +636,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -665,7 +665,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -695,7 +695,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -723,7 +723,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 ###### REST
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -753,7 +753,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 ###### REST
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate?version=((pulsar:version_number))}
 ```
 
 ###### Java
@@ -783,7 +783,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 ###### REST
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace?version=((pulsar:version_number))}
 ```
 
 ###### Java

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-non-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-non-partitioned-topics.md
@@ -50,7 +50,7 @@ $ bin/pulsar-admin topics create \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -73,7 +73,7 @@ $ bin/pulsar-admin topics delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -95,7 +95,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -151,7 +151,7 @@ $ pulsar-admin topics stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-non-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-non-persistent-topics.md
@@ -125,7 +125,7 @@ $ pulsar-admin non-persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -166,7 +166,7 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -199,7 +199,7 @@ $ bin/pulsar-admin non-persistent create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -229,7 +229,7 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/non-persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 
 #### Java
@@ -254,7 +254,7 @@ $ pulsar-admin non-persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/non-persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-partitioned-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-partitioned-topics.md
@@ -53,7 +53,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -82,7 +82,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -116,7 +116,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 #### Java
 
@@ -148,7 +148,7 @@ $ pulsar-admin topics update-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -170,7 +170,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ persistent://tenant/namespace/topic2
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin topics partitioned-stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -368,7 +368,7 @@ $ pulsar-admin topics stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-permissions.md
@@ -55,7 +55,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 ### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -83,7 +83,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 ### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=[[pulsar:version_number]]}
 
 ### Java
 
@@ -106,7 +106,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 ### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=[[pulsar:version_number]]}
 
 ### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/admin-api-persistent-topics.md
+++ b/site2/website/versioned_docs/version-2.6.2/admin-api-persistent-topics.md
@@ -31,7 +31,7 @@ $ pulsar-admin persistent list \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -57,7 +57,7 @@ $ pulsar-admin persistent grant-permission \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -88,7 +88,7 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin persistent revoke-permission \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -145,7 +145,7 @@ $ pulsar-admin persistent delete \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/persistent/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -169,7 +169,7 @@ $ pulsar-admin persistent unload \
 
 #### REST API
 
-{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/persistent/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -320,7 +320,7 @@ $ pulsar-admin persistent stats \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -436,7 +436,7 @@ $ pulsar-admin persistent stats-internal \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -464,7 +464,7 @@ msg-payload
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -488,7 +488,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 #### REST API
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -514,7 +514,7 @@ $ pulsar-admin persistent skip \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -540,7 +540,7 @@ $ pulsar-admin persistent skip-all \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 [More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:topic/subscription/:subName/skip_all)
 
@@ -567,7 +567,7 @@ $ pulsar-admin persistent reset-cursor \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/persistent/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -594,7 +594,7 @@ $ pulsar-admin persistent lookup \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/persistent/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -619,7 +619,7 @@ $ pulsar-admin persistent bundle-range \
 
 #### REST API
 
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -644,7 +644,7 @@ $ pulsar-admin persistent subscriptions \
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/persistent/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -668,7 +668,7 @@ $ pulsar-admin persistent unsubscribe \
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
@@ -294,7 +294,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -303,7 +303,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.6.2/cookbooks-retention-expiry.md
@@ -82,7 +82,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -113,7 +113,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -165,7 +165,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -196,7 +196,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -217,7 +217,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -258,7 +258,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -281,7 +281,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -303,7 +303,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.6.2/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.2/io-use.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.6.2/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.2/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.6.2/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.6.2/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -72,7 +72,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -103,7 +103,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -125,7 +125,7 @@ brokerShutdownTimeoutMs
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -148,7 +148,7 @@ brokerShutdownTimeoutMs:100
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-brokers.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-brokers.md
@@ -39,7 +39,7 @@ broker1.use.org.com:8080
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster|operation/getActiveBrokers?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -72,7 +72,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/:cluster/:broker/ownedNamespaces|operation/getOwnedNamespaes?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -103,7 +103,7 @@ $ pulsar-admin brokers update-dynamic-config --config brokerShutdownTimeoutMs --
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/brokers/configuration/:configName/:configValue|operation/updateDynamicConfiguration?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -125,7 +125,7 @@ brokerShutdownTimeoutMs
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration|operation/getDynamicConfigurationName?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -148,7 +148,7 @@ brokerShutdownTimeoutMs:100
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/brokers/configuration/values|operation/getAllDynamicConfigurations?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-clusters.md
@@ -35,7 +35,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -106,7 +106,7 @@ $ pulsar-admin clusters get cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -132,7 +132,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -162,7 +162,7 @@ $ pulsar-admin clusters delete cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -188,7 +188,7 @@ cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -212,7 +212,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-clusters.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-clusters.md
@@ -35,7 +35,7 @@ $ pulsar-admin clusters create cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster}
+{@inject: endpoint|PUT|/admin/v2/clusters/:cluster|operation/createCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -106,7 +106,7 @@ $ pulsar-admin clusters get cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster}
+{@inject: endpoint|GET|/admin/v2/clusters/:cluster|operation/getCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -132,7 +132,7 @@ $ pulsar-admin clusters update cluster-1 \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster|operation/updateCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -162,7 +162,7 @@ $ pulsar-admin clusters delete cluster-1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster}
+{@inject: endpoint|DELETE|/admin/v2/clusters/:cluster|operation/deleteCluster?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -188,7 +188,7 @@ cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters}
+{@inject: endpoint|GET|/admin/v2/clusters|operation/getClusters?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -212,7 +212,7 @@ $ pulsar-admin update-peer-clusters cluster-1 --peer-clusters cluster-2
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames}
+{@inject: endpoint|POST|/admin/v2/clusters/:cluster/peers|operation/setPeerClusterNames?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-functions.md
@@ -47,7 +47,7 @@ $ pulsar-admin functions create \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -90,7 +90,7 @@ $ pulsar-admin functions update \
 
 <!--REST Admin API-->
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -127,7 +127,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/start?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -156,7 +156,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/start?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -186,7 +186,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stop?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -215,7 +215,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/stop?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -245,7 +245,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/restart?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -274,7 +274,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/restart?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -302,7 +302,7 @@ $ pulsar-admin functions list \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -331,7 +331,7 @@ $ pulsar-admin functions delete \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -360,7 +360,7 @@ $ pulsar-admin functions get \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -389,7 +389,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/status?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -418,7 +418,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/status?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -447,7 +447,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/:instanceId/stats?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -476,7 +476,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/stats?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions trigger \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/trigger?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions putstate \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -569,7 +569,7 @@ $ pulsar-admin functions querystate \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v3/functions/:tenant/:namespace/:functionName/state/:key?version=[[pulsar:version_number]]}
 
 <!--Java Admin CLI-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-functions.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-functions.md
@@ -47,7 +47,7 @@ $ pulsar-admin functions create \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -90,7 +90,7 @@ $ pulsar-admin functions update \
 
 <!--REST Admin API-->
 
-{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|PUT|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -127,7 +127,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/start?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -156,7 +156,7 @@ $ pulsar-admin functions start \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/start?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -186,7 +186,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stop?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -215,7 +215,7 @@ $ pulsar-admin functions stop \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stop?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -245,7 +245,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/restart?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -274,7 +274,7 @@ $ pulsar-admin functions restart \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/restart?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -302,7 +302,7 @@ $ pulsar-admin functions list \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -331,7 +331,7 @@ $ pulsar-admin functions delete \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|DELETE|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -360,7 +360,7 @@ $ pulsar-admin functions get \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -389,7 +389,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/status?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -418,7 +418,7 @@ $ pulsar-admin functions status \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/status?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -447,7 +447,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/{instanceId}/stats?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -476,7 +476,7 @@ $ pulsar-admin functions stats \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/stats?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -507,7 +507,7 @@ $ pulsar-admin functions trigger \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/trigger?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -537,7 +537,7 @@ $ pulsar-admin functions putstate \
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|POST|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 <!--Java Admin API-->
 
@@ -569,7 +569,7 @@ $ pulsar-admin functions querystate \
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}
+{@inject: endpoint|GET|/admin/v3/functions/{tenant}/{namespace}/{functionName}/state/{key}?version=((pulsar:version_number))
 
 <!--Java Admin CLI-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-namespaces.md
@@ -30,7 +30,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -75,7 +75,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -101,7 +101,7 @@ test-tenant/ns2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -125,7 +125,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}?version=((pulsar:version_number))
 
 <!--Java-->
 
@@ -149,7 +149,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -177,7 +177,7 @@ cl2
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -213,7 +213,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -246,7 +246,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -274,7 +274,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -310,7 +310,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -343,7 +343,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -371,7 +371,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -399,7 +399,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -427,7 +427,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -455,7 +455,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -484,7 +484,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -512,7 +512,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -540,7 +540,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
 ```
 
 <!--Java-->
@@ -568,7 +568,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -599,7 +599,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -636,7 +636,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -668,7 +668,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -698,7 +698,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -730,7 +730,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -760,7 +760,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -792,7 +792,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -816,7 +816,7 @@ $ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -841,7 +841,7 @@ $ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/ns1 --
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
 ```
 
 ```json
@@ -871,7 +871,7 @@ $ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}
+{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
 ```
 
 <!--Java-->
@@ -903,7 +903,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 <!--REST-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}
+{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}?version=((pulsar:version_number))
 ```
 
 <!--Java-->

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-namespaces.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-namespaces.md
@@ -30,7 +30,7 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -75,7 +75,7 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -101,7 +101,7 @@ test-tenant/ns2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -125,7 +125,7 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -149,7 +149,7 @@ $ pulsar-admin namespaces set-clusters test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replication|operation/setNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -177,7 +177,7 @@ cl2
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replication|operation/getNamespaceReplicationClusters}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replication|operation/getNamespaceReplicationClusters?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -213,7 +213,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/setBacklogQuota}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/setBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -246,7 +246,7 @@ $ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuotaMap|operation/getBacklogQuotaMap}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -274,7 +274,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/backlogQuota|operation/removeBacklogQuota}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -310,7 +310,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/setPersistence}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -343,7 +343,7 @@ $ pulsar-admin namespaces get-persistence test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/persistence|operation/getPersistence}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -371,7 +371,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/unload|operation/unloadNamespaceBundle}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/unload|operation/unloadNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -399,7 +399,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/setNamespaceMessageTTL}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -427,7 +427,7 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/getNamespaceMessageTTL}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -455,7 +455,7 @@ $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|DELETE|/admin/v2/namespaces/{tenant}/{namespace}/messageTTL|operation/removeNamespaceMessageTTL}?version=((pulsar:version_number))
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -484,7 +484,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/split|operation/splitNamespaceBundle}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/{bundle}/split|operation/splitNamespaceBundle?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -512,7 +512,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/clearBacklog|operation/clearNamespaceBacklogForSubscription}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/clearBacklog|operation/clearNamespaceBacklogForSubscription?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -540,7 +540,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/{bundle}/clearBacklog|operation/clearNamespaceBundleBacklogForSubscriptio?version=[[pulsar:version_number]]n}
 ```
 
 <!--Java-->
@@ -568,7 +568,7 @@ N/A
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/setRetention}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -599,7 +599,7 @@ $ pulsar-admin namespaces get-retention test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/retention|operation/getRetention}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -636,7 +636,7 @@ $ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -668,7 +668,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/dispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/dispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -698,7 +698,7 @@ $ pulsar-admin namespaces set-subscription-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -730,7 +730,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/subscriptionDispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/subscriptionDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -760,7 +760,7 @@ $ pulsar-admin namespaces set-replicator-dispatch-rate test-tenant/ns1 \
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/setDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/setDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -792,7 +792,7 @@ $ pulsar-admin namespaces get-replicator-dispatch-rate test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/replicatorDispatchRate|operation/getDispatchRate}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/replicatorDispatchRate|operation/getDispatchRate?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -816,7 +816,7 @@ $ pulsar-admin namespaces get-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|GET|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -841,7 +841,7 @@ $ pulsar-admin namespaces set-deduplication-snapshot-interval test-tenant/ns1 --
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 ```json
@@ -871,7 +871,7 @@ $ pulsar-admin namespaces remove-deduplication-snapshot-interval test-tenant/ns1
 <!--REST API-->
 
 ```
-{@inject: endpoint|POST|/admin/v2/namespaces/{tenant}/{namespace}/deduplicationSnapshotInterval}?version=((pulsar:version_number))
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/deduplicationSnapshotInterval?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->
@@ -903,7 +903,7 @@ $ pulsar-admin namespaces unload my-tenant/my-ns
 <!--REST-->
 
 ```
-{@inject: endpoint|PUT|/admin/v2/namespaces/{tenant}/{namespace}/unload|operation/unloadNamespace}?version=((pulsar:version_number))
+{@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace/unload|operation/unloadNamespace?version=[[pulsar:version_number]]}
 ```
 
 <!--Java-->

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-permissions.md
@@ -56,7 +56,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -86,7 +86,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
 
 <!--Java-->
 
@@ -111,7 +111,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
 
 <!--Java-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-permissions.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-permissions.md
@@ -56,7 +56,7 @@ Roles `my.1.role`, `my.2.role`, `my.foo.role`, `my.bar.role`, etc. **cannot** pr
 
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/grantPermissionOnNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -86,7 +86,7 @@ $ pulsar-admin namespaces permissions test-tenant/ns1
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/permissions|operation/getPermissions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 
@@ -111,7 +111,7 @@ $ pulsar-admin namespaces revoke-permission test-tenant/ns1 \
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/permissions/:role|operation/revokePermissionsOnNamespace?version=[[pulsar:version_number]]}
 
 <!--Java-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-tenants.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-tenants.md
@@ -29,7 +29,7 @@ my-tenant-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants}
+{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -62,7 +62,7 @@ $ pulsar-admin tenants create my-tenant \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/functions/{tenant}
+{@inject: endpoint|POST|/admin/v2/functions/{tenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -96,7 +96,7 @@ $ pulsar-admin tenants get my-tenant
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant}
+{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -121,7 +121,7 @@ $ pulsar-admin tenants delete my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 
@@ -145,7 +145,7 @@ $ pulsar-admin tenants update my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=((pulsar:version_number))}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-tenants.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-tenants.md
@@ -29,7 +29,7 @@ my-tenant-2
 
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/tenants|operation/getTenants?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -62,7 +62,7 @@ $ pulsar-admin tenants create my-tenant \
 ```
 <!--REST API-->
 
-{@inject: endpoint|POST|/admin/v2/functions/{tenant?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/tenants/:tenant|operation/createTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -96,7 +96,7 @@ $ pulsar-admin tenants get my-tenant
 ```
 <!--REST API-->
 
-{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/tenants/:cluster|operation/getTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -121,7 +121,7 @@ $ pulsar-admin tenants delete my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/deleteTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 
@@ -145,7 +145,7 @@ $ pulsar-admin tenants update my-tenant
 
 <!--REST API-->
 
-{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/tenants/:cluster|operation/updateTenant?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
@@ -21,7 +21,7 @@ Whether it is persistent or non-persistent topic, you can obtain the topic resou
 
 > **Note**    
 > In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.     
-> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 ### List of topics
 
@@ -36,7 +36,7 @@ $ pulsar-admin topics list \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -58,7 +58,7 @@ $ pulsar-admin topics grant-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -89,7 +89,7 @@ $ pulsar-admin topics permissions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -118,7 +118,7 @@ $ pulsar-admin topics revoke-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -141,7 +141,7 @@ $ pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -162,7 +162,7 @@ $ pulsar-admin topics unload \
 ```
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -314,7 +314,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -446,7 +446,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -472,7 +472,7 @@ msg-payload
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -497,7 +497,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -522,7 +522,7 @@ $ pulsar-admin topics skip \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -547,7 +547,7 @@ $ pulsar-admin topics skip-all \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -571,7 +571,7 @@ $ pulsar-admin topics reset-cursor \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -597,7 +597,7 @@ $ pulsar-admin topics lookup \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -621,7 +621,7 @@ $ pulsar-admin topics bundle-range \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -645,7 +645,7 @@ $ pulsar-admin topics subscriptions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -668,7 +668,7 @@ $ pulsar-admin topics unsubscribe \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -690,7 +690,7 @@ pulsar-admin topics last-message-id topic-name
 ```
 
 <!--REST API-->
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId}
+{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=((pulsar:version_number))}
 
 <!--Java-->
 ```Java
@@ -723,7 +723,7 @@ $ bin/pulsar-admin topics create \
 > When you create a non-partitioned topic with the suffix '-partition-' followed by numeric value like 'xyz-topic-partition-x' for the topic name, if a partitioned topic with same suffix 'xyz-topic-partition-y' exists, then the numeric value(x) for the non-partitioned topic must be larger than the number of partitions(y) of the partitioned topic. Otherwise, you cannot create such a non-partitioned topic. 
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -743,7 +743,7 @@ $ bin/pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -764,7 +764,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -819,7 +819,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -854,7 +854,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 > If a non-partitioned topic with the suffix '-partition-' followed by a numeric value like 'xyz-topic-partition-10', you can not create a partitioned topic with name 'xyz-topic', because the partitions of the partitioned topic could override the existing non-partitioned topic. To create such partitioned topic, you have to delete that non-partitioned topic first.
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -879,7 +879,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -910,7 +910,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -937,7 +937,7 @@ $ pulsar-admin topics update-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -957,7 +957,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -977,7 +977,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -1053,7 +1053,7 @@ $ pulsar-admin topics partitioned-stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java
@@ -1113,7 +1113,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
 
 <!--Java-->
 ```java

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
@@ -21,7 +21,7 @@ Whether it is persistent or non-persistent topic, you can obtain the topic resou
 
 > **Note**    
 > In REST API, `:schema` stands for persistent or non-persistent. `:tenant`, `:namespace`, `:x` are variables, replace them with the real tenant, namespace, and `x` names when using them.     
-> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
+> Take {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]} as an example, to get the list of persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/persistent/my-tenant/my-namespace`. To get the list of non-persistent topics in REST API, use `https://pulsar.apache.org/admin/v2/non-persistent/my-tenant/my-namespace`.
 
 ### List of topics
 
@@ -36,7 +36,7 @@ $ pulsar-admin topics list \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -58,7 +58,7 @@ $ pulsar-admin topics grant-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/grantPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -89,7 +89,7 @@ $ pulsar-admin topics permissions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/permissions|operation/getPermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -118,7 +118,7 @@ $ pulsar-admin topics revoke-permission \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic/permissions/:role|operation/revokePermissionsOnTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -141,7 +141,7 @@ $ pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -162,7 +162,7 @@ $ pulsar-admin topics unload \
 ```
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/unload|operation/unloadTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -314,7 +314,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -446,7 +446,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -472,7 +472,7 @@ msg-payload
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/position/:messagePosition|operation/peekNthMessage?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -497,7 +497,7 @@ $ ./bin/pulsar-admin topics get-message-by-id \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/ledger/:ledgerId/entry/:entryId|operation/getMessageById?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -522,7 +522,7 @@ $ pulsar-admin topics skip \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip/:numMessages|operation/skipMessages?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -547,7 +547,7 @@ $ pulsar-admin topics skip-all \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/skip_all|operation/skipAllMessages?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -571,7 +571,7 @@ $ pulsar-admin topics reset-cursor \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic/subscription/:subName/resetcursor/:timestamp|operation/resetCursor?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -597,7 +597,7 @@ $ pulsar-admin topics lookup \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:schema/:tenant:namespace/:topic|/?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -621,7 +621,7 @@ $ pulsar-admin topics bundle-range \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/lookup/v2/topic/:topic_domain/:tenant/:namespace/:topic/bundle|/?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -645,7 +645,7 @@ $ pulsar-admin topics subscriptions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/subscriptions|operation/getSubscriptions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -668,7 +668,7 @@ $ pulsar-admin topics unsubscribe \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/:topic/subscription/:subscription|operation/deleteSubscription?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -690,7 +690,7 @@ pulsar-admin topics last-message-id topic-name
 ```
 
 <!--REST API-->
-{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=((pulsar:version_number))}
+{@inject: endpoint|Get|/admin/v2/:schema/:tenant/:namespace/:topic/lastMessageId?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```Java
@@ -723,7 +723,7 @@ $ bin/pulsar-admin topics create \
 > When you create a non-partitioned topic with the suffix '-partition-' followed by numeric value like 'xyz-topic-partition-x' for the topic name, if a partitioned topic with same suffix 'xyz-topic-partition-y' exists, then the numeric value(x) for the non-partitioned topic must be larger than the number of partitions(y) of the partitioned topic. Otherwise, you cannot create such a non-partitioned topic. 
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createNonPartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -743,7 +743,7 @@ $ bin/pulsar-admin topics delete \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:tenant/:namespace/:topic|operation/deleteTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -764,7 +764,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -819,7 +819,7 @@ $ pulsar-admin topics stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/stats|operation/getStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -854,7 +854,7 @@ $ bin/pulsar-admin topics create-partitioned-topic \
 > If a non-partitioned topic with the suffix '-partition-' followed by a numeric value like 'xyz-topic-partition-10', you can not create a partitioned topic with name 'xyz-topic', because the partitions of the partitioned topic could override the existing non-partitioned topic. To create such partitioned topic, you have to delete that non-partitioned topic first.
 
 <!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/createPartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -879,7 +879,7 @@ $ bin/pulsar-admin topics create-missed-partitions \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:namespace/:topic|operation/createMissedPartitions?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -910,7 +910,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -937,7 +937,7 @@ $ pulsar-admin topics update-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/:schema/:tenant/:cluster/:namespace/:destination/partitions|operation/updatePartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -957,7 +957,7 @@ $ bin/pulsar-admin topics delete-partitioned-topic \
 ```
 
 <!--REST API-->
-{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/:schema/:topic/:namespace/:destination/partitions|operation/deletePartitionedTopic?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -977,7 +977,7 @@ persistent://tenant/namespace/topic2
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace|operation/getPartitionedTopicList?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -1053,7 +1053,7 @@ $ pulsar-admin topics partitioned-stats \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitioned-stats|operation/getPartitionedStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java
@@ -1113,7 +1113,7 @@ $ pulsar-admin topics stats-internal \
 ```
 
 <!--REST API-->
-{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/internalStats|operation/getInternalStats?version=[[pulsar:version_number]]}
 
 <!--Java-->
 ```java

--- a/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
@@ -295,7 +295,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
 
 #### Java
 
@@ -331,7 +331,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
@@ -295,7 +295,7 @@ $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/setPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -331,7 +331,7 @@ $ pulsar-admin namespaces get-persistence my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/persistence|operation/getPersistence?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.7.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.7.0/cookbooks-retention-expiry.md
@@ -105,7 +105,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=[[pulsar:version_number]]}
 
 > **Note**  
 > To disable the retention policy, you need to set both the size and time limit to `0`. Set either size or time limit to `0` is invalid. 
@@ -140,7 +140,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -192,7 +192,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -223,7 +223,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -244,7 +244,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -285,7 +285,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -308,7 +308,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.7.0/cookbooks-retention-expiry.md
+++ b/site2/website/versioned_docs/version-2.7.0/cookbooks-retention-expiry.md
@@ -105,7 +105,7 @@ $ pulsar-admin namespaces set-retention my-tenant/my-ns \
 ```
 
 <!--REST API-->
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/retention|operation/setRetention?version=((pulsar:version_number))}
 
 > **Note**  
 > To disable the retention policy, you need to set both the size and time limit to `0`. Set either size or time limit to `0` is invalid. 
@@ -140,7 +140,7 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=((pulsar:version_number))}
 
 #### Java
 
@@ -192,7 +192,7 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -223,7 +223,7 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=((pulsar:version_number))}
 
 #### Java
 
@@ -244,7 +244,7 @@ $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=((pulsar:version_number))}
 
 #### Java
 
@@ -285,7 +285,7 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
 
 #### REST API
 
-{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL}
+{@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -308,7 +308,7 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL}
+{@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 
@@ -330,7 +330,7 @@ $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 
 #### REST API
 
-{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL}
+{@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=((pulsar:version_number))}
 
 #### Java
 

--- a/site2/website/versioned_docs/version-2.7.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=[[pulsar:version_number]]}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=[[pulsar:version_number]]}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=[[pulsar:version_number]]}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=[[pulsar:version_number]]}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=[[pulsar:version_number]]}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=[[pulsar:version_number]]}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=[[pulsar:version_number]]}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.7.0/io-use.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-use.md
@@ -183,7 +183,7 @@ For more information, see [here](io-cli.md#create).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/registerSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -260,7 +260,7 @@ For more information, see [here](io-cli.md#create-1).
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/registerSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -343,11 +343,11 @@ For more information, see [here](io-cli.md#start).
 
 * Start **all** source connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/start|operation/startSource?version=((pulsar:version_number))}
 
 * Start a **specified** source connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSource?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -371,11 +371,11 @@ For more information, see [here](io-cli.md#start-1).
 
 * Start **all** sink connectors.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/start|operation/startSink?version=((pulsar:version_number))}
 
 * Start a **specified** sink connector.
 
-    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink}
+    Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/start|operation/startSink?version=((pulsar:version_number))}
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -451,7 +451,7 @@ For more information, see [here](io-cli.md#get).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/getSourceInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -548,7 +548,7 @@ For more information, see [here](io-cli.md#get-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/getSinkInfo?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -642,7 +642,7 @@ For more information, see [here](io-cli.md#list).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/|operation/listSources?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -687,7 +687,7 @@ For more information, see [here](io-cli.md#list-1).
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/|operation/listSinks?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -738,11 +738,11 @@ For more information, see [here](io-cli.md#status).
 
 * Get the current status of **all** source connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/status|operation/getSourceStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** source connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSourceStatus?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -820,11 +820,11 @@ For more information, see [here](io-cli.md#status-1).
 
 * Get the current status of **all** sink connectors.
   
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sinkName/status|operation/getSinkStatus?version=((pulsar:version_number))}
 
 * Gets the current status of a **specified** sink connector.
 
-  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus}
+  Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v3/sinks/:tenant/:namespace/:sourceName/:instanceId/status|operation/getSinkInstanceStatus?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -906,7 +906,7 @@ For more information, see [here](io-cli.md#update).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/updateSource?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -987,7 +987,7 @@ For more information, see [here](io-cli.md#update-1).
 
 <!--REST API-->
 
-Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink}
+Send a `PUT` request to this endpoint: {@inject: endpoint|PUT|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/updateSink?version=((pulsar:version_number))}
   
 <!--Java Admin API-->
 
@@ -1076,11 +1076,11 @@ For more information, see [here](io-cli.md#stop).
 
 * Stop **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/stopSource?version=((pulsar:version_number))}
 
 * Stop a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId|operation/stopSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1158,11 +1158,11 @@ For more information, see [here](io-cli.md#stop-1).
 
 * Stop **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sinks/:tenant/:namespace/:sinkName/stop|operation/stopSink?version=((pulsar:version_number))}
 
 * Stop a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkeName/:instanceId/stop|operation/stopSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1246,11 +1246,11 @@ For more information, see [here](io-cli.md#restart).
 
 * Restart **all** source connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** source connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sourceName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1328,11 +1328,11 @@ For more information, see [here](io-cli.md#restart-1).
 
 * Restart **all** sink connectors.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/restart|operation/restartSource?version=((pulsar:version_number))}
 
 * Restart a **specified** sink connector.
   
-  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource}
+  Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v3/sources/:tenant/:namespace/:sinkName/:instanceId/restart|operation/restartSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1416,7 +1416,7 @@ For more information, see [here](io-cli.md#delete).
 
 Delete al Pulsar source connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sources/:tenant/:namespace/:sourceName|operation/deregisterSource?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 
@@ -1470,7 +1470,7 @@ For more information, see [here](io-cli.md#delete-1).
 
 Delete a sink connector.
   
-Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink}
+Send a `DELETE` request to this endpoint: {@inject: endpoint|DELETE|/admin/v3/sinks/:tenant/:namespace/:sinkName|operation/deregisterSink?version=((pulsar:version_number))}
 
 <!--Java Admin API-->
 

--- a/site2/website/versioned_docs/version-2.7.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.7.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=[[pulsar:version_number]]}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema?version=[[pulsar:version_number]]}
 
 Here is an example of a response, which is returned in JSON format.
 

--- a/site2/website/versioned_docs/version-2.7.0/schema-manage.md
+++ b/site2/website/versioned_docs/version-2.7.0/schema-manage.md
@@ -267,7 +267,7 @@ Here are examples of the `schema-definition-file` for a JSON schema.
 
 <!--REST API-->
 
-Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema}
+Send a `POST` request to this endpoint: {@inject: endpoint|POST|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/uploadSchema?version=((pulsar:version_number))}
 
 The post payload is in JSON format.
 
@@ -399,7 +399,7 @@ $ pulsar-admin schemas get <topic-name>
 
 <!--REST API-->
 
-Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema}
+Send a `GET` request to this endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -543,7 +543,7 @@ $ pulsar-admin schemas get <topic-name> --version=<version>
 
 <!--REST API-->
 
-Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema}
+Send a `GET` request to a schema endpoint: {@inject: endpoint|GET|/admin/v2/schemas/:tenant/:namespace/:topic/schema/:version|operation/getSchema?version=((pulsar:version_number))}
 
 Here is an example of a response, which is returned in JSON format.
 
@@ -705,7 +705,7 @@ $ pulsar-admin schemas delete <topic-name>
 
 <!--REST API-->
 
-Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema} 
+Send a `DELETE` request to a schema endpoint: {@inject: endpoint|DELETE|/admin/v2/schemas/:tenant/:namespace/:topic/schema|operation/deleteSchema}?version=((pulsar:version_number)) 
 
 Here is an example of a response, which is returned in JSON format.
 


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/8853

### Motivation

This pr adds a `[[pulsar.version_number]]` field to restapi in documentation after 2.3.0, and fixes the build script.


### Modifications

* Add `pulsar.version_number`
* Fixed replace script

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

After building the script:

![image](https://user-images.githubusercontent.com/1907867/101728310-31163380-3af1-11eb-9157-3045d3282025.png)

![image](https://user-images.githubusercontent.com/1907867/101728987-59eaf880-3af2-11eb-92f0-5f66f411af7f.png)


### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
