### PR TITLE
Add package management REST API show in doc

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -516,6 +516,23 @@
                   <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
                   <swaggerFileName>swaggersink</swaggerFileName>
                 </apiSource>
+                <apiSource>
+                  <springmvc>false</springmvc>
+                  <locations>org.apache.pulsar.broker.admin.v3.Packages</locations>
+                  <schemes>http,https</schemes>
+                  <basePath>/admin/v3</basePath>
+                  <info>
+                    <title>Pulsar Packages REST API</title>
+                    <version>v3</version>
+                    <description>This provides the REST API for Pulsar Packages operations</description>
+                    <license>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <name>Apache 2.0</name>
+                    </license>
+                  </info>
+                  <swaggerDirectory>${basedir}/target/docs</swaggerDirectory>
+                  <swaggerFileName>swaggerpackages</swaggerFileName>
+                </apiSource>
               </apiSources>
             </configuration>
             <executions>

--- a/site2/website/pages/en/packages-rest-api.js
+++ b/site2/website/pages/en/packages-rest-api.js
@@ -1,0 +1,21 @@
+const React = require('react');
+const CompLibrary = require('../../core/CompLibrary.js');
+
+const Container = CompLibrary.Container;
+const siteConfig = require(`${process.cwd()}/siteConfig.js`);
+
+class PackagesRestApi extends React.Component {
+    render() {
+        const swaggerUrl = `${siteConfig.baseUrl}swagger/swaggerpackages.json`
+
+        return (
+            <div className="pageContainer">
+            <Container className="mainContainer documentContainer postContainer" >
+            <script base-url={`${swaggerUrl}`} src="../js/getSwaggerByVersion.js"></script>
+            </Container>
+            </div>
+    );
+    }
+}
+
+module.exports = PackagesRestApi;

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -29,6 +29,8 @@ const createVariableInjectionPlugin = variables => {
           return renderUrl(initializedPlugin, sourceApiUrl + "#", keyparts);
       } else if (keyparts[0] == 'sink') {
         return renderUrl(initializedPlugin, sinkApiUrl + "#", keyparts);
+      } else if (keyparts[0] == 'packages') {
+        return renderUrl(initializedPlugin, packagesApiUrl + "#", keyparts);
       } else {
         keyparts = key.split("|");
         // endpoint api: endpoint|<op>
@@ -82,6 +84,7 @@ const restApiUrl = url + "/admin-rest-api";
 const functionsApiUrl = url + "/functions-rest-api";
 const sourceApiUrl = url + "/source-rest-api";
 const sinkApiUrl = url + "/sink-rest-api";
+const packagesApiUrl = url + "/packages-rest-api";
 const githubUrl = 'https://github.com/apache/incubator-pulsar';
 const baseUrl = '/';
 

--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -70,6 +70,12 @@ window.addEventListener('load', function () {
     } else {
         sinkApiVersion = restApiVersions[version][1]['version']
     }
+    let packagesApiVersion = ''
+    if (restApiVersions[version][0]['fileName'].indexOf('swaggerpackages') >= 0) {
+        packagesApiVersion = restApiVersions[version][0]['version']
+    } else {
+        packagesApiVersion = restApiVersions[version][1]['version']
+    }
     // setup rest api menu items in nav bar
     const restapis = document.querySelector("a[href='#restapis']").parentNode;
     const restapisMenu =
@@ -81,6 +87,7 @@ window.addEventListener('load', function () {
         '<li><a href="/functions-rest-api?version=' + version + '&apiversion=' + functionApiVersion + '">Functions </a></li>' +
         '<li><a href="/source-rest-api?version=' + version + '&apiversion=' + sourceApiVersion + '">Sources </a></li>' +
         '<li><a href="/sink-rest-api?version=' + version + '&apiversion=' + sinkApiVersion + '">Sinks </a></li>' +
+        '<li><a href="/packages-rest-api?version=' + version + '&apiversion=' + packagesApiVersion + '">Packages </a></li>' +
         '</ul>' +
         '</div>' +
         '</li>';
@@ -197,7 +204,8 @@ window.addEventListener('load', function () {
     if (pathName.indexOf('/admin-rest-api') >= 0
         || pathName.indexOf('/functions-rest-api') >= 0
         || pathName.indexOf('/source-rest-api') >= 0
-        || pathName.indexOf('/sink-rest-api') >= 0) {
+        || pathName.indexOf('/sink-rest-api') >= 0
+        || pathName.indexOf('/packages-rest-api') >= 0) {
         wrapperDiv.innerHTML = `<select name="apiVersion" class="version_select" id="version_select">
                                     ${apiVersionList.map(v => `<option value="${v.version}">${v.version}</option>`).join("")}
                                 </select>`;

--- a/site2/website/static/js/getSwaggerByVersion.js
+++ b/site2/website/static/js/getSwaggerByVersion.js
@@ -48,6 +48,8 @@ function getSwaggerByVersion(){
         redoc.setAttribute('spec-url', '/swagger/' + version + '/' + apiversion  + '/swaggersource.json')
     } else if (pathName.indexOf('sink-rest-api') >= 0) {
         redoc.setAttribute('spec-url', '/swagger/' + version + '/' + apiversion  + '/swaggersink.json')
+    } else if (pathName.indexOf('packages-rest-api' >= 0)) {
+        redoc.setAttribute('spec-url', '/swagger/' + version + '/' + apiversion  + '/swaggerpackages.json')
     }
     redoc.setAttribute('lazy-rendering', 'true')
     const redocLink = document.createElement('script');


### PR DESCRIPTION
---

Master Issue: #8676

*Motivation*

Show REST API examples in the website.

*Modifications*

Add website related changes for package management REST APIs.

*ScreenShot*

![Screen Shot 2020-12-10 at 5 25 18 PM](https://user-images.githubusercontent.com/24502569/101753478-a42da300-3b0d-11eb-9aa9-ec07f0354ee8.png)
