### PR TITLE
Initial checkin of PublishMessage/Publish

### DIFF
--- a/pulsar-function-go/examples/publishFunc/publishFunc.go
+++ b/pulsar-function-go/examples/publishFunc/publishFunc.go
@@ -36,16 +36,10 @@ func PublishFunc(ctx context.Context, in []byte) error {
 
 	publishTopic := "publish-topic"
 	output := append(in, 110)
-
-	producer := fctx.NewOutputMessage(publishTopic)
-	msgID, err := producer.Send(ctx, &pulsar.ProducerMessage{
+	log.Printf("publishing to additional topic %s", publishTopic)
+	fctx.Publish(publishTopic, &pulsar.ProducerMessage{
 		Payload: output,
 	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf("The output message ID is: %+v", msgID)
 	return nil
 }
 

--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	log "github.com/apache/pulsar/pulsar-function-go/logutil"
 )
 
 // FunctionContext provides contextual information to the executing function.
@@ -32,11 +33,13 @@ import (
 // message, what are our operating constraints, etc can be accessed by the
 // executing function
 type FunctionContext struct {
-	instanceConf  *instanceConf
-	userConfigs   map[string]interface{}
-	logAppender   *LogAppender
-	outputMessage func(topic string) pulsar.Producer
-	record        pulsar.Message
+	instanceConf   *instanceConf
+	userConfigs    map[string]interface{}
+	logAppender    *LogAppender
+	outputMessage  func(topic string) pulsar.Producer
+	Publish        func(topic string, payload []byte)
+	PublishMessage func(topic string, message pulsar.ProducerMessage)
+	record         pulsar.Message
 }
 
 // NewFuncContext returns a new Function context
@@ -153,8 +156,9 @@ func (c *FunctionContext) GetUserConfMap() map[string]interface{} {
 }
 
 // NewOutputMessage send message to the topic @param topicName: The name of the
-// topic for output message
+// topic for output message (DEPRECATED)
 func (c *FunctionContext) NewOutputMessage(topicName string) pulsar.Producer {
+	log.Warn("NewOutputMessage is deprecated, please use Publish() or PublishMsg()")
 	return c.outputMessage(topicName)
 }
 


### PR DESCRIPTION
fixes #9512

### Motivation

#9512

### Modifications

similar to #9512, but errors are fatal, as with normal message handling. (**FEEDBACK REQUESTED**))

### Verifying this change

- None of the tests in the Go code exercise this change, and there were no tests for NewOutputMessage either, except for very basic assertions on a producer.

This change added tests and can be verified as follows:
- I will need help testing this, because currently there are no integration tests for go pulsar functions in the SDK code. I am still unfamiliar with how they are integration / unit tested at all outside of the module

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented) (draft)
 