### PR TITLE
Support create and update source with package name

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
 import org.apache.pulsar.functions.worker.service.api.Sources;
+import org.apache.pulsar.packages.management.core.common.PackageType;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 import javax.ws.rs.WebApplicationException;
@@ -51,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
@@ -148,14 +150,17 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
             // validate parameters
             try {
                 if (isPkgUrlProvided) {
-
-                    if (!Utils.isFunctionPackageUrlSupported(sourcePkgUrl)) {
-                        throw new IllegalArgumentException("Function Package url is not valid. supported url (http/https/file)");
-                    }
-                    try {
-                        componentPackageFile = FunctionCommon.extractFileFromPkgURL(sourcePkgUrl);
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException(String.format("Encountered error \"%s\" when getting %s package from %s", e.getMessage(), ComponentTypeUtils.toString(componentType), sourcePkgUrl));
+                    if (hasPackageTypePrefix(sourcePkgUrl)) {
+                        componentPackageFile = downloadPackageFile(sourcePkgUrl);
+                    } else {
+                        if (!Utils.isFunctionPackageUrlSupported(sourcePkgUrl)) {
+                            throw new IllegalArgumentException("Function Package url is not valid. supported url (http/https/file)");
+                        }
+                        try {
+                            componentPackageFile = FunctionCommon.extractFileFromPkgURL(sourcePkgUrl);
+                        } catch (Exception e) {
+                            throw new IllegalArgumentException(String.format("Encountered error \"%s\" when getting %s package from %s", e.getMessage(), ComponentTypeUtils.toString(componentType), sourcePkgUrl));
+                        }
                     }
                     functionDetails = validateUpdateRequestParams(tenant, namespace, sourceName,
                             sourceConfig, componentPackageFile);
@@ -313,10 +318,14 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
             // validate parameters
             try {
                 if (isNotBlank(sourcePkgUrl)) {
-                    try {
-                        componentPackageFile = FunctionCommon.extractFileFromPkgURL(sourcePkgUrl);
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException(String.format("Encountered error \"%s\" when getting %s package from %s", e.getMessage(), ComponentTypeUtils.toString(componentType), sourcePkgUrl));
+                    if (hasPackageTypePrefix(sourcePkgUrl)) {
+                        componentPackageFile = downloadPackageFile(sourcePkgUrl);
+                    } else {
+                        try {
+                            componentPackageFile = FunctionCommon.extractFileFromPkgURL(sourcePkgUrl);
+                        } catch (Exception e) {
+                            throw new IllegalArgumentException(String.format("Encountered error \"%s\" when getting %s package from %s", e.getMessage(), ComponentTypeUtils.toString(componentType), sourcePkgUrl));
+                        }
                     }
                     functionDetails = validateUpdateRequestParams(tenant, namespace, sourceName,
                             mergedConfig, componentPackageFile);
@@ -718,5 +727,15 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
                 sourcePackageFile, worker().getWorkerConfig().getNarExtractionDirectory(),
                 worker().getWorkerConfig().getValidateConnectorConfig());
         return SourceConfigUtils.convert(sourceConfig, sourceDetails);
+    }
+
+    private static boolean hasPackageTypePrefix(String destPkgUrl) {
+        return Arrays.stream(PackageType.values()).anyMatch(type -> destPkgUrl.startsWith(type.toString()));
+    }
+
+    private File downloadPackageFile(String packageName) throws IOException, PulsarAdminException {
+        File file = Files.createTempFile("function", ".tmp").toFile();
+        worker().getBrokerAdmin().packages().download(packageName, file.toString());
+        return file;
     }
 }


### PR DESCRIPTION
---

Master Issue: #8676

*Motivation*

We have a new package management service that can manage all
the source packages. We can use that in the Pulsar Source to manage
source packages.
I reuse the 'packageUrl' for downloading the package from the packages 
management service. So user can use the package name as the 'packageUrl'
to download it.

*Modifications*

- Support create and update the source with package name
- Add test for this
