### PR TITLE
Support fetching metadata from entry data in publish callback

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -21,6 +21,8 @@ package org.apache.bookkeeper.mledger;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 
@@ -64,7 +66,7 @@ public interface AsyncCallbacks {
     }
 
     interface AddEntryCallback {
-        void addComplete(Position position, Object ctx);
+        void addComplete(Position position, ByteBuf entryData, Object ctx);
 
         void addFailed(ManagedLedgerException exception, Object ctx);
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -593,7 +593,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         asyncAddEntry(data, offset, length, new AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 result.position = position;
                 counter.countDown();
             }
@@ -628,7 +628,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         asyncAddEntry(data, numberOfMessages, offset, length, new AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 result.position = position;
                 counter.countDown();
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -208,6 +208,8 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
                 ReferenceCountUtil.release(data);
                 ml.notifyCursors();
                 this.recycle();
+            } else {
+                ReferenceCountUtil.release(data);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -192,21 +192,20 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
             entry.release();
         }
 
-        // We are done using the byte buffer
-        ReferenceCountUtil.release(data);
-
         PositionImpl lastEntry = PositionImpl.get(ledger.getId(), entryId);
         ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(ml);
         ml.lastConfirmedEntry = lastEntry;
 
         if (closeWhenDone) {
+            ReferenceCountUtil.release(data);
             log.info("[{}] Closing ledger {} for being full", ml.getName(), ledger.getId());
             ledger.asyncClose(this, ctx);
         } else {
             updateLatency();
             AddEntryCallback cb = callbackUpdater.getAndSet(this, null);
             if (cb != null) {
-                cb.addComplete(lastEntry, ctx);
+                cb.addComplete(lastEntry, data.asReadOnly(), ctx);
+                ReferenceCountUtil.release(data);
                 ml.notifyCursors();
                 this.recycle();
             }
@@ -229,7 +228,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
         AddEntryCallback cb = callbackUpdater.getAndSet(this, null);
         if (cb != null) {
-            cb.addComplete(PositionImpl.get(lh.getId(), entryId), ctx);
+            cb.addComplete(PositionImpl.get(lh.getId(), entryId), null, ctx);
             ml.notifyCursors();
             this.recycle();
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -1000,7 +1001,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 }
 
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     lastPosition.set(position);
                     c1.asyncMarkDelete(position, new MarkDeleteCallback() {
                         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -484,7 +486,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
             ledger1.asyncAddEntry(("entry-" + i).getBytes(), new AddEntryCallback() {
 
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     latch.countDown();
                 }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
@@ -332,7 +334,7 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
                 // not-ok
             }
 
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 // ok
             }
         }, null);
@@ -342,7 +344,7 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
                 promise.complete(null);
             }
 
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 promise.completeExceptionally(new Exception("should have failed"));
             }
         }, null);
@@ -445,7 +447,7 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
         AddEntryCallback cb = new AddEntryCallback() {
 
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 counter.countDown();
             }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -35,6 +35,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Sets;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Field;
@@ -295,7 +296,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
                         ledger.asyncAddEntry("test".getBytes(Encoding), new AddEntryCallback() {
                             @Override
-                            public void addComplete(Position position, Object ctx) {
+                            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                                 @SuppressWarnings("unchecked")
                                 Pair<ManagedLedger, ManagedCursor> pair = (Pair<ManagedLedger, ManagedCursor>) ctx;
                                 ManagedLedger ledger = pair.getLeft();
@@ -548,7 +549,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         ledger.asyncAddEntry("dummy-entry-1".getBytes(Encoding), new AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 assertNull(ctx);
 
                 counter.countDown();
@@ -577,7 +578,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             final String content = "dummy-entry-" + i;
             ledger.asyncAddEntry(content.getBytes(Encoding), new AddEntryCallback() {
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     assertNotNull(ctx);
 
                     log.info("Successfully added {}", content);
@@ -607,7 +608,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         ledger.asyncAddEntry("dummy-entry-1".getBytes(Encoding), new AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 fail("Should have failed");
             }
 
@@ -832,7 +833,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             String content = "entry-" + i;
             ledger.asyncAddEntry(content.getBytes(Encoding), new AddEntryCallback() {
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     counter.countDown();
                 }
 
@@ -2615,7 +2616,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ledger.asyncAddEntry(data.getBytes(), new AddEntryCallback() {
 
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 addSuccess.set(true);
                 latch.countDown();
             }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
@@ -478,7 +480,7 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
                 }
 
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     lastPosition.set(position);
                     c1.asyncMarkDelete(position, new MarkDeleteCallback() {
                         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -76,6 +76,9 @@ public interface Topic {
 
         void completed(Exception e, long ledgerId, long entryId);
 
+        default void setMetadataFromEntryData(ByteBuf entryData) {
+        }
+
         default long getHighestSequenceId() {
             return  -1L;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -449,12 +449,13 @@ public class PersistentTopic extends AbstractTopic
     }
 
     @Override
-    public void addComplete(Position pos, Object ctx) {
+    public void addComplete(Position pos, ByteBuf entryData, Object ctx) {
         PublishContext publishContext = (PublishContext) ctx;
         PositionImpl position = (PositionImpl) pos;
 
         // Message has been successfully persisted
         messageDeduplication.recordMessagePersisted(publishContext, position);
+        publishContext.setMetadataFromEntryData(entryData);
         publishContext.completed(null, position.getLedgerId(), position.getEntryId());
         // in order to sync the max position when cursor read entries
         transactionBuffer.syncMaxReadPositionForNormalPublish((PositionImpl) ledger.getLastConfirmedEntry());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -62,7 +62,7 @@ public class TopicTransactionBuffer implements TransactionBuffer {
         CompletableFuture<Position> completableFuture = new CompletableFuture<>();
         topic.getManagedLedger().asyncAddEntry(buffer, new AsyncCallbacks.AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 synchronized (TopicTransactionBuffer.this) {
                     if (!ongoingTxns.containsKey(txnId)) {
                         ongoingTxns.put(txnId, (PositionImpl) position);
@@ -99,7 +99,7 @@ public class TopicTransactionBuffer implements TransactionBuffer {
 
         topic.getManagedLedger().asyncAddEntry(commitMarker, new AsyncCallbacks.AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 synchronized (TopicTransactionBuffer.this) {
                     updateMaxReadPosition(txnID);
                     handleLowWaterMark(txnID, lowWaterMark);
@@ -126,7 +126,7 @@ public class TopicTransactionBuffer implements TransactionBuffer {
         ByteBuf abortMarker = Markers.newTxnAbortMarker(-1L, txnID.getMostSigBits(), txnID.getLeastSigBits());
         topic.getManagedLedger().asyncAddEntry(abortMarker, new AsyncCallbacks.AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 synchronized (TopicTransactionBuffer.this) {
                     aborts.put(txnID, (PositionImpl) position);
                     updateMaxReadPosition(txnID);
@@ -152,7 +152,7 @@ public class TopicTransactionBuffer implements TransactionBuffer {
                         txnID.getMostSigBits(), txnID.getLeastSigBits());
                 topic.getManagedLedger().asyncAddEntry(abortMarker, new AsyncCallbacks.AddEntryCallback() {
                     @Override
-                    public void addComplete(Position position, Object ctx) {
+                    public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                         synchronized (TopicTransactionBuffer.this) {
                             aborts.put(firstTxn, (PositionImpl) position);
                             updateMaxReadPosition(firstTxn);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -238,7 +238,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((AddEntryCallback) invocationOnMock.getArguments()[1]).addComplete(new PositionImpl(1, 1), null);
+                ((AddEntryCallback) invocationOnMock.getArguments()[1]).addComplete(
+                        new PositionImpl(1, 1), null, null);
                 return null;
             }
         }).when(ledgerMock).asyncAddEntry(any(byte[].class), any(AddEntryCallback.class), any());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -289,6 +289,14 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     @Test
     public void testPublishMessage() throws Exception {
 
+        doAnswer(invocationOnMock -> {
+            final ByteBuf payload = (ByteBuf) invocationOnMock.getArguments()[0];
+            final AddEntryCallback callback = (AddEntryCallback) invocationOnMock.getArguments()[1];
+            final Topic.PublishContext ctx = (Topic.PublishContext) invocationOnMock.getArguments()[2];
+            callback.addComplete(PositionImpl.latest, payload, ctx);
+            return null;
+        }).when(ledgerMock).asyncAddEntry(any(ByteBuf.class), any(AddEntryCallback.class), any());
+
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         /*
          * MessageMetadata.Builder messageMetadata = MessageMetadata.newBuilder();
@@ -299,9 +307,23 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        topic.publishMessage(payload, (exception, ledgerId, entryId) -> {
-            latch.countDown();
-        });
+        final Topic.PublishContext publishContext = new Topic.PublishContext() {
+            @Override
+            public void completed(Exception e, long ledgerId, long entryId) {
+                assertEquals(ledgerId, PositionImpl.latest.getLedgerId());
+                assertEquals(entryId, PositionImpl.latest.getEntryId());
+                latch.countDown();
+            }
+
+            @Override
+            public void setMetadataFromEntryData(ByteBuf entryData) {
+                // This method must be invoked before `completed`
+                assertEquals(latch.getCount(), 1);
+                assertEquals(entryData.array(), payload.array());
+            }
+        };
+
+        topic.publishMessage(payload, publishContext);
 
         assertTrue(latch.await(1, TimeUnit.SECONDS));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1235,6 +1235,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 ((AddEntryCallback) invocationOnMock.getArguments()[1]).addComplete(new PositionImpl(1, 1),
+                        null,
                         invocationOnMock.getArguments()[2]);
                 return null;
             }
@@ -1717,7 +1718,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             ByteBuf entry = getMessageWithMetadata(content.getBytes());
             ledger.asyncAddEntry(entry, new AddEntryCallback() {
                 @Override
-                public void addComplete(Position position, Object ctx) {
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                     latch.countDown();
                     entry.release();
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1531,7 +1531,9 @@ public class ServerCnxTest {
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((AddEntryCallback) invocationOnMock.getArguments()[1]).addComplete(new PositionImpl(-1, -1),
+                ((AddEntryCallback) invocationOnMock.getArguments()[1]).addComplete(
+                        new PositionImpl(-1, -1),
+                        null,
                         invocationOnMock.getArguments()[2]);
                 return null;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -189,7 +189,7 @@ public class MessageDuplicationTest {
         Topic.PublishContext publishContext2 = getPublishContext(producerName2, 1);
 
         persistentTopic.publishMessage(byteBuf1, publishContext1);
-        persistentTopic.addComplete(new PositionImpl(0, 1), publishContext1);
+        persistentTopic.addComplete(new PositionImpl(0, 1), null, publishContext1);
         verify(managedLedger, times(1)).asyncAddEntry(any(ByteBuf.class), any(), any());
         Long lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertTrue(lastSequenceIdPushed != null);
@@ -199,7 +199,7 @@ public class MessageDuplicationTest {
         assertEquals(lastSequenceIdPushed.longValue(), 0);
 
         persistentTopic.publishMessage(byteBuf2, publishContext2);
-        persistentTopic.addComplete(new PositionImpl(0, 2), publishContext2);
+        persistentTopic.addComplete(new PositionImpl(0, 2), null, publishContext2);
         verify(managedLedger, times(2)).asyncAddEntry(any(ByteBuf.class), any(), any());
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName2);
         assertTrue(lastSequenceIdPushed != null);
@@ -211,7 +211,7 @@ public class MessageDuplicationTest {
         byteBuf1 = getMessage(producerName1, 1);
         publishContext1 = getPublishContext(producerName1, 1);
         persistentTopic.publishMessage(byteBuf1, publishContext1);
-        persistentTopic.addComplete(new PositionImpl(0, 3), publishContext1);
+        persistentTopic.addComplete(new PositionImpl(0, 3), null, publishContext1);
         verify(managedLedger, times(3)).asyncAddEntry(any(ByteBuf.class), any(), any());
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertTrue(lastSequenceIdPushed != null);
@@ -223,7 +223,7 @@ public class MessageDuplicationTest {
         byteBuf1 = getMessage(producerName1, 5);
         publishContext1 = getPublishContext(producerName1, 5);
         persistentTopic.publishMessage(byteBuf1, publishContext1);
-        persistentTopic.addComplete(new PositionImpl(0, 4), publishContext1);
+        persistentTopic.addComplete(new PositionImpl(0, 4), null, publishContext1);
         verify(managedLedger, times(4)).asyncAddEntry(any(ByteBuf.class), any(), any());
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertTrue(lastSequenceIdPushed != null);
@@ -263,7 +263,7 @@ public class MessageDuplicationTest {
         verify(publishContext1, times(1)).completed(any(MessageDeduplication.MessageDupUnknownException.class), eq(-1L), eq(-1L));
 
         // complete seq 6 message eventually
-        persistentTopic.addComplete(new PositionImpl(0, 5), publishContext1);
+        persistentTopic.addComplete(new PositionImpl(0, 5), null, publishContext1);
 
         // simulate failure
         byteBuf1 = getMessage(producerName1, 7);
@@ -300,7 +300,7 @@ public class MessageDuplicationTest {
         publishContext1 = getPublishContext(producerName1, 8);
         persistentTopic.publishMessage(byteBuf1, publishContext1);
         verify(managedLedger, times(7)).asyncAddEntry(any(ByteBuf.class), any(), any());
-        persistentTopic.addComplete(new PositionImpl(0, 5), publishContext1);
+        persistentTopic.addComplete(new PositionImpl(0, 5), null, publishContext1);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertTrue(lastSequenceIdPushed != null);
         assertEquals(lastSequenceIdPushed.longValue(), 8);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -235,7 +235,7 @@ public class ManagedLedgerWriter {
 
                     final AddEntryCallback addEntryCallback = new AddEntryCallback() {
                         @Override
-                        public void addComplete(Position position, Object ctx) {
+                        public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                             long sendTime = (Long) (ctx);
                             messagesSent.increment();
                             bytesSent.add(payloadData.length);

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -118,7 +118,7 @@ public class MLTransactionLogImpl implements TransactionLog {
         transactionMetadataEntry.writeTo(buf);
         managedLedger.asyncAddEntry(buf, new AsyncCallbacks.AddEntryCallback() {
             @Override
-            public void addComplete(Position position, Object ctx) {
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 buf.release();
                 completableFuture.complete(position);
             }


### PR DESCRIPTION
### Motivation

[PIP-70](https://github.com/apache/pulsar/wiki/PIP-70%3A-Introduce-lightweight-broker-entry-metadata) introduced lightweight broker entry metadata which is added by related interceptor like `AppendBrokerTimestampMetadataInterceptor` before being written to bookie asynchronously. However, in the callback when entries are written to bookie successfully, the caller side can only get the ledger id and entry id, see `PublishContext#completed`:

```java
void completed(Exception e, long ledgerId, long entryId);
```

Currently there's no way to get the broker entry data in publish callback. We can access the interceptor's internal field but it may be overwritten by the next entry's broker entry metadata because the interceptor changes the internal fields when the entry was sent while the callback is invoked when the send is done.

This PR intends to expose the entry's data to callbacks, including managed ledger's add callback and the publish context's complete callback. If we want to make use of broker entry metadata or the old message metadata in future, we can use the new callbacks.

### Modifications

- Add an extra `ByteBuf` argument to `AddEntryCallback#addComplete` to expose the entry data.
- Add a default method `setMetadataFromEntryData` to `PublishContext` interface to allow implementer side retrieve some metadata from entry data.
- Add tests for `AddEntryCallback#addComplete`.
- Add tests for `PublishContext#setMetadataFromEntryData`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
1. `ManagedLedgerTest#asyncAddEntryWithoutError` verifies the read-only buffer argument `entryData`.
2. `PersistentTopicTest#testPublishMessage` verifies the new method of `PublishContext` interface.