### PR TITLE
[Broker] add if-branch for SubscriptionBusyException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -201,6 +201,8 @@ public class BrokerServiceException extends Exception {
             return PulsarApi.ServerError.PersistenceError;
         } else if (t instanceof ConsumerBusyException) {
             return PulsarApi.ServerError.ConsumerBusy;
+        } else if (t instanceof SubscriptionBusyException) {
+            return PulsarApi.ServerError.ConsumerBusy;
         } else if (t instanceof ProducerBusyException) {
             return PulsarApi.ServerError.ProducerBusy;
         } else if (t instanceof UnsupportedVersionException) {


### PR DESCRIPTION
### Motivation

when `SubscriptionBusyException` is thrown in a broker, `getClientErrorCode` doesn't deal with it and the returned code is incorrect.

### Modifications

add `else if` for `SubscriptionBusyException` in `getClientErrorCode`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.