### PR TITLE
Fix flaky testTransactionMetaStoreAssignAndFailover

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pulsar.broker.transaction.coordinator;
 
-import org.apache.pulsar.broker.PulsarService;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.pulsar.broker.PulsarService;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class TransactionMetaStoreAssignmentTest extends TransactionMetaStoreTestBase {
 
@@ -64,15 +64,18 @@ public class TransactionMetaStoreAssignmentTest extends TransactionMetaStoreTest
             pulsarServices[i] = services.get(i);
         }
         crashedMetaStore.close();
-        
-        Thread.sleep(3000);
 
-        transactionMetaStoreCount = 0;
-        for (PulsarService pulsarService : pulsarServices) {
-            transactionMetaStoreCount += pulsarService.getTransactionMetadataStoreService().getStores().size();
-        }
+        Awaitility.await()
+                .untilAsserted(() -> {
 
-        Assert.assertEquals(transactionMetaStoreCount, 16);
+                    int transactionMetaStoreCount2 = 0;
+                    for (PulsarService pulsarService : pulsarServices) {
+                        transactionMetaStoreCount2 += pulsarService.getTransactionMetadataStoreService().getStores()
+                                .size();
+                    }
+
+                    Assert.assertEquals(transactionMetaStoreCount2, 16);
+                });
 
         transactionCoordinatorClient.close();
     }


### PR DESCRIPTION
Replaced check after sleep to `untilAsserted` and extended `atMost` time to 10 seconds(default of `Awaitility`) which can reduce the fail rate