### PR TITLE
Add DataStax.com logo

### DIFF
--- a/site2/website/data/users.js
+++ b/site2/website/data/users.js
@@ -287,10 +287,10 @@ module.exports = [
         logo_white: true
     },
     {
-        name: 'Kesque',
-        url: 'https://kesque.com',
-        logo: 'https://static.kafkaesque.io/wp-content/uploads/2020/06/kesque_logo.svg',
-        logo_white: true
+        name: 'DataStax',
+        url: 'https://datastax.com',
+        logo: 'https://www.datastax.com/sites/default/files/inline-images/datastax-logotype-negative.png',
+        logo_white: false
     },
     {
         name: 'KAISA',


### PR DESCRIPTION
### Motivation
DataStax recently acquired Kesque.com, this patch replaces the references to Kesque.com with DataStax.

### Modifications
Update the website 