### PR TITLE
[pulsar-broker]Add alerts for expired/expiring soon tokens

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -551,6 +551,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                     if (!typeDefs.containsKey(summaryMetricName)) {
                         fail("Metric " + metricName + " does not have a corresponding summary type definition");
                     }
+                } else if (metricName.endsWith("_bucket")) {
+                    String summaryMetricName = metricName.substring(0, metricName.indexOf("_bucket"));
+                    if (!typeDefs.containsKey(summaryMetricName)) {
+                        fail("Metric " + metricName + " does not have a corresponding summary type definition");
+                    }
                 } else {
                     fail("Metric " + metricName + " does not have a type definition");
                 }


### PR DESCRIPTION
### Motivation

Currently, pulsar-broker does not provide additional alerts about expired and expiring soon tokens.

### Modifications

* Add additional alerts metrics for expired tokens `expiredTokenMetrics`.
* Add histogram metrics for expiring tokens `expiringTokenMinutesMetrics`, and record the remaining time in minutes.
* `expiringTokenMinutesMetrics` has the following buckets with different remaining time periods: 5 mins, 10 mins, 1 hour, 2 hours. 

### Verifying this change

This change is already covered by existing tests, such as *testExpiredTokenMetrics* and *testExpiringTokenMetrics*.

### Example case

When authenticating tokens whose remaining time is 3 mins, 7 mins, 40 mins, 100 mins and 400 mins respectively, it will output:
```
# TYPE pulsar_expiring_token_minutes histogram
pulsar_expiring_token_minutes_bucket{cluster="test",le="5.0"} 1.0
pulsar_expiring_token_minutes_bucket{cluster="test",le="10.0"} 2.0
pulsar_expiring_token_minutes_bucket{cluster="test",le="60.0"} 3.0
pulsar_expiring_token_minutes_bucket{cluster="test",le="240.0"} 4.0
pulsar_expiring_token_minutes_bucket{cluster="test",le="+Inf"} 5.0
pulsar_expiring_token_minutes_count{cluster="test"} 5.0
pulsar_expiring_token_minutes_sum{cluster="test"} 549.96325
```
in Prometheus metrics.

`pulsar_expiring_token_minutes_bucket` shows the number of tokens in different remaining periods.

When authenticating an expired token, it will output:
```
# TYPE pulsar_expired_token_count counter
pulsar_expired_token_count{cluster="test"} 1.0
```
