### PR TITLE
[fix #7814] fix java function logging appender not added to java function logger

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -231,7 +231,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     }
 
     ContextImpl setupContext() {
-        Logger instanceLog = LoggerFactory.getLogger(
+        Logger instanceLog = LoggerFactory.getILoggerFactory().getLogger(
                 "function-" + instanceConfig.getFunctionDetails().getName());
         return new ContextImpl(instanceConfig, instanceLog, client, secretsProvider,
                 collectorRegistry, metricsLabels, this.componentType, this.stats, stateManager);
@@ -478,6 +478,13 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             log.info("Unloading JAR files for function {}", instanceConfig);
             instanceCache = null;
         }
+
+        if (logAppender != null) {
+            removeLogTopicAppender(LoggerContext.getContext());
+            removeLogTopicAppender(LoggerContext.getContext(false));
+            logAppender.stop();
+            logAppender = null;
+        }
     }
 
     public String getStatsAsString() throws IOException {
@@ -600,28 +607,37 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             logAppender = new LogAppender(client, instanceConfig.getFunctionDetails().getLogTopic(),
                     FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails()));
             logAppender.start();
+            setupLogTopicAppender(LoggerContext.getContext());
         }
     }
 
     private void addLogTopicHandler() {
         if (logAppender == null) return;
-        LoggerContext context = LoggerContext.getContext(false);
+        setupLogTopicAppender(LoggerContext.getContext(false));
+    }
+
+    private void setupLogTopicAppender(LoggerContext context) {
         Configuration config = context.getConfiguration();
         config.addAppender(logAppender);
         for (final LoggerConfig loggerConfig : config.getLoggers().values()) {
             loggerConfig.addAppender(logAppender, null, null);
         }
         config.getRootLogger().addAppender(logAppender, null, null);
+        context.updateLoggers();
     }
 
     private void removeLogTopicHandler() {
         if (logAppender == null) return;
-        LoggerContext context = LoggerContext.getContext(false);
+        removeLogTopicAppender(LoggerContext.getContext(false));
+    }
+
+    private void removeLogTopicAppender(LoggerContext context) {
         Configuration config = context.getConfiguration();
         for (final LoggerConfig loggerConfig : config.getLoggers().values()) {
             loggerConfig.removeAppender(logAppender.getName());
         }
         config.getRootLogger().removeAppender(logAppender.getName());
+        context.updateLoggers();
     }
 
     private void setupInput(ContextImpl contextImpl) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -24,6 +24,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.gson.Gson;
+
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
@@ -2726,7 +2728,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
                 .build();
 
-        @Cleanup Consumer<String> consumer = client.newConsumer(Schema.STRING)
+        @Cleanup Consumer<byte[]> consumer = client.newConsumer()
                 .topic(outputTopic)
                 .subscriptionType(SubscriptionType.Exclusive)
                 .subscriptionName("test-sub")
@@ -2746,10 +2748,11 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
 
         for (int i = 0; i < numMessages; i++) {
-            Message<String> msg = consumer.receive(30, TimeUnit.SECONDS);
-            log.info("Received: {}", msg.getValue());
-            assertTrue(expectedMessages.contains(msg.getValue()));
-            expectedMessages.remove(msg.getValue());
+            Message<byte[]> msg = consumer.receive(30, TimeUnit.SECONDS);
+            String logMsg = new String(msg.getValue(), UTF_8);
+            log.info("Received: {}", logMsg);
+            assertTrue(expectedMessages.contains(logMsg));
+            expectedMessages.remove(logMsg);
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -2642,13 +2642,6 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             super.setupFunctionWorkers();
         }
 
-        Schema<?> schema;
-        if (Runtime.JAVA == runtime) {
-            schema = Schema.STRING;
-        } else {
-            schema = Schema.BYTES;
-        }
-
         String inputTopicName = "persistent://public/default/test-log-" + runtime + "-input-" + randomName(8);
         String logTopicName = "test-log-" + runtime + "-log-topic-" + randomName(8);
         try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build()) {
@@ -2732,30 +2725,12 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 .subscriptionName("test-sub")
                 .subscribe();
 
-        if (inputTopic.endsWith(".*")) {
-            @Cleanup Producer<String> producer1 = client.newProducer(Schema.STRING)
-                    .topic(inputTopic.substring(0, inputTopic.length() - 2) + "1")
-                    .create();
+        @Cleanup Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(inputTopic)
+                .create();
 
-            @Cleanup Producer<String> producer2 = client.newProducer(Schema.STRING)
-                    .topic(inputTopic.substring(0, inputTopic.length() - 2) + "2")
-                    .create();
-
-            for (int i = 0; i < numMessages / 2; i++) {
-                producer1.send("message-" + i);
-            }
-
-            for (int i = numMessages / 2; i < numMessages; i++) {
-                producer2.send("message-" + i);
-            }
-        } else {
-            @Cleanup Producer<String> producer = client.newProducer(Schema.STRING)
-                    .topic(inputTopic)
-                    .create();
-
-            for (int i = 0; i < numMessages; i++) {
-                producer.send("message-" + i);
-            }
+        for (int i = 0; i < numMessages; i++) {
+            producer.send("message-" + i);
         }
 
         Set<String> expectedMessages = new HashSet<>();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -2641,6 +2641,13 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             super.setupCluster();
             super.setupFunctionWorkers();
         }
+        
+        Schema<?> schema;
+        if (Runtime.JAVA == runtime) {
+            schema = Schema.STRING;
+        } else {
+            schema = Schema.BYTES;
+        }
 
         String inputTopicName = "persistent://public/default/test-log-" + runtime + "-input-" + randomName(8);
         String logTopicName = "test-log-" + runtime + "-log-topic-" + randomName(8);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
@@ -106,6 +106,9 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
     public static final String EXCLAMATION_GO_FILE = "exclamationFunc";
     public static final String PUBLISH_FUNCTION_GO_FILE = "exclamationFunc";
 
+    public static final String LOGGING_JAVA_CLASS =
+            "org.apache.pulsar.functions.api.examples.LoggingFunction";
+
     protected static String getExclamationClass(Runtime runtime,
                                                 boolean pyZip,
                                                 boolean extraDeps) {


### PR DESCRIPTION
Fixes #7814

### Motivation

`JavaInstanceRunnable` create an instance of logger named `"function-" + instanceConfig.getFunctionDetails().getName()` and pass it to `Function Context`, and the logger can be used to send user defined content to function's log-topic if `--log-topic` defined.

as issue #7814 mentioned, the logger is not working as expected since user cannot consume any self defined log content from `log-topic`.

this happens in process runtime with created functions, but not noticed with other situation such as `localrun` function.

Through debug to the created function, the logger in `Function Context` is different from the logger in `JavaInstanceRunnable`, such as the `contextName` as images shown below. In addition, the `LogAppender` set in `JavaInstanceRunnable` is not shown in `Function Context`'s logger as well.

![Imgur](https://i.imgur.com/39DMH6R.png)
^^^^ from JavaInstanceRunnable

![img](https://i.imgur.com/UDw5Lzt.png)
^^^^ from Function Context

After some tests, I find out that when get `LoggerContext` by `LoggerContext.getContext()`, the context's logAppender can be take effect to `Function Context`, and the `Function Context`'s logger works great.

### Modifications

Add `LogAppender` to the single context from `LoggerContext.getContext()`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.