### PR TITLE
upgrade presto version to 334 for JDK 11

### DIFF
--- a/conf/presto/config.properties
+++ b/conf/presto/config.properties
@@ -37,6 +37,6 @@ scheduler.http-client.idle-timeout=1m
 query.client.timeout=5m
 query.min-expire-age=30m
 
-presto.version=testversion
-
 node-scheduler.include-coordinator=true
+
+catalog.config-dir=/pulsar/conf/presto/catalog

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ flexible messaging model and an intuitive client API.</description>
     <hdfs-offload-version3>3.2.0</hdfs-offload-version3>
     <org.eclipse.jetty-hdfs-offload>9.3.24.v20180605</org.eclipse.jetty-hdfs-offload>
     <elasticsearch.version>7.9.1</elasticsearch.version>
-    <presto.version>332</presto.version>
+    <presto.version>334</presto.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala-library.version>2.11.12</scala-library.version>
     <debezium.version>1.0.0.Final</debezium.version>
@@ -156,7 +156,7 @@ flexible messaging model and an intuitive client API.</description>
     <aircompressor.version>0.16</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <jcommander.version>1.78</jcommander.version>
-    <commons-lang3.version>3.6</commons-lang3.version>
+    <commons-lang3.version>3.9</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.5</commons-io.version>
     <commons-codec.version>1.10</commons-codec.version>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <jersey.version>2.31</jersey.version>
-        <presto.version>332</presto.version>
+        <presto.version>334</presto.version>
         <jersey.version>2.31</jersey.version>
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
@@ -128,6 +128,12 @@
                     <artifactId>activation</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-server-main</artifactId>
+            <version>${presto.version}</version>
         </dependency>
 
         <dependency>

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorFactory.java
@@ -50,9 +50,7 @@ public class PulsarConnectorFactory implements ConnectorFactory {
     @Override
     public Connector create(String connectorId, Map<String, String> config, ConnectorContext context) {
         requireNonNull(config, "requiredConfig is null");
-        if (log.isDebugEnabled()) {
-            log.debug("Creating Pulsar connector with configs: %s", config);
-        }
+        log.info("Creating Pulsar connector with configs: %s", config);
         try {
             // A plugin is not required to use Guice; it is just very convenient
             Bootstrap app = new Bootstrap(


### PR DESCRIPTION
### Motivation

Upgrade Presto to 334 that is required to run on JDK 11.

### Modifications

Presto 334 also changes the Main class to a new package and class in a new jar, presto-server-main.jar. It has minor changes to required properties. Its dependency common-langs3 is also required to be upgraded to 3.9 to work in both JDK11.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no
### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
