### PR TITLE
[broker] Support networkTopologyScriptFileName for ScriptBasedMapping

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -24,7 +24,6 @@ import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.RE
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_MINIMUM_REGIONS_FOR_DURABILITY;
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_REGIONS_TO_WRITE;
 import static org.apache.bookkeeper.net.CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Map;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -23,6 +23,8 @@ import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.RE
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_ENABLE_VALIDATION;
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_MINIMUM_REGIONS_FOR_DURABILITY;
 import static org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy.REPP_REGIONS_TO_WRITE;
+import static org.apache.bookkeeper.net.CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Map;
@@ -180,6 +182,11 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
                             REPP_DNS_RESOLVER_CLASS,
                             ZkBookieRackAffinityMapping.class.getName()));
 
+            bkConf.setProperty(NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
+                conf.getProperties().getProperty(
+                    NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
+                    ""));
+
             ZooKeeperCache zkc = new ZooKeeperCache("bookies-racks", zkClient,
                     conf.getZooKeeperOperationTimeoutSeconds()) {
             };
@@ -224,6 +231,11 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         if (conf.isBookkeeperClientRackawarePolicyEnabled() || conf.isBookkeeperClientRegionawarePolicyEnabled()) {
             bkConf.setProperty(REPP_DNS_RESOLVER_CLASS, conf.getProperties().getProperty(REPP_DNS_RESOLVER_CLASS,
                     ZkBookieRackAffinityMapping.class.getName()));
+
+            bkConf.setProperty(NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
+                conf.getProperties().getProperty(
+                    NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
+                    ""));
         }
     }
 


### PR DESCRIPTION
### Motivation
* We want to use `org.apache.bookkeeper.net.ScriptBasedMapping` for `reppDnsResolverClass`, but it require `networkTopologyScriptFileName`.


### Modifications

* Support `networkTopologyScriptFileName` in broker conf.