### PR TITLE
[docs]add parameter for helm init cluster

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -80,9 +80,14 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 

--- a/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
@@ -81,9 +81,14 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 

--- a/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
@@ -81,9 +81,14 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 

--- a/site2/website/versioned_docs/version-2.6.3/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.3/getting-started-helm.md
@@ -81,9 +81,14 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 

--- a/site2/website/versioned_docs/version-2.7.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.0/getting-started-helm.md
@@ -81,9 +81,14 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 

--- a/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
@@ -81,8 +81,8 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
-   > NOTE: Please specify `--set initialize=true` when installing a release at the first time. `initialize=true` will start initialize jobs
-   >       to initialize the cluster metadata for both bookkeeper and pulsar clusters.
+   > **NOTE**  
+   > You need to specify `--set initialize=true` when installing Pulsar the first time. This command installs and starts Apache Pulsar.
 
     ```bash
     helm install \

--- a/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
@@ -81,6 +81,9 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
 
 3. Use the Pulsar Helm chart to install a Pulsar cluster to Kubernetes.
 
+   > NOTE: Please specify `--set initialize=true` when installing a release at the first time. `initialize=true` will start initialize jobs
+   >       to initialize the cluster metadata for both bookkeeper and pulsar clusters.
+
     ```bash
     helm install \
         --values examples/values-minikube.yaml \

--- a/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
@@ -84,6 +84,8 @@ We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) i
     ```bash
     helm install \
         --values examples/values-minikube.yaml \
+        --set initialize=true \
+        --namespace pulsar \
         pulsar-mini apache/pulsar
     ```
 


### PR DESCRIPTION
### Motivation
Failed to deploy the pulsar cluster on k8s according to the [document](http://pulsar.apache.org/docs/en/kubernetes-helm/#step-2-use-pulsar-admin-to-create-pulsar-tenantsnamespacestopics).

I checked the pulsar-helm [repository](https://github.com/apache/pulsar-helm-chart), need add parameter `--set initialize=true` to initialize the cluster metadata.

So maybe the document needs to be updated