### PR TITLE
9324 Fix hbase dependencies on javax.el:3.0.1-b06-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ flexible messaging model and an intuitive client API.</description>
     <netty-tc-native.version>2.0.33.Final</netty-tc-native.version>
     <jetty.version>9.4.35.v20201120</jetty.version>
     <jersey.version>2.31</jersey.version>
+    <javax.el.version>3.0.1-b06</javax.el.version>
     <athenz.version>1.8.38</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
@@ -576,6 +577,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-servlet</artifactId>
         <version>${jersey.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>${javax.el.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is a dependency change to remove SNAPSHOT from the transitive dependency. The SNAPSHOT build appears to be no longer available in central. By referring to the versioned build, this build should be around for much longer. 

Build errors resulted in the pulsar-io/hbase build. 

The fix here adjusts the top level pom.xml file, and adds dependency management and a version property for the same. 