### PR TITLE
Upgrade Bouncy Castle to 1.68

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -591,9 +591,9 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.66.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.66.jar
-    - org.bouncycastle-bcprov-jdk15on-1.66.jar
+    - org.bouncycastle-bcpkix-jdk15on-1.68.jar
+    - org.bouncycastle-bcprov-ext-jdk15on-1.68.jar
+    - org.bouncycastle-bcprov-jdk15on-1.68.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.14.0</log4j2.version>
-    <bouncycastle.version>1.66</bouncycastle.version>
+    <bouncycastle.version>1.68</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.11.1</jackson.version>
     <jackson.databind.version>2.11.1</jackson.databind.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -569,6 +569,6 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
--    - bcpkix-jdk15on-1.66.jar
--    - bcprov-ext-jdk15on-1.66.jar
--    - bcprov-jdk15on-1.66.jar
+-    - bcpkix-jdk15on-1.68.jar
+-    - bcprov-ext-jdk15on-1.68.jar
+-    - bcprov-jdk15on-1.68.jar


### PR DESCRIPTION
The version of Bouncy Castle that Pulsar currently depends on has security vulnerability, so upgraded it to the latest version.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28052