### PR TITLE
[Issue 9418][docs] Add how to define Pulsar resources names when using K8S runtime

### DIFF
--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -1,6 +1,6 @@
 ---
 id: admin-api-overview
-title: The Pulsar admin interface
+title: Pulsar admin interface
 sidebar_label: Overview
 ---
 
@@ -12,9 +12,9 @@ You can interact with the admin interface via:
 - A Java client interface.
 - The `pulsar-admin` CLI tool, which is available in the `bin` folder of your Pulsar installation:
 
-      ```shell
-     $ bin/pulsar-admin
-     ```
+    ```shell
+      $ bin/pulsar-admin
+    ```
 
     For details of `pulsar-admin` tool, see the [Pulsar command-line tools](reference-pulsar-admin.md) doc.
 
@@ -23,7 +23,7 @@ You can interact with the admin interface via:
 
 ## Admin setup
 
-Each of Pulsar's three admin interfaces---the `pulsar-admin` CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have enabled authentication in your Pulsar instance.
+Each of the three admin interfaces (the {@inject: rest:REST:/} API, the `pulsar-admin` CLI tool, and the [Java admin API](/api/admin)) requires some special setup if you have enabled authentication in your Pulsar instance.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->

--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -4,36 +4,31 @@ title: The Pulsar admin interface
 sidebar_label: Overview
 ---
 
-The Pulsar admin interface enables you to manage all of the important entities in a Pulsar [instance](reference-terminology.md#instance), such as [tenants](reference-terminology.md#tenant), [topics](reference-terminology.md#topic), and [namespaces](reference-terminology.md#namespace).
+The Pulsar admin interface enables you to manage all important entities in a Pulsar instance, such as tenants, topics, and namespaces.
 
-You can currently interact with the admin interface via:
+You can interact with the admin interface via:
 
-- Making HTTP calls against the admin {@inject: rest:REST:/} API provided by Pulsar [brokers](reference-terminology.md#broker). For some restful apis, they might be redirected to topic owner brokers for serving
-   with [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307), hence the HTTP callers should handle `307 Temporary Redirect`. If you are using `curl`, you should specify `-L`
-   to handle redirections.
-- The `pulsar-admin` CLI tool, which is available in the `bin` folder of your [Pulsar installation](getting-started-standalone.md):
-
-```shell
-$ bin/pulsar-admin
-```
-
-Full documentation for this tool can be found in the [Pulsar command-line tools](reference-pulsar-admin.md) doc.
-
+- Making HTTP calls against the admin {@inject: rest:REST:/} API provided by Pulsar brokers. For some restful APIs, they might be redirected to the topic owner brokers for serving with [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307), hence the HTTP callers should handle `307 Temporary Redirect`. If you use `curl`, you should specify `-L` to handle redirections.
 - A Java client interface.
+- The `pulsar-admin` CLI tool, which is available in the `bin` folder of your Pulsar installation:
 
-> #### The REST API is the admin interface
-> Under the hood, both the `pulsar-admin` CLI tool and the Java client both use the REST API. If you’d like to implement your own admin interface client, you should use the REST API as well. Full documentation can be found here.
+      ```shell
+     $ bin/pulsar-admin
+     ```
 
-In this document, examples from each of the three available interfaces will be shown.
+    For details of `pulsar-admin` tool, see the [Pulsar command-line tools](reference-pulsar-admin.md) doc.
+
+
+> **The REST API is the admin interface**. Both the `pulsar-admin` CLI tool and the Java client use the REST API. If you implement your own admin interface client, you should use the REST API. 
 
 ## Admin setup
 
-Each of Pulsar's three admin interfaces---the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have [authentication](security-overview.md#authentication-providers) enabled in your Pulsar [instance](reference-terminology.md#instance).
+Each of Pulsar's three admin interfaces---the `pulsar-admin` CLI tool, the [Java admin API](/api/admin), and the {@inject: rest:REST:/} API ---requires some special setup if you have enabled authentication in your Pulsar instance.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 
-If you have [authentication](security-overview.md#authentication-providers) enabled, you will need to provide an auth configuration to use the [`pulsar-admin`](reference-pulsar-admin.md) tool. By default, the configuration for the `pulsar-admin` tool is found in the [`conf/client.conf`](reference-configuration.md#client) file. Here are the available parameters:
+If you have enabled authentication, you need to provide an auth configuration to use the `pulsar-admin` tool. By default, the configuration for the `pulsar-admin` tool is in the [`conf/client.conf`](reference-configuration.md#client) file. The following are the available parameters:
 
 |Name|Description|Default|
 |----|-----------|-------|
@@ -47,11 +42,11 @@ If you have [authentication](security-overview.md#authentication-providers) enab
 
 <!--REST API-->
 
-You can find documentation for the REST API exposed by Pulsar [brokers](reference-terminology.md#broker) in this reference {@inject: rest:document:/}.
+You can find documentation for the REST API exposed by Pulsar brokers in this reference {@inject: rest:document:/}.
 
 <!--Java-->
 
-To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, specifying a URL for a Pulsar [broker](reference-terminology.md#broker) and a {@inject: javadoc:PulsarAdminBuilder:/admin/org/apache/pulsar/client/admin/PulsarAdminBuilder}. Here's a minimal example using `localhost`:
+To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, specifying a URL for a Pulsar broker and a {@inject: javadoc:PulsarAdminBuilder:/admin/org/apache/pulsar/client/admin/PulsarAdminBuilder}. Here's a minimal example using `localhost`:
 
 ```java
 String url = "http://localhost:8080";
@@ -70,7 +65,7 @@ PulsarAdmin admin = PulsarAdmin.builder()
 .build();
 ```
 
-If you have multiple brokers to use, you can use multi-host like Pulsar service. For example,
+If you use multiple brokers, you can use multi-host like Pulsar service. For example,
 ```java
 String url = "http://localhost:8080,localhost:8081,localhost:8082";
 // Pass auth-plugin class fully-qualified name if Pulsar-security enabled
@@ -88,3 +83,8 @@ PulsarAdmin admin = PulsarAdmin.builder()
 .build();
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+## How to define Pulsar resource names when running Pulsar in Kubernetes
+If you run Pulsar Functions or connectors on Kubernetes, you need to follow Kubernetes naming convention to define your Pulsar resource name, whichever admin interface you use.
+
+Kubernetes requires a name that can be used as a DNS subdomain name as defined in [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). Pulsar supports more legal characters than Kubernetes naming convention. If you create a Pulsar resource name with special characters that is not supported by Kubernetes (for example, including colons in a Pulsar namespace name), you cannot run functions or connectors using Kubernetes runtime.

--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -13,7 +13,7 @@ You can interact with the admin interface via:
 - The `pulsar-admin` CLI tool, which is available in the `bin` folder of your Pulsar installation:
 
     ```shell
-      $ bin/pulsar-admin
+     $ bin/pulsar-admin
     ```
 
     For details of `pulsar-admin` tool, see the [Pulsar command-line tools](reference-pulsar-admin.md) doc.
@@ -23,7 +23,7 @@ You can interact with the admin interface via:
 
 ## Admin setup
 
-Each of the three admin interfaces (the {@inject: rest:REST:/} API, the `pulsar-admin` CLI tool, and the [Java admin API](/api/admin)) requires some special setup if you have enabled authentication in your Pulsar instance.
+Each of the three admin interfaces (the `pulsar-admin` CLI tool, the {@inject: rest:REST:/} API, and the [Java admin API](/api/admin)) requires some special setup if you have enabled authentication in your Pulsar instance.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -42,11 +42,11 @@ If you have enabled authentication, you need to provide an auth configuration to
 
 <!--REST API-->
 
-You can find documentation for the REST API exposed by Pulsar brokers in this reference {@inject: rest:document:/}.
+You can find details for the REST API exposed by Pulsar brokers in this {@inject: rest:document:/}.
 
 <!--Java-->
 
-To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, specifying a URL for a Pulsar broker and a {@inject: javadoc:PulsarAdminBuilder:/admin/org/apache/pulsar/client/admin/PulsarAdminBuilder}. Here's a minimal example using `localhost`:
+To use the Java admin API, instantiate a {@inject: javadoc:PulsarAdmin:/admin/org/apache/pulsar/client/admin/PulsarAdmin} object, and specify a URL for a Pulsar broker and a {@inject: javadoc:PulsarAdminBuilder:/admin/org/apache/pulsar/client/admin/PulsarAdminBuilder}. The following is a minimal example using `localhost`:
 
 ```java
 String url = "http://localhost:8080";

--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -8,7 +8,7 @@ The Pulsar admin interface enables you to manage all important entities in a Pul
 
 You can interact with the admin interface via:
 
-- Making HTTP calls against the admin {@inject: rest:REST:/} API provided by Pulsar brokers. For some restful APIs, they might be redirected to the topic owner brokers for serving with [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307), hence the HTTP callers should handle `307 Temporary Redirect`. If you use `curl`, you should specify `-L` to handle redirections.
+- HTTP calls, which are made against the admin {@inject: rest:REST:/} API provided by Pulsar brokers. For some RESTful APIs, they might be redirected to the owner brokers for serving with [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307), hence the HTTP callers should handle `307 Temporary Redirect`. If you use `curl` commands, you should specify `-L` to handle redirections.
 - A Java client interface.
 - The `pulsar-admin` CLI tool, which is available in the `bin` folder of your Pulsar installation:
 
@@ -85,6 +85,6 @@ PulsarAdmin admin = PulsarAdmin.builder()
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ## How to define Pulsar resource names when running Pulsar in Kubernetes
-If you run Pulsar Functions or connectors on Kubernetes, you need to follow Kubernetes naming convention to define your Pulsar resource name, whichever admin interface you use.
+If you run Pulsar Functions or connectors on Kubernetes, you need to follow Kubernetes naming convention to define the names of your Pulsar resources, whichever admin interface you use.
 
 Kubernetes requires a name that can be used as a DNS subdomain name as defined in [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). Pulsar supports more legal characters than Kubernetes naming convention. If you create a Pulsar resource name with special characters that is not supported by Kubernetes (for example, including colons in a Pulsar namespace name), you cannot run functions or connectors using Kubernetes runtime.


### PR DESCRIPTION
Fixes #9418 

### Motivation
There is disconnection of Pulsar name verification and Kubernetes name verification, we need to tell users how to define Pulsar resources names when running functions and connectors in K8S.

### Modifications
- Add the above content.
- Remove some unnecessary links.