### PR TITLE
[build] Use absolute path to locate license and checkstyle plugin config

### DIFF
--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: build and check license
         if: steps.docs.outputs.changed_only == 'no'
-        run: mvn -q -B -ntp -DskipTests license:check install
+        run: mvn -q -B -ntp -DskipTests initialize license:check install
 
       - name: license check
         if: steps.docs.outputs.changed_only == 'no'

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@ flexible messaging model and an intuitive client API.</description>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <aspectj-maven-plugin.version>1.11.1</aspectj-maven-plugin.version>
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
+    <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -895,10 +896,10 @@ flexible messaging model and an intuitive client API.</description>
         <version>${cassandra.version}</version>
       </dependency>
       <dependency>
-    	<groupId>org.assertj</groupId>
-    	<artifactId>assertj-core</artifactId>
-    	<version>${assertj-core.version}</version>
-	  </dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj-core.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.projectlombok</groupId>
@@ -1015,10 +1016,10 @@ flexible messaging model and an intuitive client API.</description>
     </dependency>
 
     <dependency>
-    	<groupId>org.assertj</groupId>
-    	<artifactId>assertj-core</artifactId>
-    	<scope>test</scope>
-	 </dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -1120,13 +1121,35 @@ flexible messaging model and an intuitive client API.</description>
       </plugin>
 
       <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+        <version>${directory-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>directories</id>
+            <goals>
+              <goal>directory-of</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <property>pulsar.basedir</property>
+              <project>
+                <groupId>org.apache.pulsar</groupId>
+                <artifactId>pulsar</artifactId>
+              </project>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>${license-maven-plugin.version}</version>
         <configuration>
           <licenseSets>
             <licenseSet>
-              <header>src/license-header.txt</header>
+              <header>${pulsar.basedir}/src/license-header.txt</header>
               <excludes>
                 <exclude>LICENSE</exclude>
                 <exclude>NOTICE</exclude>
@@ -1211,6 +1234,7 @@ flexible messaging model and an intuitive client API.</description>
         </configuration>
         <executions>
           <execution>
+            <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>
@@ -1431,9 +1455,10 @@ flexible messaging model and an intuitive client API.</description>
             </dependency>
           </dependencies>
           <configuration>
-            <configLocation>buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-            <suppressionsLocation>buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
+            <configLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
+            <suppressionsLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
             <encoding>UTF-8</encoding>
+            <excludes>**/proto/*</excludes>
           </configuration>
         </plugin>
         <plugin>
@@ -1505,9 +1530,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
             <configuration>
-              <configLocation>pulsar/checkstyle.xml</configLocation>
-              <suppressionsLocation>pulsar/suppressions.xml</suppressionsLocation>
-              <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
+              <configLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
+              <suppressionsLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
+              <encoding>UTF-8</encoding>
+              <excludes>**/proto/*</excludes>
             </configuration>
           </plugin>
           <plugin>
@@ -1563,11 +1589,12 @@ flexible messaging model and an intuitive client API.</description>
                        <execution>
                           <id>check-style</id>
                           <phase>verify</phase>
-                          <configuration>
-         					  <configLocation>./buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-         					  <suppressionsLocation>/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                              <encoding>UTF-8</encoding>
-                          </configuration>
+                         <configuration>
+                           <configLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
+                           <suppressionsLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
+                           <encoding>UTF-8</encoding>
+                           <excludes>**/proto/*</excludes>
+                         </configuration>
                           <goals>
                              <goal>check</goal>
                           </goals>

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -45,27 +45,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-style</id>
-                        <phase>verify</phase>
-                        <configuration>
-                            <configLocation>../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-                            <suppressionsLocation>../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                            <encoding>UTF-8</encoding>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+
 
 </project>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -220,25 +220,7 @@
       </executions>
     </plugin>
 
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-checkstyle-plugin</artifactId>
-      <executions>
-        <execution>
-          <id>check-style</id>
-          <phase>verify</phase>
-          <configuration>
-            <configLocation>../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-            <suppressionsLocation>../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-            <encoding>UTF-8</encoding>
-            <excludes>**/proto/*</excludes>
-          </configuration>
-          <goals>
-            <goal>check</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
+
   </plugins>
   </build>
 </project>

--- a/pulsar-package-management/pom.xml
+++ b/pulsar-package-management/pom.xml
@@ -41,24 +41,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-style</id>
-                        <phase>verify</phase>
-                        <configuration>
-                            <configLocation>../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-                            <suppressionsLocation>../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                            <encoding>UTF-8</encoding>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -107,26 +107,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-style</id>
-                        <phase>verify</phase>
-                        <configuration>
-                            <configLocation>../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-                            <suppressionsLocation>../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                            <encoding>UTF-8</encoding>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -55,28 +55,5 @@
         </dependency>
 
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-style</id>
-                        <phase>verify</phase>
-                        <configuration>
-                            <configLocation>../../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-                            <suppressionsLocation>../../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                            <encoding>UTF-8</encoding>
-                            <excludes>**/proto/*</excludes>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/pulsar-transaction/pom.xml
+++ b/pulsar-transaction/pom.xml
@@ -36,27 +36,4 @@
     <module>coordinator</module>
   </modules>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-style</id>
-            <phase>verify</phase>
-            <configuration>
-              <configLocation>../buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
-              <suppressionsLocation>../buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-              <encoding>UTF-8</encoding>
-            </configuration>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
### Motivation

Fixes #8911, compiling a sub module individually in the sub module directory
Previously, the maven build failed if executed in other than the root directory if the license or checkstyle checks were run since
those plugins weren't able to find their configuration.

### Modifications


- use proposed solution of https://stackoverflow.com/a/37965143
  to set a property `pulsar.basedir` which contains the absolute path
  to the root directory
  - all other solutions don't seem to work universally in all projects,
    for example `project.parent.basedir` isn't available in the
    root project and not all projects necessarily have the root project
    as their parent project.

- when running `license:check` or `checkstyle:checkstyle` directly,
  it is necessary to add `initialize` phase to the command line,
  since the `pulsar.basedir` property gets set in the `initialize` phase.
  for example:
  `mvn initialize license:check` or
  `mvn initialize checkstyle:checkstyle`
  - This should be fine since the maven best practice is to use lifecycle phases such 
    as `mvn verify` instead of listing plugin goals on the command line.