### PR TITLE
[Issue9507][testclient] add --batch-index-ack for the pulsar-perf

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -168,6 +168,9 @@ public class PerformanceConsumer {
         @Parameter(names = {"-ioThreads", "--num-io-threads"}, description = "Set the number of threads to be " +
                 "used for handling connections to brokers, default is 1 thread")
         public int ioThreads = 1;
+    
+        @Parameter(names = {"--batch-index-ack" }, description = "Enable or disable the batch index acknowledgment")
+        public boolean batchIndexAck = false;
     }
 
     public static void main(String[] args) throws Exception {
@@ -323,6 +326,7 @@ public class PerformanceConsumer {
                 .subscriptionType(arguments.subscriptionType)
                 .subscriptionInitialPosition(arguments.subscriptionInitialPosition)
                 .autoAckOldestChunkedMessageOnQueueFull(arguments.autoAckOldestChunkedMessageOnQueueFull)
+                .enableBatchIndexAcknowledgment(arguments.batchIndexAck)
                 .replicateSubscriptionState(arguments.replicatedSubscription);
         if (arguments.maxPendingChuckedMessage > 0) {
             consumerBuilder.maxPendingChuckedMessage(arguments.maxPendingChuckedMessage);

--- a/site2/docs/performance-pulsar-perf.md
+++ b/site2/docs/performance-pulsar-perf.md
@@ -124,6 +124,7 @@ The following table lists configuration options available for the `pulsar-perf c
 | subscriber-name | Set the subscriber name prefix. | sub |
 | subscription-type | Set the subscription type. <li> Exclusive <li> Shared <li> Failover <li> Key_Shared | Exclusive |
 | trust-cert-file | Set the path for the trusted TLS certificate file. | <empty string> |
+| batch-index-ack | Enable or disable the batch index acknowledgment. | false |
 
 ## Configurations
 


### PR DESCRIPTION
add --batch-index-ack for the pulsar-perf consume command and keep it as false by default.

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #9507 

### Motivation

PIP-45 https://github.com/apache/pulsar/wiki/PIP-54:-Support-acknowledgment-at-batch-index-level introduced batch index level acknowledge but the pulsar-perf client does not support to enable it for the consumer. It's better to allow users to do the performance test for the batch index acknowledgment.

### Modifications

add --batch-index-ack for the pulsar-perf consume command and keep it as false by default.
