### PR TITLE
[Issue 4044][docs] Fix outdated docker-compose advertised address

### DIFF
--- a/docker-compose/standalone-dashboard/docker-compose.yml
+++ b/docker-compose/standalone-dashboard/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: >
       /bin/bash -c
       "bin/apply-config-from-env.py conf/standalone.conf
-      && bin/pulsar standalone"
+      && bin/pulsar standalone --advertised-address standalone"
 
   dashboard:
     image: apachepulsar/pulsar-dashboard


### PR DESCRIPTION
Fixes #4044 and #3367, completes streamnative/pulsar/issues/290

### Motivation

When you google "docker compose pulsar", the first results points to `docker-compose/standalone-dashboard/docker-compose.yml` which works for the most part if you use CLI commands such as `pulsar-admin`, but the dashboard never shows any tenant, topics, etc. This has been reported in issues such as #4044 and officially given a recommendation in streamnative/pulsar/issues/290, however, `docker-compose/standalone-dashboard/docker-compose.yml` is still outdated.

### Modifications

- Modified `docker-compose/standalone-dashboard/docker-compose.yml` to include `--advertised-address` with the name of the network host inside the docker-compose network that the dashboard can actually use.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

  - without applying this patch, run `docker-compose up`, even after 2 minutes the dashboard still doesn't show tenants or topics
  - apply the patch and then run `docker-compose up`, refresh the dashboard UI after 20 seconds and the tenants and topics show up.

