### PR TITLE
[connector]fix debezium-connector error log

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -190,11 +190,13 @@ public class PulsarSink<T> implements Sink<T> {
                 String errorMsg = null;
                 if (srcRecord instanceof PulsarRecord) {
                     errorMsg = String.format("Failed to publish to topic [%s] with error [%s] with src message id [%s]", topic, throwable.getMessage(), ((PulsarRecord) srcRecord).getMessageId());
-                    log.error(errorMsg);
                 } else {
-                    errorMsg = String.format("Failed to publish to topic [%s] with error [%s] with src sequence id [%s]", topic, throwable.getMessage(), record.getRecordSequence().get());
-                    log.error(errorMsg);
+                    errorMsg = String.format("Failed to publish to topic [%s] with error [%s]", topic, throwable.getMessage());
+                    if (record.getRecordSequence().isPresent()) {
+                        errorMsg = String.format(errorMsg + " with src sequence id [%s]", record.getRecordSequence().get());
+                    }
                 }
+                log.error(errorMsg);
                 stats.incrSinkExceptions(new Exception(errorMsg));
                 return null;
             };


### PR DESCRIPTION
### Motivation

debezium-connector exception message not clear.

### Modifications

when debezium-connector throw exception, these code will not be execute:
```
// getRecordSequence is empty
errorMsg = String.format("Failed to publish to topic [%s] with error [%s] with src sequence id [%s]", topic, throwable.getMessage(), record.getRecordSequence().get());
log.error(errorMsg);
```

After repair:
```
17:42:43,274 ERROR [public/default/debezium-mysql-source-exchange-0] [instance: 0] PulsarSink - Failed to publish to topic [public/default/xx.xx.xx] with error [org.apache.pulsar.client.api.PulsarClientException$InvalidMessageException: Message size is bigger than 5242880 bytes]
```
