### PR TITLE
[fix #9432] compactionScheduler can be null

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -97,7 +97,9 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     public void cleanup() throws Exception {
         super.internalCleanup();
 
-        compactionScheduler.shutdownNow();
+        if (compactionScheduler != null) {
+            compactionScheduler.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix #9432 

Modifications
compactionScheduler can be null, so compactionScheduler.shutdownNow() will cache NullPointerException. Add to determine whether the compactionscheduler is null