### PR TITLE
Fix testBrokerSelectionForAntiAffinityGroup by increasing OverloadedThreshold

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
@@ -66,11 +66,9 @@ public class GenericBrokerHostUsageImpl implements BrokerHostUsage {
         return usage;
     }
 
-    private void checkCpuLoad() {
-        synchronized (this) {
-            cpuUsageSum += systemBean.getSystemCpuLoad();
-            cpuUsageCount++;
-        }
+    private synchronized void checkCpuLoad() {
+        cpuUsageSum += systemBean.getSystemCpuLoad();
+        cpuUsageCount++;
     }
 
     @Override
@@ -91,19 +89,17 @@ public class GenericBrokerHostUsageImpl implements BrokerHostUsage {
         return 100 * Runtime.getRuntime().availableProcessors();
     }
 
-    private double getTotalCpuUsage() {
-        synchronized (this) {
-            double cpuUsage = cpuUsageSum / cpuUsageCount;
-            cpuUsageSum = 0d;
-            this.cpuUsageCount = 0;
-            return cpuUsage;
+    private synchronized double getTotalCpuUsage() {
+        if (cpuUsageCount == 0) {
+            return 0;
         }
+        double cpuUsage = cpuUsageSum / cpuUsageCount;
+        cpuUsageSum = 0d;
+        cpuUsageCount = 0;
+        return cpuUsage;
     }
 
     private ResourceUsage getCpuUsage() {
-        if (cpuUsageCount == 0) {
-            return new ResourceUsage(0, totalCpuLimit);
-        }
         return new ResourceUsage(getTotalCpuUsage() * totalCpuLimit, totalCpuLimit);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
@@ -55,7 +55,8 @@ public class GenericBrokerHostUsageImpl implements BrokerHostUsage {
         // Need to run checkCpuLoad first to seed with some cpu usage
         checkCpuLoad();
         doCalculateBrokerHostUsage();
-        executorService.scheduleAtFixedRate(this::checkCpuLoad, CPU_CHECK_MILLIS, CPU_CHECK_MILLIS, TimeUnit.MILLISECONDS);
+        executorService.scheduleAtFixedRate(this::checkCpuLoad, CPU_CHECK_MILLIS,
+                CPU_CHECK_MILLIS, TimeUnit.MILLISECONDS);
         executorService.scheduleAtFixedRate(this::doCalculateBrokerHostUsage, hostUsageCheckIntervalMin,
                 hostUsageCheckIntervalMin, TimeUnit.MINUTES);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
@@ -52,9 +52,7 @@ public class GenericBrokerHostUsageImpl implements BrokerHostUsage {
         this.usage = new SystemResourceUsage();
         this.totalCpuLimit = getTotalCpuLimit();
         // Call now to initialize values before the constructor returns
-        // Need to run checkCpuLoad first to seed with some cpu usage
-        checkCpuLoad();
-        doCalculateBrokerHostUsage();
+        calculateBrokerHostUsage();
         executorService.scheduleAtFixedRate(this::checkCpuLoad, CPU_CHECK_MILLIS,
                 CPU_CHECK_MILLIS, TimeUnit.MILLISECONDS);
         executorService.scheduleAtFixedRate(this::doCalculateBrokerHostUsage, hostUsageCheckIntervalMin,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -75,8 +75,6 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         this.lastCollection = 0L;
         this.usage = new SystemResourceUsage();
         this.overrideBrokerNicSpeedGbps = overrideBrokerNicSpeedGbps;
-        executorService.scheduleAtFixedRate(this::calculateBrokerHostUsage, 0,
-                hostUsageCheckIntervalMin, TimeUnit.MINUTES);
 
         boolean isCGroupsEnabled = false;
         try {
@@ -84,9 +82,10 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         } catch (Exception e) {
             log.warn("Failed to check cgroup CPU usage file: {}", e.getMessage());
         }
-
         this.isCGroupsEnabled = isCGroupsEnabled;
-        calculateBrokerHostUsage();
+
+        executorService.scheduleAtFixedRate(this::calculateBrokerHostUsage, 0,
+                hostUsageCheckIntervalMin, TimeUnit.MINUTES);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -84,7 +84,9 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         }
         this.isCGroupsEnabled = isCGroupsEnabled;
 
-        executorService.scheduleAtFixedRate(this::calculateBrokerHostUsage, 0,
+        // Call now to initialize values before the constructor returns
+        calculateBrokerHostUsage();
+        executorService.scheduleAtFixedRate(this::calculateBrokerHostUsage, hostUsageCheckIntervalMin,
                 hostUsageCheckIntervalMin, TimeUnit.MINUTES);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -114,7 +114,7 @@ public class AntiAffinityNamespaceGroupTest {
         config1.setLoadBalancerEnabled(true);
         config1.setAdvertisedAddress("localhost");
         // Don't want overloaded threshold to affect namespace placement
-        config1.setLoadBalancerBrokerOverloadedThresholdPercentage(100);
+        config1.setLoadBalancerBrokerOverloadedThresholdPercentage(400);
         createCluster(bkEnsemble.getZkClient(), config1);
         pulsar1 = new PulsarService(config1);
         pulsar1.start();
@@ -133,7 +133,7 @@ public class AntiAffinityNamespaceGroupTest {
         config2.setFailureDomainsEnabled(true);
         config2.setAdvertisedAddress("localhost");
         // Don't want overloaded threshold to affect namespace placement
-        config2.setLoadBalancerBrokerOverloadedThresholdPercentage(100);
+        config2.setLoadBalancerBrokerOverloadedThresholdPercentage(400);
         pulsar2 = new PulsarService(config2);
         pulsar2.start();
 
@@ -371,9 +371,11 @@ public class AntiAffinityNamespaceGroupTest {
      * It verifies anti-affinity with failure domain enabled with 2 brokers.
      *
      * Note: in this class's setup method, the LoadBalancerBrokerOverloadedThresholdPercentage
-     * is set to 100 to ensure that the overloaded logic doesn't affect the broker selection.
+     * is set to 400 to ensure that the overloaded logic doesn't affect the broker selection.
      * Without that configuration, two namespaces in the same anti-affinity group could
-     * be placed on the same broker.
+     * be placed on the same broker. The CPU usage can be over 100%, and if we run with more
+     * than 4 cores, it could conceivably be above 400%. If this test becomes flaky again,
+     * look at the logs to see if there is a mention of an overloaded broker.
      *
      * <pre>
      * 1. Register brokers to domain: domain-1: broker1 & domain-2: broker2

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -113,6 +113,8 @@ public class AntiAffinityNamespaceGroupTest {
         config1.setFailureDomainsEnabled(true);
         config1.setLoadBalancerEnabled(true);
         config1.setAdvertisedAddress("localhost");
+        // Don't want overloaded threshold to affect namespace placement
+        config1.setLoadBalancerBrokerOverloadedThresholdPercentage(100);
         createCluster(bkEnsemble.getZkClient(), config1);
         pulsar1 = new PulsarService(config1);
         pulsar1.start();
@@ -130,6 +132,8 @@ public class AntiAffinityNamespaceGroupTest {
         config2.setBrokerServicePort(Optional.of(0));
         config2.setFailureDomainsEnabled(true);
         config2.setAdvertisedAddress("localhost");
+        // Don't want overloaded threshold to affect namespace placement
+        config2.setLoadBalancerBrokerOverloadedThresholdPercentage(100);
         pulsar2 = new PulsarService(config2);
         pulsar2.start();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -370,6 +370,11 @@ public class AntiAffinityNamespaceGroupTest {
     /**
      * It verifies anti-affinity with failure domain enabled with 2 brokers.
      *
+     * Note: in this class's setup method, the LoadBalancerBrokerOverloadedThresholdPercentage
+     * is set to 100 to ensure that the overloaded logic doesn't affect the broker selection.
+     * Without that configuration, two namespaces in the same anti-affinity group could
+     * be placed on the same broker.
+     *
      * <pre>
      * 1. Register brokers to domain: domain-1: broker1 & domain-2: broker2
      * 2. Load-Manager receives a watch and updates brokerToDomain cache with new domain data


### PR DESCRIPTION
Fixes: #6368

Flaky-test: `AntiAffinityNamespaceGroupTest.testBrokerSelectionForAntiAffinityGroup`

TestClass is flaky. The testMethod test method fails sporadically.

See #6368 for example failures as well as for my analysis and detailed justification for this change.

In short, by setting the `LoadBalancerBrokerOverloadedThresholdPercentage` to `100`, we remove the main edge case that allows two namespaces in the same anti-affinity group to get placed on the same broker.

Note that I am assuming the following method will never return a value greater than 1, which could lead to test failure. https://github.com/apache/pulsar/blob/85f3ff4edbaa10c7894af8ad823cbce37b13829c/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java#L214-L217