### PR TITLE
CI Builds for WebSite and MacOs write too much log (missing -B option)

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -60,4 +60,4 @@ jobs:
           java-version: 1.8
 
       - name: build package
-        run: mvn clean install -DskipTests
+        run: mvn -B clean install -DskipTests

--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: build
-        run: mvn clean package -DskipTests -Pswagger
+        run: mvn -B clean package -DskipTests -Pswagger
 
       - name: clean disk
         run: |


### PR DESCRIPTION
The CI jobs  for the WebSite and for MacOs are missing the -B option and thus Maven is printing too much logs.

![Screenshot 2021-02-09 at 08 32 02](https://user-images.githubusercontent.com/9469110/107330156-7df69600-6ab1-11eb-95de-6c1ab8d3c814.png)


Modifications:
add -B (batch mode) to `mvn` commands.

I checked for other invocations of mvn without -B but I did not find any other case 