### PR TITLE
Performance consumer add batch receive

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -150,7 +150,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                     log.info(
                             "[{}] [{}] [{}] Prefetched messages: {} --- "
                                     + "Consume throughput received: {} msgs/s --- {} Mbit/s --- "
-                                    + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- batch messages: {} ---"
+                                    + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- Failed batch messages: {} ---"
                                     + "Failed acks: {}",
                             consumerImpl.getTopic(), consumerImpl.getSubscription(), consumerImpl.consumerName,
                             consumerImpl.incomingMessages.size(), THROUGHPUT_FORMAT.format(receivedMsgsRate),


### PR DESCRIPTION
### Motivation
When run perf consumer, it can't set batch receive policy

### Changes
1. add batch receive policy for perf consumer
2. correct `ConsumerStatsRecorderImpl` log key name.