### PR TITLE
[Feature] Introduce continuous offset for pulsar

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -133,6 +133,21 @@ public interface ManagedLedger {
     void asyncAddEntry(ByteBuf buffer, AddEntryCallback callback, Object ctx);
 
     /**
+     * Append a new entry asynchronously.
+     *
+     * @see #addEntry(byte[])
+     * @param buffer
+     *            buffer with the data entry
+     * @param batchSize
+     *            batch size for data entry
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    void asyncAddEntry(ByteBuf buffer, int batchSize, AddEntryCallback callback, Object ctx);
+
+    /**
      * Open a ManagedCursor in this ManagedLedger.
      *
      * <p/>If the cursors doesn't exist, a new one will be created and its position will be at the end of the

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -22,6 +22,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
@@ -32,6 +34,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 
 /**
@@ -535,4 +538,9 @@ public interface ManagedLedger {
      * Roll current ledger if it is full
      */
     void rollCurrentLedgerIfFull();
+
+    /**
+     * Find position by sequenceId.
+     * */
+    CompletableFuture<PositionImpl> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 
 /**
@@ -78,6 +79,18 @@ public interface ManagedLedger {
     Position addEntry(byte[] data) throws InterruptedException, ManagedLedgerException;
 
     /**
+     * Append a new entry to the end of a managed ledger.
+     *
+     * @param data
+     *            data entry to be persisted
+     * @param batchSize
+     *            batchSize of entry
+     * @return the Position at which the entry has been inserted
+     * @throws ManagedLedgerException
+     */
+    Position addEntry(byte[] data, int batchSize) throws InterruptedException, ManagedLedgerException;
+
+    /**
      * Append a new entry asynchronously.
      *
      * @see #addEntry(byte[])
@@ -106,6 +119,22 @@ public interface ManagedLedger {
     Position addEntry(byte[] data, int offset, int length) throws InterruptedException, ManagedLedgerException;
 
     /**
+     * Append a new entry to the end of a managed ledger.
+     *
+     * @param data
+     *            data entry to be persisted
+     * @param batchSize
+     *            batchSize of entry
+     * @param offset
+     *            offset in the data array
+     * @param length
+     *            number of bytes
+     * @return the Position at which the entry has been inserted
+     * @throws ManagedLedgerException
+     */
+    Position addEntry(byte[] data, int batchSize, int offset, int length) throws InterruptedException, ManagedLedgerException;
+
+    /**
      * Append a new entry asynchronously.
      *
      * @see #addEntry(byte[])
@@ -121,6 +150,26 @@ public interface ManagedLedger {
      *            opaque context
      */
     void asyncAddEntry(byte[] data, int offset, int length, AddEntryCallback callback, Object ctx);
+
+    /**
+     * Append a new entry asynchronously.
+     *
+     * @see #addEntry(byte[])
+     * @param data
+     *            data entry to be persisted
+     * @param batchSize
+     *            batchSize of entry
+     * @param offset
+     *            offset in the data array
+     * @param length
+     *            number of bytes
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    void asyncAddEntry(byte[] data, int batchSize, int offset, int length, AddEntryCallback callback, Object ctx);
+
 
     /**
      * Append a new entry asynchronously.
@@ -543,4 +592,9 @@ public interface ManagedLedger {
      * Find position by sequenceId.
      * */
     CompletableFuture<PositionImpl> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate);
+
+    /**
+     * Get the ManagedLedgerInterceptor for ManagedLedger.
+     * */
+    ManagedLedgerInterceptor getManagedLedgerInterceptor();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -22,8 +22,6 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
-import java.util.function.Predicate;
 
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
@@ -34,7 +32,6 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 
@@ -83,12 +80,12 @@ public interface ManagedLedger {
      *
      * @param data
      *            data entry to be persisted
-     * @param batchSize
-     *            batchSize of entry
+     * @param numberOfMessages
+     *            numberOfMessages of entry
      * @return the Position at which the entry has been inserted
      * @throws ManagedLedgerException
      */
-    Position addEntry(byte[] data, int batchSize) throws InterruptedException, ManagedLedgerException;
+    Position addEntry(byte[] data, int numberOfMessages) throws InterruptedException, ManagedLedgerException;
 
     /**
      * Append a new entry asynchronously.
@@ -123,8 +120,8 @@ public interface ManagedLedger {
      *
      * @param data
      *            data entry to be persisted
-     * @param batchSize
-     *            batchSize of entry
+     * @param numberOfMessages
+     *            numberOfMessages of entry
      * @param offset
      *            offset in the data array
      * @param length
@@ -132,7 +129,7 @@ public interface ManagedLedger {
      * @return the Position at which the entry has been inserted
      * @throws ManagedLedgerException
      */
-    Position addEntry(byte[] data, int batchSize, int offset, int length) throws InterruptedException, ManagedLedgerException;
+    Position addEntry(byte[] data, int numberOfMessages, int offset, int length) throws InterruptedException, ManagedLedgerException;
 
     /**
      * Append a new entry asynchronously.
@@ -157,8 +154,8 @@ public interface ManagedLedger {
      * @see #addEntry(byte[])
      * @param data
      *            data entry to be persisted
-     * @param batchSize
-     *            batchSize of entry
+     * @param numberOfMessages
+     *            numberOfMessages of entry
      * @param offset
      *            offset in the data array
      * @param length
@@ -168,7 +165,7 @@ public interface ManagedLedger {
      * @param ctx
      *            opaque context
      */
-    void asyncAddEntry(byte[] data, int batchSize, int offset, int length, AddEntryCallback callback, Object ctx);
+    void asyncAddEntry(byte[] data, int numberOfMessages, int offset, int length, AddEntryCallback callback, Object ctx);
 
 
     /**
@@ -190,14 +187,14 @@ public interface ManagedLedger {
      * @see #addEntry(byte[])
      * @param buffer
      *            buffer with the data entry
-     * @param batchSize
-     *            batch size for data entry
+     * @param numberOfMessages
+     *            numberOfMessages for data entry
      * @param callback
      *            callback object
      * @param ctx
      *            opaque context
      */
-    void asyncAddEntry(ByteBuf buffer, int batchSize, AddEntryCallback callback, Object ctx);
+    void asyncAddEntry(ByteBuf buffer, int numberOfMessages, AddEntryCallback callback, Object ctx);
 
     /**
      * Open a ManagedCursor in this ManagedLedger.
@@ -591,7 +588,7 @@ public interface ManagedLedger {
     /**
      * Find position by sequenceId.
      * */
-    CompletableFuture<PositionImpl> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate);
+    CompletableFuture<Position> asyncFindPosition(com.google.common.base.Predicate<Entry> predicate);
 
     /**
      * Get the ManagedLedgerInterceptor for ManagedLedger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -33,6 +33,7 @@ import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 
+import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSet;
 
 /**
@@ -75,6 +76,7 @@ public class ManagedLedgerConfig {
     private LedgerOffloader ledgerOffloader = NullLedgerOffloader.INSTANCE;
     private int newEntriesCheckDelayInMillis = 10;
     private Clock clock = Clock.systemUTC();
+    private ManagedLedgerInterceptor managedLedgerInterceptor;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;
@@ -637,4 +639,11 @@ public class ManagedLedgerConfig {
         this.newEntriesCheckDelayInMillis = newEntriesCheckDelayInMillis;
     }
 
+    public ManagedLedgerInterceptor getManagedLedgerInterceptor() {
+        return managedLedgerInterceptor;
+    }
+
+    public void setManagedLedgerInterceptor(ManagedLedgerInterceptor managedLedgerInterceptor) {
+        this.managedLedgerInterceptor = managedLedgerInterceptor;
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -157,6 +157,12 @@ public class ManagedLedgerException extends Exception {
         }
     }
 
+    public static class ManagedLedgerInterceptException extends ManagedLedgerException {
+        public ManagedLedgerInterceptException(String msg) {
+            super(msg);
+        }
+    }
+
     @Override
     public synchronized Throwable fillInStackTrace() {
         // Disable stack traces to be filled in

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1404,10 +1404,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 // If op is used by another ledger handle, we need to close it and create a new one
                 if (existsOp.ledger != null) {
                     existsOp.close();
-                    existsOp = OpAddEntry.create(existsOp.ml, existsOp.data, existsOp.callback, existsOp.ctx);
+                    existsOp = OpAddEntry.create(existsOp.ml, existsOp.data, existsOp.getBatchSize(), existsOp.callback, existsOp.ctx);
                 }
                 existsOp.setLedger(currentLedger);
-                pendingAddEntries.add(existsOp);
+                if (beforeAddEntry(existsOp)) {
+                    pendingAddEntries.add(existsOp);
+                }
             }
         } while (existsOp != null && --pendingSize > 0);
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3175,6 +3175,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             mlInfo.setTerminatedPosition(NestedPositionInfo.newBuilder().setLedgerId(lastConfirmedEntry.getLedgerId())
                     .setEntryId(lastConfirmedEntry.getEntryId()));
         }
+        if (managedLedgerInterceptor != null) {
+            managedLedgerInterceptor.onUpdateManagedLedgerInfo(propertiesMap);
+        }
         for (Map.Entry<String, String> property : propertiesMap.entrySet()) {
             mlInfo.addProperties(MLDataFormats.KeyValue.newBuilder()
                     .setKey(property.getKey()).setValue(property.getValue()));

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * Handles the life-cycle of an addEntry() operation.
  *
  */
-class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
+public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     protected ManagedLedgerImpl ml;
     LedgerHandle ledger;
     private long entryId;
@@ -272,7 +272,15 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
     public State getState() {
         return state;
     }
-    
+
+    public ByteBuf getData() {
+        return data;
+    }
+
+    public void setData(ByteBuf data) {
+        this.data = data;
+    }
+
     private final Handle<OpAddEntry> recyclerHandle;
 
     private OpAddEntry(Handle<OpAddEntry> recyclerHandle) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -48,7 +48,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
     protected ManagedLedgerImpl ml;
     LedgerHandle ledger;
     private long entryId;
-    private int batchSize;
+    private int numberOfMessages;
 
     @SuppressWarnings("unused")
     private static final AtomicReferenceFieldUpdater<OpAddEntry, AddEntryCallback> callbackUpdater =
@@ -96,11 +96,11 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         return op;
     }
 
-    public static OpAddEntry create(ManagedLedgerImpl ml, ByteBuf data, int batchSize, AddEntryCallback callback, Object ctx) {
+    public static OpAddEntry create(ManagedLedgerImpl ml, ByteBuf data, int numberOfMessages, AddEntryCallback callback, Object ctx) {
         OpAddEntry op = RECYCLER.get();
         op.ml = ml;
         op.ledger = null;
-        op.batchSize = batchSize;
+        op.numberOfMessages = numberOfMessages;
         op.data = data.retain();
         op.dataLength = data.readableBytes();
         op.callback = callback;
@@ -299,12 +299,12 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         return data;
     }
 
-    public int getBatchSize() {
-        return batchSize;
+    public int getNumberOfMessages() {
+        return numberOfMessages;
     }
 
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
+    public void setNumberOfMessages(int numberOfMessages) {
+        this.numberOfMessages = numberOfMessages;
     }
 
     public void setData(ByteBuf data) {
@@ -328,7 +328,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         ml = null;
         ledger = null;
         data = null;
-        batchSize = 0;
+        numberOfMessages = 0;
         dataLength = -1;
         callback = null;
         ctx = null;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
@@ -30,4 +30,5 @@ public interface ManagedLedgerInterceptor {
     OpAddEntry beforeAddEntry(OpAddEntry op, int batchSize);
     void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap);
     void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
+    void onUpdateManagedLedgerInfo(Map<String, String> propertiesMap);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.interceptor;
+
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.impl.OpAddEntry;
+
+import java.util.Map;
+
+/**
+ * Interceptor for ManagedLedger.
+ * */
+public interface ManagedLedgerInterceptor {
+    OpAddEntry beforeAddEntry(OpAddEntry op, int batchSize);
+    void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap);
+    void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/interceptor/ManagedLedgerInterceptor.java
@@ -19,6 +19,8 @@
 package org.apache.bookkeeper.mledger.interceptor;
 
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.common.annotation.InterfaceAudience;
+import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 
 import java.util.Map;
@@ -26,9 +28,33 @@ import java.util.Map;
 /**
  * Interceptor for ManagedLedger.
  * */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Stable
 public interface ManagedLedgerInterceptor {
+
+    /**
+     * Intercept an OpAddEntry and return an OpAddEntry.
+     * @param op an OpAddEntry to be intercepted.
+     * @param batchSize
+     * @return an OpAddEntry.
+     */
     OpAddEntry beforeAddEntry(OpAddEntry op, int batchSize);
+
+    /**
+     * Intercept when ManagedLedger is initialized.
+     * @param propertiesMap map of properties.
+     */
     void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap);
+
+    /**
+     * Intercept when ManagedLedger is initialized.
+     * @param name name of ManagedLedger
+     * @param ledgerHandle a LedgerHandle.
+     */
     void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
+
+    /**
+     * @param propertiesMap  map of properties.
+     */
     void onUpdateManagedLedgerInfo(Map<String, String> propertiesMap);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -93,4 +93,13 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
             log.error("[{}] Read last entry error.", name, e);
         }
     }
+
+    @Override
+    public void onUpdateManagedLedgerInfo(Map<String, String> propertiesMap) {
+        for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
+            if (interceptor instanceof AppendOffsetMetadataInterceptor) {
+                propertiesMap.put(OFFSET, String.valueOf(((AppendOffsetMetadataInterceptor)interceptor).getOffset()));
+            }
+        }
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.mledger.impl.OpAddEntry;
+import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
+import org.apache.pulsar.common.protocol.Commands;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(ManagedLedgerInterceptorImpl.class);
+    private static final String OFFSET = "offset";
+
+    private AtomicLong offsetGenerator;
+    private Set<BrokerEntryMetadataInterceptor> brokerEntryMetadataInterceptors;
+
+    public ManagedLedgerInterceptorImpl() {
+        offsetGenerator = new AtomicLong(-1);
+    }
+
+    public ManagedLedgerInterceptorImpl(AtomicLong offsetGenerator,
+                                        Set<BrokerEntryMetadataInterceptor> brokerEntryMetadataInterceptors) {
+        this.offsetGenerator = offsetGenerator;
+        this.brokerEntryMetadataInterceptors = brokerEntryMetadataInterceptors;
+    }
+
+    @Override
+    public OpAddEntry beforeAddEntry(OpAddEntry op, int batchSize) {
+        assert op != null;
+        assert batchSize > 0;
+        op.setData(Commands.addBrokerEntryMetadata(op.getData(),
+                brokerEntryMetadataInterceptors, offsetGenerator, batchSize));
+        return op;
+    }
+
+    @Override
+    public void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap) {
+        assert propertiesMap != null;
+        assert propertiesMap.size() > 0;
+
+        if (propertiesMap.containsKey(OFFSET)) {
+            offsetGenerator.set(Long.parseLong(propertiesMap.get(OFFSET)));
+        }
+    }
+
+    @Override
+    public void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle lh) {
+        try {
+            LedgerEntries ledgerEntries =
+                    lh.read(lh.getLastAddConfirmed() - 1, lh.getLastAddConfirmed());
+            for (LedgerEntry entry : ledgerEntries) {
+                PulsarApi.BrokerEntryMetadata brokerEntryMetadata =
+                        Commands.parseBrokerEntryMetadataIfExist(entry.getEntryBuffer());
+                if (brokerEntryMetadata != null) {
+                    if (brokerEntryMetadata.hasOffset() && offsetGenerator.get() < brokerEntryMetadata.getOffset()) {
+                        offsetGenerator.set(brokerEntryMetadata.getOffset());
+                    }
+                }
+            }
+        } catch (org.apache.bookkeeper.client.api.BKException | InterruptedException e) {
+            log.error("[{}] Read last entry error.", name, e);
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -128,7 +128,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.configuration.FieldContext;
-import org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor;
+import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataUtils;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -1098,10 +1098,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             if (isBrokerEntryMetadataEnabled()) {
                 // init managedLedger interceptor
                 for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
-                    if (interceptor instanceof AppendOffsetMetadataInterceptor) {
+                    if (interceptor instanceof AppendIndexMetadataInterceptor) {
                         // add individual AppendOffsetMetadataInterceptor for each topic
                         brokerEntryMetadataInterceptors.remove(interceptor);
-                        brokerEntryMetadataInterceptors.add(new AppendOffsetMetadataInterceptor());
+                        brokerEntryMetadataInterceptors.add(new AppendIndexMetadataInterceptor());
                     }
                 }
                 ManagedLedgerInterceptor mlInterceptor =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -83,6 +83,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerNotFoundException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -98,6 +99,7 @@ import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerFactory;
 import org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerLoader;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
+import org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
 import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
@@ -1092,6 +1094,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         }
 
         getManagedLedgerConfig(topicName).thenAccept(managedLedgerConfig -> {
+            // init managedLedger interceptor
+            ManagedLedgerInterceptor mlInterceptor =
+                    new ManagedLedgerInterceptorImpl(new AtomicLong(-1), brokerEntryMetadataInterceptors);
+            managedLedgerConfig.setManagedLedgerInterceptor(mlInterceptor);
             managedLedgerConfig.setCreateIfMissing(createIfMissing);
 
             // Once we have the configuration, we can proceed with the async open operation

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -463,6 +463,11 @@ public class Producer {
             return callback;
         }
 
+        @Override
+        public long getNumberOfMessages() {
+            return batchSize;
+        }
+
         private final Handle<MessagePublishContext> recyclerHandle;
 
         private MessagePublishContext(Handle<MessagePublishContext> recyclerHandle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -90,6 +90,10 @@ public interface Topic {
         default long getOriginalHighestSequenceId() {
             return  -1L;
         }
+
+        default long getNumberOfMessages() {
+            return  1L;
+        }
     }
 
     void publishMessage(ByteBuf headersAndPayload, PublishContext callback);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -357,7 +357,8 @@ public class PersistentTopic extends AbstractTopic
                 messageDeduplication.isDuplicate(publishContext, headersAndPayload);
         switch (status) {
             case NotDup:
-                ledger.asyncAddEntry(headersAndPayload, this, publishContext);
+                ledger.asyncAddEntry(headersAndPayload,
+                        (int) publishContext.getNumberOfMessages(), this, publishContext);
                 break;
             case Dup:
                 // Immediately acknowledge duplicated message

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -357,10 +357,7 @@ public class PersistentTopic extends AbstractTopic
                 messageDeduplication.isDuplicate(publishContext, headersAndPayload);
         switch (status) {
             case NotDup:
-                // intercept headersAndPayload and add entry metadata
-                if (appendBrokerEntryMetadata(headersAndPayload, publishContext)) {
-                    ledger.asyncAddEntry(headersAndPayload, this, publishContext);
-                }
+                ledger.asyncAddEntry(headersAndPayload, this, publishContext);
                 break;
             case Dup:
                 // Immediately acknowledge duplicated message
@@ -372,24 +369,6 @@ public class PersistentTopic extends AbstractTopic
                 decrementPendingWriteOpsAndCheck();
 
         }
-    }
-
-    private boolean appendBrokerEntryMetadata(ByteBuf headersAndPayload, PublishContext publishContext) {
-        // just return true if BrokerEntryMetadata is not enabled
-        if (!brokerService.isBrokerEntryMetadataEnabled()) {
-            return true;
-        }
-
-        try {
-            headersAndPayload =  Commands.addBrokerEntryMetadata(headersAndPayload,
-                    brokerService.getBrokerEntryMetadataInterceptors());
-        } catch (Exception e) {
-            decrementPendingWriteOpsAndCheck();
-            publishContext.completed(new BrokerServiceException.AddEntryMetadataException(e), -1, -1);
-            log.error("[{}] Failed to add broker entry metadata.", topic, e);
-            return false;
-        }
-        return true;
     }
 
     public void asyncReadEntry(PositionImpl position, AsyncCallbacks.ReadEntryCallback callback, Object ctx) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -1,0 +1,228 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.intercept;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.mledger.interceptor.ManagedLedgerInterceptor;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
+import org.apache.pulsar.common.intercept.BrokerEntryMetadataUtils;
+import org.apache.pulsar.common.protocol.Commands;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.sun.org.apache.xml.internal.serialize.OutputFormat.Defaults.Encoding;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
+    private static final Logger log = LoggerFactory.getLogger(MangedLedgerInterceptorImplTest.class);
+
+
+    @Test
+    public void testAddBrokerEntryMetadata() throws Exception {
+        final int MOCK_BATCH_SIZE = 2;
+        int numberOfEntries = 10;
+        final String ledgerAndCursorName = "topicEntryMetadataSequenceId";
+
+        ManagedLedgerInterceptor interceptor = new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors());
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(2);
+        config.setManagedLedgerInterceptor(interceptor);
+
+        ManagedLedger ledger = factory.open(ledgerAndCursorName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor(ledgerAndCursorName);
+
+        for ( int i = 0 ; i < numberOfEntries; i ++) {
+            ledger.addEntry(("message" + i).getBytes(), MOCK_BATCH_SIZE);
+        }
+
+
+        assertEquals(19, ((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset());
+        List<Entry> entryList = cursor.readEntries(numberOfEntries);
+        for (int i = 0 ; i < numberOfEntries; i ++) {
+            PulsarApi.BrokerEntryMetadata metadata =
+                    Commands.parseBrokerEntryMetadataIfExist(entryList.get(i).getDataBuffer());
+            assertNotNull(metadata);
+            assertEquals(metadata.getOffset(), (i + 1) * MOCK_BATCH_SIZE - 1);
+        }
+
+        cursor.close();;
+        ledger.close();
+        factory.shutdown();
+    }
+
+
+    @Test(timeOut = 20000)
+    public void testRecoveryOffset() throws Exception {
+        final int MOCK_BATCH_SIZE = 2;
+        ManagedLedgerInterceptor interceptor = new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors());
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setManagedLedgerInterceptor(interceptor);
+        ManagedLedger ledger = factory.open("my_recovery_offset_test_ledger", config);
+
+        ledger.addEntry("dummy-entry-1".getBytes(Encoding), MOCK_BATCH_SIZE);
+
+        ManagedCursor cursor = ledger.openCursor("c1");
+
+        ledger.addEntry("dummy-entry-2".getBytes(Encoding), MOCK_BATCH_SIZE);
+
+        assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(), MOCK_BATCH_SIZE * 2 - 1);
+
+        ledger.close();
+
+        log.info("Closing ledger and reopening");
+
+        // / Reopen the same managed-ledger
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        ledger = factory2.open("my_recovery_offset_test_ledger", config);
+
+        cursor = ledger.openCursor("c1");
+
+        assertEquals(ledger.getNumberOfEntries(), 2);
+        assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(), MOCK_BATCH_SIZE * 2 - 1);
+
+
+        List<Entry> entries = cursor.readEntries(100);
+        assertEquals(entries.size(), 1);
+        entries.forEach(e -> e.release());
+
+        cursor.close();
+        ledger.close();
+        factory2.shutdown();
+    }
+
+    @Test
+    public void testFindPositionByOffset() throws Exception {
+        final int MOCK_BATCH_SIZE = 2;
+        final int maxEntriesPerLedger = 5;
+        int maxSequenceIdPerLedger = MOCK_BATCH_SIZE * maxEntriesPerLedger;
+        ManagedLedgerInterceptor interceptor = new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors());
+
+
+        ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
+        managedLedgerConfig.setManagedLedgerInterceptor(interceptor);
+        managedLedgerConfig.setMaxEntriesPerLedger(5);
+
+        ManagedLedger ledger = factory.open("my_ml_broker_entry_metadata_test_ledger", managedLedgerConfig);
+        ManagedCursor cursor = ledger.openCursor("c1");
+
+        long firstLedgerId = -1;
+        for (int i = 0; i < maxEntriesPerLedger; i++) {
+            firstLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+        }
+
+        assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(), 9);
+
+
+        PositionImpl position = null;
+        for (int offset = 0 ; offset <= ((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(); offset ++) {
+            position = ledger.asyncFindPosition(new OffsetSearchPredicate(offset)).get();
+            assertEquals(position.getEntryId(), (offset % maxSequenceIdPerLedger) / MOCK_BATCH_SIZE);
+        }
+
+        // roll over ledger
+        long secondLedgerId = -1;
+        for (int i = 0; i < maxEntriesPerLedger; i++) {
+            secondLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+        }
+        assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(), 19);
+        assertNotEquals(firstLedgerId, secondLedgerId);
+
+        for (int offset = 0 ; offset <= ((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(); offset ++) {
+            position = ledger.asyncFindPosition(new OffsetSearchPredicate(offset)).get();
+            assertEquals(position.getEntryId(), (offset % maxSequenceIdPerLedger) / MOCK_BATCH_SIZE);
+        }
+
+        // reopen ledger
+        ledger.close();
+        // / Reopen the same managed-ledger
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        ledger = factory2.open("my_ml_broker_entry_metadata_test_ledger", managedLedgerConfig);
+
+        long thirdLedgerId = -1;
+        for (int i = 0; i < maxEntriesPerLedger; i++) {
+            thirdLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+        }
+        assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(), 29);
+        assertNotEquals(secondLedgerId, thirdLedgerId);
+
+        for (int offset = 0 ; offset <= ((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getOffset(); offset ++) {
+            position = ledger.asyncFindPosition(new OffsetSearchPredicate(offset)).get();
+            assertEquals(position.getEntryId(), (offset % maxSequenceIdPerLedger) / MOCK_BATCH_SIZE);
+        }
+        cursor.close();
+        ledger.close();
+        factory2.shutdown();
+    }
+
+    public static Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {
+        Set<String> interceptorNames = new HashSet<>();
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor");
+        return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(interceptorNames,
+                Thread.currentThread().getContextClassLoader());
+    }
+
+    class OffsetSearchPredicate implements com.google.common.base.Predicate<Entry> {
+
+        long offsetToSearch = -1;
+        public OffsetSearchPredicate(long offsetToSearch) {
+            this.offsetToSearch = offsetToSearch;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuffer sb = new StringBuffer("OffsetSearchPredicate{");
+            sb.append("offsetToSearch=").append(offsetToSearch);
+            sb.append('}');
+            return sb.toString();
+        }
+
+        @Override
+        public boolean apply(@Nullable Entry entry) {
+            try {
+                PulsarApi.BrokerEntryMetadata brokerEntryMetadata = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
+                return brokerEntryMetadata.getOffset() < offsetToSearch;
+            } catch (Exception e) {
+                log.error("Error deserialize message for message position find", e);
+            } finally {
+                entry.release();
+            }
+            return false;
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -108,7 +108,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
 
     public static byte[] appendBrokerTimestamp(ByteBuf headerAndPayloads) throws Exception {
         ByteBuf msgWithEntryMeta =
-                Commands.addBrokerEntryMetadata(headerAndPayloads, getBrokerEntryMetadataInterceptors());
+                Commands.addBrokerEntryMetadata(headerAndPayloads, getBrokerEntryMetadataInterceptors(), 1);
         byte[] byteMessage = msgWithEntryMeta.nioBuffer().array();
         msgWithEntryMeta.release();
         return byteMessage;
@@ -321,9 +321,10 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
     }
 
     public static Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {
-
-        return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(
-                Sets.newHashSet("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor"),
+        Set<String> interceptorNames = new HashSet<>();
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor");
+        return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(interceptorNames,
                 Thread.currentThread().getContextClassLoader());
     }
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -323,7 +323,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
     public static Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {
         Set<String> interceptorNames = new HashSet<>();
         interceptorNames.add("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
-        interceptorNames.add("org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor");
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor");
         return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(interceptorNames,
                 Thread.currentThread().getContextClassLoader());
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -7074,6 +7074,10 @@ public final class PulsarApi {
     // optional uint64 broker_timestamp = 1;
     boolean hasBrokerTimestamp();
     long getBrokerTimestamp();
+    
+    // optional uint64 offset = 2;
+    boolean hasOffset();
+    long getOffset();
   }
   public static final class BrokerEntryMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -7120,8 +7124,19 @@ public final class PulsarApi {
       return brokerTimestamp_;
     }
     
+    // optional uint64 offset = 2;
+    public static final int OFFSET_FIELD_NUMBER = 2;
+    private long offset_;
+    public boolean hasOffset() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public long getOffset() {
+      return offset_;
+    }
+    
     private void initFields() {
       brokerTimestamp_ = 0L;
+      offset_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -7143,6 +7158,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeUInt64(1, brokerTimestamp_);
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeUInt64(2, offset_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -7154,6 +7172,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(1, brokerTimestamp_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeUInt64Size(2, offset_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -7270,6 +7292,8 @@ public final class PulsarApi {
         super.clear();
         brokerTimestamp_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000001);
+        offset_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       
@@ -7307,6 +7331,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000001;
         }
         result.brokerTimestamp_ = brokerTimestamp_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.offset_ = offset_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -7315,6 +7343,9 @@ public final class PulsarApi {
         if (other == org.apache.pulsar.common.api.proto.PulsarApi.BrokerEntryMetadata.getDefaultInstance()) return this;
         if (other.hasBrokerTimestamp()) {
           setBrokerTimestamp(other.getBrokerTimestamp());
+        }
+        if (other.hasOffset()) {
+          setOffset(other.getOffset());
         }
         return this;
       }
@@ -7350,6 +7381,11 @@ public final class PulsarApi {
               brokerTimestamp_ = input.readUInt64();
               break;
             }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              offset_ = input.readUInt64();
+              break;
+            }
           }
         }
       }
@@ -7373,6 +7409,27 @@ public final class PulsarApi {
       public Builder clearBrokerTimestamp() {
         bitField0_ = (bitField0_ & ~0x00000001);
         brokerTimestamp_ = 0L;
+        
+        return this;
+      }
+      
+      // optional uint64 offset = 2;
+      private long offset_ ;
+      public boolean hasOffset() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public long getOffset() {
+        return offset_;
+      }
+      public Builder setOffset(long value) {
+        bitField0_ |= 0x00000002;
+        offset_ = value;
+        
+        return this;
+      }
+      public Builder clearOffset() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        offset_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -7075,9 +7075,9 @@ public final class PulsarApi {
     boolean hasBrokerTimestamp();
     long getBrokerTimestamp();
     
-    // optional uint64 offset = 2;
-    boolean hasOffset();
-    long getOffset();
+    // optional uint64 index = 2;
+    boolean hasIndex();
+    long getIndex();
   }
   public static final class BrokerEntryMetadata extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -7124,19 +7124,19 @@ public final class PulsarApi {
       return brokerTimestamp_;
     }
     
-    // optional uint64 offset = 2;
-    public static final int OFFSET_FIELD_NUMBER = 2;
-    private long offset_;
-    public boolean hasOffset() {
+    // optional uint64 index = 2;
+    public static final int INDEX_FIELD_NUMBER = 2;
+    private long index_;
+    public boolean hasIndex() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
-    public long getOffset() {
-      return offset_;
+    public long getIndex() {
+      return index_;
     }
     
     private void initFields() {
       brokerTimestamp_ = 0L;
-      offset_ = 0L;
+      index_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -7159,7 +7159,7 @@ public final class PulsarApi {
         output.writeUInt64(1, brokerTimestamp_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeUInt64(2, offset_);
+        output.writeUInt64(2, index_);
       }
     }
     
@@ -7175,7 +7175,7 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
-          .computeUInt64Size(2, offset_);
+          .computeUInt64Size(2, index_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -7292,7 +7292,7 @@ public final class PulsarApi {
         super.clear();
         brokerTimestamp_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000001);
-        offset_ = 0L;
+        index_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
@@ -7334,7 +7334,7 @@ public final class PulsarApi {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.offset_ = offset_;
+        result.index_ = index_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -7344,8 +7344,8 @@ public final class PulsarApi {
         if (other.hasBrokerTimestamp()) {
           setBrokerTimestamp(other.getBrokerTimestamp());
         }
-        if (other.hasOffset()) {
-          setOffset(other.getOffset());
+        if (other.hasIndex()) {
+          setIndex(other.getIndex());
         }
         return this;
       }
@@ -7383,7 +7383,7 @@ public final class PulsarApi {
             }
             case 16: {
               bitField0_ |= 0x00000002;
-              offset_ = input.readUInt64();
+              index_ = input.readUInt64();
               break;
             }
           }
@@ -7413,23 +7413,23 @@ public final class PulsarApi {
         return this;
       }
       
-      // optional uint64 offset = 2;
-      private long offset_ ;
-      public boolean hasOffset() {
+      // optional uint64 index = 2;
+      private long index_ ;
+      public boolean hasIndex() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
-      public long getOffset() {
-        return offset_;
+      public long getIndex() {
+        return index_;
       }
-      public Builder setOffset(long value) {
+      public Builder setIndex(long value) {
         bitField0_ |= 0x00000002;
-        offset_ = value;
+        index_ = value;
         
         return this;
       }
-      public Builder clearOffset() {
+      public Builder clearIndex() {
         bitField0_ = (bitField0_ & ~0x00000002);
-        offset_ = 0L;
+        index_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendIndexMetadataInterceptor.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendIndexMetadataInterceptor.java
@@ -22,16 +22,16 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-public class AppendOffsetMetadataInterceptor implements BrokerEntryMetadataInterceptor{
-    private final AtomicLong offsetGenerator;
+public class AppendIndexMetadataInterceptor implements BrokerEntryMetadataInterceptor{
+    private final AtomicLong indexGenerator;
 
-    public AppendOffsetMetadataInterceptor() {
-        this.offsetGenerator = new AtomicLong(-1);
+    public AppendIndexMetadataInterceptor() {
+        this.indexGenerator = new AtomicLong(-1);
     }
 
-    public void recoveryOffsetGenerator(long offset) {
-        if (offsetGenerator.get() < offset) {
-            offsetGenerator.set(offset);
+    public void recoveryIndexGenerator(long index) {
+        if (indexGenerator.get() < index) {
+            indexGenerator.set(index);
         }
     }
 
@@ -45,10 +45,10 @@ public class AppendOffsetMetadataInterceptor implements BrokerEntryMetadataInter
     public PulsarApi.BrokerEntryMetadata.Builder interceptWithBatchSize(
             PulsarApi.BrokerEntryMetadata.Builder brokerMetadata,
             int batchSize) {
-        return brokerMetadata.setOffset(offsetGenerator.addAndGet(batchSize));
+        return brokerMetadata.setIndex(indexGenerator.addAndGet(batchSize));
     }
 
-    public long getOffset() {
-        return offsetGenerator.get();
+    public long getIndex() {
+        return indexGenerator.get();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendOffsetMetadataInterceptor.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendOffsetMetadataInterceptor.java
@@ -20,22 +20,32 @@ package org.apache.pulsar.common.intercept;
 
 import org.apache.pulsar.common.api.proto.PulsarApi;
 
-/**
- * A plugin interface that allows you to intercept the client requests to
- *  the Pulsar brokers and add timestamp from broker side metadata for each entry.
- */
-public class AppendBrokerTimestampMetadataInterceptor implements BrokerEntryMetadataInterceptor {
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AppendOffsetMetadataInterceptor implements BrokerEntryMetadataInterceptor{
+    private final AtomicLong offsetGenerator;
+
+    public AppendOffsetMetadataInterceptor() {
+        this.offsetGenerator = new AtomicLong(-1);
+    }
+
+    public void recoveryOffsetGenerator(long offset) {
+        if (offsetGenerator.get() < offset) {
+            offsetGenerator.set(offset);
+        }
+    }
 
     @Override
     public PulsarApi.BrokerEntryMetadata.Builder intercept(PulsarApi.BrokerEntryMetadata.Builder brokerMetadata) {
-        return brokerMetadata.setBrokerTimestamp(System.currentTimeMillis());
+        // do nothing, just return brokerMetadata
+        return brokerMetadata;
     }
 
     @Override
     public PulsarApi.BrokerEntryMetadata.Builder interceptWithBatchSize(
             PulsarApi.BrokerEntryMetadata.Builder brokerMetadata,
             int batchSize) {
-        // do nothing, just return brokerMetadata
-        return brokerMetadata;
+        return brokerMetadata.setOffset(offsetGenerator.addAndGet(batchSize));
     }
+
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendOffsetMetadataInterceptor.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/AppendOffsetMetadataInterceptor.java
@@ -48,4 +48,7 @@ public class AppendOffsetMetadataInterceptor implements BrokerEntryMetadataInter
         return brokerMetadata.setOffset(offsetGenerator.addAndGet(batchSize));
     }
 
+    public long getOffset() {
+        return offsetGenerator.get();
+    }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataInterceptor.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataInterceptor.java
@@ -26,4 +26,6 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
  */
 public interface BrokerEntryMetadataInterceptor {
     PulsarApi.BrokerEntryMetadata.Builder intercept(PulsarApi.BrokerEntryMetadata.Builder brokerMetadata);
+    PulsarApi.BrokerEntryMetadata.Builder interceptWithBatchSize(PulsarApi.BrokerEntryMetadata.Builder brokerMetadata,
+                                                                 int batchSize);
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -1942,6 +1943,38 @@ public class Commands {
         for (BrokerEntryMetadataInterceptor interceptor : interceptors) {
             interceptor.intercept(brokerMetadataBuilder);
         }
+        PulsarApi.BrokerEntryMetadata brokerEntryMetadata = brokerMetadataBuilder.build();
+        int brokerMetaSize = brokerEntryMetadata.getSerializedSize();
+        ByteBuf brokerMeta =
+                PulsarByteBufAllocator.DEFAULT.buffer(brokerMetaSize + 6, brokerMetaSize + 6);
+        brokerMeta.writeShort(Commands.magicBrokerEntryMetadata);
+        brokerMeta.writeInt(brokerMetaSize);
+        ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(brokerMeta);
+        try {
+            brokerEntryMetadata.writeTo(outStream);
+        } catch (IOException e) {
+            // This is in-memory serialization, should not fail
+            throw new RuntimeException(e);
+        }
+        outStream.recycle();
+
+        CompositeByteBuf compositeByteBuf = PulsarByteBufAllocator.DEFAULT.compositeBuffer();
+        compositeByteBuf.addComponents(true, brokerMeta, headerAndPayload);
+        return compositeByteBuf;
+    }
+
+    public static ByteBuf addBrokerEntryMetadata(ByteBuf headerAndPayload,
+                                                 Set<BrokerEntryMetadataInterceptor> brokerInterceptors,
+                                                 AtomicLong offsetGenerator,
+                                                 int batchSize) {
+        //   | BROKER_ENTRY_METADATA_MAGIC_NUMBER | BROKER_ENTRY_METADATA_SIZE |         BROKER_ENTRY_METADATA         |
+        //   |         2 bytes                    |       4 bytes              |    BROKER_ENTRY_METADATA_SIZE bytes   |
+
+        PulsarApi.BrokerEntryMetadata.Builder brokerMetadataBuilder = PulsarApi.BrokerEntryMetadata.newBuilder();
+        for (BrokerEntryMetadataInterceptor interceptor : brokerInterceptors) {
+            interceptor.intercept(brokerMetadataBuilder);
+        }
+        brokerMetadataBuilder.setOffset(offsetGenerator.addAndGet(batchSize));
         PulsarApi.BrokerEntryMetadata brokerEntryMetadata = brokerMetadataBuilder.build();
         int brokerMetaSize = brokerEntryMetadata.getSerializedSize();
         ByteBuf brokerMeta =

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1965,7 +1965,6 @@ public class Commands {
 
     public static ByteBuf addBrokerEntryMetadata(ByteBuf headerAndPayload,
                                                  Set<BrokerEntryMetadataInterceptor> brokerInterceptors,
-                                                 AtomicLong offsetGenerator,
                                                  int batchSize) {
         //   | BROKER_ENTRY_METADATA_MAGIC_NUMBER | BROKER_ENTRY_METADATA_SIZE |         BROKER_ENTRY_METADATA         |
         //   |         2 bytes                    |       4 bytes              |    BROKER_ENTRY_METADATA_SIZE bytes   |
@@ -1973,8 +1972,8 @@ public class Commands {
         PulsarApi.BrokerEntryMetadata.Builder brokerMetadataBuilder = PulsarApi.BrokerEntryMetadata.newBuilder();
         for (BrokerEntryMetadataInterceptor interceptor : brokerInterceptors) {
             interceptor.intercept(brokerMetadataBuilder);
+            interceptor.interceptWithBatchSize(brokerMetadataBuilder, batchSize);
         }
-        brokerMetadataBuilder.setOffset(offsetGenerator.addAndGet(batchSize));
         PulsarApi.BrokerEntryMetadata brokerEntryMetadata = brokerMetadataBuilder.build();
         int brokerMetaSize = brokerEntryMetadata.getSerializedSize();
         ByteBuf brokerMeta =

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -183,7 +183,7 @@ message SingleMessageMetadata {
 // metadata added for entry from broker
 message BrokerEntryMetadata {
     optional uint64 broker_timestamp = 1;
-    optional uint64 offset = 2;
+    optional uint64 index = 2;
 }
 
 enum ServerError {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -183,6 +183,7 @@ message SingleMessageMetadata {
 // metadata added for entry from broker
 message BrokerEntryMetadata {
     optional uint64 broker_timestamp = 1;
+    optional uint64 offset = 2;
 }
 
 enum ServerError {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
@@ -154,7 +154,7 @@ public class CommandUtilsTests {
                 PulsarApi.BrokerEntryMetadata
                         .newBuilder()
                         .setBrokerTimestamp(System.currentTimeMillis())
-                        .setOffset(MOCK_BATCH_SIZE - 1)
+                        .setIndex(MOCK_BATCH_SIZE - 1)
                         .build();
         ByteBuf dataWithBrokerEntryMetadata =
                 Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors(), MOCK_BATCH_SIZE);
@@ -194,7 +194,7 @@ public class CommandUtilsTests {
                 Commands.parseBrokerEntryMetadataIfExist(dataWithBrokerEntryMetadata);
 
         assertTrue(brokerMetadata.getBrokerTimestamp() <= System.currentTimeMillis());
-        assertEquals(brokerMetadata.getOffset(), MOCK_BATCH_SIZE - 1);
+        assertEquals(brokerMetadata.getIndex(), MOCK_BATCH_SIZE - 1);
         assertEquals(data.length(), dataWithBrokerEntryMetadata.readableBytes());
 
         byte [] content = new byte[dataWithBrokerEntryMetadata.readableBytes()];
@@ -205,7 +205,7 @@ public class CommandUtilsTests {
     public Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {
         Set<String> interceptorNames = new HashSet<>();
         interceptorNames.add("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
-        interceptorNames.add("org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor");
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor");
         return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(interceptorNames,
                 Thread.currentThread().getContextClassLoader());
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
@@ -145,14 +145,19 @@ public class CommandUtilsTests {
 
     @Test
     public void testAddBrokerEntryMetadata() throws Exception {
+        int MOCK_BATCH_SIZE = 10;
         String data = "test-message";
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.buffer(data.length(), data.length());
         byteBuf.writeBytes(data.getBytes(StandardCharsets.UTF_8));
 
         PulsarApi.BrokerEntryMetadata brokerMetadata =
-                PulsarApi.BrokerEntryMetadata.newBuilder().setBrokerTimestamp(System.currentTimeMillis()).build();
+                PulsarApi.BrokerEntryMetadata
+                        .newBuilder()
+                        .setBrokerTimestamp(System.currentTimeMillis())
+                        .setOffset(MOCK_BATCH_SIZE - 1)
+                        .build();
         ByteBuf dataWithBrokerEntryMetadata =
-                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors());
+                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors(), MOCK_BATCH_SIZE);
         assertEquals(brokerMetadata.getSerializedSize() + data.length() + 6,
                 dataWithBrokerEntryMetadata.readableBytes());
 
@@ -167,7 +172,7 @@ public class CommandUtilsTests {
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.buffer(data.length(), data.length());
         byteBuf.writeBytes(data.getBytes(StandardCharsets.UTF_8));
         ByteBuf dataWithBrokerEntryMetadata =
-                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors());
+                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors(), 11);
 
         Commands.skipBrokerEntryMetadataIfExist(dataWithBrokerEntryMetadata);
         assertEquals(data.length(), dataWithBrokerEntryMetadata.readableBytes());
@@ -179,15 +184,17 @@ public class CommandUtilsTests {
 
     @Test
     public void testParseBrokerEntryMetadata() throws Exception {
+        int MOCK_BATCH_SIZE = 10;
         String data = "test-message";
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.buffer(data.length(), data.length());
         byteBuf.writeBytes(data.getBytes(StandardCharsets.UTF_8));
         ByteBuf dataWithBrokerEntryMetadata =
-                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors());
+                Commands.addBrokerEntryMetadata(byteBuf, getBrokerEntryMetadataInterceptors(), MOCK_BATCH_SIZE);
         PulsarApi.BrokerEntryMetadata brokerMetadata =
                 Commands.parseBrokerEntryMetadataIfExist(dataWithBrokerEntryMetadata);
 
         assertTrue(brokerMetadata.getBrokerTimestamp() <= System.currentTimeMillis());
+        assertEquals(brokerMetadata.getOffset(), MOCK_BATCH_SIZE - 1);
         assertEquals(data.length(), dataWithBrokerEntryMetadata.readableBytes());
 
         byte [] content = new byte[dataWithBrokerEntryMetadata.readableBytes()];
@@ -198,6 +205,7 @@ public class CommandUtilsTests {
     public Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {
         Set<String> interceptorNames = new HashSet<>();
         interceptorNames.add("org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor");
+        interceptorNames.add("org.apache.pulsar.common.intercept.AppendOffsetMetadataInterceptor");
         return BrokerEntryMetadataUtils.loadBrokerEntryMetadataInterceptors(interceptorNames,
                 Thread.currentThread().getContextClassLoader());
     }


### PR DESCRIPTION
Fixes #9038 
### Motivation

As described in [PIP-70](https://github.com/apache/pulsar/wiki/PIP-70%3A-Introduce-lightweight-broker-entry-metadata).
One of the use case for Broker entry metadata is  providing continuous message sequence-Id for messages in one topic-partition which is useful for Protocol Hanlder like KOP.

This PR enable Pulsar to support continuous offset for message based on Broker entry metadata.

### Modifications

Introduce a new field for broker entry metadta named `offset`;
Introduce a new interceptor type `ManagedLedgerInterceptor` which intercept entry in `ManagedLedger`；
Each partition will be assigned a `ManagedLedgerInterceptor` when `ManagedLedger` created;
Each Entry will be intercept for adding a  monotone increasing offset in Broker entry metadata and the offet is added by batchSize of entry;
Support find position by a given offset.
