### PR TITLE
Wait for the async broker port listener close operations to complete at shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
@@ -59,9 +59,14 @@ public class MessagingServiceShutdownHook extends Thread implements ShutdownServ
 
             executor.execute(() -> {
                 try {
-                    service.close();
-                    future.complete(null);
-                } catch (PulsarServerException e) {
+                    service.closeAsync().whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            future.completeExceptionally(throwable);
+                        } else {
+                            future.complete(result);
+                        }
+                    });
+                } catch (Exception e) {
                     future.completeExceptionally(e);
                 }
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
@@ -66,7 +66,7 @@ public class MessagingServiceShutdownHook extends Thread implements ShutdownServ
                             future.complete(result);
                         }
                     });
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     future.completeExceptionally(e);
                 }
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
@@ -66,7 +66,7 @@ public class MessagingServiceShutdownHook extends Thread implements ShutdownServ
                             future.complete(result);
                         }
                     });
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     future.completeExceptionally(e);
                 }
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -32,6 +32,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -238,6 +240,7 @@ public class PulsarService implements AutoCloseable {
 
     private final ReentrantLock mutex = new ReentrantLock();
     private final Condition isClosedCondition = mutex.newCondition();
+    private final AtomicReference<CompletableFuture<Void>> closeFutureReference = new AtomicReference<>();
     // key is listener name , value is pulsar address and pulsar ssl address
     private Map<String, AdvertisedListener> advertisedListeners;
 
@@ -297,16 +300,31 @@ public class PulsarService implements AutoCloseable {
                         .build());
     }
 
+    @Override
+    public void close() throws PulsarServerException {
+        try {
+            closeAsync().get();
+        } catch (PulsarServerException e) {
+            throw e;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof PulsarServerException) {
+                throw (PulsarServerException) e.getCause();
+            } else {
+                throw new PulsarServerException(e.getCause());
+            }
+        } catch (Exception e) {
+            throw new PulsarServerException(e);
+        }
+    }
+
     /**
      * Close the current pulsar service. All resources are released.
      */
-    @Override
-    public void close() throws PulsarServerException {
+    public CompletableFuture<Void> closeAsync() throws PulsarServerException {
         mutex.lock();
-
         try {
-            if (state == State.Closed) {
-                return;
+            if (closeFutureReference.get() != null) {
+                return closeFutureReference.get();
             }
 
             // close the service in reverse order v.s. in which they are started
@@ -324,8 +342,9 @@ public class PulsarService implements AutoCloseable {
                 this.webSocketService.close();
             }
 
+            List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
             if (this.brokerService != null) {
-                this.brokerService.close();
+                asyncCloseFutures.add(this.brokerService.closeAsync());
                 this.brokerService = null;
             }
 
@@ -430,6 +449,10 @@ public class PulsarService implements AutoCloseable {
             state = State.Closed;
             isClosedCondition.signalAll();
 
+            CompletableFuture<Void> shutdownFuture =
+                    CompletableFuture.allOf(asyncCloseFutures.toArray(new CompletableFuture[0]));
+            closeFutureReference.set(shutdownFuture);
+            return shutdownFuture;
         } catch (Exception e) {
             if (e instanceof CompletionException && e.getCause() instanceof MetadataStoreException) {
                 throw new PulsarServerException(MetadataStoreException.unwrap((CompletionException) e));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -311,7 +311,7 @@ public class PulsarService implements AutoCloseable {
                 throw new PulsarServerException(e.getCause());
             }
         } catch (InterruptedException e) {
-            throw new PulsarServerException(e);
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -653,7 +653,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 throw new PulsarServerException(e.getCause());
             }
         } catch (InterruptedException e) {
-            throw new PulsarServerException(e);
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
### Motivation

The main motivation for making this change to shut down port listeners synchronously in `BrokerService.close` is to reduce test flakiness.


While investigating the flaky test MessageIdTest, these type of exceptions were seen in logs:
```
Caused by: java.util.concurrent.RejectedExecutionException: Task org.apache.pulsar.metadata.impl.AbstractMetadataStore$$Lambda$669/1529307342@2f790c2a rejected from java.util.concurrent.ThreadPoolExecutor@ad9a9ac[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 9]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063) ~[?:1.8.0_275]
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830) ~[?:1.8.0_275]
        at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379) ~[?:1.8.0_275]
        at java.util.concurrent.Executors$DelegatedExecutorService.execute(Executors.java:668) ~[?:1.8.0_275]
        at org.apache.pulsar.metadata.impl.AbstractMetadataStore.receivedNotification(AbstractMetadataStore.java:128) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.process(ZKMetadataStore.java:320) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.zookeeper.MockZooKeeper.lambda$setData$16(MockZooKeeper.java:728) ~[testmocks-2.8.0-SNAPSHOT.jar:3.5.7]
        at com.google.common.util.concurrent.MoreExecutors$DirectExecutorService.execute(MoreExecutors.java:321) ~[guava-30.1-jre.jar:?]
        at org.apache.zookeeper.MockZooKeeper.setData(MockZooKeeper.java:683) ~[testmocks-2.8.0-SNAPSHOT.jar:3.5.7]
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.put(ZKMetadataStore.java:207) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.MetaStoreImpl.asyncUpdateLedgerIds(MetaStoreImpl.java:106) ~[managed-ledger-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.lambda$null$1(ManagedLedgerImpl.java:472) ~[managed-ledger-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) ~[managed-ledger-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        ... 6 more
```

It seems that this problem could occur when the test code is able to access the broker instance that is already terminated.

### Modifications

To understand the modifications:
The original solution was to wait up to 10 seconds until the port listeners were closed. 
A change was requested to add a new setting for this. After adding this, another change was requested to combine these operations in a way that the existing `brokerShutdownTimeoutMs` setting would also apply to the closing of the port listeners.
This solution for this adds BrokerService.closeAsync and PulsarService.closeAsync methods so that it's possible to combine the closing of the ports to the close operation that uses `brokerShutdownTimeoutMs` setting.