### PR TITLE
[docs] Add manage packages docs

### DIFF
--- a/site2/docs/admin-api-packages.md
+++ b/site2/docs/admin-api-packages.md
@@ -21,7 +21,6 @@ The following is a code sample.
 ```java
 class PackageName {
    private final PackageType type;
-   // REST API handlers.
    private final String namespace;
    private final String tenant;
    private final String name;

--- a/site2/docs/admin-api-packages.md
+++ b/site2/docs/admin-api-packages.md
@@ -1,0 +1,244 @@
+---
+id: admin-api-packages
+title: Manage packages
+sidebar_label: Packages
+---
+
+Package management enables version management and simplifies the upgrade and rollback processes for Functions, Sinks, and Sources. When you use the same function, sink and source in different namespaces, you can upload them to a common package management system.
+
+## Package name
+
+A `package` is identified by five parts: `type`, `tenant`, `namespace`, `package name`, and `version`.
+
+| Part  | Description |
+|-------|-------------|
+|`type` |The type of the package. The following types are supported: `function`, `sink` and `source`. |
+| `name`|The fully qualified name of the package: `<tenant>/<namespace>/<package name>`.|
+|`version`|The version of the package.|
+
+The following is a code sample.
+
+```
+class PackageName {
+   private final PackageType type;
+   // REST API handlers.
+   private final String namespace;
+   private final String tenant;
+   private final String name;
+   private final String version;
+}
+
+enum PackageType {
+   FUNCTION("function"), SINK("sink"), SOURCE("source");
+}
+
+```
+
+## Package URL
+A package is located using a URL. The package URL is written in the following format:
+
+```
+<type>://<tenant>/<namespace>/<package name>@<version>
+```
+
+The following are package URL examples:
+
+`sink://public/default/mysql-sink@1.0`
+`function://my-tenant/my-ns/my-function@0.1`
+`source://my-tenant/my-ns/mysql-cdc-source@2.3`
+
+The package management system stores the data, versions and metadata of each package. The metadata is shown in the following table.
+
+| metadata | Description |
+|----------|-------------|
+|description|The description of the package.|
+|contact    |The contact information of a package. For example, team email.|
+|create_time| The time when the package is created.|
+|modification_time| The time when the package is modified.|
+|properties |A key/value map that enables users to store their own information.|
+
+## Permissions
+
+The packages are organized by the tenant and namespace, so you can apply the tenant and namespace permissions to packages directly.
+
+## Package resources
+You can use the package management with command line tools, REST API and Java client.
+
+### Upload a package
+You can upload a package to the package management service in the following ways.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+```
+
+<!--REST API-->
+
+{@inject: endpoint| POST |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+Upload a package to the package management service synchronously.
+
+```java
+   void upload(PackageMetadata metadata, String packageName, String path) throws PulsarAdminException;
+```
+Upload a package to the package management service asynchronously.
+```java
+   CompletableFuture<Void> uploadAsync(PackageMetadata metadata, String packageName, String path);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Download a package
+You can download a package to the package management service in the following ways.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+```
+
+<!--REST API-->
+
+{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+Download a package to the package management service synchronously.
+
+```java
+   void download(String packageName, String path) throws PulsarAdminException;
+```
+
+Download a package to the package management service asynchronously.
+```java
+   CompletableFuture<Void> downloadAsync(String packageName, String path);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### List all versions of a package
+You can get a list of all versions of a package in the following ways.
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+bin/pulsar-admin packages list --type function public/default
+```
+
+<!--REST API-->
+
+{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+List all versions of a package synchronously.
+
+```java
+   List<String> listPackageVersions(String packageName) throws PulsarAdminException;
+```
+List all versions of a package asynchronously.
+```java
+   CompletableFuture<List<String>> listPackageVersionsAsync(String packageName);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### List all the specified type packages under a namespace
+You can get a list all the packages with the given type in a namespace in the following ways.
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+bin/pulsar-admin packages list --type function public/default
+```
+
+<!--REST API-->
+
+{@inject: endpoint|PUT|/admin/v3/packages/:type/:tenant/:namespace/?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+List all the packages with the given type in a namespace synchronously.
+
+```java
+   List<String> listPackages(String type, String namespace) throws PulsarAdminException;
+```
+List all the packages with the given type in a namespace asynchronously.
+```java
+   CompletableFuture<List<String>> listPackagesAsync(String type, String namespace);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Get the metadata of a package
+You can get the metadata of a package in the following ways.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+
+```shell
+bin/pulsar-admin packages get-metadata function://public/default/test@v1
+```
+
+<!--REST API-->
+
+{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}/metadata
+
+<!--JAVA-->
+Get the metadata of a package synchronously.
+
+```java
+   PackageMetadata getMetadata(String packageName) throws PulsarAdminException;
+```
+Get the metadata of a package asynchronously.
+```java
+   CompletableFuture<PackageMetadata> getMetadataAsync(String packageName);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Update the metadata of a package
+You can update the metadata of a package in the following ways.
+...
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+bin/pulsar-admin packages update-metadata function://public/default/example@v0.1 --description update-description
+```
+
+<!--REST API-->
+
+{@inject: endpoint| PUT |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}/metadata
+
+<!--JAVA-->
+Update a package metadata information synchronously.
+
+```java
+   void updateMetadata(String packageName, PackageMetadata metadata) throws PulsarAdminException;
+```
+Update a package metadata information asynchronously.
+```java
+   CompletableFuture<Void> updateMetadataAsync(String packageName, PackageMetadata metadata);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Delete a specified package
+You can delete a specified package with its package name in the following ways.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+The following command example deletes a package of version 0.1.
+
+```shell
+bin/pulsar-admin packages delete functions://public/default/example@v0.1
+```
+
+<!--REST API-->
+
+https://pulsar.apache.org/admin/v3/packages/{type}/{tenant}/{namespace}/{packageName}/{version}
+
+{@inject: endpoint| DELETE |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+
+<!--JAVA-->
+Delete a specified package synchronously.
+
+```java
+   void delete(String packageName) throws PulsarAdminException;
+```
+Delete a specified package asynchronously.
+```java
+   CompletableFuture<Void> deleteAsync(String packageName);
+```
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/docs/admin-api-packages.md
+++ b/site2/docs/admin-api-packages.md
@@ -18,7 +18,7 @@ A `package` is identified by five parts: `type`, `tenant`, `namespace`, `package
 
 The following is a code sample.
 
-```
+```java
 class PackageName {
    private final PackageType type;
    // REST API handlers.
@@ -37,14 +37,14 @@ enum PackageType {
 ## Package URL
 A package is located using a URL. The package URL is written in the following format:
 
-```
+```shell
 <type>://<tenant>/<namespace>/<package name>@<version>
 ```
 
 The following are package URL examples:
 
-`sink://public/default/mysql-sink@1.0`
-`function://my-tenant/my-ns/my-function@0.1`
+`sink://public/default/mysql-sink@1.0`   
+`function://my-tenant/my-ns/my-function@0.1`   
 `source://my-tenant/my-ns/mysql-cdc-source@2.3`
 
 The package management system stores the data, versions and metadata of each package. The metadata is shown in the following table.
@@ -55,7 +55,7 @@ The package management system stores the data, versions and metadata of each pac
 |contact    |The contact information of a package. For example, team email.|
 |create_time| The time when the package is created.|
 |modification_time| The time when the package is modified.|
-|properties |A key/value map that enables users to store their own information.|
+|properties |A key/value map that stores your own information.|
 
 ## Permissions
 
@@ -75,7 +75,7 @@ bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path 
 
 <!--REST API-->
 
-{@inject: endpoint| POST |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+{@inject: endpoint| POST |admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 Upload a package to the package management service synchronously.
@@ -100,7 +100,7 @@ bin/pulsar-admin packages download functions://public/default/example@v0.1 --pat
 
 <!--REST API-->
 
-{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 Download a package to the package management service synchronously.
@@ -140,7 +140,7 @@ List all versions of a package asynchronously.
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List all the specified type packages under a namespace
-You can get a list all the packages with the given type in a namespace in the following ways.
+You can get a list of all the packages with the given type in a namespace in the following ways.
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
@@ -175,7 +175,7 @@ bin/pulsar-admin packages get-metadata function://public/default/test@v1
 
 <!--REST API-->
 
-{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}/metadata
+{@inject: endpoint| GET |admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata/?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 Get the metadata of a package synchronously.
@@ -191,7 +191,6 @@ Get the metadata of a package asynchronously.
 
 ### Update the metadata of a package
 You can update the metadata of a package in the following ways.
-...
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
@@ -200,7 +199,7 @@ bin/pulsar-admin packages update-metadata function://public/default/example@v0.1
 
 <!--REST API-->
 
-{@inject: endpoint| PUT |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}/metadata
+{@inject: endpoint| PUT |admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/metadata/?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 Update a package metadata information synchronously.
@@ -227,9 +226,7 @@ bin/pulsar-admin packages delete functions://public/default/example@v0.1
 
 <!--REST API-->
 
-https://pulsar.apache.org/admin/v3/packages/{type}/{tenant}/{namespace}/{packageName}/{version}
-
-{@inject: endpoint| DELETE |admin/v3/packages/:type/:tenant/:namespace/:packageName/?version=[[pulsar:version_number]]}
+{@inject: endpoint| DELETE |admin/v3/packages/:type/:tenant/:namespace/:packageName/:version/?version=[[pulsar:version_number]]}
 
 <!--JAVA-->
 Delete a specified package synchronously.

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -123,7 +123,8 @@
       "admin-api-namespaces",
       "admin-api-permissions",
       "admin-api-topics",
-      "admin-api-functions"
+      "admin-api-functions",
+      "admin-api-packages"
     ],
     "Adaptors": [
       "adaptors-kafka",


### PR DESCRIPTION
### Motivation
In [PIP-50](https://github.com/apache/pulsar/wiki/PIP-50%3A-Package-Management), we introduce a new way to manage packages.

### Modifications

Add related doc content based on the PIP and [REST API](https://pulsar.apache.org/packages-rest-api/?version=master&apiversion=v3#operation/listPackages).