### PR TITLE
Update maven artifact version

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -333,7 +333,7 @@ The Apache Software License, Version 2.0
     - io.sundr-sundr-codegen-0.21.0.jar
     - io.sundr-sundr-core-0.21.0.jar
  * Guava
-    - com.google.guava-guava-30.0-jre.jar
+    - com.google.guava-guava-30.1-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
@@ -430,23 +430,23 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-http-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-io-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-security-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-server-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-util-9.4.33.v20201020.jar
-    - org.eclipse.jetty-jetty-xml-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.33.v20201020.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.33.v20201020.jar
+    - org.eclipse.jetty-jetty-client-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-http-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-io-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-security-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-server-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-util-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.35.v20201120.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.35.v20201120.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.3.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ flexible messaging model and an intuitive client API.</description>
     <zookeeper.version>3.5.7</zookeeper.version>
     <netty.version>4.1.51.Final</netty.version>
     <netty-tc-native.version>2.0.33.Final</netty-tc-native.version>
-    <jetty.version>9.4.33.v20201020</jetty.version>
+    <jetty.version>9.4.35.v20201120</jetty.version>
     <jersey.version>2.31</jersey.version>
     <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.3.0</hbase.version>
-    <guava.version>30.0-jre</guava.version>
+    <guava.version>30.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.14.0</prometheus-jmx.version>
     <confluent.version>5.3.2</confluent.version>
@@ -172,8 +172,8 @@ flexible messaging model and an intuitive client API.</description>
     <java-semver.version>0.9.0</java-semver.version>
     <hppc.version>0.7.3</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
-    <assertj-core.version>3.11.1</assertj-core.version>
-    <lombok.version>1.18.10</lombok.version>
+    <assertj-core.version>3.18.1</assertj-core.version>
+    <lombok.version>1.18.16</lombok.version>
     <javax.annotation-api.version>1.2</javax.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>
@@ -196,7 +196,7 @@ flexible messaging model and an intuitive client API.</description>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <confluent.version>5.2.2</confluent.version>
     <objenesis.version>3.1</objenesis.version>
-    <awaitility.version>4.0.2</awaitility.version>
+    <awaitility.version>4.0.3</awaitility.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -879,16 +879,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${testcontainers.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.arquillian.cube</groupId>
-        <artifactId>arquillian-cube-docker</artifactId>
-        <version>${arquillian-cube.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.junit</groupId>
-        <artifactId>arquillian-junit-standalone</artifactId>
-        <version>${arquillian-junit.version}</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.cassandra</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -221,7 +221,7 @@ The Apache Software License, Version 2.0
     - jackson-module-jaxb-annotations-2.11.1.jar
     - jackson-module-jsonSchema-2.11.1.jar
  * Guava
-    - guava-30.0-jre.jar
+    - guava-30.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
     - failureaccess-1.0.1.jar
  * Google Guice
@@ -439,12 +439,13 @@ The Apache Software License, Version 2.0
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty
-    - jetty-http-9.4.33.v20201020.jar
-    - jetty-io-9.4.33.v20201020.jar
-    - jetty-security-9.4.33.v20201020.jar
-    - jetty-server-9.4.33.v20201020.jar
-    - jetty-servlet-9.4.33.v20201020.jar
-    - jetty-util-9.4.33.v20201020.jar
+    - jetty-http-9.4.35.v20201120.jar
+    - jetty-io-9.4.35.v20201120.jar
+    - jetty-security-9.4.35.v20201120.jar
+    - jetty-server-9.4.35.v20201120.jar
+    - jetty-servlet-9.4.35.v20201120.jar
+    - jetty-util-9.4.35.v20201120.jar
+    - jetty-util-ajax-9.4.35.v20201120.jar
   * Java Native Access
     - jna-4.2.0.jar
     - jna-5.3.1.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -49,7 +49,7 @@
         <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
         <jackson.databind.version>2.11.1</jackson.databind.version>
         <maven.version>3.0.5</maven.version>
-        <guava.version>30.0-jre</guava.version>
+        <guava.version>30.1-jre</guava.version>
         <asynchttpclient.version>2.12.1</asynchttpclient.version>
     </properties>
 


### PR DESCRIPTION
### Motivation

Current version of libraries are out of date and have known CVE's

* CVE-2020-27218
* CVE-2020-8908

### Modification

    Update maven artifact versions
    
    * Upgrade Jetty to 9.4.35.v20201120
    * Upgade Guava to 30.1-jre
    * Upgrade AssertJ to 3.18.1
    * Upgrade Lombok to 1.18.16
    * Upgrade Awaitility to 4.0.3
    * Remove Arquillian references