### PR TITLE
[pulsar-broker] Make tenant rest-api async and use metadata-store api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -89,7 +89,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AdminResource extends PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
-    private static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
+    public static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
     public static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
     private static final String MANAGED_LEDGER_PATH_ZNODE = "/managed-ledgers";
 
@@ -169,7 +169,7 @@ public abstract class AdminResource extends PulsarWebResource {
 
     // This is a stub method for Mockito
     @Override
-    protected void validateSuperUserAccess() {
+    public void validateSuperUserAccess() {
         super.validateSuperUserAccess();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BaseResources.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BaseResources.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import lombok.Getter;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+/**
+ * Base class for all configuration resources to access configurations from metadata-store.
+ *
+ * @param <T>
+ *            type of configuration-resources.
+ */
+public class BaseResources<T> {
+
+    @Getter
+    private final MetadataStoreExtended store;
+    @Getter
+    private final MetadataCache<T> cache;
+
+    public BaseResources(MetadataStoreExtended store, Class<T> clazz) {
+        this.store = store;
+        this.cache = store.getMetadataCache(clazz);
+    }
+
+    public CompletableFuture<List<String>> getChildren(String path) {
+        return cache.getChildren(path);
+    }
+
+    public Optional<T> get(String path) throws PulsarServerException {
+        try {
+            return getAsync(path).get();
+        } catch (Exception e) {
+            throw new PulsarServerException("Failed to get data from " + path,
+                    (e instanceof ExecutionException) ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Optional<T>> getAsync(String path) {
+        return cache.get(path);
+    }
+
+    public void set(String path, Function<T, T> modifyFunction) throws PulsarServerException {
+        try {
+            setAsync(path, modifyFunction).get();
+        } catch (Exception e) {
+            throw new PulsarServerException("Failed to set data for " + path,
+                    (e instanceof ExecutionException) ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Void> setAsync(String path, Function<T, T> modifyFunction) {
+        return cache.readModifyUpdate(path, modifyFunction);
+    }
+
+    public void create(String path, T data) throws PulsarServerException {
+        try {
+            createAsync(path, data).get();
+        } catch (Exception e) {
+            throw new PulsarServerException("Failed to create " + path,
+                    (e instanceof ExecutionException) ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Void> createAsync(String path, T data) {
+        return cache.readModifyUpdateOrCreate(path, t -> data);
+    }
+
+    public void delete(String path) throws PulsarServerException {
+        try {
+            deleteAsync(path).get();
+        } catch (Exception e) {
+            throw new PulsarServerException("Failed to delete " + path,
+                    (e instanceof ExecutionException) ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Void> deleteAsync(String path) {
+        return cache.delete(path);
+    }
+
+    public boolean exists(String path) throws PulsarServerException {
+        try {
+            return existsAsync(path).get();
+        } catch (Exception e) {
+            throw new PulsarServerException("Failed to check exist " + path,
+                    (e instanceof ExecutionException) ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Boolean> existsAsync(String path) {
+        return cache.exists(path);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClusterResources.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClusterResources.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+public class ClusterResources extends BaseResources<ClusterData> {
+
+    private static final String CLUSTERS_ROOT = "/admin/clusters";
+
+    public ClusterResources(MetadataStoreExtended store) {
+        super(store, ClusterData.class);
+    }
+
+    public Set<String> list() throws PulsarServerException {
+        try {
+            return new HashSet<>(super.getChildren(CLUSTERS_ROOT).get());
+        } catch (InterruptedException e) {
+            throw new PulsarServerException(e);
+        } catch (ExecutionException e) {
+            throw new PulsarServerException(e.getCause());
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespaceResources.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespaceResources.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+public class NamespaceResources extends BaseResources<Policies> {
+    public NamespaceResources(MetadataStoreExtended store) {
+        super(store, Policies.class);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PulsarResources.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PulsarResources.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+@Getter(AccessLevel.PUBLIC)
+public class PulsarResources {
+
+    private TenantResources tenatResources;
+    private ClusterResources clusterResources;
+    private NamespaceResources namespaceResources;
+
+    public PulsarResources(MetadataStoreExtended configurationMetadataStore) {
+        tenatResources = new TenantResources(configurationMetadataStore);
+        clusterResources = new ClusterResources(configurationMetadataStore);
+        namespaceResources = new NamespaceResources(configurationMetadataStore);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantResources.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantResources.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.impl;
+
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+public class TenantResources extends BaseResources<TenantInfo> {
+    public TenantResources(MetadataStoreExtended store) {
+        super(store, TenantInfo.class);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -24,8 +24,10 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -33,35 +35,45 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.data.Stat;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TenantsBase extends AdminResource {
+public class TenantsBase extends PulsarWebResource {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantsBase.class);
 
     @GET
     @ApiOperation(value = "Get the list of existing tenants.", response = String.class, responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant doesn't exist") })
-    public List<String> getTenants() {
-        validateSuperUserAccess();
-
+    public void getTenants(@Suspended final AsyncResponse asyncResponse) {
+        final String clientAppId = clientAppId();
         try {
-            List<String> tenants = globalZk().getChildren(path(POLICIES), false);
-            tenants.sort(null);
-            return tenants;
+            validateSuperUserAccess();
         } catch (Exception e) {
-            log.error("[{}] Failed to get tenants list", clientAppId(), e);
-            throw new RestException(e);
+            asyncResponse.resume(e);
+            return;
         }
+        tenantResources().getChildren(path(POLICIES)).whenComplete((tenants, e) -> {
+            if (e != null) {
+                log.error("[{}] Failed to get tenants list", clientAppId, e);
+                asyncResponse.resume(new RestException(e));
+                return;
+            }
+            tenants.sort(null);
+            asyncResponse.resume(tenants);
+        });
     }
 
     @GET
@@ -69,18 +81,25 @@ public class TenantsBase extends AdminResource {
     @ApiOperation(value = "Get the admin configuration for a given tenant.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant does not exist") })
-    public TenantInfo getTenantAdmin(
-        @ApiParam(value = "The tenant name")
-        @PathParam("tenant") String tenant) {
-        validateSuperUserAccess();
-
+    public void getTenantAdmin(@Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant) {
+        final String clientAppId = clientAppId();
         try {
-            return tenantsCache().get(path(POLICIES, tenant))
-                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Tenant does not exist"));
+            validateSuperUserAccess();
         } catch (Exception e) {
-            log.error("[{}] Failed to get tenant {}", clientAppId(), tenant, e);
-            throw new RestException(e);
+            asyncResponse.resume(e);
         }
+
+        tenantResources().getAsync(path(POLICIES, tenant)).whenComplete((tenantInfo, e) -> {
+            if (e != null) {
+                log.error("[{}] Failed to get Tenant {}", clientAppId, e.getMessage());
+                asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Failed to get Tenant"));
+                return;
+            }
+            boolean response = tenantInfo.isPresent() ? asyncResponse.resume(tenantInfo.get())
+                    : asyncResponse.resume(new RestException(Status.NOT_FOUND, "Tenant does not exist"));
+            return;
+        });
     }
 
     @PUT
@@ -91,103 +110,113 @@ public class TenantsBase extends AdminResource {
             @ApiResponse(code = 412, message = "Tenant name is not valid"),
             @ApiResponse(code = 412, message = "Clusters can not be empty"),
             @ApiResponse(code = 412, message = "Clusters do not exist") })
-    public void createTenant(
-        @ApiParam(value = "The tenant name")
-        @PathParam("tenant") String tenant,
-        @ApiParam(value = "TenantInfo") TenantInfo config) {
-        validateSuperUserAccess();
-        validatePoliciesReadOnlyAccess();
-        validateClusters(config);
+    public void createTenant(@Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant,
+            @ApiParam(value = "TenantInfo") TenantInfo tenantInfo) {
 
+        final String clientAppId = clientAppId();
         try {
+            validateSuperUserAccess();
+            validatePoliciesReadOnlyAccess();
+            validateClusters(tenantInfo);
             NamedEntity.checkName(tenant);
-
-            int maxTenants = pulsar().getConfiguration().getMaxTenants();
-            //Due to the cost of distributed locks, no locks are added here.
-            //In a concurrent scenario, the threshold will be exceeded.
-            if (maxTenants > 0) {
-                List<String> tenants = globalZk().getChildren(path(POLICIES), false);
-                if (tenants != null && tenants.size() >= maxTenants) {
-                    throw new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants");
-                }
-            }
-            zkCreate(path(POLICIES, tenant), jsonMapper().writeValueAsBytes(config));
-            log.info("[{}] Created tenant {}", clientAppId(), tenant);
-        } catch (KeeperException.NodeExistsException e) {
-            log.warn("[{}] Failed to create already existing tenant {}", clientAppId(), tenant);
-            throw new RestException(Status.CONFLICT, "Tenant already exists");
         } catch (IllegalArgumentException e) {
             log.warn("[{}] Failed to create tenant with invalid name {}", clientAppId(), tenant, e);
-            throw new RestException(Status.PRECONDITION_FAILED, "Tenant name is not valid");
+            asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED, "Tenant name is not valid"));
+            return;
         } catch (Exception e) {
-            log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, e);
-            throw new RestException(e);
+            asyncResponse.resume(e);
+            return;
         }
+
+        tenantResources().getChildren(path(POLICIES)).whenComplete((tenants, e) -> {
+            if (e != null) {
+                log.error("[{}] Failed to create tenant ", clientAppId, e.getCause());
+                asyncResponse.resume(new RestException(e));
+                return;
+            }
+
+            int maxTenants = pulsar().getConfiguration().getMaxTenants();
+            // Due to the cost of distributed locks, no locks are added here.
+            // In a concurrent scenario, the threshold will be exceeded.
+            if (maxTenants > 0) {
+                if (tenants != null && tenants.size() >= maxTenants) {
+                    asyncResponse.resume(
+                            new RestException(Status.PRECONDITION_FAILED, "Exceed the maximum number of tenants"));
+                    return;
+                }
+            }
+            tenantResources().existsAsync(path(POLICIES, tenant)).thenAccept(exist ->{
+                if (exist) {
+                    asyncResponse.resume(new RestException(Status.CONFLICT, "Tenant already exist"));
+                    return;
+                }
+                tenantResources().createAsync(path(POLICIES, tenant), tenantInfo).thenAccept((r) -> {
+                    log.info("[{}] Created tenant {}", clientAppId(), tenant);
+                    asyncResponse.resume(Response.noContent().build());
+                }).exceptionally(ex -> {
+                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, e);
+                    asyncResponse.resume(new RestException(ex));
+                    return null;
+                });
+            }).exceptionally(ex -> {
+                log.error("[{}] Failed to create tenant {}", clientAppId(), tenant, e);
+                asyncResponse.resume(new RestException(ex));
+                return null;
+            });
+        });
     }
 
     @POST
     @Path("/{tenant}")
     @ApiOperation(value = "Update the admins for a tenant.",
-            notes = "This operation requires Pulsar super-user privileges.")
+    notes = "This operation requires Pulsar super-user privileges.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant does not exist"),
             @ApiResponse(code = 409, message = "Tenant already exists"),
             @ApiResponse(code = 412, message = "Clusters can not be empty"),
             @ApiResponse(code = 412, message = "Clusters do not exist") })
-    public void updateTenant(
-        @ApiParam(value = "The tenant name")
-        @PathParam("tenant") String tenant,
-        @ApiParam(value = "TenantInfo") TenantInfo newTenantAdmin) {
-        validateSuperUserAccess();
-        validatePoliciesReadOnlyAccess();
-        validateClusters(newTenantAdmin);
-
-        Stat nodeStat = new Stat();
+    public void updateTenant(@Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "The tenant name") @PathParam("tenant") String tenant,
+            @ApiParam(value = "TenantInfo") TenantInfo newTenantAdmin) {
         try {
-            byte[] content = globalZk().getData(path(POLICIES, tenant), null, nodeStat);
-            TenantInfo oldTenantAdmin = jsonMapper().readValue(content, TenantInfo.class);
-            List<String> clustersWithActiveNamespaces = Lists.newArrayList();
-            if (oldTenantAdmin.getAllowedClusters().size() > newTenantAdmin.getAllowedClusters().size()) {
-                // Get the colo(s) being removed from the list
-                oldTenantAdmin.getAllowedClusters().removeAll(newTenantAdmin.getAllowedClusters());
-                log.debug("Following clusters are being removed : [{}]", oldTenantAdmin.getAllowedClusters());
-                for (String cluster : oldTenantAdmin.getAllowedClusters()) {
-                    if (Constants.GLOBAL_CLUSTER.equals(cluster)) {
-                        continue;
-                    }
-                    List<String> activeNamespaces = Lists.newArrayList();
-                    try {
-                        activeNamespaces = globalZk().getChildren(path(POLICIES, tenant, cluster), false);
-                        if (activeNamespaces.size() != 0) {
-                            // There are active namespaces in this cluster
-                            clustersWithActiveNamespaces.add(cluster);
-                        }
-                    } catch (KeeperException.NoNodeException nne) {
-                        // Fine, some cluster does not have active namespace. Move on!
-                    }
-                }
-                if (!clustersWithActiveNamespaces.isEmpty()) {
-                    // Throw an exception because colos being removed are having active namespaces
-                    String msg = String.format(
-                            "Failed to update the tenant because active namespaces are present in colos %s."
-                                    + " Please delete those namespaces first",
-                            clustersWithActiveNamespaces);
-                    throw new RestException(Status.CONFLICT, msg);
-                }
-            }
-            String tenantPath = path(POLICIES, tenant);
-            globalZk().setData(tenantPath, jsonMapper().writeValueAsBytes(newTenantAdmin), -1);
-            globalZkCache().invalidate(tenantPath);
-            log.info("[{}] updated tenant {}", clientAppId(), tenant);
-        } catch (RestException re) {
-            throw re;
-        } catch (KeeperException.NoNodeException e) {
-            log.warn("[{}] Failed to update tenant {}: does not exist", clientAppId(), tenant);
-            throw new RestException(Status.NOT_FOUND, "Tenant does not exist");
+            validateSuperUserAccess();
+            validatePoliciesReadOnlyAccess();
+            validateClusters(newTenantAdmin);
         } catch (Exception e) {
-            log.error("[{}] Failed to update tenant {}", clientAppId(), tenant, e);
-            throw new RestException(e);
+            asyncResponse.resume(e);
+            return;
         }
+
+        final String clientAddId = clientAppId();
+        tenantResources().getAsync(path(POLICIES, tenant)).thenAccept(tenantAdmin -> {
+            if (!tenantAdmin.isPresent()) {
+                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Tenant " + tenant + " not found"));
+                return;
+            }
+            TenantInfo oldTenantAdmin = tenantAdmin.get();
+            Set<String> newClusters = new HashSet<>(newTenantAdmin.getAllowedClusters());
+            canUpdateCluster(tenant, oldTenantAdmin.getAllowedClusters(), newClusters).thenApply(r -> {
+                tenantResources().setAsync(path(POLICIES, tenant), old -> {
+                    return newTenantAdmin;
+                }).thenAccept(done -> {
+                    log.info("Successfully updated tenant info {}", tenant);
+                    asyncResponse.resume(Response.noContent().build());
+                }).exceptionally(ex -> {
+                    log.warn("Failed to update tenant {}", tenant, ex.getCause());
+                    asyncResponse.resume(new RestException(ex));
+                    return null;
+                });
+                return null;
+            }).exceptionally(nsEx -> {
+                asyncResponse.resume(nsEx.getCause());
+                return null;
+            });
+        }).exceptionally(ex -> {
+            log.error("[{}] Failed to get tenant {}", clientAddId, tenant, ex.getCause());
+            asyncResponse.resume(new RestException(ex));
+            return null;
+        });
     }
 
     @DELETE
@@ -196,47 +225,59 @@ public class TenantsBase extends AdminResource {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant does not exist"),
             @ApiResponse(code = 409, message = "The tenant still has active namespaces") })
-    public void deleteTenant(
-        @PathParam("tenant")
-        @ApiParam(value = "The tenant name")
-        String tenant) {
-        validateSuperUserAccess();
-        validatePoliciesReadOnlyAccess();
-
-        boolean isTenantEmpty;
+    public void deleteTenant(@Suspended final AsyncResponse asyncResponse,
+            @PathParam("tenant") @ApiParam(value = "The tenant name") String tenant) {
         try {
-            isTenantEmpty = getListOfNamespaces(tenant).isEmpty();
-        } catch (KeeperException.NoNodeException e) {
-            log.warn("[{}] Failed to delete tenant {}: does not exist", clientAppId(), tenant);
-            throw new RestException(Status.NOT_FOUND, "The tenant does not exist");
+            validateSuperUserAccess();
+            validatePoliciesReadOnlyAccess();
         } catch (Exception e) {
-            log.error("[{}] Failed to get tenant status {}", clientAppId(), tenant, e);
-            throw new RestException(e);
+            asyncResponse.resume(e);
+            return;
         }
 
-        if (!isTenantEmpty) {
-            log.warn("[{}] Failed to delete tenant {}: not empty", clientAppId(), tenant);
-            throw new RestException(Status.CONFLICT, "The tenant still has active namespaces");
-        }
-
-        try {
-            // First try to delete every cluster z-node
-            for (String cluster : globalZk().getChildren(path(POLICIES, tenant), false)) {
-                globalZk().delete(path(POLICIES, tenant, cluster), -1);
+        tenantResources().existsAsync(path(POLICIES, tenant)).thenApply(exists ->{
+            if (!exists) {
+                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Tenant doesn't exist"));
+                return null;
             }
-
-            globalZk().delete(path(POLICIES, tenant), -1);
-            log.info("[{}] Deleted tenant {}", clientAppId(), tenant);
-        } catch (Exception e) {
-            log.error("[{}] Failed to delete tenant {}", clientAppId(), tenant, e);
-            throw new RestException(e);
-        }
+            return hasActiveNamespace(tenant).thenAccept(ns -> {
+                try {
+                    // already fetched children and they should be in the cache
+                    List<CompletableFuture<Void>> clusterList = Lists.newArrayList();
+                    for (String cluster : tenantResources().getChildren(path(POLICIES, tenant)).get()) {
+                        clusterList.add(tenantResources().deleteAsync(path(POLICIES, tenant, cluster)));
+                    }
+                    FutureUtil.waitForAll(clusterList).thenAccept(c -> {
+                        tenantResources().deleteAsync(path(POLICIES, tenant)).thenAccept(t -> {
+                            log.info("[{}] Deleted tenant {}", clientAppId(), tenant);
+                            asyncResponse.resume(Response.noContent().build());
+                        }).exceptionally(ex -> {
+                            log.error("Failed to delete tenant {}", tenant, ex.getCause());
+                            asyncResponse.resume(new RestException(ex));
+                            return null;
+                        });
+                    }).exceptionally(ex -> {
+                        log.error("Failed to delete clusters under tenant {}", tenant, ex.getCause());
+                        asyncResponse.resume(new RestException(ex));
+                        return null;
+                    });
+                    log.info("[{}] Deleted tenant {}", clientAppId(), tenant);
+                } catch (Exception e) {
+                    log.error("[{}] Failed to delete tenant {}", clientAppId(), tenant, e);
+                    asyncResponse.resume(new RestException(e));
+                }
+            }).exceptionally(ex -> {
+                log.error("Failed to delete tenant due to active namespace {}", tenant, ex.getCause());
+                asyncResponse.resume(new RestException(ex));
+                return null;
+            });
+        });
     }
 
     private void validateClusters(TenantInfo info) {
         // empty cluster shouldn't be allowed
-        if (info == null || info.getAllowedClusters().stream()
-                .filter(c -> !StringUtils.isBlank(c)).collect(Collectors.toSet()).isEmpty()
+        if (info == null || info.getAllowedClusters().stream().filter(c -> !StringUtils.isBlank(c))
+                .collect(Collectors.toSet()).isEmpty()
                 || info.getAllowedClusters().stream().anyMatch(ac -> StringUtils.isBlank(ac))) {
             log.warn("[{}] Failed to validate due to clusters are empty", clientAppId());
             throw new RestException(Status.PRECONDITION_FAILED, "Clusters can not be empty");
@@ -244,11 +285,11 @@ public class TenantsBase extends AdminResource {
 
         List<String> nonexistentClusters;
         try {
-            Set<String> availableClusters = clustersListCache().get();
+            Set<String> availableClusters = clusterResources().list();
             Set<String> allowedClusters = info.getAllowedClusters();
-            nonexistentClusters = allowedClusters.stream()
-                .filter(cluster -> !(availableClusters.contains(cluster) || Constants.GLOBAL_CLUSTER.equals(cluster)))
-                .collect(Collectors.toList());
+            nonexistentClusters = allowedClusters.stream().filter(
+                    cluster -> !(availableClusters.contains(cluster) || Constants.GLOBAL_CLUSTER.equals(cluster)))
+                    .collect(Collectors.toList());
         } catch (Exception e) {
             log.error("[{}] Failed to get available clusters", clientAppId(), e);
             throw new RestException(e);
@@ -258,6 +299,4 @@ public class TenantsBase extends AdminResource {
             throw new RestException(Status.PRECONDITION_FAILED, "Clusters do not exist");
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(TenantsBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -21,12 +21,16 @@ package org.apache.pulsar.broker.web;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.pulsar.broker.admin.AdminResource.POLICIES_READONLY_FLAG_PATH;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.BoundType;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -44,6 +48,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.admin.impl.ClusterResources;
+import org.apache.pulsar.broker.admin.impl.NamespaceResources;
+import org.apache.pulsar.broker.admin.impl.TenantResources;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
@@ -65,7 +72,9 @@ import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.path.PolicyPath;
-import org.apache.zookeeper.KeeperException;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,7 +178,7 @@ public abstract class PulsarWebResource {
      * @throws WebApplicationException
      *             if not authorized
      */
-    protected void validateSuperUserAccess() {
+    public void validateSuperUserAccess() {
         if (config().isAuthenticationEnabled()) {
             String appId = clientAppId();
             if (log.isDebugEnabled()) {
@@ -245,15 +254,8 @@ public abstract class PulsarWebResource {
                     (isClientAuthenticated(clientAppId)), clientAppId);
         }
 
-        TenantInfo tenantInfo;
-
-        try {
-            tenantInfo = pulsar.getConfigurationCache().propertiesCache().get(path(POLICIES, tenant))
-                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Tenant does not exist"));
-        } catch (KeeperException.NoNodeException e) {
-            log.warn("Failed to get tenant info data for non existing tenant {}", tenant);
-            throw new RestException(Status.NOT_FOUND, "Tenant does not exist");
-        }
+        TenantInfo tenantInfo = pulsar.getPulsarResources().getTenatResources().get(path(POLICIES, tenant))
+                .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Tenant does not exist"));
 
         if (pulsar.getConfiguration().isAuthenticationEnabled() && pulsar.getConfiguration().isAuthorizationEnabled()) {
             if (!isClientAuthenticated(clientAppId)) {
@@ -308,7 +310,7 @@ public abstract class PulsarWebResource {
     protected void validateClusterForTenant(String tenant, String cluster) {
         TenantInfo tenantInfo;
         try {
-            tenantInfo = pulsar().getConfigurationCache().propertiesCache().get(path(POLICIES, tenant))
+            tenantInfo = pulsar().getPulsarResources().getTenatResources().get(path(POLICIES, tenant))
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Tenant does not exist"));
         } catch (RestException e) {
             log.warn("Failed to get tenant admin data for tenant {}", tenant);
@@ -858,5 +860,121 @@ public abstract class PulsarWebResource {
                                 operation.toString(), namespaceName, policy.toString()));
             }
         }
+    }
+
+    protected TenantResources tenantResources() {
+        return pulsar().getPulsarResources().getTenatResources();
+    }
+
+    protected ClusterResources clusterResources() {
+        return pulsar().getPulsarResources().getClusterResources();
+    }
+
+    protected NamespaceResources namespaceResources() {
+        return pulsar().getPulsarResources().getNamespaceResources();
+    }
+
+    public static ObjectMapper jsonMapper() {
+        return ObjectMapperFactory.getThreadLocal();
+    }
+
+    public void validatePoliciesReadOnlyAccess() {
+        try {
+            if (clusterResources().existsAsync(AdminResource.POLICIES_READONLY_FLAG_PATH).get()) {
+                log.debug("Policies are read-only. Broker cannot do read-write operations");
+                throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
+            }
+        } catch (Exception e) {
+            log.warn("Unable to fetch read-only policy config {}", POLICIES_READONLY_FLAG_PATH, e);
+            throw new RestException(e);
+        }
+    }
+
+    protected CompletableFuture<Void> hasActiveNamespace(String tenant) {
+        CompletableFuture<Void> activeNamespaceFuture = new CompletableFuture<>();
+        tenantResources().getChildren(path(POLICIES, tenant)).thenAccept(clusterOrNamespaceList -> {
+            if (clusterOrNamespaceList == null || clusterOrNamespaceList.isEmpty()) {
+                activeNamespaceFuture.complete(null);
+                return;
+            }
+            List<CompletableFuture<Void>> activeNamespaceListFuture = Lists.newArrayList();
+            clusterOrNamespaceList.forEach(clusterOrNamespace -> {
+                // get list of active V1 namespace
+                CompletableFuture<Void> checkNs = new CompletableFuture<>();
+                activeNamespaceListFuture.add(checkNs);
+                tenantResources().getChildren(path(POLICIES, tenant, clusterOrNamespace))
+                        .whenComplete((children, ex) -> {
+                            if (ex != null) {
+                                checkNs.completeExceptionally(ex);
+                                return;
+                            }
+                            if (children != null && !children.isEmpty()) {
+                                checkNs.completeExceptionally(
+                                        new RestException(Status.PRECONDITION_FAILED, "Tenant has active namespace"));
+                                return;
+                            }
+                            String namespace = NamespaceName.get(tenant, clusterOrNamespace).toString();
+                            // if the length is 0 then this is probably a leftover cluster from namespace
+                            // created
+                            // with the v1 admin format (prop/cluster/ns) and then deleted, so no need to
+                            // add it to the list
+                            namespaceResources().getAsync(path(POLICIES, namespace)).thenApply(data -> {
+                                if (data.isPresent()) {
+                                    checkNs.completeExceptionally(new RestException(Status.PRECONDITION_FAILED,
+                                            "Tenant has active namespace"));
+                                } else {
+                                    checkNs.complete(null);
+                                }
+                                return null;
+                            }).exceptionally(ex2 -> {
+                                if (ex2.getCause() instanceof MetadataStoreException.ContentDeserializationException) {
+                                    // it's not a valid namespace-node
+                                    checkNs.complete(null);
+                                } else {
+                                    checkNs.completeExceptionally(
+                                            new RestException(Status.INTERNAL_SERVER_ERROR, ex2.getCause()));
+                                }
+                                return null;
+                            });
+                        });
+                FutureUtil.waitForAll(activeNamespaceListFuture).thenAccept(r -> {
+                    activeNamespaceFuture.complete(null);
+                }).exceptionally(ex -> {
+                    activeNamespaceFuture.completeExceptionally(ex.getCause());
+                    return null;
+                });
+            });
+        }).exceptionally(ex -> {
+            activeNamespaceFuture.completeExceptionally(ex.getCause());
+            return null;
+        });
+        return activeNamespaceFuture;
+    }
+
+    protected CompletableFuture<Void> canUpdateCluster(String tenant, Set<String> oldClusters,
+            Set<String> newClusters) {
+        List<CompletableFuture<Void>> activeNamespaceFuture = Lists.newArrayList();
+        for (String cluster : oldClusters) {
+            if (Constants.GLOBAL_CLUSTER.equals(cluster) || newClusters.contains(cluster)) {
+                continue;
+            }
+            CompletableFuture<Void> checkNs = new CompletableFuture<>();
+            activeNamespaceFuture.add(checkNs);
+            tenantResources().getChildren(path(POLICIES, tenant, cluster)).whenComplete((activeNamespaces, ex) -> {
+                if (ex != null) {
+                    log.warn("Failed to get namespaces under {}-{}, {}", tenant, cluster, ex.getCause().getMessage());
+                    checkNs.completeExceptionally(ex.getCause());
+                    return;
+                }
+                if (activeNamespaces.size() > 0) {
+                    log.warn("{}/{} Active-namespaces {}", tenant, cluster, activeNamespaces);
+                    checkNs.completeExceptionally(new RestException(Status.PRECONDITION_FAILED, "Active namespaces"));
+                    return;
+                }
+                checkNs.complete(null);
+            });
+        }
+        return activeNamespaceFuture.isEmpty() ? CompletableFuture.completedFuture(null)
+                : FutureUtil.waitForAll(activeNamespaceFuture);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -339,7 +339,6 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             } catch (PulsarAdminException e) {
                 assertTrue(e instanceof NotFoundException);
             }
-
             // verify delete cluster failed
             try {
                 admin.clusters().deleteCluster("test");
@@ -626,6 +625,13 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test(enabled = true)
     public void properties() throws PulsarAdminException {
+        try {
+            admin.tenants().getTenantInfo("does-not-exist");
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            assertTrue(e instanceof NotFoundException);
+        }
+        
         Set<String> allowedClusters = Sets.newHashSet("test");
         TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), allowedClusters);
         admin.tenants().updateTenant("prop-xyz", tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -43,11 +43,15 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.TimeoutHandler;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
@@ -82,12 +86,13 @@ import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.stats.AllocatorStats;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
+import org.apache.pulsar.metadata.impl.AbstractMetadataStore;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooDefs.Ids;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -137,10 +142,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         doNothing().when(clusters).validateSuperUserAccess();
 
         properties = spy(new Properties());
-        properties.setServletContext(new MockServletContext());
         properties.setPulsar(pulsar);
-        doReturn(mockZooKeeperGlobal).when(properties).globalZk();
-        doReturn(configurationCache.propertiesCache()).when(properties).tenantsCache();
         doReturn("test").when(properties).clientAppId();
         doNothing().when(properties).validateSuperUserAccess();
 
@@ -402,9 +404,19 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    Object asynRequests(Consumer<TestAsyncResponse> function) throws Exception {
+        TestAsyncResponse ctx = new TestAsyncResponse();
+        function.accept(ctx);
+        ctx.latch.await();
+        if (ctx.e != null) {
+            throw (Exception) ctx.e;
+        }
+        return ctx.response;
+    }
     @Test
-    public void properties() throws Exception {
-        assertEquals(properties.getTenants(), Lists.newArrayList());
+    public void properties() throws Throwable {
+        Object response = asynRequests(ctx -> properties.getTenants(ctx));
+        assertEquals(response, Lists.newArrayList());
         verify(properties, times(1)).validateSuperUserAccess();
 
         // create local cluster
@@ -413,29 +425,33 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Set<String> allowedClusters = Sets.newHashSet();
         allowedClusters.add(configClusterName);
         TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), allowedClusters);
-        properties.createTenant("test-property", tenantInfo);
+        response = asynRequests(ctx -> properties.createTenant(ctx, "test-property", tenantInfo));
         verify(properties, times(2)).validateSuperUserAccess();
 
-        assertEquals(properties.getTenants(), Lists.newArrayList("test-property"));
+        response = asynRequests(ctx -> properties.getTenants(ctx));
+        assertEquals(response, Lists.newArrayList("test-property"));
         verify(properties, times(3)).validateSuperUserAccess();
 
-        assertEquals(properties.getTenantAdmin("test-property"), tenantInfo);
+        response = asynRequests(ctx -> properties.getTenantAdmin(ctx, "test-property"));
+        assertEquals(response, tenantInfo);
         verify(properties, times(4)).validateSuperUserAccess();
 
-        TenantInfo newPropertyAdmin = new TenantInfo(Sets.newHashSet("role1", "other-role"), allowedClusters);
-        properties.updateTenant("test-property", newPropertyAdmin);
+        final TenantInfo newPropertyAdmin = new TenantInfo(Sets.newHashSet("role1", "other-role"), allowedClusters);
+        response = asynRequests(ctx -> properties.updateTenant(ctx, "test-property", newPropertyAdmin));
         verify(properties, times(5)).validateSuperUserAccess();
 
         // Wait for updateTenant to take effect
         Thread.sleep(100);
 
-        assertEquals(properties.getTenantAdmin("test-property"), newPropertyAdmin);
-        assertNotSame(properties.getTenantAdmin("test-property"), tenantInfo);
+        response = asynRequests(ctx -> properties.getTenantAdmin(ctx, "test-property"));
+        assertEquals(response, newPropertyAdmin);
+        response = asynRequests(ctx -> properties.getTenantAdmin(ctx, "test-property"));
+        assertNotSame(response, tenantInfo);
         verify(properties, times(7)).validateSuperUserAccess();
 
         // Check creating existing property
         try {
-            properties.createTenant("test-property", tenantInfo);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "test-property", tenantInfo));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.CONFLICT.getStatusCode());
@@ -443,14 +459,14 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check non-existing property
         try {
-            properties.getTenantAdmin("non-existing");
+            response = asynRequests(ctx -> properties.getTenantAdmin(ctx, "non-existing"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
         }
 
         try {
-            properties.updateTenant("xxx-non-existing", newPropertyAdmin);
+            response = asynRequests(ctx -> properties.updateTenant(ctx, "xxx-non-existing", newPropertyAdmin));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
@@ -458,93 +474,97 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check deleting non-existing property
         try {
-            properties.deleteTenant("non-existing");
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "non-existing"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
         }
 
+        // clear caches to load data from metadata-store again
+        MetadataCacheImpl<TenantInfo> cache = (MetadataCacheImpl<TenantInfo>) pulsar.getPulsarResources()
+                .getTenatResources().getCache();
+        AbstractMetadataStore store = (AbstractMetadataStore) cache.getStore();
+        cache.invalidateAll();
+        store.invalidateAll();
         // Test zk failures
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.GET_CHILDREN
-                    && path.equals("/admin/policies");
-            });
+            return op == MockZooKeeper.Op.GET_CHILDREN && path.equals("/admin/policies");
+        });
         try {
-            properties.getTenants();
+            response = asynRequests(ctx -> properties.getTenants(ctx));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.GET
-                    && path.equals("/admin/policies/my-tenant");
-            });
+            return op == MockZooKeeper.Op.GET && path.equals("/admin/policies/my-tenant");
+        });
         try {
-            properties.getTenantAdmin("my-tenant");
+            response = asynRequests(ctx -> properties.getTenantAdmin(ctx, "my-tenant"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.GET
-                    && path.equals("/admin/policies/my-tenant");
-            });
+            return op == MockZooKeeper.Op.GET && path.equals("/admin/policies/my-tenant");
+        });
         try {
-            properties.updateTenant("my-tenant", newPropertyAdmin);
+            response = asynRequests(ctx -> properties.updateTenant(ctx, "my-tenant", newPropertyAdmin));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.CREATE
-                    && path.equals("/admin/policies/test");
-            });
+            return op == MockZooKeeper.Op.CREATE && path.equals("/admin/policies/test");
+        });
         try {
-            properties.createTenant("test", tenantInfo);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "test", tenantInfo));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.GET_CHILDREN
-                    && path.equals("/admin/policies/my-tenant");
-            });
+            return op == MockZooKeeper.Op.GET_CHILDREN && path.equals("/admin/policies/test-property");
+        });
         try {
-            properties.deleteTenant("my-tenant");
+            cache.invalidateAll();
+            store.invalidateAll();
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
-        properties.createTenant("error-property", tenantInfo);
+        response = asynRequests(ctx -> properties.createTenant(ctx, "error-property", tenantInfo));
 
         mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return op == MockZooKeeper.Op.DELETE
-                    && path.equals("/admin/policies/error-property");
-            });
+            return op == MockZooKeeper.Op.DELETE && path.equals("/admin/policies/error-property");
+        });
         try {
-            properties.deleteTenant("error-property");
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property"));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
-        properties.deleteTenant("test-property");
-        properties.deleteTenant("error-property");
-        assertEquals(properties.getTenants(), Lists.newArrayList());
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property"));
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property"));
+        response = Lists.newArrayList();
+        response = asynRequests(ctx -> properties.getTenants(ctx));
+        assertEquals(response, Lists.newArrayList());
 
         // Create a namespace to test deleting a non-empty property
-        newPropertyAdmin = new TenantInfo(Sets.newHashSet("role1", "other-role"), Sets.newHashSet("use"));
-        properties.createTenant("my-tenant", newPropertyAdmin);
+        TenantInfo newPropertyAdmin2 = new TenantInfo(Sets.newHashSet("role1", "other-role"), Sets.newHashSet("use"));
+        response = asynRequests(ctx -> properties.createTenant(ctx, "my-tenant", newPropertyAdmin2));
 
         namespaces.createNamespace("my-tenant", "use", "my-namespace", new BundlesData());
 
         try {
-            properties.deleteTenant("my-tenant");
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant"));
             fail("should have failed");
         } catch (RestException e) {
             // Ok
@@ -552,7 +572,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check name validation
         try {
-            properties.createTenant("test&", tenantInfo);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "test&", tenantInfo));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
@@ -560,7 +580,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check tenantInfo is null
         try {
-            properties.createTenant("tenant-config-is-null", null);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "tenant-config-is-null", null));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
@@ -571,7 +591,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Set<String> blankClusters = Sets.newHashSet(blankCluster);
         TenantInfo tenantWithEmptyCluster = new TenantInfo(Sets.newHashSet("role1", "role2"), blankClusters);
         try {
-            properties.createTenant("tenant-config-is-empty", tenantWithEmptyCluster);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "tenant-config-is-empty", tenantWithEmptyCluster));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
@@ -582,18 +602,18 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         containBlankClusters.add(configClusterName);
         TenantInfo tenantContainEmptyCluster = new TenantInfo(Sets.newHashSet(), containBlankClusters);
         try {
-            properties.createTenant("tenant-config-contain-empty", tenantContainEmptyCluster);
+            response = asynRequests(ctx -> properties.createTenant(ctx, "tenant-config-contain-empty", tenantContainEmptyCluster));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
 
-        AsyncResponse response = mock(AsyncResponse.class);
-        namespaces.deleteNamespace(response, "my-tenant", "use", "my-namespace", false, false);
+        AsyncResponse response2 = mock(AsyncResponse.class);
+        namespaces.deleteNamespace(response2, "my-tenant", "use", "my-namespace", false, false);
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
-        verify(response, timeout(5000).times(1)).resume(captor.capture());
+        verify(response2, timeout(5000).times(1)).resume(captor.capture());
         assertEquals(captor.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());
-        properties.deleteTenant("my-tenant");
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant"));
     }
 
     @Test
@@ -654,9 +674,9 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // create policies
         TenantInfo admin = new TenantInfo();
         admin.getAllowedClusters().add(cluster);
-        mockZooKeeperGlobal.create(PulsarWebResource.path(POLICIES, property),
-                ObjectMapperFactory.getThreadLocal().writeValueAsBytes(admin), Ids.OPEN_ACL_UNSAFE,
-                CreateMode.PERSISTENT);
+        ClusterData clusterData = new ClusterData(cluster);
+        clusters.createCluster(cluster, clusterData );
+        asynRequests(ctx -> properties.createTenant(ctx, property, admin));
 
         // customized bandwidth for this namespace
         double customizeBandwidth = 3000;
@@ -762,4 +782,85 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
     }
 
+    static class TestAsyncResponse implements AsyncResponse {
+
+        Object response;
+        Throwable e;
+        CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public boolean resume(Object response) {
+            this.response = response;
+            latch.countDown();
+            return true;
+        }
+
+        @Override
+        public boolean resume(Throwable response) {
+            this.e = response;
+            latch.countDown();
+            return true;
+        }
+
+        @Override
+        public boolean cancel() {
+            return false;
+        }
+
+        @Override
+        public boolean cancel(int retryAfter) {
+            return false;
+        }
+
+        @Override
+        public boolean cancel(Date retryAfter) {
+            return false;
+        }
+
+        @Override
+        public boolean isSuspended() {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public boolean setTimeout(long time, TimeUnit unit) {
+            return false;
+        }
+
+        @Override
+        public void setTimeoutHandler(TimeoutHandler handler) {
+
+        }
+
+        @Override
+        public Collection<Class<?>> register(Class<?> callback) {
+            return null;
+        }
+
+        @Override
+        public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks) {
+            return null;
+        }
+
+        @Override
+        public Collection<Class<?>> register(Object callback) {
+            return null;
+        }
+
+        @Override
+        public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks) {
+            return null;
+        }
+
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -283,6 +283,7 @@ public abstract class MockedPulsarServiceBaseTest {
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeperGlobal)).when(pulsar).createConfigurationMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -129,7 +129,7 @@ public class OwnerShipForCurrentServerTestBase {
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -57,12 +57,12 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.client.admin.BrokerStats;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -780,7 +780,11 @@ public class BrokerServiceTest extends BrokerTestBase {
     @Test
     public void testTopicLoadingOnDisableNamespaceBundle() throws Exception {
         final String namespace = "prop/disableBundle";
-        admin.namespaces().createNamespace(namespace);
+        try {
+            admin.namespaces().createNamespace(namespace);
+        } catch (PulsarAdminException.ConflictException e) {
+            // Ok.. (if test fails intermittently and namespace is already created)
+        }
         admin.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("test"));
 
         // own namespace bundle

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -133,7 +133,7 @@ public class TransactionTestBase {
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-
+import com.google.common.annotations.VisibleForTesting;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
+import lombok.Getter;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
@@ -49,6 +49,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
+    @Getter
     private final MetadataStore store;
     private final MetadataSerde<T> serde;
 
@@ -225,6 +226,11 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     public void invalidate(String path) {
         objCache.synchronous().invalidate(path);
+    }
+
+    @VisibleForTesting
+    public void invalidateAll() {
+        objCache.synchronous().invalidateAll();
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
 
@@ -209,6 +210,12 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     public void close() throws Exception {
         executor.shutdownNow();
         executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @VisibleForTesting
+    public void invalidateAll() {
+        childrenCache.synchronous().invalidateAll();
+        existsCache.synchronous().invalidateAll();
     }
 
     protected static String parent(String path) {

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/MockedZooKeeperClientFactoryImpl.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/MockedZooKeeperClientFactoryImpl.java
@@ -33,7 +33,7 @@ import org.apache.zookeeper.data.ACL;
 
 public class MockedZooKeeperClientFactoryImpl implements ZooKeeperClientFactory {
 
-    Queue<MockZooKeeper> createdInstances = new ConcurrentLinkedQueue<>();
+    public Queue<MockZooKeeper> createdInstances = new ConcurrentLinkedQueue<>();
 
     @Override
     public CompletableFuture<ZooKeeper> create(String serverList, SessionType sessionType, int zkSessionTimeoutMillis) {


### PR DESCRIPTION
### Motivation
As part of pulsar metadata api, we want to use metadata api for admin-resources. With this PR
- tenant API will start using metadata-store api
- making tenant admin async and remove all blocking zk call

Note: Next, I will create separate PR for rest of the admin resources.