### PR TITLE
[docs] Update tlsProviderFactoryClass example in bookkeeper.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -174,7 +174,7 @@ maxPendingAddRequestsPerThread=10000
 # tlsProvider=OpenSSL
 
 # The path to the class that provides security.
-# tlsProviderFactoryClass=org.apache.bookkeeper.security.SSLContextFactory
+# tlsProviderFactoryClass=org.apache.bookkeeper.tls.TLSContextFactory
 
 # Type of security used by server.
 # tlsClientAuthentication=true


### PR DESCRIPTION
### Motivation

`SSLContextFactory` got renamed to `TLSContextFactory` in bookkeeper 4.6.0

Refs https://github.com/apache/bookkeeper/pull/2307





Without this change, bookeeper won't start when TLS is enabled.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
