### PR TITLE
Reduce test timeout of broker gp1

### DIFF
--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: apachepulsar/pulsar-build:latest
-    timeout-minutes: 120
+    timeout-minutes: 45
 
     steps:
       - name: checkout


### PR DESCRIPTION
Our unit test of broker gp1 seems not very stable. I've checked many results of this test workflow, if it can pass, it will always be passed in less than 30 minutes, if not, it seems it will hang forever. So a 120 minutes timeout seems too long for it.