### PR TITLE
Support get topic applied policy for message TTL

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -524,10 +524,6 @@ public abstract class AdminResource extends PulsarWebResource {
         if (policies.clusterSubscribeRate.isEmpty()) {
             policies.clusterSubscribeRate.put(cluster, subscribeRate());
         }
-
-        if (policies.message_ttl_in_seconds == null) {
-            policies.message_ttl_in_seconds = config.getTtlDurationDefaultInSeconds();
-        }
     }
 
     protected BacklogQuota namespaceBacklogQuota(String namespace, String namespacePath) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -273,7 +273,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Get the message TTL for the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist") })
-    public int getNamespaceMessageTTL(@PathParam("tenant") String tenant,
+    public Integer getNamespaceMessageTTL(@PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespacePolicyOperation(NamespaceName.get(tenant, namespace), PolicyName.TTL, PolicyOperation.READ);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1538,7 +1538,8 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .orElseGet(() -> {
                     if (applied) {
                         Integer otherLevelTTL = getNamespacePolicies(namespaceName).message_ttl_in_seconds;
-                        return otherLevelTTL == null ? pulsar().getConfiguration().getTtlDurationDefaultInSeconds() : otherLevelTTL;
+                        return otherLevelTTL == null ? pulsar().getConfiguration().getTtlDurationDefaultInSeconds()
+                                : otherLevelTTL;
                     }
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1522,22 +1522,6 @@ public class PersistentTopics extends PersistentTopicsBase {
     }
 
     @GET
-    @Path("/{tenant}/{namespace}/{topic}/messageTTLApplied")
-    @ApiOperation(value = "Get message TTL applied policy for a topic")
-    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
-            @ApiResponse(code = 404, message = "Topic does not exist"),
-            @ApiResponse(code = 405, message =
-                    "Topic level policy is disabled, enable the topic level policy and retry")})
-    public int getMessageTTLApplied(@PathParam("tenant") String tenant,
-                                    @PathParam("namespace") String namespace,
-                                    @PathParam("topic") @Encoded String encodedTopic) {
-        validateTopicName(tenant, namespace, encodedTopic);
-        Integer messageTTL = getTopicPolicies(topicName).map(TopicPolicies::getMessageTTLInSeconds)
-                .orElse(getNamespacePolicies(namespaceName).message_ttl_in_seconds);
-        return messageTTL == null ? pulsar().getConfiguration().getTtlDurationDefaultInSeconds() : messageTTL;
-    }
-
-    @GET
     @Path("/{tenant}/{namespace}/{topic}/messageTTL")
     @ApiOperation(value = "Get message TTL in seconds for a topic")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
@@ -1546,11 +1530,18 @@ public class PersistentTopics extends PersistentTopicsBase {
                     "Topic level policy is disabled, enable the topic level policy and retry")})
     public Integer getMessageTTL(@PathParam("tenant") String tenant,
                              @PathParam("namespace") String namespace,
-                             @PathParam("topic") @Encoded String encodedTopic) {
+                             @PathParam("topic") @Encoded String encodedTopic,
+                             @QueryParam("applied") boolean applied) {
         validateTopicName(tenant, namespace, encodedTopic);
         return getTopicPolicies(topicName)
                 .map(TopicPolicies::getMessageTTLInSeconds)
-                .orElse(null);
+                .orElseGet(() -> {
+                    if (applied) {
+                        Integer otherLevelTTL = getNamespacePolicies(namespaceName).message_ttl_in_seconds;
+                        return otherLevelTTL == null ? pulsar().getConfiguration().getTtlDurationDefaultInSeconds() : otherLevelTTL;
+                    }
+                    return null;
+                });
     }
 
     @POST

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -705,7 +705,6 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
         policies.max_unacked_messages_per_subscription = 200000;
         policies.max_unacked_messages_per_consumer = 50000;
-        policies.message_ttl_in_seconds = pulsar.getConfiguration().getTtlDurationDefaultInSeconds();
 
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
         assertEquals(admin.namespaces().getPermissions("prop-xyz/ns1"), policies.auth_policies.namespace_auth);
@@ -2576,8 +2575,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testGetTtlDurationDefaultInSeconds() throws Exception {
         conf.setTtlDurationDefaultInSeconds(3600);
-        int seconds = admin.namespaces().getPolicies("prop-xyz/ns1").message_ttl_in_seconds;
-        assertEquals(seconds, 3600);
+        Integer seconds = admin.namespaces().getPolicies("prop-xyz/ns1").message_ttl_in_seconds;
+        assertNull(seconds);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -34,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
@@ -84,7 +86,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         admin.topics().removeMessageTTL(testTopic);
         messageTTL = admin.topics().getMessageTTL(testTopic);
         log.info("Message TTL {} get on topic: {}", testTopic, messageTTL);
-        Assert.assertEquals(messageTTL.intValue(), 0);
+        Assert.assertNull(messageTTL);
     }
 
     @Test
@@ -109,7 +111,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         // Check default topic level message TTL.
         Integer messageTTL = admin.topics().getMessageTTL(testTopic);
         log.info("Message TTL {} get on topic: {}", testTopic, messageTTL);
-        Assert.assertEquals(messageTTL.intValue(), 0);
+        Assert.assertNull(messageTTL);
 
         admin.topics().setMessageTTL(testTopic, 200);
         log.info("Message TTL set success on topic: {}", testTopic);
@@ -124,7 +126,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
     public void testTopicPolicyDisabled() throws Exception {
         this.conf.setSystemTopicEnabled(true);
         this.conf.setTopicLevelPoliciesEnabled(false);
-        stopBroker();
+        super.internalCleanup();
         super.internalSetup();
 
         admin.clusters().createCluster("test", new ClusterData(pulsar.getWebServiceAddress()));
@@ -156,23 +158,65 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Method method = PersistentTopic.class.getDeclaredMethod("getMessageTTL");
         method.setAccessible(true);
 
-        int namespaceMessageTTL = admin.namespaces().getNamespaceMessageTTL(myNamespace);
-        Assert.assertEquals(namespaceMessageTTL, 3600);
-        Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
+        Integer namespaceMessageTTL = admin.namespaces().getNamespaceMessageTTL(myNamespace);
+        Assert.assertNull(namespaceMessageTTL);
+        Assert.assertEquals(method.invoke(persistentTopic), 3600);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
-        Thread.sleep(500);
-        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 10);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 10));
         Assert.assertEquals((int)method.invoke(persistentTopic), 10);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
-        Thread.sleep(500);
-        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 0);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 0));
         Assert.assertEquals((int)method.invoke(persistentTopic), 0);
 
         admin.namespaces().removeNamespaceMessageTTL(myNamespace);
-        Thread.sleep(500);
-        Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace), 3600);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertNull(admin.namespaces().getNamespaceMessageTTL(myNamespace)));
+        Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
+    }
+
+    @Test(timeOut = 20000)
+    public void testDifferentLevelPolicyApplied() throws Exception {
+        final String topicName = testTopic + UUID.randomUUID();
+        admin.topics().createNonPartitionedTopic(topicName);
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+        Method method = PersistentTopic.class.getDeclaredMethod("getMessageTTL");
+        method.setAccessible(true);
+        //namespace-level default value is null
+        Integer namespaceMessageTTL = admin.namespaces().getNamespaceMessageTTL(myNamespace);
+        Assert.assertNull(namespaceMessageTTL);
+        //topic-level default value is null
+        Integer topicMessageTTL = admin.topics().getMessageTTL(topicName);
+        Assert.assertNull(topicMessageTTL);
+        //use broker-level by default
+        int topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        Assert.assertEquals(topicMessageTTLApplied, 3600);
+
+        admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 10));
+        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        Assert.assertEquals(topicMessageTTLApplied, 10);
+
+        admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 0));
+        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        Assert.assertEquals(topicMessageTTLApplied, 0);
+
+        admin.topics().setMessageTTL(topicName, 20);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertNotNull(admin.topics().getMessageTTL(topicName)));
+        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        Assert.assertEquals(topicMessageTTLApplied, 20);
+
+        admin.namespaces().removeNamespaceMessageTTL(myNamespace);
+        admin.topics().removeMessageTTL(topicName);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> Assert.assertEquals(admin.topics().getMessageTTLApplied(topicName), 3600));
         Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -192,31 +192,31 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Integer topicMessageTTL = admin.topics().getMessageTTL(topicName);
         Assert.assertNull(topicMessageTTL);
         //use broker-level by default
-        int topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        int topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 3600);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 10));
-        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 10);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 0));
-        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 0);
 
         admin.topics().setMessageTTL(topicName, 20);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
                 -> Assert.assertNotNull(admin.topics().getMessageTTL(topicName)));
-        topicMessageTTLApplied = admin.topics().getMessageTTLApplied(topicName);
+        topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 20);
 
         admin.namespaces().removeNamespaceMessageTTL(myNamespace);
         admin.topics().removeMessageTTL(topicName);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
-                -> Assert.assertEquals(admin.topics().getMessageTTLApplied(topicName), 3600));
+                -> Assert.assertEquals(admin.topics().getMessageTTL(topicName, true).intValue(), 3600));
         Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -645,7 +645,6 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.topicDispatchRate.put("test", ConfigHelper.topicDispatchRate(conf));
         policies.subscriptionDispatchRate.put("test", ConfigHelper.subscriptionDispatchRate(conf));
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
-        policies.message_ttl_in_seconds = pulsar.getConfiguration().getTtlDurationDefaultInSeconds();
 
         policies.max_unacked_messages_per_subscription = 200000;
         policies.max_unacked_messages_per_consumer = 50000;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -821,7 +821,7 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    int getNamespaceMessageTTL(String namespace) throws PulsarAdminException;
+    Integer getNamespaceMessageTTL(String namespace) throws PulsarAdminException;
 
     /**
      * Get the message TTL for a namespace asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1612,7 +1612,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
-    int getMessageTTLApplied(String topic) throws PulsarAdminException;
+    Integer getMessageTTL(String topic, boolean applied) throws PulsarAdminException;
 
     /**
      * Remove message TTL for a topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1604,7 +1604,15 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    int getMessageTTL(String topic) throws PulsarAdminException;
+    Integer getMessageTTL(String topic) throws PulsarAdminException;
+
+    /**
+     * Get message TTL applied for a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    int getMessageTTLApplied(String topic) throws PulsarAdminException;
 
     /**
      * Remove message TTL for a topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -616,7 +616,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public int getNamespaceMessageTTL(String namespace) throws PulsarAdminException {
+    public Integer getNamespaceMessageTTL(String namespace) throws PulsarAdminException {
         try {
             return getNamespaceMessageTTLAsync(namespace).
                     get(this.readTimeoutMs, TimeUnit.MILLISECONDS);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2015,7 +2015,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     public int getMessageTTLApplied(String topic) throws PulsarAdminException {
         try {
             TopicName topicName = validateTopic(topic);
-            WebTarget path = topicPath(topicName, "messageTTLApplied");
+            WebTarget path = topicPath(topicName, "messageTTL");
+            path = path.queryParam("applied", true);
             return request(path).get(new GenericType<Integer>() {});
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2003,21 +2003,14 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public Integer getMessageTTL(String topic) throws PulsarAdminException {
         return getMessageTTL(topic, false);
-        try {
-            TopicName topicName = validateTopic(topic);
-            WebTarget path = topicPath(topicName, "messageTTL");
-            return request(path).get(new GenericType<Integer>() {});
-        } catch (Exception e) {
-            throw getApiException(e);
-        }
     }
 
     @Override
-    public int getMessageTTLApplied(String topic) throws PulsarAdminException {
+    public Integer getMessageTTL(String topic, boolean applied) throws PulsarAdminException {
         try {
             TopicName topicName = validateTopic(topic);
             WebTarget path = topicPath(topicName, "messageTTL");
-            path = path.queryParam("applied", true);
+            path = path.queryParam("applied", applied);
             return request(path).get(new GenericType<Integer>() {});
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2002,6 +2002,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMessageTTL(String topic) throws PulsarAdminException {
+        return getMessageTTL(topic, false);
         try {
             TopicName topicName = validateTopic(topic);
             WebTarget path = topicPath(topicName, "messageTTL");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2001,10 +2001,21 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public int getMessageTTL(String topic) throws PulsarAdminException {
+    public Integer getMessageTTL(String topic) throws PulsarAdminException {
         try {
             TopicName topicName = validateTopic(topic);
             WebTarget path = topicPath(topicName, "messageTTL");
+            return request(path).get(new GenericType<Integer>() {});
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public int getMessageTTLApplied(String topic) throws PulsarAdminException {
+        try {
+            TopicName topicName = validateTopic(topic);
+            WebTarget path = topicPath(topicName, "messageTTLApplied");
             return request(path).get(new GenericType<Integer>() {});
         } catch (Exception e) {
             throw getApiException(e);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -858,7 +858,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getLastMessageId(eq("persistent://myprop/clust/ns1/ds1"));
 
         cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10"));
         verify(mockTopics).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10);
@@ -873,7 +873,7 @@ public class PulsarAdminToolTest {
                 , eq(new MessageIdImpl(1, 1, -1)), eq(true));
 
         cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getMessageTTLApplied("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1", true);
 
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -857,11 +857,24 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("last-message-id persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getLastMessageId(eq("persistent://myprop/clust/ns1/ds1"));
 
+        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).getMessageTTL("persistent://myprop/clust/ns1/ds1");
+
+        cmdTopics.run(split("set-message-ttl persistent://myprop/clust/ns1/ds1 -t 10"));
+        verify(mockTopics).setMessageTTL("persistent://myprop/clust/ns1/ds1", 10);
+
+        cmdTopics.run(split("remove-message-ttl persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).removeMessageTTL("persistent://myprop/clust/ns1/ds1");
+
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(admin);
         cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds2 -s sub1 -m 1:1 -e"));
         verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
                 , eq(new MessageIdImpl(1, 1, -1)), eq(true));
+
+        cmdTopics.run(split("get-message-ttl persistent://myprop/clust/ns1/ds1 -ap"));
+        verify(mockTopics).getMessageTTLApplied("persistent://myprop/clust/ns1/ds1");
+
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1081,10 +1081,17 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-ap", "--applied" }, description = "Get the applied policy of the topic")
+        private boolean applied = false;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            print(admin.topics().getMessageTTL(persistentTopic));
+            if (applied) {
+                print(admin.topics().getMessageTTLApplied(persistentTopic));
+            } else {
+                print(admin.topics().getMessageTTL(persistentTopic));
+            }
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1087,11 +1087,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            if (applied) {
-                print(admin.topics().getMessageTTLApplied(persistentTopic));
-            } else {
-                print(admin.topics().getMessageTTL(persistentTopic));
-            }
+            print(admin.topics().getMessageTTL(persistentTopic, applied));
         }
     }
 


### PR DESCRIPTION
Master Issue: #9216

### Motivation
Provide a way to get the applied policy of the topic. In Pulsar, the topic will apply the topic level policy if present or apply the namespace policy if present or use the broker level configuration. It needs to support get the applied policy for a topic that might use the namespace policy or topic policy or broker level default configuration.

### Modifications
1 Now if there is no data at the namespace-level, the broker-level data will be returned by default, so I fix it
2 Now if there is no data at the topic-level, the data at the namespace-level will be returned by default, so I fix it
3 Add applied interface
4 Since the initial value becomes null, the corresponding unit test is modified

### Verifying this change
unit test:
testDifferentLevelPolicyApplied
