### PR TITLE
[pulsar-managed-ledger-admin] Fix deleting multiple ledgers

### DIFF
--- a/bin/pulsar-managed-ledger-admin
+++ b/bin/pulsar-managed-ledger-admin
@@ -98,16 +98,21 @@ def deleteLedgerIdsFromManagedLedgerInfo(zk, mlPath, deletLedgerIds):
         
         ledgerInfoList = mlInfo.ledgerInfo
         
-        for ledgerInfo in ledgerInfoList:
+        i = 0
+        while i < len(ledgerInfoList):
+            ledgerInfo = ledgerInfoList[i]
             if ledgerInfo.ledgerId in deletLedgerIds:
                 ledgerInfoList.remove(ledgerInfo)
-                updatedMlInfo = None
-                if isTextFormat:
-                    updatedMlInfo = MessageToString(mlInfo, True)
-                else:
-                    updatedMlInfo = mlInfo.SerializeToString(); 
-                zk.set(mlPath, updatedMlInfo, version=mlStat.version)
-                print('Updated {} with value\n{}'.format(mlPath, str(mlInfo)))
+            else:
+                i += 1
+        
+        updatedMlInfo = None
+        if isTextFormat:
+            updatedMlInfo = MessageToString(mlInfo, True)
+        else:
+            updatedMlInfo = mlInfo.SerializeToString(); 
+        zk.set(mlPath, updatedMlInfo, version=mlStat.version)
+        print('Updated {} with value\n{}'.format(mlPath, str(mlInfo)))
         
     except Exception as e:
             traceback.print_exc()


### PR DESCRIPTION
### Motivation

There are 2 main problems in pulsar-managed-ledger-admin when deleting multiple ledgers

- Removing a ledger while iterating through the ledger list will lead to skipping the next ledger in the list
- Only the first attempt to change the zookeeper's data will succeed, the second will fail due to version error

Logs for the second problem:
```
Traceback (most recent call last):
  File "/Users/milos/Downloads/pulsar/bin/pulsar-managed-ledger-admin", line 109, in deleteLedgerIdsFromManagedLedgerInfo
    zk.set(mlPath, updatedMlInfo, version=mlStat.version)
  File "/usr/local/lib/python3.9/site-packages/kazoo/client.py", line 1359, in set
    return self.set_async(path, value, version).get()
  File "/usr/local/lib/python3.9/site-packages/kazoo/handlers/utils.py", line 75, in get
    raise self._exception
kazoo.exceptions.BadVersionError
Failed to delete ledgerIds for /managed-ledgers/public/default/persistent/events-other due to BadVersionError()
```
### Modifications

Changed iterating through the loop with a while loop and index instead of foreach and handling index increment.
Changed updating zookeeper's data only once when the loop is finished.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
