### PR TITLE
[Issue 9187][Client]Add support for the JSON format token.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
@@ -28,6 +28,9 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
@@ -84,7 +87,13 @@ public class AuthenticationToken implements Authentication, EncodedAuthenticatio
                 }
             };
         } else {
-            this.tokenSupplier = () -> encodedAuthParamString;
+            try {
+                // Read token from json string
+                JsonObject authParams = new Gson().fromJson(encodedAuthParamString, JsonObject.class);
+                this.tokenSupplier = () -> authParams.get("token").getAsString();
+            } catch (JsonSyntaxException e) {
+                this.tokenSupplier = () -> encodedAuthParamString;
+            }
         }
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -159,4 +159,16 @@ public class AuthenticationTokenTest {
         assertEquals(authData.getCommandData(), "my-test-token-string");
         authToken.close();
     }
+
+    @Test
+    public void testAuthTokenConfigFromJson() throws Exception{
+        AuthenticationToken authToken = new AuthenticationToken();
+        authToken.configure("{\"token\":\"my-test-token-string\"}");
+        assertEquals(authToken.getAuthMethodName(), "token");
+
+        AuthenticationDataProvider authData = authToken.getAuthData();
+        assertTrue(authData.hasDataFromCommand());
+        assertEquals(authData.getCommandData(), "my-test-token-string");
+        authToken.close();
+    }
 }


### PR DESCRIPTION

Master Issue: #9187 
### Motivation

Currently, `brokerClientAuthenticationParameters` does not support being set via JSON formatted string, like:
```
brokerClientAuthenticationParameters={"token":"token-string"}
```
This PR Add support for the JSON format token setting.

### Modifications

* Add support for the JSON format token

### Verifying this change

This change is already covered by existing tests, such as *testAuthTokenConfigFromJson*.
