### PR TITLE
[Build]Add provided dependency to make IDE eaiser to analyse code

### DIFF
--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -72,6 +72,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-allblobstore</artifactId>
+      <version>${jclouds.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>


### PR DESCRIPTION
Since we have used shaded dependency, which IDE may not analyze well, add a provided dependency will make IDE find the right dependency code and make less error report without changing the build result.