### PR TITLE
Fix a couple of bugs in exclusive producer 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -386,7 +386,8 @@ public abstract class AbstractTopic implements Topic {
             case Shared:
                 if (hasExclusiveProducer || !waitingExclusiveProducers.isEmpty()) {
                     return FutureUtil.failedFuture(
-                            new ProducerBusyException("Topic has an existing exclusive producer: " + exclusiveProducerName));
+                            new ProducerBusyException(
+                                    "Topic has an existing exclusive producer: " + exclusiveProducerName));
                 } else {
                     // Normal producer getting added, we don't need a new epoch
                     return CompletableFuture.completedFuture(topicEpoch);
@@ -395,7 +396,8 @@ public abstract class AbstractTopic implements Topic {
             case Exclusive:
                 if (hasExclusiveProducer || !waitingExclusiveProducers.isEmpty()) {
                     return FutureUtil.failedFuture(
-                            new ProducerFencedException("Topic has an existing exclusive producer: " + exclusiveProducerName));
+                            new ProducerFencedException(
+                                    "Topic has an existing exclusive producer: " + exclusiveProducerName));
                 } else if (!producers.isEmpty()) {
                     return FutureUtil.failedFuture(new ProducerFencedException("Topic has existing shared producers"));
                 } else if (producer.getTopicEpoch().isPresent()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -386,7 +386,7 @@ public abstract class AbstractTopic implements Topic {
             case Shared:
                 if (hasExclusiveProducer || !waitingExclusiveProducers.isEmpty()) {
                     return FutureUtil.failedFuture(
-                            new ProducerFencedException("Topic has an existing exclusive producer: " + exclusiveProducer));
+                            new ProducerBusyException("Topic has an existing exclusive producer: " + exclusiveProducer));
                 } else {
                     // Normal producer getting added, we don't need a new epoch
                     return CompletableFuture.completedFuture(topicEpoch);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -76,6 +76,10 @@ public class ExclusiveProducerTest extends BrokerTestBase {
     @Test(dataProvider = "topics")
     public void simpleTest(String type, boolean partitioned) throws Exception {
         String topic = newTopic(type, partitioned);
+        simpleTest(topic);
+    }
+
+    private void simpleTest(String topic) throws Exception {
 
         Producer<String> p1 = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
@@ -285,6 +289,18 @@ public class ExclusiveProducerTest extends BrokerTestBase {
 
         // Now P2 should get created
         fp2.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test(dataProvider = "topics")
+    public void exclusiveWithConsumers(String type, boolean partitioned) throws Exception {
+        String topic = newTopic(type, partitioned);
+
+        pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("test")
+                .subscribe();
+
+        simpleTest(topic);
     }
 
     private String newTopic(String type, boolean isPartitioned) throws Exception {


### PR DESCRIPTION
### Motivation

When multiple producers contend to become the exclusive producer.  A race condition can occur and the following exception can happen but gets silently swallowed which eventually leads to a client timeout.

```
21:44:46.038 [ForkJoinPool.commonPool-worker-2] ERROR org.apache.pulsar.broker.service.AbstractTopic - got error: java.util.NoSuchElementException
java.util.NoSuchElementException: null
	at java.util.concurrent.ConcurrentHashMap$KeyIterator.next(ConcurrentHashMap.java:3416) ~[?:1.8.0_231]
	at java.util.concurrent.ConcurrentHashMap$KeyIterator.nextElement(ConcurrentHashMap.java:3423) ~[?:1.8.0_231]
	at org.apache.pulsar.broker.service.AbstractTopic.incrementTopicEpochIfNeeded(AbstractTopic.java:399) ~[pulsar-broker.jar:2.8.0-SNAPSHOT]
	at org.apache.pulsar.broker.service.AbstractTopic.addProducer(AbstractTopic.java:346) ~[pulsar-broker.jar:2.8.0-SNAPSHOT]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.addProducer(PersistentTopic.java:509) ~[pulsar-broker.jar:2.8.0-SNAPSHOT]
	at org.apache.pulsar.broker.service.ServerCnx.lambda$null$22(ServerCnx.java:1183) ~[pulsar-broker.jar:2.8.0-SNAPSHOT]
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[?:1.8.0_231]
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:632) ~[?:1.8.0_231]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_231]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962) ~[?:1.8.0_231]
	at org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.lambda$null$6(BookkeeperSchemaStorage.java:230) ~[pulsar-broker.jar:2.8.0-SNAPSHOT]
	at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:822) [?:1.8.0_231]
	at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:797) [?:1.8.0_231]
	at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:443) [?:1.8.0_231]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) [?:1.8.0_231]
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) [?:1.8.0_231]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) [?:1.8.0_231]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157) [?:1.8.0_231]

```


Also `USAGE_COUNT_UPDATER` is used incorrectly in `handleProducerRemoved()`