### PR TITLE
Support get topic applied policy for InactiveTopic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2192,13 +2192,7 @@ public abstract class NamespacesBase extends AdminResource {
         validateNamespacePolicyOperation(namespaceName, PolicyName.INACTIVE_TOPIC, PolicyOperation.READ);
 
         Policies policies = getNamespacePolicies(namespaceName);
-        if (policies.inactive_topic_policies == null) {
-            return new InactiveTopicPolicies(config().getBrokerDeleteInactiveTopicsMode()
-                    , config().getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds()
-                    , config().isBrokerDeleteInactiveTopicsEnabled());
-        } else {
-            return policies.inactive_topic_policies;
-        }
+        return policies.inactive_topic_policies;
     }
 
     protected void internalSetInactiveTopic(InactiveTopicPolicies inactiveTopicPolicies) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -865,6 +865,21 @@ public class PersistentTopicsBase extends AdminResource {
         return completableFuture;
     }
 
+    protected CompletableFuture<InactiveTopicPolicies> internalGetInactiveTopicPolicies(boolean applied) {
+        InactiveTopicPolicies inactiveTopicPolicies = getTopicPolicies(topicName)
+                .map(TopicPolicies::getInactiveTopicPolicies)
+                .orElseGet(() -> {
+                    if (applied) {
+                        InactiveTopicPolicies policies = getNamespacePolicies(namespaceName).inactive_topic_policies;
+                        return policies == null ? new InactiveTopicPolicies(config().getBrokerDeleteInactiveTopicsMode(),
+                                config().getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(),
+                                config().isBrokerDeleteInactiveTopicsEnabled()) : policies;
+                    }
+                    return null;
+                });
+        return CompletableFuture.completedFuture(inactiveTopicPolicies);
+    }
+
     protected CompletableFuture<Void> internalSetInactiveTopicPolicies(InactiveTopicPolicies inactiveTopicPolicies) {
         TopicPolicies topicPolicies = null;
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -871,7 +871,8 @@ public class PersistentTopicsBase extends AdminResource {
                 .orElseGet(() -> {
                     if (applied) {
                         InactiveTopicPolicies policies = getNamespacePolicies(namespaceName).inactive_topic_policies;
-                        return policies == null ? new InactiveTopicPolicies(config().getBrokerDeleteInactiveTopicsMode(),
+                        return policies == null ? new InactiveTopicPolicies(
+                                config().getBrokerDeleteInactiveTopicsMode(),
                                 config().getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(),
                                 config().isBrokerDeleteInactiveTopicsEnabled()) : policies;
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -483,14 +483,20 @@ public class PersistentTopics extends PersistentTopicsBase {
     public void getInactiveTopicPolicies(@Suspended final AsyncResponse asyncResponse,
                                          @PathParam("tenant") String tenant,
                                          @PathParam("namespace") String namespace,
-                                         @PathParam("topic") @Encoded String encodedTopic) {
+                                         @PathParam("topic") @Encoded String encodedTopic,
+                                         @QueryParam("applied") boolean applied) {
         validateTopicName(tenant, namespace, encodedTopic);
-        TopicPolicies topicPolicies = getTopicPolicies(topicName).orElse(new TopicPolicies());
-        if (topicPolicies.isInactiveTopicPoliciesSet()) {
-            asyncResponse.resume(topicPolicies.getInactiveTopicPolicies());
-        } else {
-            asyncResponse.resume(Response.noContent().build());
-        }
+        internalGetInactiveTopicPolicies(applied).whenComplete((res, ex) -> {
+            if (ex instanceof RestException) {
+                log.error("Failed get InactiveTopicPolicies", ex);
+                asyncResponse.resume(ex);
+            } else if (ex != null) {
+                log.error("Failed get InactiveTopicPolicies", ex);
+                asyncResponse.resume(new RestException(ex));
+            } else {
+                asyncResponse.resume(res);
+            }
+        });
     }
 
     @POST

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -50,6 +50,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 public class InactiveTopicDeleteTest extends BrokerTestBase {
@@ -542,5 +544,58 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
                 -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic3)));
         Assert.assertFalse(admin.topics().getList(namespace).contains(topic));
+    }
+
+    @Test(timeOut = 30000)
+    public void testInactiveTopicApplied() throws Exception {
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        super.baseSetup();
+
+        final String namespace = "prop/ns-abc";
+        final String topic = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
+        pulsarClient.newProducer().topic(topic).create().close();
+        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+                .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
+        //namespace-level default value is null
+        assertNull(admin.namespaces().getInactiveTopicPolicies(namespace));
+        //topic-level default value is null
+        assertNull(admin.topics().getInactiveTopicPolicies(topic));
+        //use broker-level by default
+        InactiveTopicPolicies brokerLevelPolicy =
+                new InactiveTopicPolicies(conf.getBrokerDeleteInactiveTopicsMode(),
+                        conf.getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(),
+                        conf.isBrokerDeleteInactiveTopicsEnabled());
+        Assert.assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), brokerLevelPolicy);
+        //set namespace-level policy
+        InactiveTopicPolicies namespaceLevelPolicy =
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                20, false);
+        admin.namespaces().setInactiveTopicPolicies(namespace, namespaceLevelPolicy);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> assertNotNull(admin.namespaces().getInactiveTopicPolicies(namespace)));
+        InactiveTopicPolicies policyFromBroker = admin.topics().getInactiveTopicPoliciesApplied(topic);
+        assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 20);
+        assertFalse(policyFromBroker.isDeleteWhileInactive());
+        assertEquals(policyFromBroker.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_no_subscriptions);
+        // set topic-level policy
+        InactiveTopicPolicies topicLevelPolicy =
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up,
+                        30, false);
+        admin.topics().setInactiveTopicPolicies(topic, topicLevelPolicy);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> assertNotNull(admin.topics().getInactiveTopicPolicies(topic)));
+        policyFromBroker = admin.topics().getInactiveTopicPoliciesApplied(topic);
+        assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 30);
+        assertFalse(policyFromBroker.isDeleteWhileInactive());
+        assertEquals(policyFromBroker.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        //remove topic-level policy
+        admin.topics().removeInactiveTopicPolicies(topic);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), namespaceLevelPolicy));
+        //remove namespace-level policy
+        admin.namespaces().removeInactiveTopicPolicies(namespace);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+                -> assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), brokerLevelPolicy));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -566,7 +566,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 new InactiveTopicPolicies(conf.getBrokerDeleteInactiveTopicsMode(),
                         conf.getBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(),
                         conf.isBrokerDeleteInactiveTopicsEnabled());
-        Assert.assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), brokerLevelPolicy);
+        Assert.assertEquals(admin.topics().getInactiveTopicPolicies(topic, true), brokerLevelPolicy);
         //set namespace-level policy
         InactiveTopicPolicies namespaceLevelPolicy =
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
@@ -574,7 +574,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.namespaces().setInactiveTopicPolicies(namespace, namespaceLevelPolicy);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
                 -> assertNotNull(admin.namespaces().getInactiveTopicPolicies(namespace)));
-        InactiveTopicPolicies policyFromBroker = admin.topics().getInactiveTopicPoliciesApplied(topic);
+        InactiveTopicPolicies policyFromBroker = admin.topics().getInactiveTopicPolicies(topic, true);
         assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 20);
         assertFalse(policyFromBroker.isDeleteWhileInactive());
         assertEquals(policyFromBroker.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_no_subscriptions);
@@ -585,17 +585,17 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().setInactiveTopicPolicies(topic, topicLevelPolicy);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
                 -> assertNotNull(admin.topics().getInactiveTopicPolicies(topic)));
-        policyFromBroker = admin.topics().getInactiveTopicPoliciesApplied(topic);
+        policyFromBroker = admin.topics().getInactiveTopicPolicies(topic, true);
         assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 30);
         assertFalse(policyFromBroker.isDeleteWhileInactive());
         assertEquals(policyFromBroker.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
         //remove topic-level policy
         admin.topics().removeInactiveTopicPolicies(topic);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
-                -> assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), namespaceLevelPolicy));
+                -> assertEquals(admin.topics().getInactiveTopicPolicies(topic, true), namespaceLevelPolicy));
         //remove namespace-level policy
         admin.namespaces().removeInactiveTopicPolicies(namespace);
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
-                -> assertEquals(admin.topics().getInactiveTopicPoliciesApplied(topic), brokerLevelPolicy));
+                -> assertEquals(admin.topics().getInactiveTopicPolicies(topic, true), brokerLevelPolicy));
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1808,7 +1808,15 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
-    InactiveTopicPolicies getInactiveTopicPoliciesApplied(String topic) throws PulsarAdminException;
+    InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get inactive topic policies applied for a topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic, boolean applied);
     /**
      * get inactive topic policies of a topic.
      * @param topic

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1803,6 +1803,13 @@ public interface Topics {
     CompletableFuture<Void> removeMaxUnackedMessagesOnConsumerAsync(String topic);
 
     /**
+     * Get inactive topic policies applied for a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    InactiveTopicPolicies getInactiveTopicPoliciesApplied(String topic) throws PulsarAdminException;
+    /**
      * get inactive topic policies of a topic.
      * @param topic
      * @return

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1597,6 +1597,18 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public InactiveTopicPolicies getInactiveTopicPoliciesApplied(String topic) throws PulsarAdminException {
+        try {
+            TopicName topicName = validateTopic(topic);
+            WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
+            path = path.queryParam("applied", true);
+            return request(path).get(new GenericType<InactiveTopicPolicies>() {});
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
     public InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException {
         try {
             return getInactiveTopicPoliciesAsync(topic).

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1597,21 +1597,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public InactiveTopicPolicies getInactiveTopicPoliciesApplied(String topic) throws PulsarAdminException {
+    public InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException {
         try {
-            TopicName topicName = validateTopic(topic);
-            WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
-            path = path.queryParam("applied", true);
-            return request(path).get(new GenericType<InactiveTopicPolicies>() {});
-        } catch (Exception e) {
-            throw getApiException(e);
-        }
-    }
-
-    @Override
-    public InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException {
-        try {
-            return getInactiveTopicPoliciesAsync(topic).
+            return getInactiveTopicPoliciesAsync(topic, applied).
                     get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw (PulsarAdminException) e.getCause();
@@ -1624,9 +1612,10 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic) {
+    public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic, boolean applied) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
+        path = path.queryParam("applied", applied);
         final CompletableFuture<InactiveTopicPolicies> future = new CompletableFuture<>();
         asyncGetRequest(path, new InvocationCallback<InactiveTopicPolicies>() {
             @Override
@@ -1640,6 +1629,16 @@ public class TopicsImpl extends BaseResource implements Topics {
             }
         });
         return future;
+    }
+
+    @Override
+    public InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException {
+        return getInactiveTopicPolicies(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic) {
+        return getInactiveTopicPoliciesAsync(topic, false);
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -862,6 +862,9 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("reset-cursor persistent://myprop/clust/ns1/ds2 -s sub1 -m 1:1 -e"));
         verify(mockTopics).resetCursor(eq("persistent://myprop/clust/ns1/ds2"), eq("sub1")
                 , eq(new MessageIdImpl(1, 1, -1)), eq(true));
+
+        cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -ap"));
+        verify(mockTopics).getInactiveTopicPoliciesApplied("persistent://myprop/clust/ns1/ds1");
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -824,7 +824,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).setDeduplicationSnapshotInterval("persistent://myprop/clust/ns1/ds1", 99);
 
         cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", false);
         cmdTopics.run(split("remove-inactive-topic-policies persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -e -t 1s -m delete_when_no_subscriptions"));
@@ -864,7 +864,7 @@ public class PulsarAdminToolTest {
                 , eq(new MessageIdImpl(1, 1, -1)), eq(true));
 
         cmdTopics.run(split("get-inactive-topic-policies persistent://myprop/clust/ns1/ds1 -ap"));
-        verify(mockTopics).getInactiveTopicPoliciesApplied("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopics).getInactiveTopicPolicies("persistent://myprop/clust/ns1/ds1", true);
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1901,10 +1901,17 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-ap", "--applied" }, description = "Get the applied policy of the topic")
+        private boolean applied = false;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            print(admin.topics().getInactiveTopicPolicies(persistentTopic));
+            if (applied) {
+                print(admin.topics().getInactiveTopicPoliciesApplied(persistentTopic));
+            } else {
+                print(admin.topics().getInactiveTopicPolicies(persistentTopic));
+            }
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1907,11 +1907,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            if (applied) {
-                print(admin.topics().getInactiveTopicPoliciesApplied(persistentTopic));
-            } else {
-                print(admin.topics().getInactiveTopicPolicies(persistentTopic));
-            }
+            print(admin.topics().getInactiveTopicPolicies(persistentTopic, applied));
         }
     }
 


### PR DESCRIPTION
Master Issue: #9216

### Modifications
1 Now if there is no data at the namespace-level, the broker-level data will be returned by default, so let it return null
2 add query param `applied` for getInactiveTopic
3 add `applied` API for client

### Verifying this change
unit test:
InactiveTopicDeleteTest#testInactiveTopicApplied