### PR TITLE
[MINOR] remove duplicate test case in MessageChunkingTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -80,18 +80,6 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    @Test
-    public void testInvalidConfig() throws Exception {
-        final String topicName = "persistent://my-property/my-ns/my-topic1";
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
-        // batching and chunking can't be enabled together
-        try {
-            Producer<byte[]> producer = producerBuilder.enableChunking(true).enableBatching(true).create();
-            fail("producer creation should have fail");
-        } catch (IllegalArgumentException ie) {
-            // Ok
-        }
-    }
 
     @Test
     public void testLargeMessage() throws Exception {


### PR DESCRIPTION
both testInvalidConfig and testInvalidUseCaseForChunking are test the same logic.
remove testInvalidConfig

see 
https://github.com/apache/pulsar/blob/2fd878a8f4bfdd5cffa7fa6450714ec1ad25f514/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java#L89
and 
https://github.com/apache/pulsar/blob/2fd878a8f4bfdd5cffa7fa6450714ec1ad25f514/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java#L316