### PR TITLE
[pulsar-client-api] Fix Unavailable Hash Range Condition

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -175,7 +175,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         @Cleanup
         Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
-                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE-1)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
@@ -296,7 +296,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         @Cleanup
         Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
-                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE-1)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
@@ -362,7 +362,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         @Cleanup
         Consumer<Integer> consumer3 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
-                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE)));
+                .ranges(Range.of(40001, KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE-1)));
 
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -107,7 +107,7 @@ public abstract class KeySharedPolicy {
             }
             for (int i = 0; i < ranges.size(); i++) {
                 Range range1 = ranges.get(i);
-                if (range1.getStart() < 0 || range1.getEnd() > DEFAULT_HASH_RANGE_SIZE) {
+                if (range1.getStart() < 0 || range1.getEnd() >= DEFAULT_HASH_RANGE_SIZE) {
                     throw new IllegalArgumentException("Ranges must be [0, 65535] but provided range is " + range1);
                 }
                 for (int j = 0; j < ranges.size(); j++) {


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar/blob/3b2c8526a96fc90e948dbeb510e8400a628c749a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java#L110-L112

When range is [0, 65536], the above condition is false.

### Modification
Change from `range1.getEnd() > DEFAULT_HASH_RANGE_SIZE` to `range1.getEnd() >= DEFAULT_HASH_RANGE_SIZE`.