### PR TITLE
[C++] Add detail logs for schema related messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1167,9 +1167,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
 
                             schemaVersionFuture.exceptionally(exception -> {
-                                final String message = (exception.getCause() != null)
-                                        ? exception.getCause().toString()
-                                        : exception.getMessage();
+                                String message = exception.getMessage();
+                                if (exception.getCause() != null) {
+                                    message += (" caused by " + exception.getCause().toString());
+                                }
                                 commandSender.sendErrorResponse(requestId,
                                         BrokerServiceException.getClientErrorCode(exception),
                                         message);
@@ -1730,7 +1731,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
                 schemaVersionFuture.exceptionally(ex -> {
                     ServerError errorCode = BrokerServiceException.getClientErrorCode(ex);
-                    final String message = (ex.getCause() != null) ? ex.getCause().toString() : ex.getMessage();
+                    String message = ex.getMessage();
+                    if (ex.getCause() != null) {
+                        message += (" caused by " + ex.getCause().toString());
+                    }
                     commandSender.sendGetOrCreateSchemaErrorResponse(requestId, errorCode, message);
                     return null;
                 }).thenAccept(schemaVersion -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1167,9 +1167,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
 
                             schemaVersionFuture.exceptionally(exception -> {
+                                final String message = (exception.getCause() != null)
+                                        ? exception.getCause().toString()
+                                        : exception.getMessage();
                                 commandSender.sendErrorResponse(requestId,
                                         BrokerServiceException.getClientErrorCode(exception),
-                                        exception.getMessage());
+                                        message);
                                 producers.remove(producerId, producerFuture);
                                 return null;
                             });
@@ -1727,7 +1730,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
                 schemaVersionFuture.exceptionally(ex -> {
                     ServerError errorCode = BrokerServiceException.getClientErrorCode(ex);
-                    commandSender.sendGetOrCreateSchemaErrorResponse(requestId, errorCode, ex.getMessage());
+                    final String message = (ex.getCause() != null) ? ex.getCause().toString() : ex.getMessage();
+                    commandSender.sendGetOrCreateSchemaErrorResponse(requestId, errorCode, message);
                     return null;
                 }).thenAccept(schemaVersion -> {
                     commandSender.sendGetOrCreateSchemaResponse(requestId, schemaVersion);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1169,7 +1169,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             schemaVersionFuture.exceptionally(exception -> {
                                 String message = exception.getMessage();
                                 if (exception.getCause() != null) {
-                                    message += (" caused by " + exception.getCause().toString());
+                                    message += (" caused by " + exception.getCause());
                                 }
                                 commandSender.sendErrorResponse(requestId,
                                         BrokerServiceException.getClientErrorCode(exception),
@@ -1733,7 +1733,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     ServerError errorCode = BrokerServiceException.getClientErrorCode(ex);
                     String message = ex.getMessage();
                     if (ex.getCause() != null) {
-                        message += (" caused by " + ex.getCause().toString());
+                        message += (" caused by " + ex.getCause());
                     }
                     commandSender.sendGetOrCreateSchemaErrorResponse(requestId, errorCode, message);
                     return null;

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -976,6 +976,7 @@ void ClientConnection::handleIncomingCommand() {
                     const CommandError& error = incomingCmd_.error();
                     Result result = getResult(error.error());
                     LOG_WARN(cnxString_ << "Received error response from server: " << result
+                                        << (error.has_message() ? (" (" + error.message() + ")") : "")
                                         << " -- req_id: " << error.request_id());
 
                     Lock lock(mutex_);


### PR DESCRIPTION
### Motivation

If broker failed to parse the schema, the logs of C++/Python client is poor because when C++ client handles the `Error` response, it doesn't print the `message` field that is filled by broker. On the other hand, if the `InvalidSchemaDataException` is thrown by `StructSchemaDataValidator#throwInvalidSchemaDataException`, the detail error message will be written to the exception's cause. The String that `getMessage()` returns is not enough

### Modifications

- When `tryAddSchema` failed, add the exception cause's message to the error message that's sent to client.
- Print `Error` response's `message` field to logs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. Take #9483 (which is to be fixed) as the example, before this PR, the client side's log is like

> Received error response from server: IncompatibleSchema -- req_id: 0

After this PR, the client side's log will be

> Received error response from server: IncompatibleSchema (Invalid schema definition data for AVRO schema caused by org.apache.avro.SchemaParseException: Undefined name: "array") -- req_id: 0