### PR TITLE
Migrate some ledgers metadata changes to an independent class

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -18,11 +18,10 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import io.netty.buffer.ByteBuf;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.bookkeeper.mledger;
 
 public interface ManagedLedgerMetaStore {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
@@ -1,0 +1,4 @@
+package org.apache.bookkeeper.mledger;
+
+public interface ManagedLedgerMetaStore {
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMetaStore.java
@@ -25,15 +25,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.util.CallbackMutex;
 
 public interface ManagedLedgerMetaStore {
     interface NewInfoBuilder {
-        MLDataFormats.ManagedLedgerInfo build(Map<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> newLedgers);
+        MLDataFormats.ManagedLedgerInfo build(Map<Long, LedgerInfo> newLedgers);
     }
 
     interface LedgerInfoTransformation {
-        MLDataFormats.ManagedLedgerInfo.LedgerInfo transform(MLDataFormats.ManagedLedgerInfo.LedgerInfo oldInfo) throws
+        LedgerInfo transform(LedgerInfo oldInfo) throws
                 ManagedLedgerException;
     }
 
@@ -59,7 +60,7 @@ public interface ManagedLedgerMetaStore {
 
     CallbackMutex getMetadataMutex();
 
-    MLDataFormats.ManagedLedgerInfo.LedgerInfo put(Long ledgerId, MLDataFormats.ManagedLedgerInfo.LedgerInfo info);
+    LedgerInfo put(Long ledgerId, LedgerInfo info);
 
     Long lastLedgerId();
 
@@ -71,7 +72,7 @@ public interface ManagedLedgerMetaStore {
 
     void closeLedger(long ledgerId, long ledgerLength, long entriesCountInLedger, long closeTimeInMillis);
 
-    Optional<MLDataFormats.ManagedLedgerInfo.LedgerInfo> get(Long ledgerId);
+    Optional<LedgerInfo> get(Long ledgerId);
 
     CompletableFuture<InitializeResult> initialize(String name, boolean createIfMissing);
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -347,7 +347,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                             LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(id)
                                     .setEntries(lh.getLastAddConfirmed() + 1).setSize(lh.getLength())
                                     .setTimestamp(clock.millis()).build();
-                            ledgerMetaStore.ledgers.put(id, info);
+                            ledgerMetaStore.put(id, info);
                             if (managedLedgerInterceptor != null) {
                                 managedLedgerInterceptor.onManagedLedgerLastLedgerInitialize(name, lh);
                             }
@@ -446,6 +446,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
                 lastConfirmedEntry = new PositionImpl(lh.getId(), -1);
                 // bypass empty ledgers, find last ledger with Message if possible.
+                // TODO can abstract to a method?
                 while (lastConfirmedEntry.getEntryId() == -1) {
                     Map.Entry<Long, LedgerInfo> formerLedger = ledgerMetaStore.ledgers
                             .lowerEntry(lastConfirmedEntry.getLedgerId());
@@ -458,7 +459,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
 
                 LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setTimestamp(0).build();
-                ledgerMetaStore.ledgers.put(lh.getId(), info);
+                ledgerMetaStore.put(lh.getId(), info);
 
                 // Save it back to ensure all nodes exist
                 store.asyncUpdateLedgerIds(name, getManagedLedgerInfo(), ledgersStat, storeLedgersCb);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
@@ -69,6 +69,31 @@ public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
         return ledgers.put(ledgerId, info);
     }
 
+    public Long lastLedgerId() {
+        return ledgers.lastKey();
+    }
+
+    public boolean isEmpty() {
+        return ledgers.isEmpty();
+    }
+
+    public void remove(Long ledgerId) {
+        ledgers.remove(ledgerId);
+    }
+
+    public int size() {
+        return ledgers.size();
+    }
+
+    public Optional<LedgerInfo> get(Long ledgerId) {
+        final LedgerInfo ledgerInfo = ledgers.get(ledgerId);
+        if (ledgerInfo == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(ledgerInfo);
+        }
+    }
+
     synchronized CompletableFuture<InitializeResult> initialize(String name, boolean createIfMissing) {
         final CompletableFuture<InitializeResult> initResult = new CompletableFuture<>();
         store.getManagedLedgerInfo(name, createIfMissing,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.HashMap;
@@ -9,10 +28,11 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerMetaStore;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.metadata.api.Stat;
 
 public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
-    final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
+    final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
     final MetaStore store;
 
     public ManagedLedgerMetaStoreImpl(MetaStore metaStore) {
@@ -45,6 +65,10 @@ public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
         }
     }
 
+    LedgerInfo put(Long ledgerId, LedgerInfo info) {
+        return ledgers.put(ledgerId, info);
+    }
+
     synchronized CompletableFuture<InitializeResult> initialize(String name, boolean createIfMissing) {
         final CompletableFuture<InitializeResult> initResult = new CompletableFuture<>();
         store.getManagedLedgerInfo(name, createIfMissing,
@@ -67,7 +91,7 @@ public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
                         }
 
 
-                        for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ls : result.getLedgerInfoList()) {
+                        for (LedgerInfo ls : result.getLedgerInfoList()) {
                             ledgers.put(ls.getLedgerId(), ls);
                         }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
@@ -1,15 +1,84 @@
 package org.apache.bookkeeper.mledger.impl;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerMetaStore;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.pulsar.metadata.api.Stat;
 
 public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
     final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
-    final MetaStore metaStore;
+    final MetaStore store;
 
     public ManagedLedgerMetaStoreImpl(MetaStore metaStore) {
-        this.metaStore = metaStore;
+        this.store = metaStore;
+    }
+
+    static public class InitializeResult {
+        private Stat stat;
+        private Optional<PositionImpl> terminatedPosition;
+        private Map<String, String> propertiesMap;
+
+        public InitializeResult(Stat stat,
+                                Optional<PositionImpl> terminatedPosition,
+                                Map<String, String> propertiesMap) {
+            this.stat = stat;
+            this.terminatedPosition = terminatedPosition;
+            this.propertiesMap = propertiesMap;
+        }
+
+        public Stat getStat() {
+            return stat;
+        }
+
+        public Optional<PositionImpl> getTerminatedPosition() {
+            return terminatedPosition;
+        }
+
+        public Map<String, String> getPropertiesMap() {
+            return propertiesMap;
+        }
+    }
+
+    synchronized CompletableFuture<InitializeResult> initialize(String name, boolean createIfMissing) {
+        final CompletableFuture<InitializeResult> initResult = new CompletableFuture<>();
+        store.getManagedLedgerInfo(name, createIfMissing,
+                new MetaStore.MetaStoreCallback<MLDataFormats.ManagedLedgerInfo>() {
+                    @Override
+                    public void operationComplete(MLDataFormats.ManagedLedgerInfo result, Stat stat) {
+                        final Optional<PositionImpl> terminatedPosition;
+                        if (result.hasTerminatedPosition()) {
+                            terminatedPosition = Optional.of(new PositionImpl(result.getTerminatedPosition()));
+                        } else {
+                            terminatedPosition = Optional.empty();
+                        }
+                        final Map<String, String> propertiesMap = new HashMap<>();
+
+                        if (result.getPropertiesCount() > 0) {
+                            for (int i = 0; i < result.getPropertiesCount(); i++) {
+                                MLDataFormats.KeyValue property = result.getProperties(i);
+                                propertiesMap.put(property.getKey(), property.getValue());
+                            }
+                        }
+
+
+                        for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ls : result.getLedgerInfoList()) {
+                            ledgers.put(ls.getLedgerId(), ls);
+                        }
+
+                        initResult.complete(new InitializeResult(stat, terminatedPosition, propertiesMap));
+                    }
+
+                    @Override
+                    public void operationFailed(ManagedLedgerException.MetaStoreException e) {
+                        initResult.completeExceptionally(e);
+                    }
+                });
+        return initResult;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMetaStoreImpl.java
@@ -1,0 +1,15 @@
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.bookkeeper.mledger.ManagedLedgerMetaStore;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+
+public class ManagedLedgerMetaStoreImpl implements ManagedLedgerMetaStore {
+    final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
+    final MetaStore metaStore;
+
+    public ManagedLedgerMetaStoreImpl(MetaStore metaStore) {
+        this.metaStore = metaStore;
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -18,10 +18,9 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import com.google.common.collect.Range;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-
-import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
@@ -57,12 +56,12 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                 state = State.LedgerOpened;
 
                 for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
-                    ledgers.put(ls.getLedgerId(), ls);
+                    ledger2333.put(ls.getLedgerId(), ls);
                 }
 
                 // Last ledger stat may be zeroed, we must update it
-                if (ledgers.size() > 0 && ledgers.lastEntry().getValue().getEntries() == 0) {
-                    long lastLedgerId = ledgers.lastKey();
+                if (ledger2333.size() > 0 && ledger2333.lastEntry().getValue().getEntries() == 0) {
+                    long lastLedgerId = ledger2333.lastKey();
 
                     // Fetch last add confirmed for last ledger
                     bookKeeper.newOpenLedgerOp().withRecovery(false).withLedgerId(lastLedgerId)
@@ -72,7 +71,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                     LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
                                             .setEntries(lastAddConfirmed + 1).setSize(readHandle.getLength())
                                             .setTimestamp(clock.millis()).build();
-                                    ledgers.put(lastLedgerId, info);
+                                    ledger2333.put(lastLedgerId, info);
 
                                     future.complete(createReadOnlyCursor(startPosition));
                                 }).exceptionally(ex -> {
@@ -81,7 +80,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                         // The last ledger was empty, so we cannot read the last add confirmed.
                                         LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
                                                 .setEntries(0).setSize(0).setTimestamp(clock.millis()).build();
-                                        ledgers.put(lastLedgerId, info);
+                                        ledger2333.put(lastLedgerId, info);
                                         future.complete(createReadOnlyCursor(startPosition));
                                     } else {
                                         future.completeExceptionally(new ManagedLedgerException(ex));
@@ -94,7 +93,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                     // The last ledger was empty, so we cannot read the last add confirmed.
                                     LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId).setEntries(0)
                                             .setSize(0).setTimestamp(clock.millis()).build();
-                                    ledgers.put(lastLedgerId, info);
+                                    ledger2333.put(lastLedgerId, info);
                                     future.complete(createReadOnlyCursor(startPosition));
                                 } else {
                                     future.completeExceptionally(new ManagedLedgerException(ex));
@@ -121,16 +120,17 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
     }
 
     private ReadOnlyCursor createReadOnlyCursor(PositionImpl startPosition) {
-        if (ledgers.isEmpty()) {
+        if (ledger2333.isEmpty()) {
             lastConfirmedEntry = PositionImpl.earliest;
-        } else if (ledgers.lastEntry().getValue().getEntries() > 0) {
+        } else if (ledger2333.lastEntry().getValue().getEntries() > 0) {
             // Last ledger has some of the entries
-            lastConfirmedEntry = new PositionImpl(ledgers.lastKey(), ledgers.lastEntry().getValue().getEntries() - 1);
+            lastConfirmedEntry = new PositionImpl(ledger2333.lastKey(),
+                    ledger2333.lastEntry().getValue().getEntries() - 1);
         } else {
             // Last ledger is empty. If there is a previous ledger, position on the last entry of that ledger
-            if (ledgers.size() > 1) {
-                long lastLedgerId = ledgers.lastKey();
-                LedgerInfo li = ledgers.headMap(lastLedgerId, false).lastEntry().getValue();
+            if (ledger2333.size() > 1) {
+                long lastLedgerId = ledger2333.lastKey();
+                LedgerInfo li = ledger2333.headMap(lastLedgerId, false).lastEntry().getValue();
                 lastConfirmedEntry = new PositionImpl(li.getLedgerId(), li.getEntries() - 1);
             } else {
                 lastConfirmedEntry = PositionImpl.earliest;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.ImmutableSet;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -713,13 +712,12 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         long fourthLedgerId = ledger.getLedgersInfoAsList().get(3).getLedgerId();
 
         // make an ledger empty
-        Field ledgersField = ledger.getClass().getDeclaredField("ledger2333");
-        ledgersField.setAccessible(true);
-        Map<Long, LedgerInfo> ledgers = (Map<Long,LedgerInfo>)ledgersField.get(ledger);
-        ledgers.put(secondLedgerId,
-                    ledgers.get(secondLedgerId).toBuilder().setEntries(0).setSize(0).build());
+        Map<Long, LedgerInfo> ledgers = ledger.getLedgersInfo();
 
-        PositionImpl firstUnoffloaded = (PositionImpl)ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        ledgers.put(secondLedgerId,
+                ledgers.get(secondLedgerId).toBuilder().setEntries(0).setSize(0).build());
+
+        PositionImpl firstUnoffloaded = (PositionImpl) ledger.offloadPrefix(ledger.getLastConfirmedEntry());
         assertEquals(firstUnoffloaded.getLedgerId(), fourthLedgerId);
         assertEquals(firstUnoffloaded.getEntryId(), 0);
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -713,7 +713,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         long fourthLedgerId = ledger.getLedgersInfoAsList().get(3).getLedgerId();
 
         // make an ledger empty
-        Field ledgersField = ledger.getClass().getDeclaredField("ledgers");
+        Field ledgersField = ledger.getClass().getDeclaredField("ledger2333");
         ledgersField.setAccessible(true);
         Map<Long, LedgerInfo> ledgers = (Map<Long,LedgerInfo>)ledgersField.get(ledger);
         ledgers.put(secondLedgerId,


### PR DESCRIPTION
Main issue: https://github.com/apache/pulsar/issues/9425
Eliminate direct touch of `ManagedLedgerMetaStoreImpl.ledgers` and `ManagedLedgerMetaStoreImpl.metadataMutex` from outside is a target to achieve but is hard to be finished in one patch, so they are still used somewhere in this patch.