### PR TITLE
Upgrade TestContainers to 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@ flexible messaging model and an intuitive client API.</description>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
+    <docker-java.version>3.2.7</docker-java.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -599,6 +600,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
+      </dependency>
+      
+      <dependency>
+         <groupId>com.github.docker-java</groupId>
+         <artifactId>docker-java-core</artifactId>
+         <version>${docker-java.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
     <disruptor.version>3.4.0</disruptor.version>
-    <testcontainers.version>1.14.3</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.3.0</testng.version>
     <mockito.version>3.0.0</mockito.version>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -121,6 +121,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-io-jdbc-postgres</artifactId>
       <version>${project.version}</version>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -47,14 +47,14 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     }
 
     protected void beforeStop() {
-        if (null == containerId) {
+        if (null == getContainerId()) {
             return;
         }
 
         // dump the container log
         DockerUtils.dumpContainerLogToTarget(
             getDockerClient(),
-            containerId
+            getContainerId()
         );
     }
 
@@ -66,7 +66,7 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
 
     public void tailContainerLog() {
         CompletableFuture.runAsync(() -> {
-            while (null == containerId) {
+            while (null == getContainerId()) {
                 try {
                     TimeUnit.MILLISECONDS.sleep(100);
                 } catch (InterruptedException e) {
@@ -74,7 +74,7 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
                 }
             }
 
-            LogContainerCmd logContainerCmd = this.dockerClient.logContainerCmd(containerId);
+            LogContainerCmd logContainerCmd = this.dockerClient.logContainerCmd(getContainerId());
             logContainerCmd.withStdOut(true).withStdErr(true).withFollowStream(true);
             logContainerCmd.exec(new LogContainerResultCallback() {
                 @Override
@@ -88,7 +88,7 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     public String getContainerLog() {
         StringBuilder sb = new StringBuilder();
 
-        LogContainerCmd logContainerCmd = this.dockerClient.logContainerCmd(containerId);
+        LogContainerCmd logContainerCmd = this.dockerClient.logContainerCmd(getContainerId());
         logContainerCmd.withStdOut(true).withStdErr(true);
         try {
             logContainerCmd.exec(new LogContainerResultCallback() {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PrestoWorkerContainer.java
@@ -43,10 +43,10 @@ public class PrestoWorkerContainer extends PulsarContainer<PrestoWorkerContainer
     @Override
     protected void beforeStop() {
         super.beforeStop();
-        if (null != containerId) {
+        if (null != getContainerId()) {
             DockerUtils.dumpContainerDirToTargetCompressed(
                     getDockerClient(),
-                    containerId,
+                    getContainerId(),
                     "/pulsar/lib/presto/var/log"
             );
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -100,10 +100,10 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
     @Override
     protected void beforeStop() {
         super.beforeStop();
-        if (null != containerId) {
+        if (null != getContainerId()) {
             DockerUtils.dumpContainerDirToTargetCompressed(
                 getDockerClient(),
-                containerId,
+                getContainerId(),
                 "/var/log/pulsar"
             );
         }
@@ -149,7 +149,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
         beforeStart();
         super.start();
         afterStart();
-        log.info("Start pulsar service {} at container {}", serviceName, containerName);
+        log.info("Start pulsar service {} at container {}", serviceName, getContainerId());
     }
 
     @Override
@@ -159,13 +159,13 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
         }
 
         PulsarContainer another = (PulsarContainer) o;
-        return containerName.equals(another.containerName)
+        return getContainerId().equals(another.getContainerId())
             && super.equals(another);
     }
 
     @Override
     public int hashCode() {
         return 31 * super.hashCode() + Objects.hash(
-            containerName);
+                getContainerId());
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/WorkerContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/WorkerContainer.java
@@ -41,10 +41,10 @@ public class WorkerContainer extends PulsarContainer<WorkerContainer> {
     @Override
     protected void beforeStop() {
         super.beforeStop();
-        if (null != containerId) {
+        if (null != getContainerId()) {
             DockerUtils.dumpContainerDirToTargetCompressed(
                     getDockerClient(),
-                    containerId,
+                    getContainerId(),
                     "/pulsar/logs/functions"
             );
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
@@ -61,10 +61,10 @@ public class ZKContainer<SelfT extends PulsarContainer<SelfT>> extends PulsarCon
     @Override
     protected void beforeStop() {
         super.beforeStop();
-        if (null != containerId && dumpZkDataBeforeStop) {
+        if (null != getContainerId() && dumpZkDataBeforeStop) {
             DockerUtils.dumpContainerDirToTargetCompressed(
                 getDockerClient(),
-                containerId,
+                getContainerId(),
                 "/pulsar/data/zookeeper"
             );
         }


### PR DESCRIPTION
### Motivation

Integration tests are failing on Macs with newer versions of Docker. 

The problem is described in https://github.com/testcontainers/testcontainers-java/issues/3166 and there's a fix in TestContainers 1.15.1.