### PR TITLE
Fix typo in wokerserviceloader

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.functions.worker.service;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import com.sun.corba.se.pept.protocol.ProtocolHandler;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -66,7 +65,7 @@ public class WorkerServiceLoader {
     }
 
     /**
-     * Load the worker service according to the handler definition.
+     * Load the worker service according to the worker service definition.
      *
      * @param metadata the worker service definition.
      * @return
@@ -76,7 +75,7 @@ public class WorkerServiceLoader {
         NarClassLoader ncl = NarClassLoader.getFromArchive(
             metadata.getArchivePath().toAbsolutePath().toFile(),
             Collections.emptySet(),
-            ProtocolHandler.class.getClassLoader(), narExtractionDirectory);
+            WorkerService.class.getClassLoader(), narExtractionDirectory);
 
         WorkerServiceDefinition phDef = getWorkerServiceDefinition(ncl);
         if (StringUtils.isBlank(phDef.getHandlerClass())) {


### PR DESCRIPTION
### Motivation
Fix typo in WorkerServiceLoader.java to avoid error while project build under java 15:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project pulsar-functions-worker: Compilation failure
[ERROR] /Users/jia/ws/code/pulsar/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java:[23,38] package com.sun.corba.se.pept.protocol does not exist
```

### Modifications

Fix to the right type.

### Verifying this change

build passed
