### PR TITLE
[Issue 8978][docker] Updated openssl to 1.1.1i in the docker images

### DIFF
--- a/pulsar-client-cpp/docker/Dockerfile
+++ b/pulsar-client-cpp/docker/Dockerfile
@@ -54,12 +54,12 @@ RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz && \
     rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
 
 # Compile OpenSSL
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-    tar xvfz OpenSSL_1_1_0j.tar.gz && \
-    cd openssl-OpenSSL_1_1_0j/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz && \
+    tar xvfz OpenSSL_1_1_1i.tar.gz && \
+    cd openssl-OpenSSL_1_1_1i/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ no-shared linux-x86_64 && \
     make && make install && \
-    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+    rm -rf /OpenSSL_1_1_1i.tar.gz /openssl-OpenSSL_1_1_1i
 
 # Download and compile boost
 RUN curl -O -L https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -51,12 +51,12 @@ RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz  && \
     rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
 
 # Compile OpenSSL
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-   tar xfz OpenSSL_1_1_0j.tar.gz && \
-   cd openssl-OpenSSL_1_1_0j/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz && \
+   tar xfz OpenSSL_1_1_1i.tar.gz && \
+   cd openssl-OpenSSL_1_1_1i/ && \
    ./Configure -fPIC no-shared linux-x86_64 && \
    make -j8 && make install && \
-   rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+   rm -rf /OpenSSL_1_1_1i.tar.gz /openssl-OpenSSL_1_1_1i
 
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.11.3/protobuf-cpp-3.11.3.tar.gz && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -51,12 +51,12 @@ RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz  && \
     rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
 
 # Compile OpenSSL
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-   tar xfz OpenSSL_1_1_0j.tar.gz && \
-   cd openssl-OpenSSL_1_1_0j/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz && \
+   tar xfz OpenSSL_1_1_1i.tar.gz && \
+   cd openssl-OpenSSL_1_1_1i/ && \
    ./Configure -fPIC no-shared linux-x86_64 && \
    make -j8 && make install && \
-   rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+   rm -rf /OpenSSL_1_1_1i.tar.gz /openssl-OpenSSL_1_1_1i
 
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.11.3/protobuf-cpp-3.11.3.tar.gz && \

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -80,18 +80,18 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
     make && make install && \
     rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
 
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-    tar xvfz OpenSSL_1_1_0j.tar.gz && \
-    cd openssl-OpenSSL_1_1_0j/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz && \
+    tar xvfz OpenSSL_1_1_1i.tar.gz && \
+    cd openssl-OpenSSL_1_1_1i/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make && make install && \
-    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+    rm -rf /OpenSSL_1_1_1i.tar.gz /openssl-OpenSSL_1_1_1i
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
     tar xvfz curl-7.61.0.tar.gz && \
     cd curl-7.61.0 && \
-    CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
+    CFLAGS="-fPIC -Wl,rpath,/usr/local/ssl/lib" ./configure --with-ssl=/usr/local/ssl/ && \
     make && make install && \
     rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
 

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -80,12 +80,12 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
     make && make install && \
     rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
 
-RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
-    tar xvfz OpenSSL_1_1_0j.tar.gz && \
-    cd openssl-OpenSSL_1_1_0j/ && \
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz && \
+    tar xvfz OpenSSL_1_1_1i.tar.gz && \
+    cd openssl-OpenSSL_1_1_1i/ && \
     ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
     make && make install && \
-    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+    rm -rf /OpenSSL_1_1_1i.tar.gz /openssl-OpenSSL_1_1_1i
 
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \


### PR DESCRIPTION
Fixes #8978

### Motivation


The openssl library used to build the c and python clients is out of support.

### Modifications

updated openssl from 1.1.0j to 1.1.1i in the Dockerfiles

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
This pull request updates the OpenSSL dependency


### Documentation

  - None
