### PR TITLE
fix max topic for namespace does not work

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -812,7 +812,7 @@ public abstract class AdminResource extends PulsarWebResource {
         try {
             String topicPartitionPath = joinPath(MANAGED_LEDGER_PATH_ZNODE,
                     namespaceName.toString(), topicDomain.value());
-            List<String> topics = globalZk().getChildren(topicPartitionPath, false);
+            List<String> topics = localZk().getChildren(topicPartitionPath, false);
             topicPartitions = topics.stream()
                     .map(s -> String.format("%s://%s/%s", topicDomain.value(), namespaceName.toString(), decode(s)))
                     .collect(Collectors.toList());


### PR DESCRIPTION
### Motivation
This PR fix max topic for namespace does not work. 

Max topic configuration for namespace does not work well. This is caused by  currently we use globalZK to get the children node of  "/managed-ledgers/tenant/namespace/domain" when caculate the number of existed topics.  

 Znode of  "/managed-ledgers/tenant/namespace/domain" should be accessed by localZK  instead.



