### PR TITLE
Remove jsoncpp references

### DIFF
--- a/pulsar-client-cpp/docker/Dockerfile
+++ b/pulsar-client-cpp/docker/Dockerfile
@@ -126,14 +126,6 @@ RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.12.1.tar.gz && \
     make && make install && \
     rm -rf /v3.12.1.tar.gz /CMake-3.12.1
 
-# Compile JSON CPP
-RUN curl -O -L  https://github.com/open-source-parsers/jsoncpp/archive/1.8.0.tar.gz && \
-    tar xvfz 1.8.0.tar.gz && \
-    cd jsoncpp-1.8.0 && \
-    cmake . -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
-    make && make install && \
-    rm -rf /1.8.0.tar.gz /jsoncpp-1.8.0
-
 # LibCurl
 RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
     tar xvfz curl-7.61.0.tar.gz && \

--- a/pulsar-client-cpp/docs/MainPage.md
+++ b/pulsar-client-cpp/docs/MainPage.md
@@ -37,7 +37,6 @@ You need to have the following installed to use the C++ client:
 * [Log4CXX](https://logging.apache.org/log4cxx)
 * [libcurl](https://curl.haxx.se/libcurl/)
 * [Google Test](https://github.com/google/googletest)
-* [JsonCpp](https://github.com/open-source-parsers/jsoncpp)
 
 ## Compilation
 

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -40,14 +40,6 @@ RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.8.2.tar.gz && \
     make && make install && \
     rm -rf /v3.8.2.tar.gz /CMake-3.8.2
 
-# Compile JSON CPP
-RUN curl -O -L  https://github.com/open-source-parsers/jsoncpp/archive/1.8.0.tar.gz && \
-    tar xvfz 1.8.0.tar.gz && \
-    cd jsoncpp-1.8.0 && \
-    cmake . -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
-    make && make install && \
-    rm -rf /1.8.0.tar.gz /jsoncpp-1.8.0
-
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz && \
     tar xvfz protobuf-cpp-3.3.0.tar.gz && \

--- a/pulsar-client-cpp/pkg/licenses/LICENSE.txt
+++ b/pulsar-client-cpp/pkg/licenses/LICENSE.txt
@@ -207,7 +207,6 @@ This package is statically linked with libraries with the following licenses:
 
 MIT:
  * Boost https://www.boost.org -- LICENSE-boost.txt
- * JsonCpp -- https://github.com/open-source-parsers/jsoncpp -- LICENSE-jsoncpp.txt
  * Libcurl -- https://curl.haxx.se -- LICENSE-libcurl.txt
 
 ZLib -- ZLib license -- LICENSE-zlib.txt

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -40,14 +40,6 @@ RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.8.2.tar.gz && \
     make && make install && \
     rm -rf /v3.8.2.tar.gz /CMake-3.8.2
 
-# Compile JSON CPP
-RUN curl -O -L  https://github.com/open-source-parsers/jsoncpp/archive/1.8.0.tar.gz && \
-    tar xvfz 1.8.0.tar.gz && \
-    cd jsoncpp-1.8.0 && \
-    cmake . -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
-    make && make install && \
-    rm -rf /1.8.0.tar.gz /jsoncpp-1.8.0
-
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz && \
     tar xvfz protobuf-cpp-3.3.0.tar.gz && \


### PR DESCRIPTION
* Remove jsoncpp references from dockerfiles and documentation.
* jsoncpp dependencies were removed from puslar-cpp in pr (#3528)