### PR TITLE
[C++] Remove Boost::System runtime dependency

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -154,9 +154,9 @@ else()
 endif (LINK_STATIC)
 
 if (MSVC)
-  find_package(Boost REQUIRED COMPONENTS program_options regex system date_time)
+  find_package(Boost REQUIRED COMPONENTS program_options regex date_time)
 else()
-  find_package(Boost REQUIRED COMPONENTS program_options regex system)
+  find_package(Boost REQUIRED COMPONENTS program_options regex)
 endif()
 
 if (BUILD_PYTHON_WRAPPER)
@@ -252,7 +252,6 @@ include_directories(
 set(COMMON_LIBS
   ${COMMON_LIBS}
   ${Boost_REGEX_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
   ${CURL_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${ZLIB_LIBRARIES}

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -157,7 +157,9 @@ endif (LINK_STATIC)
 find_package(Boost)
 set(BOOST_COMPONENTS program_options regex)
 
-if (Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 69)
+if (NOT Boost_VERSION_MAJOR OR
+        (Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 69)
+        )
     # Boost System does not require linking since 1.69
     set(BOOST_COMPONENTS ${BOOST_COMPONENTS} system)
 endif()

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -153,11 +153,20 @@ else()
     endif (USE_LOG4CXX)
 endif (LINK_STATIC)
 
-if (MSVC)
-  find_package(Boost REQUIRED COMPONENTS program_options regex date_time)
-else()
-  find_package(Boost REQUIRED COMPONENTS program_options regex)
+
+find_package(Boost)
+set(BOOST_COMPONENTS program_options regex)
+
+if (Boost_VERSION_MAJOR==1 && Boost_VERSION_MINOR<69)
+    # Boost System does not require linking since 1.69
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} system)
 endif()
+
+if (MSVC)
+  set(BOOST_COMPONENTS ${BOOST_COMPONENTS} date_time)
+endif()
+
+find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 if (BUILD_PYTHON_WRAPPER)
     find_package(PythonLibs REQUIRED)
@@ -252,6 +261,7 @@ include_directories(
 set(COMMON_LIBS
   ${COMMON_LIBS}
   ${Boost_REGEX_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   ${CURL_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${ZLIB_LIBRARIES}

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -157,7 +157,7 @@ endif (LINK_STATIC)
 find_package(Boost)
 set(BOOST_COMPONENTS program_options regex)
 
-if (Boost_VERSION_MAJOR==1 && Boost_VERSION_MINOR<69)
+if (Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 69)
     # Boost System does not require linking since 1.69
     set(BOOST_COMPONENTS ${BOOST_COMPONENTS} system)
 endif()


### PR DESCRIPTION
### Motivation

Linking with Boost::System was only required by Asio if we were not using C++11 flags. Since this was updated a while ago, we don't need to link with System anymore.