### PR TITLE
[CI] Remove usage of diff-only action with paths-ignore

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,9 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
+    paths-ignore: ['site2/**', 'deployment/**']
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
@@ -43,14 +45,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -60,12 +55,10 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -74,16 +67,13 @@ jobs:
           df -h
 
       - name: build package
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: build cpp artifacts
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           echo "Build C++ client library"
           export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF"
           pulsar-client-cpp/docker-build.sh
 
       - name: run c++ tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh pulsar-client-cpp/docker-tests.sh

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -51,34 +51,24 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: InstallTool
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.18.0
           ./bin/golangci-lint --version
 
       - name: Build
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           go build ./...
 
       - name: CheckStyle
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           ./bin/golangci-lint run -c ./golangci.yml ./pf

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -53,21 +53,13 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Run tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           cd pulsar-function-go
           go test -v $(go list ./... | grep -v examples)

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -51,20 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -73,21 +66,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-backwards-compatibility.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -51,20 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -73,26 +66,20 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run pulsar cli integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-cli.xml -DintegrationTests -DredirectTestOutputToFile=false
 
       - name: run pulsar auth integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-auth.xml -DintegrationTests -DredirectTestOutputToFile=false
 

--- a/.github/workflows/ci-integration-function-state.yaml
+++ b/.github/workflows/ci-integration-function-state.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -51,20 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -73,21 +66,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-function-state.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -51,20 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -73,29 +66,22 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: run integration messaging tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-messaging.xml -DintegrationTests -DredirectTestOutputToFile=false
 
       - name: run integration proxy tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-proxy.xml -DintegrationTests -DredirectTestOutputToFile=false
 
       - name: run integration proxy with WebSocket tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-proxy-websocket.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,29 +65,22 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration function
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=function
 
       - name: run integration source
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=source
 
       - name: run integraion sink
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-process.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=sink

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,18 +65,13 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-schema.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,21 +65,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-sql.xml -DintegrationTests -DredirectTestOutputToFile=false -DtestForkCount=1

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,21 +65,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-standalone.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,29 +65,22 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration function
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=function
 
       - name: run integration source
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=source
 
       - name: run integraion sink
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-thread.xml -DintegrationTests -DredirectTestOutputToFile=false -Dgroups=sink

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,21 +65,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=tiered-filesystem-storage.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,21 +65,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=tiered-jcloud-storage.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -50,20 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -72,18 +65,13 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/retry.sh mvn -B -f tests/pom.xml test -DintegrationTestSuiteFile=pulsar-transaction.xml -DintegrationTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -43,14 +44,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -59,22 +53,18 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up JDK 1.8
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
       # license check fails with 3.6.2 so we have to downgrade
       - name: Set up Maven
-        if: steps.docs.outputs.changed_only == 'no'
         uses: apache/pulsar-test-infra/setup-maven@master
         with:
           maven-version: 3.6.1
 
       - name: build and check license
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp -DskipTests initialize license:check install
 
       - name: license check
-        if: steps.docs.outputs.changed_only == 'no'
         run: src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -51,20 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -73,21 +66,16 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run shade tests
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -f tests/pom.xml test -DShadeTests -DredirectTestOutputToFile=false

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,14 +46,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -61,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_1'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh BROKER_GROUP_1
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,12 +46,6 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -60,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_2'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh BROKER_GROUP_2
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,14 +46,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -61,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_API'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh BROKER_CLIENT_API
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,14 +46,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -61,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_IMPL'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,12 +46,6 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -60,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_OTHER'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh BROKER_CLIENT_OTHER
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,12 +46,6 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:
@@ -60,11 +55,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: build modules pulsar-proxy
-        if: steps.docs.outputs.changed_only == 'no'
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'PROXY'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh PROXY
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -22,10 +22,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore: ['site2/**', 'deployment/**']
   push:
     branches:
       - branch-*
-
+    paths-ignore: ['site2/**', 'deployment/**']
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3
 
@@ -45,14 +46,7 @@ jobs:
           fetch-depth: 25
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
-
       - name: run unit test 'OTHER'
-        if: steps.docs.outputs.changed_only == 'no'
         run: ./build/run_unit_group.sh OTHER
 
       - name: package surefire artifacts


### PR DESCRIPTION
Fixes #9526

### Motivation

- `diff-only` has a critical bug https://github.com/apache/pulsar-test-infra/issues/12
  which is also reported as https://github.com/apache/pulsar/issues/9526

- GitHub Actions has paths-ignore feature which makes the `diff-only` action obsolete
  - docs for paths-ignore: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

### Modifications

- Replace `diff-only` with the usage of `paths-ignore`