### PR TITLE
support peek broker entry metadta

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -2031,6 +2031,15 @@ public class Commands {
         }
     }
 
+    public static PulsarApi.BrokerEntryMetadata peekBrokerEntryMetadataIfExist(
+            ByteBuf headerAndPayloadWithBrokerEntryMetadata) {
+        final int readerIndex = headerAndPayloadWithBrokerEntryMetadata.readerIndex();
+        PulsarApi.BrokerEntryMetadata entryMetadata =
+                parseBrokerEntryMetadataIfExist(headerAndPayloadWithBrokerEntryMetadata);
+        headerAndPayloadWithBrokerEntryMetadata.readerIndex(readerIndex);
+        return entryMetadata;
+    }
+
     public static ByteBuf serializeMetadataAndPayload(ChecksumType checksumType,
                                                       MessageMetadata msgMetadata, ByteBuf payload) {
         // / Wire format


### PR DESCRIPTION
### Motivation
This pull requeset adds `Commands.peekBrokerEntryMetadataIfExist` method to support peek broker entry metadata.

This will be used in protocol handler KOP.  
Currently, when handles `FetchRequest`, KOP will
1. firset read `Entry` out of ledger
2. get offset from `Enty` for caculating next offset to read from and building `MemoryRecordsBuilder`
3. traverse every `Entry` and add each message into `MemoryRecordsBuilder`
we need the `Entry` twice, first for peeking the offset and second for buiding `MemoryRecordsBuilder`.

So, it's better that pulsar `Commands` can support only peek the broker entry metadata without changing the original entry content.

