### PR TITLE
Ignore When Replicated Subscription is Disabled by Broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -619,10 +619,8 @@ public class PersistentTopic extends AbstractTopic
 
         if (replicatedSubscriptionState
                 && !brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions()) {
-            future.completeExceptionally(
-                    new NotAllowedException("Replicated Subscriptions is disabled by broker.")
-            );
-            return future;
+            log.warn("Replicated Subscription is disabled by broker.");
+            replicatedSubscriptionState = false;
         }
 
         if (subType == SubType.Key_Shared

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionConfigTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionConfigTest.java
@@ -122,14 +122,18 @@ public class ReplicatedSubscriptionConfigTest extends ProducerConsumerBase {
         consumer.close();
     }
 
-    @Test(expectedExceptions = PulsarClientException.NotAllowedException.class)
-    public void testDisableReplicatedSubscriptions() throws PulsarClientException {
+    @Test
+    public void testDisableReplicatedSubscriptions() throws Exception {
         this.conf.setEnableReplicatedSubscriptions(false);
         String topic = "disableReplicatedSubscriptions-" + System.nanoTime();
-        pulsarClient.newConsumer()
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
                 .subscriptionName("sub")
                 .replicateSubscriptionState(true)
                 .subscribe();
+
+        TopicStats stats = admin.topics().getStats(topic);
+        assertFalse(stats.subscriptions.get("sub").isReplicated);
+        consumer.close();
     }
 }


### PR DESCRIPTION
In regards to requests from consumers used `.replicateSubscriptionState(true)`, ignore it when replicated subscription is disabled by brokers.

When replicated subscription is changed from ON to OFF, all consumers who used `.replicateSubscriptionState(true)` and were already connected will not be able to connect to brokers.

Considering the risk, fixed like this.
