### PR TITLE
PIP-45: Add MetadataCache implementation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -82,7 +82,7 @@ import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Stat;
-import org.apache.pulsar.metadata.impl.zookeeper.ZKMetadataStore;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -109,7 +109,7 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.metadata.api.Stat;
-import org.apache.pulsar.metadata.impl.zookeeper.ZKMetadataStore;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.MockZooKeeper;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
@@ -32,7 +32,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.metadata.api.Stat;
-import org.apache.pulsar.metadata.impl.zookeeper.ZKMetadataStore;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.MockZooKeeper;

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -34,6 +34,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -18,14 +18,17 @@
  */
 package org.apache.pulsar.metadata.api;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.Beta;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.cache.MetadataCache;
 
 /**
  * Metadata store client interface.
@@ -56,7 +59,7 @@ public interface MetadataStore extends AutoCloseable {
      * If the path itself does not exist, it will return an empty list.
      *
      * @param path
-     *            webSocketProxyEnabled
+     *            the path of the key to get from the store
      * @return a future to track the async request
      */
     CompletableFuture<List<String>> getChildren(String path);
@@ -109,4 +112,32 @@ public interface MetadataStore extends AutoCloseable {
      * @return a future to track the async request
      */
     CompletableFuture<Void> delete(String path, Optional<Long> expectedVersion);
+
+    /**
+     * Register a listener that will be called on changes in the underlying store.
+     *
+     * @param listener
+     *            a consumer of notifications
+     */
+    void registerListener(Consumer<Notification> listener);
+
+    /**
+     * Create a metadata cache specialized for a specific class.
+     *
+     * @param <T>
+     * @param clazz
+     *            the class type to be used for serialization/deserialization
+     * @return the metadata cache object
+     */
+    <T> MetadataCache<T> getMetadataCache(Class<T> clazz);
+
+    /**
+     * Create a metadata cache specialized for a specific class.
+     *
+     * @param <T>
+     * @param typeRef
+     *            the type ref description to be used for serialization/deserialization
+     * @return the metadata cache object
+     */
+    <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef);
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
@@ -22,7 +22,8 @@ import java.io.IOException;
 
 import lombok.experimental.UtilityClass;
 
-import org.apache.pulsar.metadata.impl.zookeeper.ZKMetadataStore;
+import org.apache.pulsar.metadata.impl.LocalMemoryMetadataStore;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 
 /**
  * Factory class for {@link MetadataStore}.
@@ -41,6 +42,10 @@ public class MetadataStoreFactory {
      *             if the metadata store initialization fails
      */
     public static MetadataStore create(String metadataURL, MetadataStoreConfig metadataStoreConfig) throws IOException {
-        return new ZKMetadataStore(metadataURL, metadataStoreConfig);
+        if (metadataURL.startsWith("memory://")) {
+            return new LocalMemoryMetadataStore(metadataURL, metadataStoreConfig);
+        } else {
+            return new ZKMetadataStore(metadataURL, metadataStoreConfig);
+        }
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import lombok.Data;
+
+@Data
+public final class Notification {
+    /**
+     * The type of the event being notified.
+     */
+    private final NotificationType type;
+
+    /**
+     * Path of the kev/value pair interested by the notification
+     */
+    private final String path;
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/NotificationType.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/NotificationType.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+public enum NotificationType {
+    Created,
+    Modified,
+    ChildrenChanged,
+    Deleted
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/MetadataCache.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.cache;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+
+/**
+ * Represent the caching layer access for a specific type of objects.
+ */
+public interface MetadataCache<T> {
+
+    /**
+     * Tries to fetch one item from the cache or fallback to the store if not present.
+     * <p>
+     * If the key is not found, the {@link Optional} will be empty.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Optional<T>> get(String path);
+
+    /**
+     * Check if an object is present in cache without triggering a load from the metadata store.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @return the cached object or an empty {@link Optional} is the cache doesn't have the object
+     */
+    Optional<T> getIfCached(String path);
+
+    /**
+     * Return all the nodes (lexicographically sorted) that are children to the specific path.
+     *
+     * If the path itself does not exist, it will return an empty list.
+     *
+     * @param path
+     *            the path of the key to get from the store
+     * @return a future to track the async request
+     */
+    CompletableFuture<List<String>> getChildren(String path);
+
+    /**
+     * Read whether a specific path exists.
+     *
+     * Note: In case of keys with multiple levels (eg: '/a/b/c'), checking the existence of a parent (eg. '/a') might
+     * not necessarily return true, unless the key had been explicitly created.
+     *
+     * @param path
+     *            the path of the key to check on the store
+     * @return a future to track the async request
+     */
+    CompletableFuture<Boolean> exists(String path);
+
+    /**
+     * Perform an atomic read-modify-update of the value.
+     * <p>
+     * The modify function can potentially be called multiple times if there are concurrent updates happening.
+     * <p>
+     * If the object does not exist yet, the <code>modifyFunction</code> will get passed an {@link Optional#empty()}
+     * object.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @param modifyFunction
+     *            a function that will be passed the current value and returns a modified value to be stored
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Void> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction);
+
+    /**
+     * Perform an atomic read-modify-update of the value.
+     * <p>
+     * The modify function can potentially be called multiple times if there are concurrent updates happening.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @param modifyFunction
+     *            a function that will be passed the current value and returns a modified value to be stored
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Void> readModifyUpdate(String path, Function<T, T> modifyFunction);
+
+    /**
+     * Create a new object in the metadata store.
+     * <p>
+     * This operation will make sure to keep the cache consistent.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @param value
+     *            the object to insert in metadata store
+     * @return a future to track the completion of the operation
+     * @throws AlreadyExistsException
+     *             If the object is already present.
+     */
+    CompletableFuture<Void> create(String path, T value);
+
+    /**
+     * Delete an object from the metadata store.
+     * <p>
+     * This operation will make sure to keep the cache consistent.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @return a future to track the completion of the operation
+     * @throws NotFoundException
+     *             if the object is not present in the metadata store.
+     */
+    CompletableFuture<Void> delete(String path);
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeSimpleType.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeSimpleType.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.cache.impl;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+import java.io.IOException;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+public class JSONMetadataSerdeSimpleType<T> implements MetadataSerde<T> {
+
+    private final JavaType typeRef;
+
+    public JSONMetadataSerdeSimpleType(JavaType typeRef) {
+        this.typeRef = typeRef;
+    }
+
+    @Override
+    public byte[] serialize(T value) throws IOException {
+        return ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value);
+    }
+
+    @Override
+    public T deserialize(byte[] content) throws IOException {
+        return ObjectMapperFactory.getThreadLocal().readValue(content, typeRef);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.cache.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.io.IOException;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+public class JSONMetadataSerdeTypeRef<T> implements MetadataSerde<T> {
+
+    private final TypeReference<T> typeRef;
+
+    public JSONMetadataSerdeTypeRef(TypeReference<T> typeRef) {
+        this.typeRef = typeRef;
+    }
+
+    @Override
+    public byte[] serialize(T value) throws IOException {
+        return ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value);
+    }
+
+    @Override
+    public T deserialize(byte[] content) throws IOException {
+        return ObjectMapperFactory.getThreadLocal().readValue(content, typeRef);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -1,0 +1,246 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.cache.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.cache.MetadataCache;
+
+public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notification> {
+
+    private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    private final MetadataStore store;
+    private final MetadataSerde<T> serde;
+
+    private final AsyncLoadingCache<String, Optional<Entry<T, Stat>>> objCache;
+
+    public MetadataCacheImpl(MetadataStore store, TypeReference<T> typeRef) {
+        this(store, new JSONMetadataSerdeTypeRef<>(typeRef));
+    }
+
+    public MetadataCacheImpl(MetadataStore store, JavaType type) {
+        this(store, new JSONMetadataSerdeSimpleType<>(type));
+    }
+
+    private MetadataCacheImpl(MetadataStore store, MetadataSerde<T> serde) {
+        this.store = store;
+        this.serde = serde;
+
+        this.objCache = Caffeine.newBuilder()
+                .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .buildAsync(new AsyncCacheLoader<String, Optional<Entry<T, Stat>>>() {
+                    @Override
+                    public CompletableFuture<Optional<Entry<T, Stat>>> asyncLoad(String key, Executor executor) {
+                        return readValueFromStore(key);
+                    }
+
+                    @Override
+                    public CompletableFuture<Optional<Entry<T, Stat>>> asyncReload(String key,
+                            Optional<Entry<T, Stat>> oldValue, Executor executor) {
+                        return readValueFromStore(key);
+                    }
+                });
+    }
+
+    private CompletableFuture<Optional<Entry<T, Stat>>> readValueFromStore(String path) {
+        return store.get(path)
+                .thenCompose(optRes -> {
+                    if (!optRes.isPresent()) {
+                        return FutureUtils.value(Optional.empty());
+                    }
+
+                    try {
+                        T obj = serde.deserialize(optRes.get().getValue());
+                        return FutureUtils
+                                .value(Optional.of(new SimpleImmutableEntry<T, Stat>(obj, optRes.get().getStat())));
+                    } catch (Throwable t) {
+                        return FutureUtils.exception(new ContentDeserializationException(t));
+                    }
+                });
+    }
+
+    @Override
+    public CompletableFuture<Optional<T>> get(String path) {
+        return objCache.get(path)
+                .thenApply(optRes -> optRes.map(Entry::getKey));
+    }
+
+    @Override
+    public Optional<T> getIfCached(String path) {
+        CompletableFuture<Optional<Map.Entry<T, Stat>>> future = objCache.getIfPresent(path);
+        if (future != null && future.isDone() && !future.isCompletedExceptionally()) {
+            return future.join().map(Entry::getKey);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction) {
+        return objCache.get(path)
+                .thenCompose(optEntry -> {
+                    Optional<T> currentValue;
+                    long expectedVersion;
+
+                    if (optEntry.isPresent()) {
+                        currentValue = Optional.of(optEntry.get().getKey());
+                        expectedVersion = optEntry.get().getValue().getVersion();
+                    } else {
+                        currentValue = Optional.empty();
+                        expectedVersion = -1;
+                    }
+
+                    T newValueObj;
+                    byte[] newValue;
+                    try {
+                        newValueObj = modifyFunction.apply(currentValue);
+                        newValue = serde.serialize(newValueObj);
+                    } catch (Throwable t) {
+                        return FutureUtils.exception(t);
+                    }
+
+                    return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
+                        // Make sure we have the value cached before the operation is completed
+                        objCache.put(path,
+                                FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(newValueObj, stat))));
+                    });
+                });
+    }
+
+    @Override
+    public CompletableFuture<Void> readModifyUpdate(String path, Function<T, T> modifyFunction) {
+        return objCache.get(path)
+                .thenCompose(optEntry -> {
+                    if (!optEntry.isPresent()) {
+                        return FutureUtils.exception(new NotFoundException(""));
+                    }
+
+                    Map.Entry<T, Stat> entry = optEntry.get();
+                    T currentValue = entry.getKey();
+                    long expectedVersion = optEntry.get().getValue().getVersion();
+
+                    T newValueObj;
+                    byte[] newValue;
+                    try {
+                        newValueObj = modifyFunction.apply(currentValue);
+                        newValue = serde.serialize(newValueObj);
+                    } catch (Throwable t) {
+                        return FutureUtils.exception(t);
+                    }
+
+                    return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
+                        // Make sure we have the value cached before the operation is completed
+                        objCache.put(path,
+                                FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(newValueObj, stat))));
+                    });
+                });
+    }
+
+    @Override
+    public CompletableFuture<Void> create(String path, T value) {
+        byte[] content;
+        try {
+            content = serde.serialize(value);
+        } catch (Throwable t) {
+            return FutureUtils.exception(t);
+        }
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        store.put(path, content, Optional.of(-1L))
+                .thenAccept(stat -> {
+                    // Make sure we have the value cached before the operation is completed
+                    objCache.put(path, FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(value, stat))));
+                    future.complete(null);
+                }).exceptionally(ex -> {
+                    if (ex.getCause() instanceof BadVersionException) {
+                        // Use already exists exception to provide more self-explanatory error message
+                        future.completeExceptionally(new AlreadyExistsException(ex.getCause()));
+                    } else {
+                        future.completeExceptionally(ex.getCause());
+                    }
+                    return null;
+                });
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String path) {
+        return store.delete(path, Optional.empty())
+                .thenAccept(v -> {
+                    // Mark in the cache that the object was removed
+                    objCache.put(path, FutureUtils.value(Optional.empty()));
+                });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(String path) {
+        return store.exists(path);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getChildren(String path) {
+        return store.getChildren(path);
+    }
+
+    @Override
+    public void accept(Notification t) {
+        String path = t.getPath();
+        switch (t.getType()) {
+        case Created:
+        case Modified:
+            if (objCache.synchronous().getIfPresent(path) != null) {
+                // Trigger background refresh of the cached item
+                objCache.synchronous().refresh(path);
+            }
+            break;
+
+        case Deleted:
+            objCache.synchronous().invalidate(path);
+            break;
+
+        default:
+            break;
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataSerde.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.cache.impl;
+
+import java.io.IOException;
+
+public interface MetadataSerde<T> {
+
+    byte[] serialize(T value) throws IOException;
+
+    T deserialize(byte[] content) throws IOException;
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.cache.MetadataCache;
+import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
+
+@Slf4j
+public abstract class AbstractMetadataStore implements MetadataStore, Consumer<Notification> {
+
+    private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+    private final CopyOnWriteArrayList<Consumer<Notification>> listeners = new CopyOnWriteArrayList<>();
+    protected final ExecutorService executor;
+    private final AsyncLoadingCache<String, List<String>> childrenCache;
+    private final AsyncLoadingCache<String, Boolean> existsCache;
+    private final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
+
+    protected abstract CompletableFuture<List<String>> getChildrenFromStore(String path);
+
+    protected abstract CompletableFuture<Boolean> existsFromStore(String path);
+
+    protected AbstractMetadataStore() {
+        this.executor = Executors
+                .newSingleThreadExecutor(new DefaultThreadFactory("metadata-store"));
+        registerListener(this);
+
+        this.childrenCache = Caffeine.newBuilder()
+                .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .buildAsync(new AsyncCacheLoader<String, List<String>>() {
+                    @Override
+                    public CompletableFuture<List<String>> asyncLoad(String key, Executor executor) {
+                        return getChildrenFromStore(key);
+                    }
+
+                    @Override
+                    public CompletableFuture<List<String>> asyncReload(String key, List<String> oldValue,
+                            Executor executor) {
+                        return getChildrenFromStore(key);
+                    }
+                });
+
+        this.existsCache = Caffeine.newBuilder()
+                .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .buildAsync(new AsyncCacheLoader<String, Boolean>() {
+                    @Override
+                    public CompletableFuture<Boolean> asyncLoad(String key, Executor executor) {
+                        return existsFromStore(key);
+                    }
+
+                    @Override
+                    public CompletableFuture<Boolean> asyncReload(String key, Boolean oldValue,
+                            Executor executor) {
+                        return existsFromStore(key);
+                    }
+                });
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(Class<T> clazz) {
+        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this,
+                TypeFactory.defaultInstance().constructSimpleType(clazz, null));
+        metadataCaches.add(metadataCache);
+        return metadataCache;
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef) {
+        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this, typeRef);
+        metadataCaches.add(metadataCache);
+        return metadataCache;
+    }
+
+    @Override
+    public final CompletableFuture<List<String>> getChildren(String path) {
+        return childrenCache.get(path);
+    }
+
+    @Override
+    public final CompletableFuture<Boolean> exists(String path) {
+        return existsCache.get(path);
+    }
+
+    @Override
+    public void registerListener(Consumer<Notification> listener) {
+        listeners.add(listener);
+    }
+
+    protected void receivedNotification(Notification notification) {
+        executor.execute(() -> {
+            listeners.forEach(listener -> {
+                try {
+                    listener.accept(notification);
+                } catch (Throwable t) {
+                    log.error("Failed to process metadata store notification", t);
+                }
+            });
+        });
+    }
+
+    @Override
+    public void accept(Notification n) {
+        String path = n.getPath();
+        NotificationType type = n.getType();
+
+        if (type == NotificationType.Created || type == NotificationType.Deleted) {
+            existsCache.synchronous().invalidate(path);
+        }
+
+        if (type == NotificationType.ChildrenChanged) {
+            childrenCache.synchronous().invalidate(path);
+        }
+
+        if (type == NotificationType.Created || type == NotificationType.Deleted || type == NotificationType.Modified) {
+            metadataCaches.forEach(c -> c.accept(n));
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.Data;
+
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.Stat;
+
+public class LocalMemoryMetadataStore extends AbstractMetadataStore implements MetadataStore {
+
+    @Data
+    private static class Value {
+        final long version;
+        final byte[] data;
+        final long createdTimestamp;
+        final long modifiedTimestamp;
+    }
+
+    private final NavigableMap<String, Value> map;
+
+    public LocalMemoryMetadataStore(String metadataURL, MetadataStoreConfig metadataStoreConfig) throws IOException {
+        map = new TreeMap<>();
+    }
+
+    @Override
+    public synchronized CompletableFuture<Optional<GetResult>> get(String path) {
+        if (!isValidPath(path)) {
+            return FutureUtils.exception(new MetadataStoreException(""));
+        }
+
+        Value v = map.get(path);
+        if (v != null) {
+            return FutureUtils.value(
+                    Optional.of(new GetResult(v.data, new Stat(v.version, v.createdTimestamp, v.modifiedTimestamp))));
+        } else {
+            return FutureUtils.value(Optional.empty());
+        }
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<String>> getChildrenFromStore(String path) {
+        if (!isValidPath(path)) {
+            return FutureUtils.exception(new MetadataStoreException(""));
+        }
+
+        String firstKey = path.equals("/") ? path : path + "/";
+        String lastKey = path.equals("/") ? "0" : path + "0"; // '0' is lexicographically just after '/'
+
+        List<String> children = new ArrayList<>();
+        map.subMap(firstKey, false, lastKey, false).forEach((key, value) -> {
+            String relativePath = key.replace(firstKey, "");
+            if (!relativePath.contains("/")) {
+                // Only return first-level children
+                children.add(relativePath);
+            }
+        });
+
+        return FutureUtils.value(children);
+    }
+
+    @Override
+    public synchronized CompletableFuture<Boolean> existsFromStore(String path) {
+        if (!isValidPath(path)) {
+            return FutureUtils.exception(new MetadataStoreException(""));
+        }
+
+        Value v = map.get(path);
+        return FutureUtils.value(v != null ? true : false);
+    }
+
+    @Override
+    public synchronized CompletableFuture<Stat> put(String path, byte[] data, Optional<Long> optExpectedVersion) {
+        if (!isValidPath(path)) {
+            return FutureUtils.exception(new MetadataStoreException(""));
+        }
+
+        boolean hasVersion = optExpectedVersion.isPresent();
+        int expectedVersion = optExpectedVersion.orElse(-1L).intValue();
+
+        long now = System.currentTimeMillis();
+
+        if (hasVersion && expectedVersion == -1) {
+            Value newValue = new Value(0, data, now, now);
+            Value existingValue = map.putIfAbsent(path, newValue);
+            if (existingValue != null) {
+                return FutureUtils.exception(new BadVersionException(""));
+            } else {
+                receivedNotification(new Notification(NotificationType.Created, path));
+                String parent = parent(path);
+                if (parent != null) {
+                    receivedNotification(new Notification(NotificationType.ChildrenChanged, parent));
+                }
+                return FutureUtils.value(new Stat(0, now, now));
+            }
+        } else {
+            Value existingValue = map.get(path);
+            long existingVersion = existingValue != null ? existingValue.version : -1;
+            if (hasVersion && expectedVersion != existingVersion) {
+                return FutureUtils.exception(new BadVersionException(""));
+            } else {
+                long newVersion = existingValue != null ? existingValue.version + 1 : 0;
+                long createdTimestamp = existingValue != null ? existingValue.createdTimestamp : now;
+                Value newValue = new Value(newVersion, data, createdTimestamp, now);
+                map.put(path, newValue);
+
+                NotificationType type = existingValue == null ? NotificationType.Created : NotificationType.Modified;
+                receivedNotification(new Notification(type, path));
+                if (type == NotificationType.Created) {
+                    String parent = parent(path);
+                    if (parent != null) {
+                        receivedNotification(new Notification(NotificationType.ChildrenChanged, parent));
+                    }
+                }
+                return FutureUtils
+                        .value(new Stat(newValue.version, newValue.createdTimestamp, newValue.modifiedTimestamp));
+            }
+        }
+    }
+
+    @Override
+    public synchronized CompletableFuture<Void> delete(String path, Optional<Long> optExpectedVersion) {
+        if (!isValidPath(path)) {
+            return FutureUtils.exception(new MetadataStoreException(""));
+        }
+
+        Value value = map.get(path);
+        if (value == null) {
+            return FutureUtils.exception(new NotFoundException(""));
+        } else if (value != null && optExpectedVersion.isPresent() && optExpectedVersion.get() != value.version) {
+            return FutureUtils.exception(new BadVersionException(""));
+        } else {
+            map.remove(path);
+            receivedNotification(new Notification(NotificationType.Deleted, path));
+            String parent = parent(path);
+            if (parent != null) {
+                receivedNotification(new Notification(NotificationType.ChildrenChanged, parent));
+            }
+            return FutureUtils.value(null);
+        }
+    }
+
+    private static boolean isValidPath(String path) {
+        if (path == null || !path.startsWith("/")) {
+            return false;
+        }
+
+        return path != "/" || !path.endsWith("/");
+    }
+
+    private static String parent(String path) {
+        int idx = path.lastIndexOf('/');
+        if (idx <= 0) {
+            // No parent
+            return null;
+        }
+
+        return path.substring(0, idx);
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.CompletionException;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+public abstract class BaseMetadataStoreTest {
+    protected TestZKServer zks;
+
+    @BeforeClass
+    void setup() throws Exception {
+        zks = new TestZKServer();
+    }
+
+    @AfterClass
+    void teardown() throws Exception {
+        zks.close();
+    }
+
+    @DataProvider(name = "impl")
+    public Object[][] implementations() {
+        return new Object[][] {
+                { "ZooKeeper", zks.getConnectionString() },
+                { "Memory", "memory://local" },
+        };
+    }
+
+    protected String newKey() {
+        return "/key-" + System.nanoTime();
+    }
+
+    static void assertException(CompletionException e, Class<?> clazz) {
+        assertException(e.getCause(), clazz);
+    }
+
+    static void assertException(Throwable t, Class<?> clazz) {
+        assertTrue(clazz.isInstance(t), String.format("Exception %s is not of type %s", t.getClass(), clazz));
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
+
+import lombok.AllArgsConstructor;
+import lombok.Cleanup;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.cache.MetadataCache;
+import org.testng.annotations.Test;
+
+public class MetadataCacheTest extends BaseMetadataStoreTest {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    static class MyClass {
+        String a;
+        int b;
+    }
+
+    @Test(dataProvider = "impl")
+    public void emptyCacheTest(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        assertEquals(objCache.getIfCached("/non-existing-key"), Optional.empty());
+        assertEquals(objCache.getIfCached("/non-existing-key/child"), Optional.empty());
+
+        assertEquals(objCache.get("/non-existing-key").join(), Optional.empty());
+        assertEquals(objCache.get("/non-existing-key/child").join(), Optional.empty());
+
+        try {
+            objCache.delete("/non-existing-key").join();
+            fail("should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+
+        try {
+            objCache.delete("/non-existing-key/child").join();
+            fail("should have failed");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void insertionDeletionWitGenericType(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<Map<String, String>> objCache = store
+                .getMetadataCache(new TypeReference<Map<String, String>>() {
+                });
+
+        String key1 = newKey();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+
+        Map<String, String> v = new TreeMap<>();
+        v.put("a", "1");
+        v.put("b", "2");
+        objCache.create(key1, v).join();
+
+        assertEquals(objCache.getIfCached(key1), Optional.of(v));
+        assertEquals(objCache.get(key1).join(), Optional.of(v));
+
+        objCache.delete(key1).join();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+        assertEquals(objCache.get(key1).join(), Optional.empty());
+    }
+
+    @Test(dataProvider = "impl")
+    public void insertionDeletion(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+
+        MyClass value1 = new MyClass("a", 1);
+        objCache.create(key1, value1).join();
+
+        MyClass value2 = new MyClass("a", 2);
+
+        try {
+            objCache.create(key1, value2).join();
+            fail("should have failed to create");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), AlreadyExistsException.class);
+        }
+
+        assertEquals(objCache.getIfCached(key1), Optional.of(value1));
+        assertEquals(objCache.get(key1).join(), Optional.of(value1));
+
+        objCache.delete(key1).join();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+        assertEquals(objCache.get(key1).join(), Optional.empty());
+    }
+
+    @Test(dataProvider = "impl")
+    public void insertionOutsideCache(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        MyClass value1 = new MyClass("a", 1);
+        store.put(key1, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value1), Optional.of(-1L)).join();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+        assertEquals(objCache.get(key1).join(), Optional.of(value1));
+    }
+
+    @Test(dataProvider = "impl")
+    public void insertionOutsideCacheWithGenericType(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataCache<Map<String, String>> objCache = store
+                .getMetadataCache(new TypeReference<Map<String, String>>() {
+                });
+
+        String key1 = newKey();
+
+        Map<String, String> v = new TreeMap<>();
+        v.put("a", "1");
+        v.put("b", "2");
+        store.put(key1, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(v), Optional.of(-1L)).join();
+
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+        assertEquals(objCache.get(key1).join(), Optional.of(v));
+    }
+
+    @Test(dataProvider = "impl")
+    public void invalidJsonContent(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        store.put(key1, "-------".getBytes(), Optional.of(-1L)).join();
+
+        try {
+            objCache.get(key1).join();
+            fail("should have failed to deserialize");
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), ContentDeserializationException.class);
+        }
+        assertEquals(objCache.getIfCached(key1), Optional.empty());
+    }
+
+    @Test(dataProvider = "impl")
+    public void readModifyUpdate(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        MyClass value1 = new MyClass("a", 1);
+        objCache.create(key1, value1).join();
+
+        objCache.readModifyUpdate(key1, v -> {
+            return new MyClass(v.a, v.b + 1);
+        }).join();
+
+        Optional<MyClass> newValue1 = objCache.get(key1).join();
+        assertTrue(newValue1.isPresent());
+        assertEquals(newValue1.get().a, "a");
+        assertEquals(newValue1.get().b, 2);
+
+        // Should fail if the key does not exist
+        try {
+            objCache.readModifyUpdate(newKey(), v -> {
+                return new MyClass(v.a, v.b + 1);
+            }).join();
+        } catch (CompletionException e) {
+            assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void readModifyUpdateOrCreate(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        objCache.readModifyUpdateOrCreate(key1, optValue -> {
+            if (optValue.isPresent()) {
+                return new MyClass(optValue.get().a, optValue.get().b + 1);
+            } else {
+                return new MyClass("a", 1);
+            }
+        }).join();
+
+        Optional<MyClass> newValue1 = objCache.get(key1).join();
+        assertTrue(newValue1.isPresent());
+        assertEquals(newValue1.get().a, "a");
+        assertEquals(newValue1.get().b, 1);
+
+        objCache.readModifyUpdateOrCreate(key1, optValue -> {
+            assertTrue(optValue.isPresent());
+            return new MyClass(optValue.get().a, optValue.get().b + 1);
+        }).join();
+
+        newValue1 = objCache.get(key1).join();
+        assertTrue(newValue1.isPresent());
+        assertEquals(newValue1.get().a, "a");
+        assertEquals(newValue1.get().b, 2);
+    }
+
+}


### PR DESCRIPTION
### Motivation

Third part of implementation for PIP-45: 

 * Added listener that can be added to the store
 * Defined `MetadataCache` that acts as an object cache on top of the data store
 * Added `LocalMemoryMetadataStore` as a reference implementation that can be used in tests.