### PR TITLE
[Build] build with unix lineEnding in Windows

### DIFF
--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -35,9 +35,11 @@
   <fileSets>
     <fileSet>
       <directory>${basedir}/../../conf</directory>
+      <lineEnding>unix</lineEnding>
     </fileSet>
     <fileSet>
       <directory>${basedir}/../../bin</directory>
+      <lineEnding>unix</lineEnding>
       <fileMode>755</fileMode>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
### Motivation
When build pulsar in Windows using "mvn clean install -DskipTests" and upload the tar.gz file in /distribution/server/target to Linux server, the package can not be executed because the sh files and bin files in /bin are using Windows line ending.

### Modifications
Specify unix line ending when building pulsar. 

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: ( no)
  - The admin cli options: ( no)
  - Anything that affects deployment: (yes )
