### PR TITLE
remove consumer unnecessary locks

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -126,8 +126,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private final int receiverQueueRefillThreshold;
 
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
-
     private final UnAckedMessageTracker unAckedMessageTracker;
     private final AcknowledgmentsGroupingTracker acknowledgmentsGroupingTracker;
     private final NegativeAcksTracker negativeAcksTracker;
@@ -409,7 +407,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         CompletableFuture<Message<T>> result = cancellationHandler.createFuture();
         Message<T> message = null;
         try {
-            lock.writeLock().lock();
             message = incomingMessages.poll(0, TimeUnit.MILLISECONDS);
             if (message == null) {
                 pendingReceives.add(result);
@@ -418,8 +415,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             result.completeExceptionally(e);
-        } finally {
-            lock.writeLock().unlock();
         }
 
         if (message != null) {
@@ -470,32 +465,28 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     protected CompletableFuture<Messages<T>> internalBatchReceiveAsync() {
         CompletableFutureCancellationHandler cancellationHandler = new CompletableFutureCancellationHandler();
         CompletableFuture<Messages<T>> result = cancellationHandler.createFuture();
-        try {
-            lock.writeLock().lock();
-            if (pendingBatchReceives == null) {
-                pendingBatchReceives = Queues.newConcurrentLinkedQueue();
-            }
-            if (hasEnoughMessagesForBatchReceive()) {
-                MessagesImpl<T> messages = getNewMessagesImpl();
-                Message<T> msgPeeked = incomingMessages.peek();
-                while (msgPeeked != null && messages.canAdd(msgPeeked)) {
-                    Message<T> msg = incomingMessages.poll();
-                    if (msg != null) {
-                        messageProcessed(msg);
-                        Message<T> interceptMsg = beforeConsume(msg);
-                        messages.add(interceptMsg);
-                    }
-                    msgPeeked = incomingMessages.peek();
-                }
-                result.complete(messages);
-            } else {
-                OpBatchReceive<T> opBatchReceive = OpBatchReceive.of(result);
-                pendingBatchReceives.add(opBatchReceive);
-                cancellationHandler.setCancelAction(() -> pendingBatchReceives.remove(opBatchReceive));
-            }
-        } finally {
-            lock.writeLock().unlock();
+        if (pendingBatchReceives == null) {
+            pendingBatchReceives = Queues.newConcurrentLinkedQueue();
         }
+        if (hasEnoughMessagesForBatchReceive()) {
+            MessagesImpl<T> messages = getNewMessagesImpl();
+            Message<T> msg = null;
+            do {
+                msg = incomingMessages.poll();
+                if (msg != null) {
+                    messageProcessed(msg);
+                    Message<T> interceptMsg = beforeConsume(msg);
+                    messages.add(interceptMsg);
+                }
+            } while (msg != null && messages.canAdd());
+
+            result.complete(messages);
+        } else {
+            OpBatchReceive<T> opBatchReceive = OpBatchReceive.of(result);
+            pendingBatchReceives.add(opBatchReceive);
+            cancellationHandler.setCancelAction(() -> pendingBatchReceives.remove(opBatchReceive));
+        }
+
         return result;
     }
 
@@ -948,14 +939,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     private void failPendingReceive() {
-        lock.readLock().lock();
-        try {
-            if (pinnedExecutor != null && !pinnedExecutor.isShutdown()) {
-                failPendingReceives(this.pendingReceives);
-                failPendingBatchReceives(this.pendingBatchReceives);
-            }
-        } finally {
-            lock.readLock().unlock();
+        if (pinnedExecutor != null && !pinnedExecutor.isShutdown()) {
+            failPendingReceives(this.pendingReceives);
+            failPendingBatchReceives(this.pendingBatchReceives);
         }
     }
 
@@ -1053,23 +1039,18 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     uncompressedPayload, createEncryptionContext(msgMetadata), cnx, schema, redeliveryCount);
             uncompressedPayload.release();
 
-            lock.readLock().lock();
-            try {
-                // Enqueue the message so that it can be retrieved when application calls receive()
-                // if the conf.getReceiverQueueSize() is 0 then discard message if no one is waiting for it.
-                // if asyncReceive is waiting then notify callback without adding to incomingMessages queue
-                if (deadLetterPolicy != null && possibleSendToDeadLetterTopicMessages != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()) {
-                    possibleSendToDeadLetterTopicMessages.put((MessageIdImpl)message.getMessageId(), Collections.singletonList(message));
-                }
-                if (peekPendingReceive() != null) {
-                    notifyPendingReceivedCallback(message, null);
-                } else if (enqueueMessageAndCheckBatchReceive(message)) {
-                    if (hasPendingBatchReceive()) {
-                        notifyPendingBatchReceivedCallBack();
-                    }
-                }
-            } finally {
-                lock.readLock().unlock();
+            // Enqueue the message so that it can be retrieved when application calls receive()
+            // if the conf.getReceiverQueueSize() is 0 then discard message if no one is waiting for it.
+            // if asyncReceive is waiting then notify callback without adding to incomingMessages queue
+            if (deadLetterPolicy != null && possibleSendToDeadLetterTopicMessages != null &&
+                    redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()) {
+                possibleSendToDeadLetterTopicMessages.put((MessageIdImpl)message.getMessageId(),
+                        Collections.singletonList(message));
+            }
+            if (peekPendingReceive() != null) {
+                notifyPendingReceivedCallback(message, null);
+            } else if (enqueueMessageAndCheckBatchReceive(message) && hasPendingBatchReceive()) {
+                notifyPendingBatchReceivedCallBack();
             }
         } else {
             // handle batch message enqueuing; uncompressed payload has all messages in batch
@@ -1280,17 +1261,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (possibleToDeadLetter != null) {
                     possibleToDeadLetter.add(message);
                 }
-                lock.readLock().lock();
-                try {
-                    if (peekPendingReceive() != null) {
-                        notifyPendingReceivedCallback(message, null);
-                    } else if (enqueueMessageAndCheckBatchReceive(message)) {
-                        if (hasPendingBatchReceive()) {
-                            notifyPendingBatchReceivedCallBack();
-                        }
-                    }
-                } finally {
-                    lock.readLock().unlock();
+
+                if (peekPendingReceive() != null) {
+                    notifyPendingReceivedCallback(message, null);
+                } else if (enqueueMessageAndCheckBatchReceive(message) && hasPendingBatchReceive()) {
+                    notifyPendingBatchReceivedCallBack();
                 }
                 singleMessagePayload.release();
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -56,6 +56,18 @@ public class MessagesImpl<T> implements Messages<T> {
         return true;
     }
 
+    protected boolean canAdd() {
+        if (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 > maxNumberOfMessages) {
+            return false;
+        }
+
+        if (maxSizeOfMessages > 0 && currentSizeOfMessages + 1 > maxSizeOfMessages) {
+            return false;
+        }
+
+        return true;
+    }
+
     protected void add(Message<T> message) {
         if (message == null) {
             return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagesImpl.java
@@ -56,18 +56,6 @@ public class MessagesImpl<T> implements Messages<T> {
         return true;
     }
 
-    protected boolean canAdd() {
-        if (maxNumberOfMessages > 0 && currentNumberOfMessages + 1 > maxNumberOfMessages) {
-            return false;
-        }
-
-        if (maxSizeOfMessages > 0 && currentSizeOfMessages + 1 > maxSizeOfMessages) {
-            return false;
-        }
-
-        return true;
-    }
-
     protected void add(Message<T> message) {
         if (message == null) {
             return;


### PR DESCRIPTION
### Motivation
1. The `ConsumerImpl` has many unnecessary locks for thread-safe Queue, such as `Queues.newConcurrentLinkedQueue`, `GrowableArrayBlockingQueue`, `ConcurrentLinkedQueue` 

### Changes
1. Remove unnecessary locks in `ConsumerImpl`

Related to PR#8207