### PR TITLE
set service-url required to false, service-url is not required if ena…

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -216,6 +216,18 @@ public class PulsarAdminToolTest {
 
         clusters.run(split("get-peer-clusters my-cluster"));
         verify(mockClusters).getPeerClusterNames("my-cluster");
+
+        // test create cluster without --url
+        clusters = new CmdClusters(admin);
+
+        clusters.run(split("create my-secure-cluster --url-secure https://my-service.url:4443"));
+        verify(mockClusters).createCluster("my-secure-cluster", new ClusterData(null, "https://my-service.url:4443"));
+
+        clusters.run(split("update my-secure-cluster --url-secure https://my-service.url:4443"));
+        verify(mockClusters).updateCluster("my-secure-cluster", new ClusterData(null, "https://my-service.url:4443"));
+
+        clusters.run(split("delete my-secure-cluster"));
+        verify(mockClusters).deleteCluster("my-secure-cluster");
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -58,7 +58,7 @@ public class CmdClusters extends CmdBase {
         @Parameter(description = "cluster-name\n", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--url", description = "service-url", required = true)
+        @Parameter(names = "--url", description = "service-url", required = false)
         private String serviceUrl;
 
         @Parameter(names = "--url-secure", description = "service-url for secure connection", required = false)
@@ -89,7 +89,7 @@ public class CmdClusters extends CmdBase {
         @Parameter(description = "cluster-name\n", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--url", description = "service-url", required = true)
+        @Parameter(names = "--url", description = "service-url", required = false)
         private String serviceUrl;
 
         @Parameter(names = "--url-secure", description = "service-url for secure connection", required = false)


### PR DESCRIPTION
Fixes #9126

Master Issue: #<xyz>

### Motivation
there is ` --url ` required restriction for adding cluster if TLS is enabled, here we only need the --url-secure/--broker-url-secure params

### Modifications
set `service-url` required to false, `service-url` is not required if enable TLS for pulsar cluster.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
