### PR TITLE
[Issue 9155][build]Fixing the mac build if you use a different openssl

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -73,6 +73,8 @@ endif(NOT LOG_CATEGORY_NAME)
 
 add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME} -DBUILDING_PULSAR -DBOOST_ALL_NO_LIB -DBOOST_ALLOW_DEPRECATED_HEADERS)
 
+set(OPENSSL_ROOT_DIR /usr/lib64/)
+
 ### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
 ### After find the libs, will unset related cache, and will not affact another same call to find_package.
 if (APPLE)
@@ -80,7 +82,6 @@ if (APPLE)
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl/)
 endif ()
 
-set(OPENSSL_ROOT_DIR /usr/lib64/)
 set(OPENSSL_USE_STATIC_LIBS FALSE)
 find_package(OpenSSL REQUIRED)
 set(RECORD_OPENSSL_SSL_LIBRARY ${OPENSSL_SSL_LIBRARY})


### PR DESCRIPTION
Fixes #9155

### Motivation
When I attempted to build the c library on macosx with openssl 1.1.1i it failed with linkage errors. I tracked those errors down to the fact that the OPENSLL_ROOT_DIR was incorrect outside of mac vms used by the upstream.

### Modifications

I set the default value first and then reset it only if running on mac.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:
No

### Documentation

  -None