### PR TITLE
Fixes canceling of duplicate workflow runs

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-cancel-duplicate-workflows.yaml
+++ b/.github/workflows/ci-cancel-duplicate-workflows.yaml
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - Cancel duplicate workflows
+on:
+  workflow_run:
+    # this could be any workflow that is always executed by PUSH/PR operation
+    workflows: ["CI - Unit"]
+    types: ['requested']
+
+jobs:
+
+  cancel-workflow-runs:
+    runs-on: ubuntu-20.04
+    steps:
+      # the potiuk/cancel-workflow-run action has been allow-listed by
+      # the Apache Infrastructure
+      - name: cancel duplicate ci-build-macos.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-build-macos.yaml
+      - name: cancel duplicate ci-go-functions-style.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-go-functions-style.yaml
+      - name: cancel duplicate ci-go-functions-test.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-go-functions-test.yaml
+      - name: cancel duplicate ci-integration-backwards-compatibility.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-backwards-compatibility.yaml
+      - name: cancel duplicate ci-integration-cli.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-cli.yaml
+      - name: cancel duplicate ci-integration-function-state.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-function-state.yaml
+      - name: cancel duplicate ci-integration-messaging.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName:  ci-integration-messaging.yaml
+      - name: cancel duplicate ci-integration-process.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-process.yaml
+      - name: cancel duplicate ci-integration-schema.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-schema.yaml
+      - name: cancel duplicate ci-integration-sql.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-sql.yaml
+      - name: cancel duplicate ci-integration-standalone.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-standalone.yaml
+      - name: cancel duplicate ci-integration-thread.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-thread.yaml
+      - name: cancel duplicate
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-tiered-filesystem.yaml
+      - name: cancel duplicate
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-tiered-filesystem.yaml
+      - name: cancel duplicate ci-license.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-license.yaml
+      - name: cancel duplicate ci-integration-tiered-jcloud.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-tiered-jcloud.yaml
+      - name: cancel duplicate ci-integration-transaction.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-integration-transaction.yaml
+      - name: cancel duplicate ci-pulsar-website-build.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-pulsar-website-build.yaml
+      - name: cancel duplicate ci-shade-test.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-shade-test.yaml
+      - name: cancel duplicate ci-unit.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit.yaml
+      - name: cancel duplicate ci-unit-broker-broker-gp1.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-broker-broker-gp1.yaml
+      - name: cancel duplicate ci-unit-broker-broker-gp2.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-broker-broker-gp2.yaml
+      - name: cancel duplicate ci-unit-broker-client-api.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-broker-client-api.yaml
+      - name: cancel duplicate ci-unit-broker-client-impl.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-broker-client-impl.yaml
+      - name: cancel duplicate ci-unit-broker-other.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-broker-other.yaml
+      - name: cancel duplicate ci-unit-proxy.yaml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: ci-unit-proxy.yaml

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -45,11 +45,6 @@ jobs:
         go-version: [1.11, 1.12, 1.13, 1.14]
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -47,11 +47,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-function-state.yaml
+++ b/.github/workflows/ci-integration-function-state.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -36,11 +36,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -31,11 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -39,11 +39,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: cancel previous runs
-        uses: apache/airflow-cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The previous way of canceling workflow runs was flawed because
it was run as part of `pull_request` workflows - which did not
work for fork PRs. The reason is, that `pull_request` workflows
are executed with "read-only" `GITHUB_TOKEN`. Therefore running
the action within the PR ends with 'resource not accessible by
integration` error.

This PR implements cancel action in the way that it was intended:
the 'cancel-workflow-run' action runs within a `workflow_run`
triggered workflow which has two characteristics:

* it runs only using master version of workflow (so this workflow
  will become active only after we merge it to master)

* it runs using 'write' GITHUB_TOKEN - this allows actually to
  cancel the workflows withot the 'resource...' error.

In order to optimise a number of machines/jobs started, there is
only one 'CI - Cancel duplicate workflows' workflow, which
has one job with many steps - each steps cancels duplicates in a
different workflow. This `workflow_run` is triggered by the
`CI - Unit` workflow, which has been somewhat arbitrary chosen - but
this could be any of the workflows that runs with every PR.

Runing this as a single workflow/job has several benefits:

* only one job is started and takes less of the queue
* one machine is initialized once for all steps thus the overhead
  of creating machine is much smaller
* splitting workflows to separate steps has the benefit of seeing
  each cancelling action separately

The reason why it is done as copy&paste rather than matrix or
yaml anchor are simple:

* matrix creates sepearate job for each matrix entry - increasing
  the job queue as well as adding overhead of machine creation
* Github Action does not support yaml anchors

All the `cancel` actions run with `allDuplicates` cancel mode
which causes them to agressively kill all duplicates even in
high-strain queu case - the first of the cancel jobs that starts
running will activelly kill all the duplicates of all the
workflows from all PRs running in the repository.
