### PR TITLE
[docs] add batching in limitations of key-shared mode

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -288,6 +288,7 @@ In *Key_Shared* mode, multiple consumers can attach to the same subscription. Me
 > When you use Key_Shared mode, be aware that:
 > * You need to specify a key or orderingKey for messages
 > * You cannot use cumulative acknowledgment with Key_Shared mode.
+> * Your producers should disable batching
 
 ![Key_Shared subscriptions](assets/pulsar-key-shared-subscriptions.png)
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -286,9 +286,9 @@ In *Key_Shared* mode, multiple consumers can attach to the same subscription. Me
 
 > #### Limitations of Key_Shared mode
 > When you use Key_Shared mode, be aware that:
-> * You need to specify a key or orderingKey for messages
+> * You need to specify a key or orderingKey for messages.
 > * You cannot use cumulative acknowledgment with Key_Shared mode.
-> * Your producers should disable batching
+> * Your producers should disable batching or use a key-based batch builder.
 
 ![Key_Shared subscriptions](assets/pulsar-key-shared-subscriptions.png)
 


### PR DESCRIPTION
### Motivation

Using KeyShared with batching can lead to vicious bugs as batching remove the guarantee of having a unique consumer handling a given key. I've spent some time debugging this and think it worth stating that in the key-shared limitation

### Modifications

Just added Batching as a limitation of Key-Shared mode. 

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

yes

This change is already covered by existing tests, such as *(please describe tests)*.

yes

