### PR TITLE
[Docs]Add documentation for consumerless subscriptions and their modes

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -243,10 +243,7 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
 ### Consumerless Subscriptions and Their Corresponding Modes
-If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
-includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
-option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
-connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+When a subscription has no consumers, its subscription mode is undefined. A subscription's mode is defined when a consumer connects to the subscription, and the mode can be changed by restarting all consumers with a different configuration.
 
 ### Exclusive
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -242,6 +242,12 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers(shared, failover, key_shared).
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
+### Consumerless Subscriptions and Their Corresponding Modes
+If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
+includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
+option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
+connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+
 ### Exclusive
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If multiple consumers subscribe to a topic using the same subscription, an error occurs.

--- a/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
@@ -244,10 +244,7 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
 ### Consumerless Subscriptions and Their Corresponding Modes
-If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
-includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
-option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
-connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+When a subscription has no consumers, its subscription mode is undefined. A subscription's mode is defined when a consumer connects to the subscription, and the mode can be changed by restarting all consumers with a different configuration.
 
 ### Exclusive
 

--- a/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
@@ -243,6 +243,12 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers(shared, failover, key_shared).
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
+### Consumerless Subscriptions and Their Corresponding Modes
+If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
+includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
+option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
+connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+
 ### Exclusive
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If multiple consumers subscribe to a topic using the same subscription, an error occurs.

--- a/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
@@ -244,10 +244,7 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
 ### Consumerless Subscriptions and Their Corresponding Modes
-If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
-includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
-option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
-connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+When a subscription has no consumers, its subscription mode is undefined. A subscription's mode is defined when a consumer connects to the subscription, and the mode can be changed by restarting all consumers with a different configuration.
 
 ### Exclusive
 

--- a/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
@@ -243,6 +243,12 @@ A subscription is a named configuration rule that determines how messages are de
 > * If you want to achieve "message queuing" among consumers, share the same subscription name among multiple consumers(shared, failover, key_shared).
 > * If you want to achieve both effects simultaneously, combine exclusive subscription mode with other subscription modes for consumers.
 
+### Consumerless Subscriptions and Their Corresponding Modes
+If, at any point in time, there are no consumers for a given subscription, a subscription has no specified mode. This
+includes new subscriptions and existing subscriptions that no longer have any consumers. As a consequence, there is no
+option to specify the subscription mode when creating a subscription. The mode is established when the consumer makes its
+connection, and the mode can be "changed" by restarting all consumers with a different configuration.
+
 ### Exclusive
 
 In *exclusive* mode, only a single consumer is allowed to attach to the subscription. If multiple consumers subscribe to a topic using the same subscription, an error occurs.


### PR DESCRIPTION
### Motivation

This PR seeks to clarify subscriptions without consumers by adding new documentation. In https://github.com/apache/pulsar/issues/8906, @merlimat helped me understand these subscriptions, and this PR adds that knowledge to the documentation. [Here](https://github.com/apache/pulsar/issues/8906#issuecomment-742836792) is the specific comment that provides the basis for this PR.

### Modifications

Adds documentation in the subscription mode section to describe how subscription modes are defined and that they are undefined when there aren't consumers.

This is only a documentation change.
