### PR TITLE
Fix the metadata setup compatibility issue

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -115,6 +115,8 @@ public class PulsarClusterMetadataSetup {
                 description = "The metadata service URI of the existing BookKeeper cluster that you want to use")
         private String existingBkMetadataServiceUri;
 
+        // Hide and marked as deprecated this flag because we use the new name '--existing-bk-metadata-service-uri' to
+        // pass the service url. For compatibility of the command, we should keep both to avoid the exceptions.
         @Deprecated
         @Parameter(names = {
             "--bookkeeper-metadata-service-uri"},

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -68,6 +68,22 @@ public class ClusterMetadataSetupTest {
         // expected not exist
         assertNull(localZk.exists("/ledgers", false));
 
+        String[] bookkeeperMetadataServiceUriArgs = {
+            "--cluster", "testReSetupClusterMetadata-cluster",
+            "--zookeeper", zkConnection,
+            "--configuration-store", zkConnection,
+            "--bookkeeper-metadata-service-uri", "zk+null://" + zkConnection + "/chroot/ledgers",
+            "--web-service-url", "http://127.0.0.1:8080",
+            "--web-service-url-tls", "https://127.0.0.1:8443",
+            "--broker-service-url", "pulsar://127.0.0.1:6650",
+            "--broker-service-url-tls","pulsar+ssl://127.0.0.1:6651"
+        };
+
+        PulsarClusterMetadataSetup.main(bookkeeperMetadataServiceUriArgs);
+        ZooKeeper bookkeeperMetadataServiceUriZk = PulsarClusterMetadataSetup.initZk(zkConnection, 30000);
+        // expected not exist
+        assertNull(bookkeeperMetadataServiceUriZk.exists("/ledgers", false));
+
         String[] args1 = {
                 "--cluster", "testReSetupClusterMetadata-cluster",
                 "--zookeeper", zkConnection,


### PR DESCRIPTION
---

*Motivation*

#8269 change the arguments name which causes the setup
metadata command is not compatible with old versions.
For keeping the compatibility of the setup metadata command,
we should avoid deleting the existing arguments. If we need to
change it, it's better to keep the old arguments and mark it
deprecates and hide them.
