### PR TITLE
[Docs] Optimize helm deploy description about the first deployment (#9416)

### DIFF
--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -352,7 +352,7 @@ helm upgrade --install pulsar apache/pulsar \
 ```
 > **Note**
 > 
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -350,6 +350,8 @@ helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+> 
 > For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.

--- a/site2/docs/helm-deploy.md
+++ b/site2/docs/helm-deploy.md
@@ -350,6 +350,7 @@ helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.5.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.5.0/helm-deploy.md
@@ -363,7 +363,7 @@ helm upgrade --install pulsar charts/pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use `--version <installation version>` option if you would like to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.5.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.5.0/helm-deploy.md
@@ -361,6 +361,9 @@ helm upgrade --install pulsar charts/pulsar \
     --timeout 600 \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use `--version <installation version>` option if you would like to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.0/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar apache/pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.1/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.1/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.1/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.1/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.2/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.2/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.2/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.2/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.3/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.3/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.6.3/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.6.3/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.7.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.7.0/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.7.0/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.7.0/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar apache/pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.7.1/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.7.1/helm-deploy.md
@@ -351,6 +351,9 @@ helm upgrade --install pulsar apache/pulsar \
     --timeout 10m \
     --set [your configuration options]
 ```
+> **Note**
+>
+> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 

--- a/site2/website/versioned_docs/version-2.7.1/helm-deploy.md
+++ b/site2/website/versioned_docs/version-2.7.1/helm-deploy.md
@@ -353,7 +353,7 @@ helm upgrade --install pulsar apache/pulsar \
 ```
 > **Note**
 >
-> For the first deployment, add `--set initialize=true` option to initialize bookie and pulsar cluster meta.
+> For the first deployment, add `--set initialize=true` option to initialize bookie and Pulsar cluster metadata.
 
 You can also use the `--version <installation version>` option if you want to install a specific version of Pulsar Helm chart.
 


### PR DESCRIPTION
# Motivation
The `--set initialize=true` option is necessary for initializing bookie and pulsar cluster meta, which is not clear in current document.

# Modifications
Optimize helm deploy description about the first deployment as mentioned in #9416 .