### PR TITLE
Make bookkeeper shell more userfriendly

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -38,7 +38,6 @@ fi
 
 if [ "x$JMXDISABLE" = "x" ]
 then
-    echo "JMX enabled by default" >&2
     # for some reason these two options are necessary on jdk6 on Ubuntu
     #   accord to the docs they are not necessary, but otw jconsole cannot
     #   do a local attach
@@ -170,6 +169,12 @@ OPTS="$OPTS -Djava.net.preferIPv4Stack=true"
 
 # log directory & file
 BOOKIE_LOG_APPENDER=${BOOKIE_LOG_APPENDER:-"Console"}
+
+# send bookie shell output to console unconditionally
+if [ $COMMAND == "shell" ]; then
+BOOKIE_LOG_APPENDER=Console
+fi
+
 BOOKIE_LOG_DIR=${BOOKIE_LOG_DIR:-"$BK_HOME/logs"}
 BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"bookkeeper-server.log"}
 


### PR DESCRIPTION
BookKeeper shell is not writing the output to the Console, this makes the tool pretty useless for command line users.

With this change we will have the same result as in the standard "bookkeeper shell" tool bundled with Apache BookKeeper

Changes:
- remove "JMX is enabled by default": it is only annoying
- set Console as Appender in case of "shell" execution