### PR TITLE
Fix the set-project-version scripts

### DIFF
--- a/src/set-project-version.sh
+++ b/src/set-project-version.sh
@@ -38,7 +38,5 @@ OLD_VERSION=`python ${ROOT_DIR}/src/get-project-version.py`
 mvn versions:set -DnewVersion=$NEW_VERSION
 mvn versions:set -DnewVersion=$NEW_VERSION -pl buildtools
 mvn versions:set -DnewVersion=$NEW_VERSION -pl pulsar-sql/presto-distribution
-# install the new version of root pom local, so `update-parent` can update the right parent version
-sed -i -e "s/${OLD_VERSION}/${NEW_VERSION}/g" protobuf-shaded/pom.xml
 
 popd


### PR DESCRIPTION
---

*Motivation*

We introduce a new way to handle the proto and remove the
'protobuf-shaded/pom.xml' in the PR #9046.
We need to remove the set version in the scripts.
