### PR TITLE
[Pulsar SQL] Fix injection factory cast error (fix master broken)

### DIFF
--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <jersey.version>2.31</jersey.version>
         <presto.version>332</presto.version>
-        <jersey.version>2.31</jersey.version>
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
         <objectsize.version>0.0.12</objectsize.version>
@@ -84,30 +83,6 @@
             <artifactId>jersey-client</artifactId>
             <version>${jersey.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-
-        <dependency>
-           <groupId>org.glassfish.jersey.containers</groupId>
-           <artifactId>jersey-container-servlet-core</artifactId>
-           <version>${jersey.version}</version>
-        </dependency>
-
-        <dependency>
-           <groupId>org.glassfish.jersey.containers</groupId>
-           <artifactId>jersey-container-servlet</artifactId>
-           <version>${jersey.version}</version>
-       </dependency>
 
         <dependency>
             <groupId>io.prestosql</groupId>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -108,12 +108,6 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>pulsar-client-original</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.glassfish.jersey.internal.inject.InjectionManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +99,7 @@ public class PulsarSqlSchemaInfoProvider implements SchemaInfoProvider {
     }
 
     private SchemaInfo loadSchema(BytesSchemaVersion bytesSchemaVersion) throws PulsarAdminException {
+        Thread.currentThread().setContextClassLoader(InjectionManagerFactory.class.getClassLoader());
         return pulsarAdmin.schemas()
                 .getSchemaInfo(topicName.toString(), ByteBuffer.wrap(bytesSchemaVersion.get()).getLong());
     }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
@@ -99,9 +99,14 @@ public class PulsarSqlSchemaInfoProvider implements SchemaInfoProvider {
     }
 
     private SchemaInfo loadSchema(BytesSchemaVersion bytesSchemaVersion) throws PulsarAdminException {
-        Thread.currentThread().setContextClassLoader(InjectionManagerFactory.class.getClassLoader());
-        return pulsarAdmin.schemas()
-                .getSchemaInfo(topicName.toString(), ByteBuffer.wrap(bytesSchemaVersion.get()).getLong());
+        ClassLoader originalContextLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(InjectionManagerFactory.class.getClassLoader());
+            return pulsarAdmin.schemas()
+                    .getSchemaInfo(topicName.toString(), ByteBuffer.wrap(bytesSchemaVersion.get()).getLong());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextLoader);
+        }
     }
 
 


### PR DESCRIPTION
Fixes #9470

### Motivation

Fix master CI problem. 

error log
```
2021-02-04T10:14:12.161+0800 ERROR remote-task-callback-4 io.prestosql.execution.StageStateMachine Stage 20210204_021409_00001_siuzy.1 failed
java.lang.RuntimeException: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException$GettingAuthenticationDataException: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at org.apache.pulsar.sql.presto.PulsarRecordCursor.advanceNextPosition(PulsarRecordCursor.java:450)
 at io.prestosql.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:90)
 at io.prestosql.operator.TableScanOperator.getOutput(TableScanOperator.java:302)
 at io.prestosql.operator.Driver.processInternal(Driver.java:379)
 at io.prestosql.operator.Driver.lambda$processFor$8(Driver.java:283)
 at io.prestosql.operator.Driver.tryWithLock(Driver.java:675)
 at io.prestosql.operator.Driver.processFor(Driver.java:276)
 at io.prestosql.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1075)
 at io.prestosql.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
 at io.prestosql.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
 at io.prestosql.$gen.Presto_332__testversion____20210204_021336_2.run(Unknown Source)
 at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
 at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException$GettingAuthenticationDataException: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
 at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
 at org.apache.pulsar.sql.presto.PulsarRecordCursor.advanceNextPosition(PulsarRecordCursor.java:448)
 ... 13 more
Caused by: org.apache.pulsar.client.admin.PulsarAdminException: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException$GettingAuthenticationDataException: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:229)
 at org.apache.pulsar.client.admin.internal.SchemasImpl$3.failed(SchemasImpl.java:150)
 at org.apache.pulsar.client.admin.internal.BaseResource.asyncGetRequest(BaseResource.java:166)
 at org.apache.pulsar.client.admin.internal.SchemasImpl.getSchemaInfoAsync(SchemasImpl.java:141)
 at org.apache.pulsar.client.admin.internal.SchemasImpl.getSchemaInfo(SchemasImpl.java:125)
 at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.loadSchema(PulsarSqlSchemaInfoProvider.java:123)
 at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.access$000(PulsarSqlSchemaInfoProvider.java:52)
 at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider$1.load(PulsarSqlSchemaInfoProvider.java:64)
 at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider$1.load(PulsarSqlSchemaInfoProvider.java:61)
 at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
 at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
 at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
 at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
 at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
 at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974)
 at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935)
 at org.apache.pulsar.sql.presto.PulsarSqlSchemaInfoProvider.getSchemaByVersion(PulsarSqlSchemaInfoProvider.java:79)
 ... 14 more
Caused by: java.util.concurrent.ExecutionException: org.apache.pulsar.client.admin.PulsarAdminException$GettingAuthenticationDataException: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
 at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
 at org.apache.pulsar.client.admin.internal.BaseResource.request(BaseResource.java:67)
 at org.apache.pulsar.client.admin.internal.BaseResource.asyncGetRequest(BaseResource.java:164)
 ... 28 more
Caused by: org.apache.pulsar.client.admin.PulsarAdminException.GettingAuthenticationDataException: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at org.apache.pulsar.client.admin.internal.BaseResource.lambda$requestAsync$1(BaseResource.java:106)
 at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774)
 at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:792)
 at java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2153)
 at org.apache.pulsar.client.admin.internal.BaseResource.requestAsync(BaseResource.java:87)
 ... 30 more
Caused by: java.lang.ClassCastException: Cannot cast org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory to org.glassfish.jersey.internal.inject.InjectionManagerFactory
 at java.lang.Class.cast(Class.java:3369)
 at org.glassfish.jersey.internal.ServiceFinder$LazyObjectIterator.hasNext(ServiceFinder.java:690)
 at org.glassfish.jersey.internal.inject.Injections.lookupService(Injections.java:88)
 at org.glassfish.jersey.internal.inject.Injections.lookupInjectionManagerFactory(Injections.java:73)
 at org.glassfish.jersey.internal.inject.Injections.createInjectionManager(Injections.java:44)
 at org.glassfish.jersey.client.ClientConfig$State.initRuntime(ClientConfig.java:412)
 at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(Values.java:317)
 at org.glassfish.jersey.client.ClientConfig.getRuntime(ClientConfig.java:807)
 at org.glassfish.jersey.client.ClientRequest.getClientRuntime(ClientRequest.java:219)
 at org.glassfish.jersey.client.ClientRequest.getInjectionManager(ClientRequest.java:610)
 at org.glassfish.jersey.client.JerseyWebTarget.onBuilder(JerseyWebTarget.java:364)
 at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:199)
 at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:36)
 at org.apache.pulsar.client.admin.internal.BaseResource.lambda$requestAsync$1(BaseResource.java:96)
 ... 34 more
```

### Modifications

1. set thread context classLoader.
2. remove useless dependencies.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

