### PR TITLE
Fix reading metrics will always get stuck in some cases

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
@@ -70,7 +70,7 @@ public class PrometheusMetricsServlet extends HttpServlet {
                         res.getOutputStream(), metricsProviders);
                 context.complete();
 
-            } catch (IOException e) {
+            } catch (Exception e) {
                 log.error("Failed to generate prometheus stats", e);
                 res.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
                 context.complete();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
@@ -23,13 +23,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import io.prometheus.client.CollectorRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.functions.instance.InstanceConfig;
@@ -42,7 +42,6 @@ import org.apache.pulsar.functions.secretsprovider.SecretsProvider;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.functioncache.FunctionCacheManager;
 import org.apache.pulsar.functions.instance.JavaInstanceRunnable;
-import org.apache.pulsar.functions.utils.io.Connector;
 import org.apache.pulsar.functions.worker.ConnectorsManager;
 
 /**
@@ -246,7 +245,7 @@ public class ThreadRuntime implements Runtime {
     @Override
     public String getPrometheusMetrics() throws IOException {
         if (javaInstanceRunnable == null) {
-            throw new RuntimeException("javaInstanceRunnable is not initialized");
+            throw new PulsarServerException("javaInstanceRunnable is not initialized");
         }
         return javaInstanceRunnable.getStatsAsString();
     }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
@@ -245,6 +245,9 @@ public class ThreadRuntime implements Runtime {
 
     @Override
     public String getPrometheusMetrics() throws IOException {
+        if (javaInstanceRunnable == null) {
+            throw new RuntimeException("javaInstanceRunnable is not initialized");
+        }
         return javaInstanceRunnable.getStatsAsString();
     }
 


### PR DESCRIPTION
### Motivation
When `javaInstanceRunnable` has not been initialized yet, and client calls `FunctionsStatsGenerator#generate`, the NPE will be triggered.
Since only `IOException` is caught here, the client's request will be blocked all the time.

The following unit tests are affected and often fail to execute:
`org.apache.pulsar.io.PulsarFunctionE2ETest#testReadCompactedSink`

### Modifications
Catch all exceptions
