### PR TITLE
Fix regression in apply-config-from-env.py

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -57,10 +57,6 @@ for conf_filename in conf_files:
     for k in sorted(os.environ.keys()):
         v = os.environ[k].strip()
 
-        # Quote the value if it contains a space.
-        if v.find(" ") >= 0:
-            v = '\"%s\"' % v
-
         # Hide the value in logs if is password.
         if "password" in k:
             displayValue = "********"
@@ -80,10 +76,6 @@ for conf_filename in conf_files:
         v = os.environ[k]
         if not k.startswith(PF_ENV_PREFIX):
             continue
-
-        # Quote the value if it contains a space.
-        if v.find(" ") >= 0:
-            v = '\"%s\"' % v
 
         # Hide the value in logs if is password.
         if "password" in k:

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@ flexible messaging model and an intuitive client API.</description>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-    <testReuseFork>false</testReuseFork>
-    <testForkCount>1</testForkCount>
+    <testReuseFork>true</testReuseFork>
+    <testForkCount>4</testForkCount>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
     <docker.organization>apachepulsar</docker.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@ flexible messaging model and an intuitive client API.</description>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-    <testReuseFork>true</testReuseFork>
-    <testForkCount>4</testForkCount>
+    <testReuseFork>false</testReuseFork>
+    <testForkCount>1</testForkCount>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
     <docker.organization>apachepulsar</docker.organization>


### PR DESCRIPTION
### Motivation

Fix the regression that introduced in #8709 

In #8709, if values contain spaces, the value will be wrapped as "value", this will introduce break changes while users already have some configs with the value that contains spaces, so this PR is reverting this change.

If users want to ensure some values are processed as a group, they should use `export key=\"value\"` instead of implicitly adding `""` when encountering spaces

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
