### PR TITLE
Fix locking for ConsumerImpl when creating deadLetterProducer.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -166,7 +166,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private final DeadLetterPolicy deadLetterPolicy;
 
-    private Producer<T> deadLetterProducer;
+    private volatile Producer<T> deadLetterProducer;
 
     private volatile Producer<T> retryLetterProducer;
     private final ReadWriteLock createProducerLock = new ReentrantReadWriteLock();
@@ -702,8 +702,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                    processPossibleToDLQ((MessageIdImpl)messageId);
                     if (deadLetterProducer == null) {
                         try {
+                            createProducerLock.writeLock().lock();
                             if (deadLetterProducer == null) {
-                                createProducerLock.writeLock().lock();
                                 deadLetterProducer = client.newProducer(schema)
                                         .topic(this.deadLetterPolicy
                                         .getDeadLetterTopic())
@@ -712,9 +712,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             }
                         } catch (Exception e) {
                            log.error("Create dead letter producer exception with topic: {}", deadLetterPolicy.getDeadLetterTopic(), e);
-                       } finally {
+                        } finally {
                            createProducerLock.writeLock().unlock();
-                       }
+                        }
                    }
                    if (deadLetterProducer != null) {
                        propertiesMap.put(RetryMessageUtil.SYSTEM_PROPERTY_REAL_TOPIC, originTopicNameStr);
@@ -1816,12 +1816,17 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (deadLetterMessages != null) {
             if (deadLetterProducer == null) {
                 try {
-                    deadLetterProducer = client.newProducer(schema)
-                            .topic(this.deadLetterPolicy.getDeadLetterTopic())
-                            .blockIfQueueFull(false)
-                            .create();
+                    createProducerLock.writeLock().lock();
+                    if (deadLetterProducer == null) {
+                        deadLetterProducer = client.newProducer(schema)
+                                .topic(this.deadLetterPolicy.getDeadLetterTopic())
+                                .blockIfQueueFull(false)
+                                .create();
+                    }
                 } catch (Exception e) {
                     log.error("Create dead letter producer exception with topic: {}", deadLetterPolicy.getDeadLetterTopic(), e);
+                } finally {
+                    createProducerLock.writeLock().unlock();
                 }
             }
             if (deadLetterProducer != null) {


### PR DESCRIPTION
Fixes #9162

### Motivation
When we check if we need to create producer for DLQ, we used double-checked locking, https://github.com/apache/pulsar/blame/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L701-L712
however we should do the second check after we acquired the lock, and the field we're checking should be a volatile field.

### Modifications
Fix the double-checked locking and make the field volatile.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
