### PR TITLE
Enable Function Workers to use exclusive producer to write to internal topics

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
@@ -27,12 +27,13 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
@@ -253,14 +254,36 @@ public class FunctionMetaDataManager implements AutoCloseable {
     }
 
     /**
+     * Acquires a exclusive producer.  This method cannot return null.  It can only return a valid exclusive producer
+     * or throw NotLeaderAnymore exception.
+     * @param isLeader if the worker is still the leader
+     * @return A valid exclusive producer
+     * @throws WorkerUtils.NotLeaderAnymore if the worker is no longer the leader.
+     */
+    public Producer<byte[]> acquireExclusiveWrite(Supplier<Boolean> isLeader) throws WorkerUtils.NotLeaderAnymore {
+        // creates exclusive producer for metadata topic
+        return WorkerUtils.createExclusiveProducerWithRetry(
+                pulsarClient,
+                workerConfig.getFunctionMetadataTopic(),
+                workerConfig.getWorkerId() + "-leader",
+                isLeader, 1000);
+    }
+
+    /**
      * Called by the leader service when this worker becomes the leader.
      * We first get exclusive producer on the metadata topic. Next we drain the tailer
      * to ensure that we have caught up to metadata topic. After which we close the tailer.
      * Note that this method cannot be syncrhonized because the tailer might still be processing messages
      */
-    public void acquireLeadership() {
+    public void acquireLeadership(Producer<byte[]> exclusiveProducer) {
         log.info("FunctionMetaDataManager becoming leader by creating exclusive producer");
-        FunctionMetaDataTopicTailer tailer = internalAcquireLeadership();
+        if (exclusiveLeaderProducer != null) {
+            log.error("FunctionMetaData Manager entered invalid state");
+            errorNotifier.triggerError(new IllegalStateException());
+        }
+        this.exclusiveLeaderProducer = exclusiveProducer;
+        FunctionMetaDataTopicTailer tailer = this.functionMetaDataTopicTailer;
+        this.functionMetaDataTopicTailer = null;
         // Now that we have created the exclusive producer, wait for reader to get over
         if (tailer != null) {
             try {
@@ -272,21 +295,6 @@ public class FunctionMetaDataManager implements AutoCloseable {
             tailer.close();
         }
         log.info("FunctionMetaDataManager done becoming leader");
-    }
-
-    private synchronized FunctionMetaDataTopicTailer internalAcquireLeadership() {
-        if (exclusiveLeaderProducer == null) {
-            exclusiveLeaderProducer = WorkerUtils.createExclusiveProducerWithRetry(
-                    pulsarClient,
-                    workerConfig.getFunctionMetadataTopic(),
-                    workerConfig.getWorkerId() + "-leader");
-        } else {
-            log.error("Logic Error in FunctionMetaData Manager");
-            errorNotifier.triggerError(new IllegalStateException());
-        }
-        FunctionMetaDataTopicTailer tailer = this.functionMetaDataTopicTailer;
-        this.functionMetaDataTopicTailer = null;
-        return tailer;
     }
 
     /**

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
@@ -21,10 +21,13 @@ package org.apache.pulsar.functions.worker;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerEventListener;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImpl;
+
+import java.util.function.Supplier;
 
 @Slf4j
 public class LeaderService implements AutoCloseable, ConsumerEventListener {
@@ -35,6 +38,7 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
     private final SchedulerManager schedulerManager;
     private final FunctionRuntimeManager functionRuntimeManager;
     private final FunctionMetaDataManager functionMetaDataManager;
+    private final MembershipManager membershipManager;
     private ConsumerImpl<byte[]> consumer;
     private final WorkerConfig workerConfig;
     private final PulsarClient pulsarClient;
@@ -50,6 +54,7 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
                          SchedulerManager schedulerManager,
                          FunctionRuntimeManager functionRuntimeManager,
                          FunctionMetaDataManager functionMetaDataManager,
+                         MembershipManager membershipManager,
                          ErrorNotifier errorNotifier) {
         this.workerConfig = workerService.getWorkerConfig();
         this.pulsarClient = pulsarClient;
@@ -57,6 +62,7 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
         this.schedulerManager = schedulerManager;
         this.functionRuntimeManager = functionRuntimeManager;
         this.functionMetaDataManager = functionMetaDataManager;
+        this.membershipManager = membershipManager;
         this.errorNotifier = errorNotifier;
         consumerName = String.format(
                 "%s:%s:%d",
@@ -95,10 +101,29 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
                 functionMetaDataManager.getIsInitialized().get();
                 functionRuntimeManager.getIsInitialized().get();
 
+                // attempt to acquire exclusive publishers to both the metadata topic and assignments topic
+                // we should keep trying to acquire exclusive producers as long as we are still the leader
+                Supplier<Boolean> checkIsStillLeader = () -> membershipManager.getLeader().getWorkerId().equals(workerConfig.getWorkerId());
+                Producer<byte[]> scheduleManagerExclusiveProducer = null;
+                Producer<byte[]> functionMetaDataManagerExclusiveProducer = null;
+                try {
+                    scheduleManagerExclusiveProducer = schedulerManager.acquireExclusiveWrite(checkIsStillLeader);
+                    functionMetaDataManagerExclusiveProducer = functionMetaDataManager.acquireExclusiveWrite(checkIsStillLeader);
+                } catch (WorkerUtils.NotLeaderAnymore e) {
+                    log.info("Worker {} is not leader anymore. Exiting becoming leader routine.", consumer);
+                    if (scheduleManagerExclusiveProducer != null) {
+                        scheduleManagerExclusiveProducer.close();
+                    }
+                    if (functionMetaDataManagerExclusiveProducer != null) {
+                        functionMetaDataManagerExclusiveProducer.close();
+                    }
+                    return;
+                }
+
                 // make sure scheduler is initialized because this worker
                 // is the leader and may need to start computing and writing assignments
                 // also creates exclusive producer for assignment topic
-                schedulerManager.initialize();
+                schedulerManager.initialize(scheduleManagerExclusiveProducer);
 
                 // trigger read to the end of the topic and exit
                 // Since the leader can just update its in memory assignments cache directly
@@ -106,7 +131,7 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
                 functionAssignmentTailer.close();
 
                 // need to move function meta data manager into leader mode
-                functionMetaDataManager.acquireLeadership();
+                functionMetaDataManager.acquireLeadership(functionMetaDataManagerExclusiveProducer);
 
                 isLeader = true;
             } catch (Throwable th) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -497,6 +497,7 @@ public class PulsarWorkerService implements WorkerService {
               schedulerManager,
               functionRuntimeManager,
               functionMetaDataManager,
+              membershipManager,
               errorNotifier);
 
             log.info("/** Start Leader Service **/");

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -61,9 +61,6 @@ import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -34,7 +34,6 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.prometheus.client.CollectorRegistry;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -61,7 +60,6 @@ import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.Assignment;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactoryConfig;
-import org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler;
 import org.mockito.Mockito;
@@ -84,6 +82,7 @@ public class SchedulerManagerTest {
     private ScheduledExecutorService executor;
     private LeaderService leaderService;
     private ErrorNotifier errorNotifier;
+    private PulsarClient pulsarClient;
 
     @BeforeMethod
     public void setup() {
@@ -116,10 +115,11 @@ public class SchedulerManagerTest {
         when(builder.blockIfQueueFull(anyBoolean())).thenReturn(builder);
         when(builder.compressionType(any(CompressionType.class))).thenReturn(builder);
         when(builder.sendTimeout(anyInt(), any(TimeUnit.class))).thenReturn(builder);
+        when(builder.accessMode(any())).thenReturn(builder);
 
         when(builder.createAsync()).thenReturn(CompletableFuture.completedFuture(producer));
 
-        PulsarClient pulsarClient = mock(PulsarClient.class);
+        pulsarClient = mock(PulsarClient.class);
         when(pulsarClient.newProducer()).thenReturn(builder);
 
         this.executor = Executors
@@ -820,7 +820,7 @@ public class SchedulerManagerTest {
     }
 
     @Test
-    public void testAssignmentWorkerDoesNotExist() throws InterruptedException, NoSuchMethodException, TimeoutException, ExecutionException {
+    public void testAssignmentWorkerDoesNotExist() throws Exception {
         List<Function.FunctionMetaData> functionMetaDataList = new LinkedList<>();
         long version = 5;
         Function.FunctionMetaData function1 = Function.FunctionMetaData.newBuilder()
@@ -879,9 +879,12 @@ public class SchedulerManagerTest {
     }
 
     private void callSchedule() throws InterruptedException,
-            TimeoutException, ExecutionException {
+            TimeoutException, ExecutionException, WorkerUtils.NotLeaderAnymore {
 
-        schedulerManager.initialize();
+        if (leaderService.isLeader()) {
+            Producer<byte[]> exclusiveProducer = schedulerManager.acquireExclusiveWrite(() -> true);
+            schedulerManager.initialize(exclusiveProducer);
+        }
         Future<?> complete = schedulerManager.schedule();
 
         complete.get(30, TimeUnit.SECONDS);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.worker;
+
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WorkerUtilsTest {
+
+    @Test
+    public void testCreateExclusiveProducerWithRetry() {
+        Producer<byte[]> producer = mock(Producer.class);
+        ProducerBuilder<byte[]> builder = mock(ProducerBuilder.class);
+        when(builder.topic(anyString())).thenReturn(builder);
+        when(builder.producerName(anyString())).thenReturn(builder);
+        when(builder.enableBatching(anyBoolean())).thenReturn(builder);
+        when(builder.blockIfQueueFull(anyBoolean())).thenReturn(builder);
+        when(builder.compressionType(any(CompressionType.class))).thenReturn(builder);
+        when(builder.sendTimeout(anyInt(), any(TimeUnit.class))).thenReturn(builder);
+        when(builder.accessMode(any())).thenReturn(builder);
+        when(builder.createAsync()).thenReturn(CompletableFuture.completedFuture(producer));
+
+        PulsarClient pulsarClient = mock(PulsarClient.class);
+        when(pulsarClient.newProducer()).thenReturn(builder);
+
+        Producer<byte[]> p = null;
+        try {
+            p = WorkerUtils.createExclusiveProducerWithRetry(pulsarClient, "test-topic", "test-producer", () -> true, 0);
+        } catch (WorkerUtils.NotLeaderAnymore notLeaderAnymore) {
+            Assert.fail();
+        }
+        Assert.assertNotNull(p);
+        verify(builder, times(1)).topic(eq("test-topic"));
+        verify(builder, times(1)).producerName(eq("test-producer"));
+        verify(builder, times(1)).accessMode(eq(ProducerAccessMode.Exclusive));
+
+        CompletableFuture completableFuture = new CompletableFuture();
+        completableFuture.completeExceptionally(new PulsarClientException.ProducerFencedException("test"));
+        when(builder.createAsync()).thenReturn(completableFuture);
+        try {
+            WorkerUtils.createExclusiveProducerWithRetry(pulsarClient, "test-topic", "test-producer", () -> false, 0);
+            Assert.fail();
+        } catch (WorkerUtils.NotLeaderAnymore notLeaderAnymore) {
+
+        }
+
+        AtomicInteger i = new AtomicInteger();
+        try {
+            WorkerUtils.createExclusiveProducerWithRetry(pulsarClient, "test-topic", "test-producer", new Supplier<Boolean>() {
+
+                @Override
+                public Boolean get() {
+                    if (i.getAndIncrement() < 6) {
+                        return true;
+                    }
+                    return false;
+                }
+            }, 0);
+            Assert.fail();
+        } catch (WorkerUtils.NotLeaderAnymore notLeaderAnymore) {
+
+        }
+    }
+}


### PR DESCRIPTION

### Motivation

To maintain correctness, we need to use exclusive producer to write to the internal topics Pulsar Functions to manage metadata / state.
