### PR TITLE
[docs]Add topic-level policy config

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1766,7 +1766,7 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
-From Pulsar 2.7.0, you can set topic-level policies. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+From Pulsar 2.7.0, the namespace level policies are available on topic  level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
 
 ```shell
 systemTopicEnabled=true

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1759,11 +1759,18 @@ Options
 |`--broker`|Broker name to get namespace-isolation policies attached to it||
 
 ## `topics`
-Operations for managing Pulsar topics (both persistent and non persistent)
+Operations for managing Pulsar topics (both persistent and non-persistent). 
 
 Usage
 ```bash
 $ pulsar-admin topics subcommand
+```
+
+From Pulsar 2.7.0, you can set topic-level policies. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+
+```shell
+systemTopicEnabled=true
+topicLevelPoliciesEnabled=true
 ```
 
 Subcommands

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1766,7 +1766,7 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
-From Pulsar 2.7.0, some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+From Pulsar 2.7.0, some namespace-level policies are available on topic level. To enable topic-level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
 
 ```shell
 systemTopicEnabled=true
@@ -1822,6 +1822,36 @@ Subcommands
 * `get-deduplication`
 * `set-deduplication`
 * `remove-deduplication`
+* `get-max-producers`
+* `set-max-producers`
+* `remove-max-producers`
+* `get-max-consumers`
+* `set-max-consumers`
+* `remove-max-consumers`
+* `get-retention`
+* `set-retention`
+* `remove-retention`
+* `get-dispatch-rate`
+* `set-dispatch-rate`
+* `remove-dispatch-rate`
+* `get-compaction-threshold`
+* `set-compaction-threshold`
+* `remove-compaction-threshold`
+* `get-offload-policies`
+* `set-offload-policies`
+* `remove-offload-policies`
+* `get-max-unacked-messages-per-subscription`
+* `set-max-unacked-messages-per-subscription`
+* `remove-max-unacked-messages-per-subscription`
+* `get-max-unacked-messages-per-consumer`
+* `set-max-unacked-messages-per-consumer`
+* `remove-max-unacked-messages-per-consumer`
+* `get-delayed-delivery`
+* `set-delayed-delivery`
+* `remove-delayed-delivery`
+* `get-inactive-topic-policies`
+* `set-inactive-topic-policies`
+* `remove-inactive-topic-policies`
 
 ### `compact`
 Run compaction on the specified topic (persistent topics only)

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1766,7 +1766,7 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
-From Pulsar 2.7.0, the namespace level policies are available on topic  level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+From Pulsar 2.7.0, some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
 
 ```shell
 systemTopicEnabled=true

--- a/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
@@ -1764,7 +1764,7 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
-Some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+Some namespace-level policies are available on topic level. To enable topic-level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
 
 ```shell
 systemTopicEnabled=true
@@ -1820,6 +1820,36 @@ Subcommands
 * `get-deduplication`
 * `set-deduplication`
 * `remove-deduplication`
+* `get-max-producers`
+* `set-max-producers`
+* `remove-max-producers`
+* `get-max-consumers`
+* `set-max-consumers`
+* `remove-max-consumers`
+* `get-retention`
+* `set-retention`
+* `remove-retention`
+* `get-dispatch-rate`
+* `set-dispatch-rate`
+* `remove-dispatch-rate`
+* `get-compaction-threshold`
+* `set-compaction-threshold`
+* `remove-compaction-threshold`
+* `get-offload-policies`
+* `set-offload-policies`
+* `remove-offload-policies`
+* `get-max-unacked-messages-per-subscription`
+* `set-max-unacked-messages-per-subscription`
+* `remove-max-unacked-messages-per-subscription`
+* `get-max-unacked-messages-per-consumer`
+* `set-max-unacked-messages-per-consumer`
+* `remove-max-unacked-messages-per-consumer`
+* `get-delayed-delivery`
+* `set-delayed-delivery`
+* `remove-delayed-delivery`
+* `get-inactive-topic-policies`
+* `set-inactive-topic-policies`
+* `remove-inactive-topic-policies`
 
 ### `compact`
 Run compaction on the specified topic (persistent topics only)

--- a/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
@@ -1764,6 +1764,13 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
+Some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+
+```shell
+systemTopicEnabled=true
+topicLevelPoliciesEnabled=true
+```
+
 Subcommands
 * `compact`
 * `compaction-status`

--- a/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
@@ -1767,7 +1767,7 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
-Some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+Some namespace-level policies are available on topic level. To enable topic-level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
 
 ```shell
 systemTopicEnabled=true
@@ -1823,6 +1823,36 @@ Subcommands
 * `get-deduplication`
 * `set-deduplication`
 * `remove-deduplication`
+* `get-max-producers`
+* `set-max-producers`
+* `remove-max-producers`
+* `get-max-consumers`
+* `set-max-consumers`
+* `remove-max-consumers`
+* `get-retention`
+* `set-retention`
+* `remove-retention`
+* `get-dispatch-rate`
+* `set-dispatch-rate`
+* `remove-dispatch-rate`
+* `get-compaction-threshold`
+* `set-compaction-threshold`
+* `remove-compaction-threshold`
+* `get-offload-policies`
+* `set-offload-policies`
+* `remove-offload-policies`
+* `get-max-unacked-messages-per-subscription`
+* `set-max-unacked-messages-per-subscription`
+* `remove-max-unacked-messages-per-subscription`
+* `get-max-unacked-messages-per-consumer`
+* `set-max-unacked-messages-per-consumer`
+* `remove-max-unacked-messages-per-consumer`
+* `get-delayed-delivery`
+* `set-delayed-delivery`
+* `remove-delayed-delivery`
+* `get-inactive-topic-policies`
+* `set-inactive-topic-policies`
+* `remove-inactive-topic-policies`
 
 ### `compact`
 Run compaction on the specified topic (persistent topics only)

--- a/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
@@ -1767,6 +1767,13 @@ Usage
 $ pulsar-admin topics subcommand
 ```
 
+Some namespace level policies are available on topic level. To enable topic level policy in Pulsar, you need to configure the following parameters in the `broker.conf` file. 
+
+```shell
+systemTopicEnabled=true
+topicLevelPoliciesEnabled=true
+```
+
 Subcommands
 * `compact`
 * `compaction-status`


### PR DESCRIPTION
### Motivation
Topic-level policies are available since Pulsar 2.7.0.

### Modifications

Add how to configure topic-level policies.

Related to #9161 