### PR TITLE
remove duplicated broker prometheus metrics type

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -149,9 +149,15 @@ public class PrometheusMetricsGenerator {
                         continue;
                     }
                 } else {
-                    stream.write("# TYPE ").write(entry.getKey().replace("brk_", "pulsar_")).write(' ')
-                            .write(getTypeStr(metricType)).write('\n');
-                    stream.write(entry.getKey().replace("brk_", "pulsar_"))
+
+
+                    String name = entry.getKey();
+                    if (!names.contains(name)) {
+                        stream.write("# TYPE ").write(entry.getKey().replace("brk_", "pulsar_")).write(' ')
+                                .write(getTypeStr(metricType)).write('\n');
+                        names.add(name);
+                    }
+                    stream.write(name.replace("brk_", "pulsar_"))
                             .write("{cluster=\"").write(cluster).write('"');
                 }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -601,7 +601,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         Pattern typePattern = Pattern.compile("^#\\s+TYPE\\s+(\\w+)\\s+(\\w+)");
         Pattern metricNamePattern = Pattern.compile("^(\\w+)\\{.+");
 
-	    Splitter.on("\n").split(metricsStr).forEach(line -> {
+        Splitter.on("\n").split(metricsStr).forEach(line -> {
             if (line.isEmpty()) {
                 return;
             }
@@ -618,15 +618,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                     typeDefs.put(metricName, type);
                 } else {
                     fail("Duplicate type definition found for TYPE definition " + metricName);
-                    System.out.println(metricsStr);
-
                 }
                 // From https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
                 // "The TYPE line for a metric name must appear before the first sample is reported for that metric name."
                 if (metricNames.containsKey(metricName)) {
-                    System.out.println(metricsStr);
                     fail("TYPE definition for " + metricName + " appears after first sample");
-
                 }
             } else {
                 Matcher metricMatcher = metricNamePattern.matcher(line);


### PR DESCRIPTION
### Motivation

If there are multiple topics from different namespaces, the broker prometheus metrics will print out duplicated `# TYPE` definition for pulsar_ml_AddEntryBytesRate and other managed ledger metrics.

In fact, this problem can be verified by `promtool` https://github.com/prometheus/prometheus#building-from-source

On the broker, run this command to check validity of Pulsar broker metric format.
`curl localhost:8080/metrics/ | ~/go/bin/promtool check metrics`

### Modifications

To prevent duplicated metrics type definition, the definition is now tracked and only printed out once. It leverages the existing metrics name Set already defined under parseMetricsToPrometheusMetrics() in PrometheusMetricsGenerator.java

### Verifying this change

- [ x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

Added two topics under new namespaces to trigger conditions that duplicated prometheus type could happen previously under testManagedLedgerStats() of PrometheusMetricsTest.java. Updated test cases checks this duplicated type problem.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
