### PR TITLE
Fix potential http get hangs in the Pulsar Admin

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.ServiceUnavailableException;
@@ -46,7 +45,6 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ErrorData;
-import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,11 +159,11 @@ public abstract class BaseResource {
         return future;
     }
 
-    public <T> Future<T> asyncGetRequest(final WebTarget target, InvocationCallback<T> callback) {
+    public <T> void asyncGetRequest(final WebTarget target, InvocationCallback<T> callback) {
         try {
-            return request(target).async().get(callback);
+            request(target).async().get(callback);
         } catch (PulsarAdminException cae) {
-            return FutureUtil.failedFuture(cae);
+            callback.failed(cae);
         }
     }
 


### PR DESCRIPTION
### Motivation

Currently, for the HTTP async get method, we pass a callback and return a future. This is confusing which one is the right result. And if exception throws, will return a future that complete with exception but the callback have not been called. All the caller of the `asyncGetRequest` handles the callback, not the returned future, this will lead a potential hangs in the Pulsar Admin since the callback might never be called.

### Modifications

Change the `asyncGetRequest` method to only handle the callback and use `void` as the return type.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
