### PR TITLE
[logging] Enable Log4j2 Garbage Free Logging to reduce GC pressure

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -289,6 +289,8 @@ OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
 OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
 OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
+# Configure log4j2 to disable servlet webapp detection so that Garbage free logging can be used
+OPTS="$OPTS -Dlog4j2.is.webapp=false"
 
 # Functions related logging
 OPTS="$OPTS -Dpulsar.functions.process.container.log.dir=$PULSAR_LOG_DIR"


### PR DESCRIPTION
### Motivation

Log4j2 has a Garbage Free logging mode which reduces GC pressure since the garbage created by logging is very low ("garbage free"). This mode is the default of Log4j2 unless there is javax.servlet.Servlet class available at runtime.

In Pulsar there is javax.servlet.Servlet class available at runtime and Log4j2's J2EE/JEE web application detection disables Log4j2 Garbage Free logging mode. Log4j2 Garbage Free logging mode doesn't support unloading & loading web applications which would be done in traditional J2EE application servers. 

Since Pulsar isn't a J2EE/JEE server and doesn't need to unload & reload J2EE/JEE web applications, it's the correct thing to disable Log4j2's web application detection so that the more performant Log4j2 Garbage Free logging mode can be used. 

The performance benefits of the Garbage Free logging mode is described in the Log4j2 documentation:
https://logging.apache.org/log4j/2.x/manual/garbagefree.html


### Modifications

- Configure log4j2 to disable servlet webapp detection so that Garbage
  free logging can be used.

  - Log4j2 will disable Garbage free logging if there is javax.servlet.Servlet class
    available at runtime unless "-Dlog4j2.is.webapp=false" is passed
    on the command line.
    - See source code at
      https://github.com/apache/logging-log4j2/blob/master/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java#L25-L41

  - Documented at https://logging.apache.org/log4j/2.x/manual/garbagefree.html
    "From version 2.6, Log4j runs in "garbage free" mode by default where objects
     and buffers are reused and no temporary objects are allocated as much as possible.
     There is also a "low garbage" mode which is not completely garbage free but does
     not use ThreadLocal fields. This is the default mode when Log4j detects it is
     running in a web application."
    ...
    "ThreadLocal fields holding non-JDK classes can cause memory leaks in web applications
     when the application server's thread pool continues to reference these fields after
     the web application is undeployed. To avoid causing memory leaks, Log4j will not use
     these ThreadLocals when it detects that it is used in a web application (when the
     javax.servlet.Servlet class is in the classpath, or when system property log4j2.isWebapp
     is set to "true")."
