### PR TITLE
Fix performance issue caused by invalid logging configuration

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -287,6 +287,7 @@ PULSAR_ROUTING_APPENDER_DEFAULT=${PULSAR_ROUTING_APPENDER_DEFAULT:-"Console"}
 OPTS="$OPTS -Dpulsar.log.appender=$PULSAR_LOG_APPENDER"
 OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
 OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
+OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
 
 # Functions related logging


### PR DESCRIPTION
### Motivation

Profiling a 3 node Pulsar cluster running with 2.7.0 version showed allocation hotspots in `log.debug` methods. This indicated that the root logger level was set to debug.

### Modifications

- Configure the root log level in `bin/pulsar` startup script to
  use `info` level by default. This can be done by setting
  the `pulsar.log.root.level` system property.

- since the root log level was debug, all code blocks within
  `log.isDebugEnabled()` got executed.
  This caused a lot of unnecessary memory allocations and wasted CPU cycles.
