### PR TITLE
[SpotBugs][pulsar-io]Enable spotbugs for batch-discovery-triggerers and batch-data-generator

### DIFF
--- a/pulsar-io/batch-data-generator/pom.xml
+++ b/pulsar-io/batch-data-generator/pom.xml
@@ -71,6 +71,27 @@
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-nar-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>spotbugs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pulsar-io/batch-data-generator/src/main/java/org/apache/pulsar/io/batchdatagenerator/BatchDataGeneratorPushSource.java
+++ b/pulsar-io/batch-data-generator/src/main/java/org/apache/pulsar/io/batchdatagenerator/BatchDataGeneratorPushSource.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.BatchPushSource;
 import org.apache.pulsar.io.core.SourceContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -54,13 +55,14 @@ public class BatchDataGeneratorPushSource extends BatchPushSource<Person> implem
   public void discover(Consumer taskEater) throws Exception {
     log.info("Generating one task for each instance");
     for (int i = 0; i < sourceContext.getNumInstances(); ++i) {
-      taskEater.accept(String.format("something-%d", System.currentTimeMillis()).getBytes());
+      taskEater.accept(String.format("something-%d", System.currentTimeMillis()).getBytes(StandardCharsets.UTF_8));
     }
   }
 
   @Override
   public void prepare(byte[] instanceSplit) throws Exception {
-    log.info("Instance " + sourceContext.getInstanceId() + " got a new discovered task {}", new String(instanceSplit));
+    log.info("Instance " + sourceContext.getInstanceId() + " got a new discovered task {}",
+            new String(instanceSplit, StandardCharsets.UTF_8));
     executor.submit(this);
   }
 

--- a/pulsar-io/batch-data-generator/src/main/java/org/apache/pulsar/io/batchdatagenerator/BatchDataGeneratorSource.java
+++ b/pulsar-io/batch-data-generator/src/main/java/org/apache/pulsar/io/batchdatagenerator/BatchDataGeneratorSource.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.BatchSource;
 import org.apache.pulsar.io.core.SourceContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -46,14 +47,14 @@ public class BatchDataGeneratorSource implements BatchSource<Person> {
     public void discover(Consumer<byte[]> taskEater) {
         log.info("Generating one task for each instance");
         for (int i = 0; i < sourceContext.getNumInstances(); ++i) {
-            taskEater.accept("something".getBytes());
+            taskEater.accept("something".getBytes(StandardCharsets.UTF_8));
         }
     }
 
     @Override
     public void prepare(byte[] instanceSplit) {
         log.info("Instance " + sourceContext.getInstanceId() + " got a new discovered task");
-        final String str = new String(instanceSplit);
+        final String str = new String(instanceSplit, StandardCharsets.UTF_8);
         final String expected = "something";
         assert str.equals(expected);
         iteration = 0;

--- a/pulsar-io/batch-data-generator/src/main/resources/findbugsExclude.xml
+++ b/pulsar-io/batch-data-generator/src/main/resources/findbugsExclude.xml
@@ -1,0 +1,22 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindBugsFilter>
+</FindBugsFilter>

--- a/pulsar-io/batch-discovery-triggerers/pom.xml
+++ b/pulsar-io/batch-discovery-triggerers/pom.xml
@@ -52,4 +52,30 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pulsar-io/batch-discovery-triggerers/src/main/resources/findbugsExclude.xml
+++ b/pulsar-io/batch-discovery-triggerers/src/main/resources/findbugsExclude.xml
@@ -1,0 +1,22 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindBugsFilter>
+</FindBugsFilter>


### PR DESCRIPTION

Master Issue: #8843 

### Motivation

Enable spotbugs for the pulsar-io module. 

### Modifications

Enable soptbugs for pulsar-io/batch-discovery-triggerers and pulsar-io/batch-data-generator

### Verifying this change

```
mvn clean install -pl pulsar-io/batch-discovery-triggerers
mvn clean install -pl pulsar-io/batch-data-generator
```