### PR TITLE
add properties default value for SchemaInfoBuilder

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/SchemaInfo.java
@@ -60,6 +60,7 @@ public class SchemaInfo {
     /**
      * Additional properties of the schema definition (implementation defined).
      */
+    @Builder.Default
     private Map<String, String> properties = Collections.emptyMap();
 
     public String getSchemaDefinition() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -18,13 +18,17 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
-import static org.testng.Assert.assertEquals;
-
+import com.google.common.collect.Maps;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * Unit test {@link org.apache.pulsar.common.schema.SchemaInfo}.
@@ -280,4 +284,38 @@ public class SchemaInfoTest {
         assertEquals(si.toString(), jsonifiedStr);
     }
 
+    public static class SchemaInfoBuilderTest {
+
+        @Test
+        public void testUnsetProperties() {
+            final SchemaInfo schemaInfo = SchemaInfo.builder()
+                    .type(SchemaType.STRING)
+                    .schema(new byte[0])
+                    .name("string")
+                    .build();
+
+            assertEquals(schemaInfo.getSchema(), new byte[0]);
+            assertEquals(schemaInfo.getType(), SchemaType.STRING);
+            assertEquals(schemaInfo.getName(), "string");
+            assertEquals(schemaInfo.getProperties(), Maps.newHashMap());
+        }
+
+        @Test
+        public void testSetProperties() {
+            final Map<String, String> map = Maps.newHashMap();
+            map.put("test", "value");
+            final SchemaInfo schemaInfo = SchemaInfo.builder()
+                    .type(SchemaType.STRING)
+                    .schema(new byte[0])
+                    .name("string")
+                    .properties(map)
+                    .build();
+
+            assertEquals(schemaInfo.getSchema(), new byte[0]);
+            assertEquals(schemaInfo.getType(), SchemaType.STRING);
+            assertEquals(schemaInfo.getName(), "string");
+            assertEquals(schemaInfo.getProperties(), Maps.newHashMap(map));
+        }
+
+    }
 }


### PR DESCRIPTION
### Motivation

When using SchemaInfoBuilder to create a SchemaInfo, not setting properties will result in an NPE. properties are optional in SchemaInfo and have default values.

### Modifications

Add default values for properties in SchemaInfoBuilder

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (**yes** / no)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
