### PR TITLE
[pulsar-metadata] return alreadyExist error-code when node exists

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -33,6 +33,7 @@ import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -130,7 +131,7 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
             Value newValue = new Value(0, data, now, now);
             Value existingValue = map.putIfAbsent(path, newValue);
             if (existingValue != null) {
-                return FutureUtils.exception(new BadVersionException(""));
+                return FutureUtils.exception(new AlreadyExistsException(""));
             } else {
                 receivedNotification(new Notification(NotificationType.Created, path));
                 String parent = parent(path);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -213,7 +214,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
                                     future.complete(new Stat(name, 0, 0, 0));
                                 } else if (code == Code.NODEEXISTS) {
                                     // We're emulating a request to create node, so the version is invalid
-                                    future.completeExceptionally(getException(Code.BADVERSION, path));
+                                    future.completeExceptionally(getException(Code.NODEEXISTS, path));
                                 } else {
                                     future.completeExceptionally(getException(code, path));
                                 }
@@ -296,6 +297,8 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
             return new BadVersionException(ex);
         case NONODE:
             return new NotFoundException(ex);
+        case NODEEXISTS:
+            return new AlreadyExistsException(ex);
         default:
             return new MetadataStoreException(ex);
         }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
@@ -110,7 +111,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
             store.put(key1, "value-2".getBytes(), Optional.of(-1L)).join();
             fail("Should have failed");
         } catch (CompletionException e) {
-            assertException(e, BadVersionException.class);
+            assertException(e, AlreadyExistsException.class);
         }
 
         try {


### PR DESCRIPTION
### Motivation
Right now, MetadataStore returns `BadVersion` error when node already exists instead `AlreadyExists` error-code. There are many usecases which require correct error code to handle failures. for example: [partitioned-topic](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java#L291) considers `AlreadyExists` error as successful result but instead metadata-api returns `BadVersion` error which creates complication while handling failures.
So, return correct error-code(`AlreadyExists`) if node already exists while creating metadata key-placeholder,