### PR TITLE
[C++] Removed usages of boost::regex

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.4) 
+cmake_minimum_required(VERSION 3.4)
 project (pulsar-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
@@ -155,7 +155,7 @@ endif (LINK_STATIC)
 
 
 find_package(Boost)
-set(BOOST_COMPONENTS program_options regex)
+set(BOOST_COMPONENTS program_options)
 
 if (NOT Boost_VERSION_MAJOR OR
         (Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 69)
@@ -166,6 +166,15 @@ endif()
 
 if (MSVC)
   set(BOOST_COMPONENTS ${BOOST_COMPONENTS} date_time)
+endif()
+
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+    # GCC 4.8.2 implementation of std::regex is buggy
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} regex)
+    set(CMAKE_CXX_FLAGS " -DPULSAR_USE_BOOST_REGEX")
+    MESSAGE(STATUS "Using Boost::Regex")
+else()
+    MESSAGE(STATUS "Using std::regex")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
@@ -286,7 +295,7 @@ if (NOT MSVC)
     )
 else()
     set(COMMON_LIBS
-    ${COMMON_LIBS} 
+    ${COMMON_LIBS}
     wldap32.lib
     Normaliz.lib)
 endif()

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -35,6 +35,9 @@ MESSAGE(STATUS "BUILD_TESTS:  " ${BUILD_TESTS})
 option(BUILD_PYTHON_WRAPPER "Build Pulsar Python wrapper" ON)
 MESSAGE(STATUS "BUILD_PYTHON_WRAPPER:  " ${BUILD_PYTHON_WRAPPER})
 
+option(BUILD_PERF_TOOLS "Build Pulsar CLI perf producer/consumer" OFF)
+MESSAGE(STATUS "BUILD_PERF_TOOLS:  " ${BUILD_PERF_TOOLS})
+
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
@@ -155,7 +158,6 @@ endif (LINK_STATIC)
 
 
 find_package(Boost)
-set(BOOST_COMPONENTS program_options)
 
 if (NOT Boost_VERSION_MAJOR OR
         (Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 69)
@@ -175,6 +177,10 @@ if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
     MESSAGE(STATUS "Using Boost::Regex")
 else()
     MESSAGE(STATUS "Using std::regex")
+endif()
+
+if(BUILD_PERF_TOOLS)
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} program_options)
 endif()
 
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
@@ -340,7 +346,9 @@ set(CLIENT_LIBS
 )
 
 add_subdirectory(lib)
-add_subdirectory(perf)
+if(BUILD_PERF_TOOLS)
+    add_subdirectory(perf)
+endif(BUILD_PERF_TOOLS)
 add_subdirectory(examples)
 
 if (BUILD_TESTS)

--- a/pulsar-client-cpp/lib/NamedEntity.cc
+++ b/pulsar-client-cpp/lib/NamedEntity.cc
@@ -18,8 +18,20 @@
  */
 #include "NamedEntity.h"
 
-const boost::regex NamedEntity::pattern = boost::regex("^[-=:.\\w]*$");
-
 bool NamedEntity::checkName(const std::string& name) {
-    return boost::regex_match(name, pattern) ? true : false;
+    for (char c : name) {
+        switch (c) {
+            case '=':
+            case ':':
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                return false;
+            default:
+                break;
+        }
+    }
+
+    return true;
 }

--- a/pulsar-client-cpp/lib/NamedEntity.cc
+++ b/pulsar-client-cpp/lib/NamedEntity.cc
@@ -24,6 +24,7 @@ bool NamedEntity::checkName(const std::string& name) {
             case '=':
             case ':':
             case ' ':
+            case '!':
             case '\t':
             case '\r':
             case '\n':

--- a/pulsar-client-cpp/lib/NamedEntity.h
+++ b/pulsar-client-cpp/lib/NamedEntity.h
@@ -16,16 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef _PULSAR_NAMED_ENTITY_HEADER_
-#define _PULSAR_NAMED_ENTITY_HEADER_
+#pragma once
 
-#include <boost/regex.hpp>
+#include <string>
 
 class NamedEntity {
-   private:
-    static const boost::regex pattern;
-
    public:
     static bool checkName(const std::string& name);
 };
-#endif

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -251,9 +251,9 @@ ConsumerImplPtr PartitionedConsumerImpl::newInternalConsumer(unsigned int partit
                                                    internalListenerExecutor_, true, Partitioned);
 
     const auto shared_this = const_cast<PartitionedConsumerImpl*>(this)->shared_from_this();
-    consumer->getConsumerCreatedFuture().addListener(std::bind(
-        &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_this, std::placeholders::_1,
-        std::placeholders::_2, partition));
+    consumer->getConsumerCreatedFuture().addListener(
+        std::bind(&PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_this,
+                  std::placeholders::_1, std::placeholders::_2, partition));
     consumer->setPartitionIndex(partition);
 
     LOG_DEBUG("Creating Consumer for single Partition - " << topicPartitionName << "SubName - "

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -229,7 +229,8 @@ ConsumerConfiguration PartitionedConsumerImpl::getSinglePartitionConsumerConfig(
     config.setBrokerConsumerStatsCacheTimeInMs(conf_.getBrokerConsumerStatsCacheTimeInMs());
 
     const auto shared_this = const_cast<PartitionedConsumerImpl*>(this)->shared_from_this();
-    config.setMessageListener(std::bind(&PartitionedConsumerImpl::messageReceived, shared_this, _1, _2));
+    config.setMessageListener(std::bind(&PartitionedConsumerImpl::messageReceived, shared_this,
+                                        std::placeholders::_1, std::placeholders::_2));
 
     // Apply total limit of receiver queue size across partitions
     // NOTE: if it's called by handleGetPartitions(), the queue size of new internal consumers may be smaller
@@ -251,7 +252,8 @@ ConsumerImplPtr PartitionedConsumerImpl::newInternalConsumer(unsigned int partit
 
     const auto shared_this = const_cast<PartitionedConsumerImpl*>(this)->shared_from_this();
     consumer->getConsumerCreatedFuture().addListener(std::bind(
-        &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_this, _1, _2, partition));
+        &PartitionedConsumerImpl::handleSinglePartitionConsumerCreated, shared_this, std::placeholders::_1,
+        std::placeholders::_2, partition));
     consumer->setPartitionIndex(partition);
 
     LOG_DEBUG("Creating Consumer for single Partition - " << topicPartitionName << "SubName - "
@@ -573,7 +575,8 @@ void PartitionedConsumerImpl::runPartitionUpdateTask() {
 void PartitionedConsumerImpl::getPartitionMetadata() {
     using namespace std::placeholders;
     lookupServicePtr_->getPartitionMetadataAsync(topicName_)
-        .addListener(std::bind(&PartitionedConsumerImpl::handleGetPartitions, shared_from_this(), _1, _2));
+        .addListener(std::bind(&PartitionedConsumerImpl::handleGetPartitions, shared_from_this(),
+                               std::placeholders::_1, std::placeholders::_2));
 }
 
 void PartitionedConsumerImpl::handleGetPartitions(Result result,

--- a/pulsar-client-cpp/lib/Url.cc
+++ b/pulsar-client-cpp/lib/Url.cc
@@ -23,13 +23,12 @@
 #include <sstream>
 
 #ifdef PULSAR_USE_BOOST_REGEX
-#  include <boost/regex.hpp>
-#  define PULSAR_REGEX_NAMESPACE boost
+#include <boost/regex.hpp>
+#define PULSAR_REGEX_NAMESPACE boost
 #else
-#  include <regex>
-#  define PULSAR_REGEX_NAMESPACE std
+#include <regex>
+#define PULSAR_REGEX_NAMESPACE std
 #endif
-
 
 namespace pulsar {
 

--- a/pulsar-client-cpp/lib/Url.cc
+++ b/pulsar-client-cpp/lib/Url.cc
@@ -18,8 +18,18 @@
  */
 #include "Url.h"
 
-#include <boost/regex.hpp>
+#include <map>
+
 #include <sstream>
+
+#ifdef PULSAR_USE_BOOST_REGEX
+#  include <boost/regex.hpp>
+#  define PULSAR_REGEX_NAMESPACE boost
+#else
+#  include <regex>
+#  define PULSAR_REGEX_NAMESPACE std
+#endif
+
 
 namespace pulsar {
 
@@ -39,14 +49,14 @@ static const std::map<std::string, int>& defaultPortsMap() {
 
 bool Url::parse(const std::string& urlStr, Url& url) {
     std::vector<std::string> values;
-    static const boost::regex expression(
+    static const PULSAR_REGEX_NAMESPACE::regex expression(
         //       proto                 host               port
         "^(\?:([^:/\?#]+)://)\?(\\w+[^/\?#:]*)(\?::(\\d+))\?"
         //       path                  file       parameters
         "(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)\?(\\\?(.*))\?");
 
-    boost::cmatch groups;
-    if (!boost::regex_match(urlStr.c_str(), groups, expression)) {
+    PULSAR_REGEX_NAMESPACE::cmatch groups;
+    if (!PULSAR_REGEX_NAMESPACE::regex_match(urlStr.c_str(), groups, expression)) {
         // Invalid url
         return false;
     }

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -18,16 +18,6 @@
  */
 #include <lib/auth/AuthAthenz.h>
 
-#include <string.h>
-#include <time.h>
-
-#include <openssl/sha.h>
-#include <openssl/rsa.h>
-#include <openssl/ec.h>
-#include <openssl/pem.h>
-
-#include <curl/curl.h>
-
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 namespace ptree = boost::property_tree;

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -45,9 +45,9 @@ namespace ptree = boost::property_tree;
 #include <mutex>
 
 #ifdef PULSAR_USE_BOOST_REGEX
-#  include <boost/regex.hpp>
+#include <boost/regex.hpp>
 #else
-#  include <regex>
+#include <regex>
 #endif
 
 DECLARE_LOG_OBJECT()
@@ -367,15 +367,15 @@ PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     // scheme mediatype[;base64] path file
 
 #ifdef PULSAR_USE_BOOST_REGEX
-   static const boost::regex expression(
-         "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
-   boost::cmatch groups;
-   if (boost::regex_match(uri, groups, expression)) {
-       uriSt.scheme = groups.str(1);
-       uriSt.mediaTypeAndEncodingType = groups.str(2);
-       uriSt.data = groups.str(4);
-   }
-#else // !PULSAR_USE_BOOST_REGEX
+    static const boost::regex expression(
+        "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
+    boost::cmatch groups;
+    if (boost::regex_match(uri, groups, expression)) {
+        uriSt.scheme = groups.str(1);
+        uriSt.mediaTypeAndEncodingType = groups.str(2);
+        uriSt.data = groups.str(4);
+    }
+#else   // !PULSAR_USE_BOOST_REGEX
     static const std::regex expression(
         R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?(\/[^?#]+)?)");
     std::cmatch groups;
@@ -385,7 +385,7 @@ PrivateKeyUri ZTSClient::parseUri(const char *uri) {
         uriSt.data = groups.str(3);
         uriSt.path = groups.str(4);
     }
-#endif //PULSAR_USE_BOOST_REGEX
+#endif  // PULSAR_USE_BOOST_REGEX
     return uriSt;
 }
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -38,12 +38,17 @@
 #include <boost/property_tree/ptree.hpp>
 namespace ptree = boost::property_tree;
 
-#include <boost/regex.hpp>
 #include <boost/xpressive/xpressive.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 
 #include <mutex>
+
+#ifdef PULSAR_USE_BOOST_REGEX
+#  include <boost/regex.hpp>
+#else
+#  include <regex>
+#endif
 
 DECLARE_LOG_OBJECT()
 
@@ -360,15 +365,27 @@ const std::string ZTSClient::getHeader() const { return roleHeader_; }
 PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     PrivateKeyUri uriSt;
     // scheme mediatype[;base64] path file
-    static const boost::regex expression(
-        "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
-    boost::cmatch groups;
-    if (boost::regex_match(uri, groups, expression)) {
+
+#ifdef PULSAR_USE_BOOST_REGEX
+   static const boost::regex expression(
+         "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
+   boost::cmatch groups;
+   if (boost::regex_match(uri, groups, expression)) {
+       uriSt.scheme = groups.str(1);
+       uriSt.mediaTypeAndEncodingType = groups.str(2);
+       uriSt.data = groups.str(4);
+   }
+#else // !PULSAR_USE_BOOST_REGEX
+    static const std::regex expression(
+        R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?(\/[^?#]+)?)");
+    std::cmatch groups;
+    if (std::regex_match(uri, groups, expression)) {
         uriSt.scheme = groups.str(1);
         uriSt.mediaTypeAndEncodingType = groups.str(2);
-        uriSt.data = groups.str(4);
-        uriSt.path = groups.str(3) + groups.str(4);
+        uriSt.data = groups.str(3);
+        uriSt.path = groups.str(4);
     }
+#endif //PULSAR_USE_BOOST_REGEX
     return uriSt;
 }
 }  // namespace pulsar

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -59,15 +59,6 @@ if (APPLE)
                          ${Boost_PYTHON27-MT_LIBRARY_RELEASE}
                          ${Boost_PYTHON37-MT_LIBRARY_RELEASE}
                          ${Boost_PYTHON38-MT_LIBRARY_RELEASE})
-
-    if (LINK_STATIC)
-        # When linking statically on MacOS, include also libicu since it's now required by boost::regex
-        find_library(ICU_DATA REQUIRED NAMES libicudata.a PATHS /usr/local/opt/icu4c/lib)
-        find_library(ICU_I18N REQUIRED NAMES libicui18n.a PATHS /usr/local/opt/icu4c/lib)
-        find_library(ICU_UUC REQUIRED NAMES libicuuc.a PATHS /usr/local/opt/icu4c/lib)
-
-        set(ICU_LIBS ${ICU_DATA} ${ICU_I18N} ${ICU_UUC})
-    endif ()
 endif()
 
 message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -18,11 +18,10 @@
  */
 #include <pulsar/Client.h>
 #include <gtest/gtest.h>
-#include <boost/date_time/posix_time/ptime.hpp>
-#include <boost/bind.hpp>
 #include <lib/LogUtils.h>
 
 DECLARE_LOG_OBJECT()
+
 
 #include "../lib/Future.h"
 #include "../lib/Utils.h"

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -22,7 +22,6 @@
 
 DECLARE_LOG_OBJECT()
 
-
 #include "../lib/Future.h"
 #include "../lib/Utils.h"
 

--- a/pulsar-client-cpp/tests/ZTSClientTest.cc
+++ b/pulsar-client-cpp/tests/ZTSClientTest.cc
@@ -39,7 +39,7 @@ TEST(ZTSClientTest, testZTSClient) {
     {
         PrivateKeyUri uri = ZTSClientWrapper::parseUri("file:///path/to/private.key");
         ASSERT_EQ("file", uri.scheme);
-        ASSERT_EQ("///path/to/private.key", uri.path);
+        ASSERT_EQ("/path/to/private.key", uri.path);
     }
 
     {


### PR DESCRIPTION
### Motivation

Remove boost::regex which is the only remaining runtime boost dependency.

### Changes

Removed the usage of `boost::regex`, substituting with `std::regex`. We only need to use boost::regex with old gcc versions that have buggy implementation of regexes. In particular, this happens with G++ 4.8.2  which is the one used when building `manylinux1` Python wheel files.