### PR TITLE
Fix flaky test ConsumedLedgersTrimTest.testConsumedLedgersTrimNoSubscriptions

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -142,6 +143,14 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         // the lastMessageId is still on the previous ledger
         restartBroker();
         // force load topic
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            try {
+                pulsar.getBrokerService().getTopicIfExists(topicName).get(3, TimeUnit.SECONDS).get();
+                return true;
+            } catch (Exception ignored) {
+            }
+            return false;
+        });
         pulsar.getAdminClient().topics().getStats(topicName);
         MessageId messageIdAfterRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
         LOG.info("lastmessageid " + messageIdAfterRestart);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
@@ -143,14 +145,8 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         // the lastMessageId is still on the previous ledger
         restartBroker();
         // force load topic
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
-            try {
-                pulsar.getBrokerService().getTopicIfExists(topicName).get(3, TimeUnit.SECONDS).get();
-                return true;
-            } catch (Exception ignored) {
-            }
-            return false;
-        });
+        Awaitility.await().ignoreExceptions().untilAsserted(()
+                -> assertNotNull(pulsar.getBrokerService().getTopicIfExists(topicName).get(3, TimeUnit.SECONDS).get()));
         pulsar.getAdminClient().topics().getStats(topicName);
         MessageId messageIdAfterRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
         LOG.info("lastmessageid " + messageIdAfterRestart);


### PR DESCRIPTION
Fixes #9409
### Motivation
After restarting, it takes time to load the topic, and this admin api will throw an exception when the topic cannot be queried.
This problem can easily be triggered when this unit test is called in a loop. Therefore, I added a judgment to determine whether the topic is loaded. After that, I called it 100 times in a loop and no exception was seen.
