### PR TITLE
[pulsar-client] Handle NPE while receiving ack for closed producer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -376,7 +376,15 @@ public class ClientCnx extends PulsarHandler {
                     ledgerId, entryId);
         }
 
-        producers.get(producerId).ackReceived(this, sequenceId, highestSequenceId, ledgerId, entryId);
+        ProducerImpl<?> producer = producers.get(producerId);
+        if (producer != null) {
+            producer.ackReceived(this, sequenceId, highestSequenceId, ledgerId, entryId);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Producer is {} already closed, ignore published message [{}-{}]", producerId, ledgerId,
+                        entryId);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Handle NPE when client receives ack for published message by a already closed producer.

```
[pulsar-client-io-1-1] WARN ClientCnx - [id: 0xcf858ea5, L:/1.1.1.1:1111 - R:pulsar-broker1.uswest.com/2.2.2.2:6651] Exception caught: null
java.lang.NullPointerException: null
at org.apache.pulsar.client.impl.ClientCnx.handleSendReceipt(ClientCnx.java:379) ~[?]
at org.apache.pulsar.shade.org.apache.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:189) ~[?]
at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[?]
at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[?]
```