### PR TITLE
[WIP][Presto]Support authentication in pulsar presto

### DIFF
--- a/conf/presto/password-authenticator.properties
+++ b/conf/presto/password-authenticator.properties
@@ -1,0 +1,1 @@
+password-authenticator.name=pulsar

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -70,6 +70,12 @@
         </dependency>
 
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-broker-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jctools</groupId>
             <artifactId>jctools-core</artifactId>
             <version>${jctools.version}</version>

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticator.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticator.java
@@ -18,22 +18,14 @@
  */
 package org.apache.pulsar.sql.presto;
 
-import com.google.common.collect.ImmutableList;
-import io.prestosql.spi.Plugin;
-import io.prestosql.spi.connector.ConnectorFactory;
-import io.prestosql.spi.security.PasswordAuthenticatorFactory;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.PasswordAuthenticator;
 
-/**
- * Implementation of the Pulsar plugin for Pesto.
- */
-public class PulsarPlugin implements Plugin {
-    @Override
-    public Iterable<ConnectorFactory> getConnectorFactories() {
-        return ImmutableList.of(new PulsarConnectorFactory());
-    }
+import java.security.Principal;
 
+public class PulsarPasswordAuthenticator implements PasswordAuthenticator {
     @Override
-    public Iterable<PasswordAuthenticatorFactory> getPasswordAuthenticatorFactories() {
-        return ImmutableList.of(new PulsarPasswordAuthenticatorFactory());
+    public Principal createAuthenticatedPrincipal(String user, String password) {
+        throw new AccessDeniedException("Test for auth-presto.");
     }
 }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorFactory.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.log.Logger;
+import io.prestosql.spi.security.PasswordAuthenticator;
+import io.prestosql.spi.security.PasswordAuthenticatorFactory;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class PulsarPasswordAuthenticatorFactory implements PasswordAuthenticatorFactory {
+
+    private static final Logger log = Logger.get(PulsarPasswordAuthenticatorFactory.class);
+
+    @Override
+    public String getName() {
+        return "pulsar";
+    }
+
+    @Override
+    public PasswordAuthenticator create(Map<String, String> config) {
+        log.info("Creating password authenticator.");
+        if (log.isDebugEnabled()){
+            log.debug("Creating Pulsar password authenticator with configs: %s", config);
+        }
+        try {
+            // A plugin is not required to use Guice; it is just very convenient
+            Bootstrap app = new Bootstrap(
+                    new PulsarPasswordAuthenticatorModule()
+            );
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            PulsarPasswordAuthenticator authenticator = injector.getInstance(PulsarPasswordAuthenticator.class);
+            return authenticator;
+        } catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorFactory.java
@@ -56,6 +56,7 @@ public class PulsarPasswordAuthenticatorFactory implements PasswordAuthenticator
                     .initialize();
 
             PulsarPasswordAuthenticator authenticator = injector.getInstance(PulsarPasswordAuthenticator.class);
+            authenticator.initialize();
             return authenticator;
         } catch (Exception e) {
             throwIfUnchecked(e);

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorModule.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarPasswordAuthenticatorModule.java
@@ -18,22 +18,16 @@
  */
 package org.apache.pulsar.sql.presto;
 
-import com.google.common.collect.ImmutableList;
-import io.prestosql.spi.Plugin;
-import io.prestosql.spi.connector.ConnectorFactory;
-import io.prestosql.spi.security.PasswordAuthenticatorFactory;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 
 /**
- * Implementation of the Pulsar plugin for Pesto.
+ * This class defines binding of classes in the Presto password authenticator.
  */
-public class PulsarPlugin implements Plugin {
+public class PulsarPasswordAuthenticatorModule implements Module {
     @Override
-    public Iterable<ConnectorFactory> getConnectorFactories() {
-        return ImmutableList.of(new PulsarConnectorFactory());
-    }
-
-    @Override
-    public Iterable<PasswordAuthenticatorFactory> getPasswordAuthenticatorFactories() {
-        return ImmutableList.of(new PulsarPasswordAuthenticatorFactory());
+    public void configure(Binder binder) {
+        binder.bind(PulsarPasswordAuthenticator.class).in(Scopes.SINGLETON);
     }
 }


### PR DESCRIPTION

### Motivation

Currently, we don't have any security-related integration between Pulsar and Presto. We need support using Pulsar authentication provider as an authenticator in Presto to authenticate SQL requests sent to a coordinator.

### Modifications

* Add PulsarPasswordAuthenticator
* Use AuthenticationProviderBasic to authenticate SQL requests in presto-sql.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
