### PR TITLE
More friendly error hint when use type in wrong formated namespace

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
@@ -102,8 +102,10 @@ public class NamespaceName implements ServiceUnitId {
             } else {
                 throw new IllegalArgumentException("Invalid namespace format. namespace: " + namespace);
             }
-        } catch (NullPointerException e) {
-            throw new IllegalArgumentException("Invalid namespace format. namespace: " + namespace, e);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("Invalid namespace format."
+                    + " expected <tenant>/<namespace> or <tenant>/<cluster>/<namespace> "
+                    + "but got: " + namespace, e);
         }
         this.namespace = namespace;
     }


### PR DESCRIPTION
This patch will tell the user the expected namespace format when got errors in the namespace parse.