### PR TITLE
Fix master broker while subscribe to non-persistent partitioned topic without topic auto-creation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1635,7 +1635,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                         final ClusterReplicationMetrics clusterReplicationMetrics = pulsarStats
                                 .getClusterReplicationMetrics();
                         replicationClients.forEach((cluster, client) -> {
-                            clusterReplicationMetrics.remove(clusterReplicationMetrics.getKeyName(namespaceName, cluster));
+                            clusterReplicationMetrics.remove(clusterReplicationMetrics.getKeyName(namespaceName,
+                                    cluster));
                         });
                     }
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1623,19 +1623,21 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             synchronized (multiLayerTopicsMap) {
                 ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>> namespaceMap = multiLayerTopicsMap
                         .get(namespaceName);
-                ConcurrentOpenHashMap<String, Topic> bundleMap = namespaceMap.get(bundleName);
-                bundleMap.remove(topic);
-                if (bundleMap.isEmpty()) {
-                    namespaceMap.remove(bundleName);
-                }
+                if (namespaceMap != null) {
+                    ConcurrentOpenHashMap<String, Topic> bundleMap = namespaceMap.get(bundleName);
+                    bundleMap.remove(topic);
+                    if (bundleMap.isEmpty()) {
+                        namespaceMap.remove(bundleName);
+                    }
 
-                if (namespaceMap.isEmpty()) {
-                    multiLayerTopicsMap.remove(namespaceName);
-                    final ClusterReplicationMetrics clusterReplicationMetrics = pulsarStats
-                            .getClusterReplicationMetrics();
-                    replicationClients.forEach((cluster, client) -> {
-                        clusterReplicationMetrics.remove(clusterReplicationMetrics.getKeyName(namespaceName, cluster));
-                    });
+                    if (namespaceMap.isEmpty()) {
+                        multiLayerTopicsMap.remove(namespaceName);
+                        final ClusterReplicationMetrics clusterReplicationMetrics = pulsarStats
+                                .getClusterReplicationMetrics();
+                        replicationClients.forEach((cluster, client) -> {
+                            clusterReplicationMetrics.remove(clusterReplicationMetrics.getKeyName(namespaceName, cluster));
+                        });
+                    }
                 }
             }
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
@@ -63,15 +63,15 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    @Test(dataProvider = "topicDomainProvider")
+    @Test(dataProvider = "topicDomainProvider", timeOut = 60000)
     public void testCreateConsumerForPartitionedTopicWhenDisableTopicAutoCreation(TopicDomain domain) throws PulsarAdminException, PulsarClientException {
-        conf.setAllowAutoTopicCreation(false);
+        conf.setAllowAutoTopicCreation(domain.equals(TopicDomain.non_persistent));
         final String topic = domain.value() + "://public/default/testCreateConsumerWhenDisableTopicAutoCreation";
         admin.topics().createPartitionedTopic(topic, 3);
         Assert.assertNotNull(pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe());
     }
 
-    @Test(dataProvider = "topicDomainProvider")
+    @Test(dataProvider = "topicDomainProvider", timeOut = 60000)
     public void testCreateConsumerForNonPartitionedTopicWhenDisableTopicAutoCreation(TopicDomain domain) throws PulsarClientException {
         conf.setAllowAutoTopicCreation(false);
         final String topic = domain.value() + "://public/default/testCreateConsumerForNonPartitionedTopicWhenDisableTopicAutoCreation";
@@ -88,7 +88,7 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         }
     }
 
-    @Test(dataProvider = "topicDomainProvider")
+    @Test(dataProvider = "topicDomainProvider", timeOut = 60000)
     public void testCreateConsumerForPartitionedTopicWhenEnableTopicAutoCreation(TopicDomain domain) throws PulsarAdminException, PulsarClientException {
         conf.setAllowAutoTopicCreation(true);
         final String topic = domain.value() + "://public/default/testCreateConsumerForPartitionedTopicWhenEnableTopicAutoCreation";
@@ -96,14 +96,14 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         Assert.assertNotNull(pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe());
     }
 
-    @Test(dataProvider = "topicDomainProvider")
+    @Test(dataProvider = "topicDomainProvider", timeOut = 60000)
     public void testCreateConsumerForNonPartitionedTopicWhenEnableTopicAutoCreation(TopicDomain domain) throws PulsarClientException {
         conf.setAllowAutoTopicCreation(true);
         final String topic = domain.value() + "://public/default/testCreateConsumerForNonPartitionedTopicWhenEnableTopicAutoCreation";
         Assert.assertNotNull(pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe());
     }
 
-    @Test
+    @Test(timeOut = 60000)
     public void testCreateConsumerForPartitionedTopicUpdateWhenDisableTopicAutoCreation() throws Exception {
         conf.setAllowAutoTopicCreation(false);
         final String topic = "testCreateConsumerForPartitionedTopicUpdateWhenDisableTopicAutoCreation-" + System.currentTimeMillis();
@@ -118,7 +118,7 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         Assert.assertEquals(consumer.getConsumers().size(), 5);
     }
 
-    @Test
+    @Test(timeOut = 60000)
     public void testCreateMissedPartitions() throws JsonProcessingException, KeeperException, InterruptedException, PulsarAdminException, PulsarClientException {
         conf.setAllowAutoTopicCreation(false);
         final String topic = "testCreateMissedPartitions";


### PR DESCRIPTION
### Motivation

After #9029 merged, the non-persistent topic can be created when enabling the topic auto-creation, Otherwise, the client will get a `Topic does not exist` exception. This looks like a concurrent merge related issue, but I'm not able to find another PR related to this issue.

This PR is fixing the test that wants to subscribe to a partitioned non-persistent topic but disabled the topic auto-creation. Currently, the fix is enabling the topic auto-creation for the test. For non-persistent topics, we don't persist any metadata for it in the metadata server, so for users who want to use the non-persistent topic, they must enable the topic auto-creation.

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
