### PR TITLE
[docs] The bookkeeper minimum configuration don't need ledgerManagerType property

### DIFF
--- a/site2/docs/administration-zk-bk.md
+++ b/site2/docs/administration-zk-bk.md
@@ -189,9 +189,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/administration-zk-bk.md
@@ -228,9 +228,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 > Consult the official [BookKeeper docs](http://bookkeeper.apache.org) for more information about BookKeeper.

--- a/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
@@ -228,9 +228,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the zookeeper root path used by Bookkeeper, use zkLedgersRootPath=/MY-PREFIX/ledgers instead of zkServers=localhost:2181/MY-PREFIX

--- a/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
@@ -234,9 +234,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the zookeeper root path used by Bookkeeper, use zkLedgersRootPath=/MY-PREFIX/ledgers instead of zkServers=localhost:2181/MY-PREFIX

--- a/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
@@ -226,9 +226,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the zookeeper root path that Bookkeeper uses, use zkLedgersRootPath=/MY-PREFIX/ledgers instead of zkServers=localhost:2181/MY-PREFIX

--- a/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
@@ -189,9 +189,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
@@ -189,9 +189,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
@@ -189,9 +189,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.6.3/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.3/administration-zk-bk.md
@@ -189,9 +189,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
@@ -190,9 +190,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.

--- a/site2/website/versioned_docs/version-2.7.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.1/administration-zk-bk.md
@@ -190,9 +190,6 @@ ledgerDirectories=data/bookkeeper/ledgers
 
 # Point to local ZK quorum
 zkServers=zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181
-
-# Change the ledger manager type
-ledgerManagerType=hierarchical
 ```
 
 To change the ZooKeeper root path that BookKeeper uses, use `zkLedgersRootPath=/MY-PREFIX/ledgers` instead of `zkServers=localhost:2181/MY-PREFIX`.


### PR DESCRIPTION
### Motivation


* The bookkeeper minimum configuration don't need ledgerManagerType property, and this property was labeled `Drepcated` sine 19 Sep 2017 https://github.com/apache/bookkeeper/commit/eba4d6e5d7eab8beab699c6dba8ac41e5ceec3db

### Modifications

* delete the following config
```xml
# Change the ledger manager type
ledgerManagerType=hierarchical
```
