### PR TITLE
Reduce test retry count to zero

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
@@ -25,8 +25,7 @@ public class RetryAnalyzer implements IRetryAnalyzer {
 
     private int count = 0;
 
-    // Only try again once
-    private static final int MAX_RETRIES = Integer.valueOf(System.getProperty("testRetryCount", "1"));
+    private static final int MAX_RETRIES = Integer.valueOf(System.getProperty("testRetryCount", "0"));
 
     @Override
     public boolean retry(ITestResult result) {

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ flexible messaging model and an intuitive client API.</description>
     <testReuseFork>true</testReuseFork>
     <testForkCount>4</testForkCount>
     <testRealAWS>false</testRealAWS>
-    <testRetryCount>1</testRetryCount>
+    <testRetryCount>0</testRetryCount>
     <docker.organization>apachepulsar</docker.organization>
 
     <!-- apache commons -->
@@ -601,7 +601,7 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
       </dependency>
-      
+
       <dependency>
          <groupId>com.github.docker-java</groupId>
          <artifactId>docker-java-core</artifactId>


### PR DESCRIPTION
Our current tests will auto-retry failed tests, which could lead to some problems:

* If one method in one test class failed, all methods in the test class will be retriggered, which will make the test easier to timeout and generate more noise logs to make us harder to locate the error log.
* The failed method may have changed the test environment, and then the second try may report different error info, which will mislead us to solve the problem, too.
* Auto retry is useful to pass flaky tests, but have a low return on investment for the same reason shown above.