### PR TITLE
Ensure that temporary directories are deleted during tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdvertisedAddressTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdvertisedAddressTest.java
@@ -42,7 +42,7 @@ public class AdvertisedAddressTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
+        bkEnsemble = new LocalBookkeeperEnsemble(1, 0, () -> 0);
         bkEnsemble.start();
 
         ServiceConfiguration config = new ServiceConfiguration();
@@ -52,6 +52,9 @@ public class AdvertisedAddressTest {
         config.setAdvertisedAddress("localhost");
         config.setBrokerServicePort(Optional.ofNullable(0));
         config.setAdvertisedAddress(advertisedAddress);
+        config.setManagedLedgerDefaultEnsembleSize(1);
+        config.setManagedLedgerDefaultWriteQuorum(1);
+        config.setManagedLedgerDefaultAckQuorum(1);
         config.setManagedLedgerMaxEntriesPerLedger(5);
         config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
         pulsar = new PulsarService(config);

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -38,6 +38,8 @@ import java.net.Socket;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -64,6 +66,7 @@ import org.apache.bookkeeper.stream.server.StreamStorageLifecycleComponent;
 import org.apache.bookkeeper.stream.storage.api.cluster.ClusterInitializer;
 import org.apache.bookkeeper.stream.storage.impl.cluster.ZkClusterInitializer;
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
@@ -169,6 +172,16 @@ public class LocalBookkeeperEnsemble {
     StreamStorageLifecycleComponent streamStorage;
     Integer streamStoragePort = 4181;
 
+    // directories created by this instance
+    // it is safe to drop them on stop
+    List<File> temporaryDirectories = new ArrayList<>();
+
+    private File createTempDirectory(String seed) throws IOException {
+        File res = Files.createTempDirectory(seed).toFile();
+        temporaryDirectories.add(res);
+        return res;
+    }
+
     private void runZookeeper(int maxCC) throws IOException {
         // create a ZooKeeper server(dataDir, dataLogDir, port)
         LOG.info("Starting ZK server");
@@ -176,7 +189,7 @@ public class LocalBookkeeperEnsemble {
         // ClientBase.setupTestEnv();
 
         File zkDataDir = isNotBlank(zkDataDirName) ? Files.createDirectories(Paths.get(zkDataDirName)).toFile()
-                : Files.createTempDirectory("zktest").toFile();
+                : createTempDirectory("zktest");
 
         if (this.clearOldData) {
             cleanDirectory(zkDataDir);
@@ -270,7 +283,7 @@ public class LocalBookkeeperEnsemble {
 
             File bkDataDir = isNotBlank(bkDataDirName)
                     ? Files.createDirectories(Paths.get(bkDataDirName + Integer.toString(i))).toFile()
-                    : Files.createTempDirectory("bk" + Integer.toString(i) + "test").toFile();
+                    : createTempDirectory("bk" + Integer.toString(i) + "test");
 
             if (this.clearOldData) {
                 cleanDirectory(bkDataDir);
@@ -489,6 +502,11 @@ public class LocalBookkeeperEnsemble {
             zkDataCleanupManager.shutdown();
         }
         LOG.debug("Local ZK/BK stopped");
+        for (File managedDir : temporaryDirectories) {
+            LOG.info("deleting test directory {}", managedDir);
+            FileUtils.deleteDirectory(managedDir);
+        }
+        temporaryDirectories.clear();
     }
 
     /* Watching SyncConnected event from ZooKeeper */


### PR DESCRIPTION
### Motivation
The test suite (especially pulsar-broker) creates lots of temporary files, that accumulate on CI and also they fill up the /tmp dir during development (if you dare to run all of the tests locally)

### Modifications

Modify LocalBookKeeperEnsemble to delete all the temporary directories it created at boot.
We are not deleting directories that are passed externally from the constructor (like in Pulsar Standalone)

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.