### PR TITLE
remove hbase-server dependency

### DIFF
--- a/pulsar-io/hbase/pom.xml
+++ b/pulsar-io/hbase/pom.xml
@@ -72,12 +72,6 @@
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-server</artifactId>
-            <version>${hbase.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-common</artifactId>
             <version>${hbase.version}</version>
         </dependency>


### PR DESCRIPTION
Our repository actually don't need to use this dependency.
It slow down the build cycle and triggered CI fail now because some of its dependency is set to private now.