### PR TITLE
[pulsar-broker] Handle bad-version in metadata-store if broker updates zk-metadata from zk-client

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -327,6 +327,11 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
         receivedNotification(new Notification(type, event.getPath()));
     }
 
+    @VisibleForTesting
+    public ZooKeeper getZooKeeper() {
+        return zkc;
+    }
+
     private static CreateMode getCreateMode(EnumSet<CreateOption> options) {
         if (options.contains(CreateOption.Ephemeral)) {
             if (options.contains(CreateOption.Sequential)) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -327,11 +327,6 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
         receivedNotification(new Notification(type, event.getPath()));
     }
 
-    @VisibleForTesting
-    public ZooKeeper getZooKeeper() {
-        return zkc;
-    }
-
     private static CreateMode getCreateMode(EnumSet<CreateOption> options) {
         if (options.contains(CreateOption.Ephemeral)) {
             if (options.contains(CreateOption.Sequential)) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -39,7 +39,7 @@ import org.assertj.core.util.Files;
 @Slf4j
 public class TestZKServer implements AutoCloseable {
 
-    private final ZooKeeperServer zks;
+    protected final ZooKeeperServer zks;
     private final File zkDataDir;
     private final ServerCnxnFactory serverFactory;
 


### PR DESCRIPTION
### Motivation

Metadata-store reads the metadata,  caches the data and version in metadata-cache. now, if metadata-znode gets updated by zk-client directly then next update  by metadata-cache on that znode will fail with BadVersion-error as metadata-cache doesn't have the latest version. 

To address this issue, broker should use metadata-store from every component until then metadata-cache should handle BadVersion exception, invalidate cache and retry once to handle such issue. 

```
java.util.concurrent.CompletionException: org.apache.pulsar.metadata.api.MetadataStoreException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion for /key-1102400377941301
	at java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:375)
	at java.util.concurrent.CompletableFuture.join(CompletableFuture.java:1947)
	at org.apache.pulsar.metadata.MetadataCacheTest.readModifyUpdateBadVersionRetry(MetadataCacheTest.java:288)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.pulsar.metadata.api.MetadataStoreException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion for /key-1102400377941301
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.getException(ZKMetadataStore.java:286)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$17(ZKMetadataStore.java:233)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```