### PR TITLE
Comment out lo4j2 script example in order to save resources in pulsar-admin

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -40,12 +40,12 @@ Configuration:
         value: "Console"
 
   # Example: logger-filter script
-  Scripts:
-    ScriptFile:
-      name: filter.js
-      language: JavaScript
-      path: ./conf/log4j2-scripts/filter.js
-      charset: UTF-8
+#  Scripts:
+#    ScriptFile:
+#      name: filter.js
+#      language: JavaScript
+#      path: ./conf/log4j2-scripts/filter.js
+#      charset: UTF-8
 
   Appenders:
 


### PR DESCRIPTION
Our default configuration file for log4j includes and example about how to use Javascript based filters.

Enabling that lo4j feature forces log4j runtime to perform Nashorn JS engine initialisation, this basically slows down pulsar-admin startup.

When you run on JDK11+ you also see a warning "Warning: Nashorn engine is planned to be removed from a future JDK release" that is very annoying for users. 

This change is part of a little series of patches about improving pulsar-admin startup speed