### PR TITLE
[Test]Reduce rabbitmq failure rate

### DIFF
--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -81,6 +81,11 @@
       <version>6.1.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.io.rabbitmq.sink;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -67,14 +66,7 @@ public class RabbitMQSinkTest {
 
         // open should success
         // rabbitmq service may need time to initialize
-        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> {
-            try {
-                sink.open(configs, null);
-                return true;
-            } catch (Exception e) {
-                return false;
-            }
-        });
+        Awaitility.await().untilAsserted(() -> sink.open(configs, null));
 
         // write should success
         Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.rabbitmq.sink;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,7 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.SinkRecord;
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSink;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -65,22 +67,14 @@ public class RabbitMQSinkTest {
 
         // open should success
         // rabbitmq service may need time to initialize
-        int tryCount = 5;
-        Exception lastError = null;
-        while (tryCount > 0) {
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> {
             try {
-                tryCount -= 1;
                 sink.open(configs, null);
-                break;
+                return true;
             } catch (Exception e) {
-                lastError = e;
+                return false;
             }
-            Thread.sleep(1000);
-        }
-
-        if (tryCount == 0 && lastError != null) {
-            throw lastError;
-        }
+        });
 
         // write should success
         Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");


### PR DESCRIPTION
The RabbitMQ service in tests startup asynchronously, so connect sometimes failed because the service is not prepared yet, try multiple times to reduce the failure rate.