### PR TITLE
Fix NPE in PersistentStickyKeyDispatcherMultipleConsumers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -175,7 +175,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Consumer consumer = current.getKey();
             List<Entry> entriesWithSameKey = current.getValue();
             int entriesWithSameKeyCount = entriesWithSameKey.size();
-            final int availablePermits = Math.max(consumer.getAvailablePermits(), 0);
+            final int availablePermits = consumer == null ? 0 : Math.max(consumer.getAvailablePermits(), 0);
             int maxMessagesForC = Math.min(entriesWithSameKeyCount, availablePermits);
             int messagesForC = getRestrictedMaxEntriesForConsumer(consumer, entriesWithSameKey,
                     maxMessagesForC, readType);


### PR DESCRIPTION
Fixes #8960

### Motivation
If use HashRangeExclusiveStickyKeyConsumerSelector(Key_Shared), NPE may occurs.

### Modifications
fix npe

### Verifying this change
PersistentStickyKeyDispatcherMultipleConsumersTest.java 
