### PR TITLE
[Issue 8091][Pulsar SQL] Add presto password authenticators plugin

### DIFF
--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>presto-pulsar</module>
         <module>presto-pulsar-plugin</module>
+        <module>presto-password-authenticators-plugin</module>
         <module>presto-distribution</module>
     </modules>
 

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -161,6 +161,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>presto-password-authenticators-plugin</artifactId>
+            <version>${project.version}</version>
+            <type>tar.gz</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <version>${objenesis.version}</version>

--- a/pulsar-sql/presto-distribution/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-distribution/src/assembly/assembly.xml
@@ -40,6 +40,17 @@
             <directory>${basedir}/../presto-pulsar-plugin/target/pulsar-presto-connector/</directory>
             <outputDirectory>plugin/</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../presto-password-authenticators-plugin/target/presto-password-authenticators-plugin</directory>
+            <outputDirectory>plugin/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../presto-password-authenticators-plugin/target/</directory>
+            <outputDirectory>plugin/presto-password-authenticators-plugin</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>

--- a/pulsar-sql/presto-password-authenticators-plugin/pom.xml
+++ b/pulsar-sql/presto-password-authenticators-plugin/pom.xml
@@ -1,0 +1,75 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-sql</artifactId>
+        <version>2.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-password-authenticators-plugin</artifactId>
+    <name>Pulsar SQL :: Presto Password Authenticators</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.prestosql</groupId>
+            <artifactId>presto-password-authenticators</artifactId>
+            <version>${presto.version}</version>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>true</attach>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                    <descriptors>
+                        <descriptor>src/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pulsar-sql/presto-password-authenticators-plugin/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-password-authenticators-plugin/src/assembly/assembly.xml
@@ -1,0 +1,39 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>dir</format>
+    </formats>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <scope>runtime</scope>
+            <excludes>
+              <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/pulsar-sql/presto-password-authenticators-plugin/src/main/resources/META-INF/services/io.prestosql.spi.Plugin
+++ b/pulsar-sql/presto-password-authenticators-plugin/src/main/resources/META-INF/services/io.prestosql.spi.Plugin
@@ -1,0 +1,1 @@
+io.prestosql.plugin.password.PasswordAuthenticatorPlugin


### PR DESCRIPTION
Fixes #8091

### Motivation


In order to use authentication in Presto (and Pulsar SQL), the password authenticators plugin must be present in the distribution. If you configure password authentication and the plugin is not present, the server will not start.

### Modifications

This update pulls in the password authenticators plugin from the PrestoSQL build and packages as part of the presto distribution used by the `pulsar sql-worker run`  command.

### Verifying this change

I have built a Docker image with this change and confirmed that file-based password authentication works with this change. Since the plugin comes from the Presto build, I don't think we need any extra tests for it. Adding an integration test would be difficult because configuring authentication in Presto requires HTTPS to also be set up.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes. Adds a new dependency on the Presto password plugin.
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

The plugin can be configured by modifying the files in the `/etc/conf/presto` directory by following the PulsarSQL (now Trino) documentation. For example, this [link](https://trino.io/docs/current/security/password-file.html#) explains has to configure file-based password authentication. 