### PR TITLE
Improve error handling when broker doesn't trust client certificates

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataCommand.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataCommand.java
@@ -23,7 +23,9 @@ import java.security.cert.Certificate;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AuthenticationDataCommand implements AuthenticationDataSource {
     protected final String authData;
     protected final SocketAddress remoteAddress;
@@ -94,6 +96,7 @@ public class AuthenticationDataCommand implements AuthenticationDataSource {
         try {
             return sslSession.getPeerCertificates();
         } catch (SSLPeerUnverifiedException e) {
+            log.error("Failed to verify the peer's identity", e);
             return null;
         }
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTls.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTls.java
@@ -72,6 +72,9 @@ public class AuthenticationProviderTls implements AuthenticationProvider {
             // Example:
             // CN=Steve Kille,O=Isode Limited,C=GB
             Certificate[] certs = authData.getTlsCertificates();
+            if (null == certs) {
+                throw new AuthenticationException("Failed to get TLS certificates from client");
+            }
             String distinguishedName = ((X509Certificate) certs[0]).getSubjectX500Principal().getName();
             for (String keyValueStr : distinguishedName.split(",")) {
                 String[] keyValue = keyValueStr.split("=", 2);


### PR DESCRIPTION
*Motivation*

When TLS throws `SSLPeerUnverifiedException`, broker doesn't log any information and just returns `null`.
It makes users very hard to debug problem.

*Changes*

Improve the error handling when broker doesn't trust client certificates.

See more details at https://github.com/apache/pulsar/issues/8963

