### PR TITLE
Fix DelayedDelivery at the broker level has a default value

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2193,14 +2193,7 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected DelayedDeliveryPolicies internalGetDelayedDelivery() {
         validateNamespacePolicyOperation(namespaceName, PolicyName.DELAYED_DELIVERY, PolicyOperation.READ);
-
-        Policies policies = getNamespacePolicies(namespaceName);
-        if (policies.delayed_delivery_policies == null) {
-            return new DelayedDeliveryPolicies(config().getDelayedDeliveryTickTimeMillis(),
-                    config().isDelayedDeliveryEnabled());
-        } else {
-            return policies.delayed_delivery_policies;
-        }
+        return getNamespacePolicies(namespaceName).delayed_delivery_policies;
     }
 
     protected InactiveTopicPolicies internalGetInactiveTopic() {


### PR DESCRIPTION

### Motivation
`delayedDeliveryEnabled` at the broker level is enabled by default, but at the namespace level is not set.
But now the value can be obtained directly through `admin.namespaces().getDelayedDelivery(namespace)`. 
This makes users very confused, we did not set the policy, but it has value.
Therefore, `null` should be returned by default

