### PR TITLE
[Functions-worker] Fix broker and functions-worker authentication compatibility

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -61,9 +61,10 @@ pulsarWebServiceUrl: http://localhost:8080
 ############################################
 # security settings for pulsar broker client
 ############################################
-brokerClientAuthenticationEnabled: false
 # The path to trusted certificates used by the Pulsar client to authenticate with Pulsar brokers
 # brokerClientTrustCertsFilePath:
+# Whether to enable the broker client authentication used by function workers to talk to brokers
+# brokerClientAuthenticationEnabled: false
 # the authentication plugin to be used by the pulsar client used in worker service
 # brokerClientAuthenticationPlugin:
 # the authentication parameter to be used by the pulsar client used in worker service

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/config/TestWorkerConfig.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/config/TestWorkerConfig.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.config;
+
+import org.apache.pulsar.functions.worker.WorkerConfig;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+public class TestWorkerConfig {
+    @Test
+    public void validateAuthenticationCompatibleWorkerConfig() {
+        WorkerConfig workerConfig = new WorkerConfig();
+
+        workerConfig.setAuthenticationEnabled(false);
+        Assert.assertFalse(workerConfig.isAuthenticationEnabled());
+        workerConfig.setBrokerClientAuthenticationEnabled(null);
+        Assert.assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
+
+        workerConfig.setAuthenticationEnabled(true);
+        Assert.assertTrue(workerConfig.isAuthenticationEnabled());
+        workerConfig.setBrokerClientAuthenticationEnabled(null);
+        Assert.assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
+
+        workerConfig.setBrokerClientAuthenticationEnabled(true);
+        workerConfig.setAuthenticationEnabled(false);
+        Assert.assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
+        workerConfig.setAuthenticationEnabled(true);
+        Assert.assertTrue(workerConfig.isBrokerClientAuthenticationEnabled());
+
+        workerConfig.setBrokerClientAuthenticationEnabled(false);
+        workerConfig.setAuthenticationEnabled(false);
+        Assert.assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
+        workerConfig.setAuthenticationEnabled(true);
+        Assert.assertFalse(workerConfig.isBrokerClientAuthenticationEnabled());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The `brokerClientAuthenticationEnabled` is boxed type in `WebConfig.java` for solve broker and functions-worker authentication compatibility, so `brokerClientAuthenticationEnabled` should not be in `conf/functions-worker.yml`.

### Modifications

- commented out  `brokerClientAuthenticationEnabled` in `conf/functions-worker.yml`
