### PR TITLE
[Java Client] Batch version of acknowledgeAsync will return a completed future before individual messages complete

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -29,8 +29,6 @@ import org.testng.annotations.Test;
 
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
@@ -54,79 +52,79 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
         return new Object[][] {
 
                 // Default batch receive policy.
-                { BatchReceivePolicy.DEFAULT_POLICY, true, 1000},
+                { BatchReceivePolicy.DEFAULT_POLICY, true, 1000, false},
                 // Only receive timeout limitation.
                 { BatchReceivePolicy.builder()
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), true, 1000
+                        .build(), true, 1000, false
                 },
                 // Only number of messages in a single batch receive limitation.
                 { BatchReceivePolicy.builder()
                         .maxNumMessages(10)
-                        .build(), true, 1000
+                        .build(), true, 1000, false
                 },
                 // Number of messages and timeout limitation
                 { BatchReceivePolicy.builder()
                         .maxNumMessages(13)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), true, 1000
+                        .build(), true, 1000, false
                 },
                 // Size of messages and timeout limitation
                 { BatchReceivePolicy.builder()
                         .maxNumBytes(64)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), true, 1000
+                        .build(), true, 1000, false
                 },
                 // Default batch receive policy.
-                { BatchReceivePolicy.DEFAULT_POLICY, false, 1000 },
+                { BatchReceivePolicy.DEFAULT_POLICY, false, 1000, false },
                 // Only receive timeout limitation.
                 { BatchReceivePolicy.builder()
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 1000
+                        .build(), false, 1000, false
                 },
                 // Only number of messages in a single batch receive limitation.
                 { BatchReceivePolicy.builder()
                         .maxNumMessages(10)
-                        .build(), false, 1000
+                        .build(), false, 1000, false
                 },
                 // Number of messages and timeout limitation
                 { BatchReceivePolicy.builder()
                         .maxNumMessages(13)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 1000
+                        .build(), false, 1000, false
                 },
                 // Size of messages and timeout limitation
                 { BatchReceivePolicy.builder()
                         .maxNumBytes(64)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 1000
+                        .build(), false, 1000, false
                 },
                 // Number of message limitation exceed receiverQueue size
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(70)
-                        .build(), true, 50
+                        .build(), true, 50, false
                 },
                 // Number of message limitation exceed receiverQueue size and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(50)
                         .timeout(10, TimeUnit.MILLISECONDS)
-                        .build(), true, 30
+                        .build(), true, 30, false
                 },
                 // Number of message limitation is negative and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(-10)
                         .timeout(10, TimeUnit.MILLISECONDS)
-                        .build(), true, 10
+                        .build(), true, 10, false
                 },
                 // Size of message limitation is negative and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumBytes(-100)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), true, 30
+                        .build(), true, 30, false
                 },
                 // Number of message limitation and size of message limitation are both negative and timeout limitation
                 {
@@ -134,34 +132,34 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                         .maxNumMessages(-10)
                         .maxNumBytes(-100)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), true, 30
+                        .build(), true, 30, false
                 },
                 // Number of message limitation exceed receiverQueue size
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(70)
-                        .build(), false, 50
+                        .build(), false, 50, false
                 },
                 // Number of message limitation exceed receiverQueue size and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(50)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 30
+                        .build(), false, 30, false
                 },
                 // Number of message limitation is negative and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumMessages(-10)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 30
+                        .build(), false, 30, false
                 },
                 // Size of message limitation is negative and timeout limitation
                 {
                     BatchReceivePolicy.builder()
                         .maxNumBytes(-100)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 30
+                        .build(), false, 30, false
                 },
                 // Number of message limitation and size of message limitation are both negative and timeout limitation
                 {
@@ -169,7 +167,7 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                         .maxNumMessages(-10)
                         .maxNumBytes(-100)
                         .timeout(50, TimeUnit.MILLISECONDS)
-                        .build(), false, 30
+                        .build(), false, 30, false
                 },
                 // Only timeout present
                 {
@@ -177,7 +175,7 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                             .maxNumMessages(0)
                             .maxNumBytes(0)
                             .timeout(50, TimeUnit.MILLISECONDS)
-                            .build(), false, 30
+                            .build(), false, 30, false
                 },
                 // Only timeout present
                 {
@@ -185,48 +183,184 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                                 .maxNumMessages(-1)
                                 .maxNumBytes(-1)
                                 .timeout(50, TimeUnit.MILLISECONDS)
-                                .build(), false, 30
+                                .build(), false, 30, false
+                },
+
+                // Ack receipt
+                // Default batch receive policy.
+                { BatchReceivePolicy.DEFAULT_POLICY, true, 1000, true },
+                // Only receive timeout limitation.
+                { BatchReceivePolicy.builder()
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), true, 1000, true
+                },
+                // Only number of messages in a single batch receive limitation.
+                { BatchReceivePolicy.builder()
+                        .maxNumMessages(10)
+                        .build(), true, 1000, true
+                },
+                // Number of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumMessages(13)
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), true, 1000, true
+                },
+                // Size of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumBytes(64)
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), true, 1000, true
+                },
+                // Default batch receive policy.
+                { BatchReceivePolicy.DEFAULT_POLICY, false, 1000, true },
+                // Only receive timeout limitation.
+                { BatchReceivePolicy.builder()
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), false, 1000, true
+                },
+                // Only number of messages in a single batch receive limitation.
+                { BatchReceivePolicy.builder()
+                        .maxNumMessages(10)
+                        .build(), false, 1000, true
+                },
+                // Number of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumMessages(13)
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), false, 1000, true
+                },
+                // Size of messages and timeout limitation
+                { BatchReceivePolicy.builder()
+                        .maxNumBytes(64)
+                        .timeout(50, TimeUnit.MILLISECONDS)
+                        .build(), false, 1000, true
+                },
+                // Number of message limitation exceed receiverQueue size
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(70)
+                                .build(), true, 50, true
+                },
+                // Number of message limitation exceed receiverQueue size and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(50)
+                                .timeout(10, TimeUnit.MILLISECONDS)
+                                .build(), true, 30, true
+                },
+                // Number of message limitation is negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(-10)
+                                .timeout(10, TimeUnit.MILLISECONDS)
+                                .build(), true, 10, true
+                },
+                // Size of message limitation is negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumBytes(-100)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), true, 30, true
+                },
+                // Number of message limitation and size of message limitation are both negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(-10)
+                                .maxNumBytes(-100)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), true, 30, true
+                },
+                // Number of message limitation exceed receiverQueue size
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(70)
+                                .build(), false, 50, true
+                },
+                // Number of message limitation exceed receiverQueue size and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(50)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
+                },
+                // Number of message limitation is negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(-10)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
+                },
+                // Size of message limitation is negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumBytes(-100)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
+                },
+                // Number of message limitation and size of message limitation are both negative and timeout limitation
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(-10)
+                                .maxNumBytes(-100)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
+                },
+                // Only timeout present
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(0)
+                                .maxNumBytes(0)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
+                },
+                // Only timeout present
+                {
+                        BatchReceivePolicy.builder()
+                                .maxNumMessages(-1)
+                                .maxNumBytes(-1)
+                                .timeout(50, TimeUnit.MILLISECONDS)
+                                .build(), false, 30, true
                 }
         };
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    public void testBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         final String topic = "persistent://my-property/my-ns/batch-receive-non-partition-" + UUID.randomUUID();
-        testBatchReceive(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+        testBatchReceive(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    public void testBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         final String topic = "persistent://my-property/my-ns/batch-receive-" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
-        testBatchReceive(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+        testBatchReceive(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testAsyncBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
-        final String topic = "persistent://my-property/my-ns/batch-receive-non-partition-async-" + UUID.randomUUID();
-        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+    public void testAsyncBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
+        final String topic = "persistent://my-property/my-ns/batch-receiync-" + UUID.randomUUID();
+        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testAsyncBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    public void testAsyncBatchReceivePartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         final String topic = "persistent://my-property/my-ns/batch-receive-async-" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
-        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+        testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testBatchReceiveAndRedeliveryNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    public void testBatchReceiveAndRedeliveryNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         final String topic = "persistent://my-property/my-ns/batch-receive-and-redelivery-non-partition-" + UUID.randomUUID();
-        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test(dataProvider = "batchReceivePolicy")
-    public void testBatchReceiveAndRedeliveryPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    public void testBatchReceiveAndRedeliveryPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         final String topic = "persistent://my-property/my-ns/batch-receive-and-redelivery-" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
-        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce, receiverQueueSize);
+        testBatchReceiveAndRedelivery(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
     @Test
@@ -260,7 +394,9 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
         }
     }
 
-    private void testBatchReceive(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    private void testBatchReceive(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce,
+                                  int receiverQueueSize, boolean enableAckReceipt) throws Exception {
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).ioThreads(10).build();
         ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
         if (!batchProduce) {
             producerBuilder.enableBatching(false);
@@ -273,16 +409,19 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                 .subscriptionName("s1")
                 .receiverQueueSize(receiverQueueSize)
                 .batchReceivePolicy(batchReceivePolicy)
+                .isAckReceiptEnabled(enableAckReceipt)
+                .enableBatchIndexAcknowledgment(enableAckReceipt)
                 .subscribe();
         sendMessagesAsyncAndWait(producer, 100);
         batchReceiveAndCheck(consumer, 100);
     }
 
-    private void testBatchReceiveAsync(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    private void testBatchReceiveAsync(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         if (batchReceivePolicy.getTimeoutMs() <= 0) {
             return;
         }
 
+        PulsarClient pulsarClient = PulsarClient.builder().ioThreads(10).serviceUrl(lookupUrl.toString()).build();
         ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
         if (!batchProduce) {
             producerBuilder.enableBatching(false);
@@ -296,15 +435,17 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                 .subscriptionName("s1")
                 .receiverQueueSize(receiverQueueSize)
                 .batchReceivePolicy(batchReceivePolicy)
+                .isAckReceiptEnabled(isEnableAckReceipt)
+                .enableBatchIndexAcknowledgment(isEnableAckReceipt)
                 .subscribe();
 
         sendMessagesAsyncAndWait(producer, 100);
-        CountDownLatch latch = new CountDownLatch(100);
+        CountDownLatch latch = new CountDownLatch(101);
         receiveAsync(consumer, 100, latch);
         latch.await();
     }
 
-    private void testBatchReceiveAndRedelivery(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize) throws Exception {
+    private void testBatchReceiveAndRedelivery(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
         ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
         if (!batchProduce) {
             producerBuilder.enableBatching(false);
@@ -317,6 +458,8 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                 .subscriptionName("s1")
                 .receiverQueueSize(receiverQueueSize)
                 .batchReceivePolicy(batchReceivePolicy)
+                .isAckReceiptEnabled(isEnableAckReceipt)
+                .enableBatchIndexAcknowledgment(isEnableAckReceipt)
                 .ackTimeout(1, TimeUnit.SECONDS)
                 .subscribe();
         sendMessagesAsyncAndWait(producer, 100);
@@ -340,7 +483,8 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                 if (messages.size() < expected) {
                     ForkJoinPool.commonPool().execute(() -> receiveAsync(consumer, expected - messages.size(), latch));
                 } else {
-                    Assert.assertEquals(expected, 0);
+                    Assert.assertEquals(expected - messages.size(), 0);
+                    latch.countDown();
                 }
             }
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -339,7 +339,7 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "batchReceivePolicy")
     public void testAsyncBatchReceiveNonPartitionedTopic(BatchReceivePolicy batchReceivePolicy, boolean batchProduce, int receiverQueueSize, boolean isEnableAckReceipt) throws Exception {
-        final String topic = "persistent://my-property/my-ns/batch-receiync-" + UUID.randomUUID();
+        final String topic = "persistent://my-property/my-ns/batch-receive-non-partition-async-" + UUID.randomUUID();
         testBatchReceiveAsync(topic, batchReceivePolicy, batchProduce, receiverQueueSize, isEnableAckReceipt);
     }
 
@@ -475,11 +475,8 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                     log.info("Get message {} from batch", message.getValue());
                     latch.countDown();
                 }
-                try {
-                    consumer.acknowledge(messages);
-                } catch (PulsarClientException e) {
-                    log.error("Ack message error", e);
-                }
+                consumer.acknowledgeAsync(messages);
+
                 if (messages.size() < expected) {
                     ForkJoinPool.commonPool().execute(() -> receiveAsync(consumer, expected - messages.size(), latch));
                 } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -396,7 +396,6 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
 
     private void testBatchReceive(String topic, BatchReceivePolicy batchReceivePolicy, boolean batchProduce,
                                   int receiverQueueSize, boolean enableAckReceipt) throws Exception {
-        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).ioThreads(10).build();
         ProducerBuilder<String> producerBuilder = pulsarClient.newProducer(Schema.STRING).topic(topic);
         if (!batchProduce) {
             producerBuilder.enableBatching(false);
@@ -476,7 +475,6 @@ public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
                     latch.countDown();
                 }
                 consumer.acknowledgeAsync(messages);
-
                 if (messages.size() < expected) {
                     ForkJoinPool.commonPool().execute(() -> receiveAsync(consumer, expected - messages.size(), latch));
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -374,9 +374,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         try {
             List<MessageId> messageIds = new ArrayList<>();
             messages.forEach(message -> messageIds.add(message.getMessageId()));
-            CompletableFuture<Void> completableFuture = acknowledgeAsync(messageIds);
-
-            return completableFuture;
+            return acknowledgeAsync(messageIds);
         } catch (NullPointerException npe) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidMessageException(npe.getMessage()));
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -22,7 +22,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
+
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -369,8 +372,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     @Override
     public CompletableFuture<Void> acknowledgeAsync(Messages<?> messages) {
         try {
-            messages.forEach(this::acknowledgeAsync);
-            return CompletableFuture.completedFuture(null);
+            List<MessageId> messageIds = new ArrayList<>();
+            messages.forEach(message -> messageIds.add(message.getMessageId()));
+            CompletableFuture<Void> completableFuture = acknowledgeAsync(messageIds);
+
+            return completableFuture;
         } catch (NullPointerException npe) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidMessageException(npe.getMessage()));
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -142,8 +142,12 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     // change currentFuture. but we can lock by the read lock, because the currentFuture is not change
                     // any ack operation is allowed.
                     this.lock.readLock().lock();
-                    addListAcknowledgment(messageIds);
-                    return this.currentIndividualAckFuture;
+                    if (messageIds.size() != 0) {
+                        addListAcknowledgment(messageIds);
+                        return this.currentIndividualAckFuture;
+                    } else {
+                        return CompletableFuture.completedFuture(null);
+                    }
                 } finally {
                     this.lock.readLock().unlock();
                     if (acknowledgementGroupTimeMicros == 0 || pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {


### PR DESCRIPTION
## Motivation

Fixes #9344 

### Verifying this change

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

