### PR TITLE
[C++] Fix ServerError is not converted to string in log

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -136,6 +136,11 @@ static Result getResult(ServerError serverError) {
     return ResultUnknownError;
 }
 
+inline std::ostream& operator<<(std::ostream& os, ServerError error) {
+    os << getResult(error);
+    return os;
+}
+
 static bool file_exists(const std::string& path) {
     if (path.empty()) {
         return false;


### PR DESCRIPTION
Fixes #9211 

### Motivation

In some code of C++ client, the protobuf generated `ServerError` is passed to `LOG_XXX` directly, so the logs only contain the enum integer value but not the description string. This PR is to fix it for more readable logs.

### Modifications

The `ClientConnection.cc` already provides a `getResult` function for converting `ServerError` to `Result` , but some references of `ServerError` don't call the function. So this PR overrides `operator<<` for `ServerError` and convert it to `Result` in `LOG_XXX` macros that use `std::stringstream::operator<<` to serialize variables to string.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.