### PR TITLE
[Python] Fix nested Map or Array in schema doesn't work

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -355,8 +355,11 @@ class Map(Field):
         super(Map, self).validate_type(name, val)
 
         for k, v in val.items():
-            # Make it compatible with Python2, where key may be `unicode` type
-            if type(k) != str and type(k.encode()) != str:
+            # Make it compatible with Python2, where key may be `unicode` type. There's no `unicode` type in Python3. 
+            # Therefore here we use the `encode` method to try to convert `k` to `str`.
+            #   1. `unicode` type: type(k.encode()) == str.
+            #   2. Other types like `int`: dir(k).count('encode') == 0.
+            if type(k) != str and (dir(k).count('encode') == 0 or type(k.encode()) != str):
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
             if type(v) != self.value_type.python_type():
                 raise TypeError('Map values for field ' + name + ' should all be of type '

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -355,7 +355,8 @@ class Map(Field):
         super(Map, self).validate_type(name, val)
 
         for k, v in val.items():
-            if type(k) != str:
+            # Make it compatible with Python2, where key may be `unicode` type
+            if type(k) != str and type(k.encode()) != str:
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
             if type(v) != self.value_type.python_type():
                 raise TypeError('Map values for field ' + name + ' should all be of type '

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -334,7 +334,7 @@ class Array(Field):
     def schema(self):
         return {
             'type': self.type(),
-            'items': self.array_type.schema() if isinstance(self.array_type, Record) 
+            'items': self.array_type.schema() if isinstance(self.array_type, (Array, Map, Record))
                 else self.array_type.type()
         }
 
@@ -366,6 +366,6 @@ class Map(Field):
     def schema(self):
         return {
             'type': self.type(),
-            'values': self.value_type.schema() if isinstance(self.value_type, Record)
+            'values': self.value_type.schema() if isinstance(self.value_type, (Array, Map, Record))
                 else self.value_type.type()
         }

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -355,11 +355,7 @@ class Map(Field):
         super(Map, self).validate_type(name, val)
 
         for k, v in val.items():
-            # Make it compatible with Python2, where key may be `unicode` type. There's no `unicode` type in Python3. 
-            # Therefore here we use the `encode` method to try to convert `k` to `str`.
-            #   1. `unicode` type: type(k.encode()) == str.
-            #   2. Other types like `int`: dir(k).count('encode') == 0.
-            if type(k) != str and (dir(k).count('encode') == 0 or type(k.encode()) != str):
+            if type(k) != str and not is_unicode(k):
                 raise TypeError('Map keys for field ' + name + '  should all be strings')
             if type(v) != self.value_type.python_type():
                 raise TypeError('Map values for field ' + name + ' should all be of type '
@@ -373,3 +369,9 @@ class Map(Field):
             'values': self.value_type.schema() if isinstance(self.value_type, (Array, Map, Record))
                 else self.value_type.type()
         }
+
+
+# Python3 has no `unicode` type, so here we use a tricky way to check if the type of `x` is `unicode` in Python2
+# and also make it work well with Python3.
+def is_unicode(x):
+    return 'encode' in dir(x) and type(x.encode()) == str

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -660,7 +660,6 @@ class SchemaTest(TestCase):
 
             producer.send(record)
             msg = consumer.receive()
-            print("Receive {} from {}", msg.value().values, msg.topic_name())
             self.assertEqual(msg.value().values, record.values)
             consumer.acknowledge(msg)
             consumer.close()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -668,24 +668,6 @@ class SchemaTest(TestCase):
 
         client.close()
 
-    def test_avro_array_map(self):
-        class ArrayMap(Record):
-            values = Array(Map(Integer()))
-
-        topic = 'my-avro-array-map-topic'
-        client = pulsar.Client(self.serviceUrl)
-        producer = client.create_producer(topic, schema=AvroSchema(ArrayMap))
-        consumer = client.subscribe(topic, 'sub', schema=AvroSchema(ArrayMap))
-
-        r = ArrayMap(values=[{"A": 1}, {"B": 2}])
-        producer.send(r)
-
-        msg = consumer.receive()
-        print("Receive {} from {}", msg.value().values, msg.topic_name())
-        self.assertEqual(msg.value().values, r.values)
-        client.close()
-
-
     def test_default_value(self):
         class MyRecord(Record):
             A = Integer()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -624,6 +624,41 @@ class SchemaTest(TestCase):
         self.assertEqual(MyEnum.C, msg.value().v)
         client.close()
 
+    def test_avro_map_array(self):
+        class MapArray(Record):
+            values = Map(Array(Integer()))
+
+        topic = 'my-avro-map-array-topic'
+        client = pulsar.Client(self.serviceUrl)
+        producer = client.create_producer(topic, schema=AvroSchema(MapArray))
+        consumer = client.subscribe(topic, 'sub', schema=AvroSchema(MapArray))
+
+        r = MapArray(values={"A": [1, 2], "B": [3]})
+        producer.send(r)
+
+        msg = consumer.receive()
+        print("Receive {} from {}", msg.value().values, msg.topic_name())
+        self.assertEqual(msg.value().values, r.values)
+        client.close()
+
+    def test_avro_array_map(self):
+        class ArrayMap(Record):
+            values = Array(Map(Integer()))
+
+        topic = 'my-avro-array-map-topic'
+        client = pulsar.Client(self.serviceUrl)
+        producer = client.create_producer(topic, schema=AvroSchema(ArrayMap))
+        consumer = client.subscribe(topic, 'sub', schema=AvroSchema(ArrayMap))
+
+        r = ArrayMap(values=[{"A": 1}, {"B": 2}])
+        producer.send(r)
+
+        msg = consumer.receive()
+        print("Receive {} from {}", msg.value().values, msg.topic_name())
+        self.assertEqual(msg.value().values, r.values)
+        client.close()
+
+
     def test_default_value(self):
         class MyRecord(Record):
             A = Integer()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -628,14 +628,25 @@ class SchemaTest(TestCase):
         class MapArray(Record):
             values = Map(Array(Integer()))
 
+        class MapMap(Record):
+            values = Map(Map(Integer()))
+
         class ArrayMap(Record):
             values = Array(Map(Integer()))
 
+        class ArrayArray(Record):
+            values = Array(Array(Integer()))
+
+        topic_prefix = "my-avro-map-array-topic-"
         data_list = (
-            ("my-avro-map-array-topic-0", AvroSchema(MapArray),
+            (topic_prefix + "0", AvroSchema(MapArray),
                 MapArray(values={"A": [1, 2], "B": [3]})),
-            ("my-avro-map-array-topic-1", AvroSchema(ArrayMap),
+            (topic_prefix + "1", AvroSchema(MapMap),
+                MapMap(values={"A": {"B": 2},})),
+            (topic_prefix + "2", AvroSchema(ArrayMap),
                 ArrayMap(values=[{"A": 1}, {"B": 2}, {"C": 3}])),
+            (topic_prefix + "3", AvroSchema(ArrayArray),
+                ArrayArray(values=[[1, 2, 3], [4]])),
         )
 
         client = pulsar.Client(self.serviceUrl)


### PR DESCRIPTION
Fixes #9483 

### Motivation

Currently Python client doesn't handle nested `Map` or `Array` well, the generated schema string is invalid. It's because when `Map`/`Array`'s `schema()` method set the `values` field of schema string, it only ignores the `Record` type but not `Map` and `Array`.

### Modifications

- Fix nested Map or Array in schema doesn't work.
- Add 4 tests for `Map<Map>`, `Map<Array>`, `Array<Array>`, `Array<Map>` to cover all nested cases that involve `Map` or `Array`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added SchemaTest.test_avro_map_array to schema_test.py*