### PR TITLE
Add spotbug checks for pulsar-client-api module

### DIFF
--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -46,5 +46,17 @@
     </dependencies>
 
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pulsar-client-api/src/main/resources/findbugsExclude.xml
+++ b/pulsar-client-api/src/main/resources/findbugsExclude.xml
@@ -1,0 +1,50 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindBugsFilter>
+  <!-- Ignore the array access related expose bugs -->
+  <Match>
+    <Class name="org.apache.pulsar.client.api.EncryptionKeyInfo"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.common.api.EncryptionContext$EncryptionKey"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.common.schema.SchemaInfo"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.common.schema.SchemaInfo$SchemaInfoBuilder"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.pulsar.common.api.AuthData"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <!-- The implementation of Schema#encode may have side effect so the return value can be ignored -->
+  <Match>
+    <Class name="org.apache.pulsar.client.api.Schema"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
### Motivation

Add spotbugs plugin for pulsar-client-api module.

### Modifications

The most potential bugs are related to the raw array's getter/setter/constructor and the rest one is just a default method of an interface, so we just ignore these spotbugs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
