### PR TITLE
[docs] Update spark and Kafka info

### DIFF
--- a/site2/docs/adaptors-kafka.md
+++ b/site2/docs/adaptors-kafka.md
@@ -103,13 +103,13 @@ while (true) {
 ## Complete Examples
 
 You can find the complete producer and consumer examples
-[here](https://github.com/apache/pulsar/tree/master/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/examples).
+[here](https://github.com/apache/pulsar-adapters/tree/master/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/examples).
 
 ## Compatibility matrix
 
 Currently the Pulsar Kafka wrapper supports most of the operations offered by the Kafka API.
 
-#### Producer
+### Producer
 
 APIs:
 
@@ -154,7 +154,7 @@ Properties:
 | `value.serializer`                      | Yes       |                                                                               |
 
 
-#### Consumer
+### Consumer
 
 The following table lists consumer APIs.
 

--- a/site2/docs/adaptors-spark.md
+++ b/site2/docs/adaptors-spark.md
@@ -4,15 +4,19 @@ title: Pulsar adaptor for Apache Spark
 sidebar_label: Apache Spark
 ---
 
+## Spark structured streaming connector
+Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. For details, refer to [Pulsar Spark Connector in StreamNative Hub](https://hub.streamnative.io/).
+
+## Spark streaming connector
 The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
 
 An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
 
-## Prerequisites
+### Prerequisites
 
 To use the receiver, include a dependency for the `pulsar-spark` library in your Java configuration.
 
-### Maven
+#### Maven
 
 If you're using Maven, add this to your `pom.xml`:
 
@@ -28,7 +32,7 @@ If you're using Maven, add this to your `pom.xml`:
 </dependency>
 ```
 
-### Gradle
+#### Gradle
 
 If you're using Gradle, add this to your `build.gradle` file:
 
@@ -40,7 +44,7 @@ dependencies {
 }
 ```
 
-## Usage
+### Usage
 
 Pass an instance of `SparkStreamingPulsarReceiver` to the `receiverStream` method in `JavaStreamingContext`:
 
@@ -69,4 +73,3 @@ Pass an instance of `SparkStreamingPulsarReceiver` to the `receiverStream` metho
 ```
 
 For a complete example, click [here](https://github.com/apache/pulsar-adapters/blob/master/examples/spark/src/main/java/org/apache/spark/streaming/receiver/example/SparkStreamingPulsarReceiverExample.java). In this example, the number of messages that contain the string "Pulsar" in received messages is counted.
-


### PR DESCRIPTION
### Motivation
1. All pulsar-adapters are moved into a new repo:https://github.com/apache/pulsar-adapters, the original example links are broken.
2. Except the Spark streaming connector, Pulsar also support Spark Structured Streaming connector.

### Modifications
1. Update the links in the docs as new links.
2. Add info for Spark Structured streaming connector.
3. Adjust the manual structure accordingly.
