### PR TITLE
Initial python 3.9 client wheel build support

### DIFF
--- a/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
+++ b/pulsar-client-cpp/docker/build-client-lib-within-docker.sh
@@ -23,9 +23,9 @@ set -e -x
 
 cd /pulsar/pulsar-client-cpp
 
-find . -name CMakeCache.txt | xargs rm
-find . -name CMakeFiles | xargs rm -rf
-rm lib/*.pb.*
+find . -name CMakeCache.txt | xargs -r rm
+find . -name CMakeFiles | xargs -r rm -rf
+rm -f lib/*.pb.*
 
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON \
         -DPYTHON_INCLUDE_DIR=/opt/python/$PYTHON_SPEC/include/python$PYTHON_VERSION \

--- a/pulsar-client-cpp/docker/build-client-lib.sh
+++ b/pulsar-client-cpp/docker/build-client-lib.sh
@@ -28,6 +28,7 @@ cd $ROOT_DIR
 
 PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
+   '3.9 cp39-cp39'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do
@@ -42,7 +43,7 @@ for line in "${PYTHON_VERSIONS[@]}"; do
 
     VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
     COMMAND="/pulsar/pulsar-client-cpp/docker/build-client-lib-within-docker.sh"
-    DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
+    DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE_NAME}"
 
     $DOCKER_CMD bash -c "${COMMAND}"
 

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -33,6 +33,7 @@ PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
+   '3.9 cp39-cp39'
 )
 
 function contains() {

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -30,6 +30,7 @@ PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
+   '3.9 cp39-cp39'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/docker/push-images.sh
+++ b/pulsar-client-cpp/docker/push-images.sh
@@ -32,6 +32,7 @@ PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
+   '3.9 cp39-cp39'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -52,7 +52,8 @@ endif()
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
                         ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY}
                         ${Boost_PYTHON34_LIBRARY} ${Boost_PYTHON35_LIBRARY}
-                        ${Boost_PYTHON36_LIBRARY} ${Boost_PYTHON38_LIBRARY})
+                        ${Boost_PYTHON36_LIBRARY} ${Boost_PYTHON38_LIBRARY}
+                        ${Boost_PYTHON39_LIBRARY})
 
 if (APPLE)
     set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS}


### PR DESCRIPTION
- Fix `build-client-lib-within-docker.sh`
- Fix `build-client-lib.sh` and add py39
- Add py39 to remaining docker build scripts

### Motivation

A python 3.9 client wheel is missing. This is an initial attempt to add it. I'm mainly concerned about Fedora + RHEL7.

### Modifications

Mostly just fixing up / modifying build scripts used with docker.

I don't know enough about the build system. I made sufficient changes for me to
be able to do this (roughly):

```console
$ cd pulsar-client-cpp/docker
$ ./create-images.sh
$ ./build-client-lib.sh
$ export BUILD_IMAGE_NAME=pulsar-build
$ ./build-wheels.sh 3.9 cp39-cp39
```

When I built the wheel on my laptop, I commented out all other versions or
specified just 3.9.

### TODO: Documentation

As a new user, it was confusing figuring out how exactly to build this. I can take a quick stab at doc updates after this is merged.