### PR TITLE
Allow to build Pulsar with JDK11 and -Dmaven.compiler.release=8

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -36,11 +36,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.sun.org.apache.xml.internal.serialize.OutputFormat.Defaults.Encoding;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -93,11 +93,11 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         config.setManagedLedgerInterceptor(interceptor);
         ManagedLedger ledger = factory.open("my_recovery_index_test_ledger", config);
 
-        ledger.addEntry("dummy-entry-1".getBytes(Encoding), MOCK_BATCH_SIZE);
+        ledger.addEntry("dummy-entry-1".getBytes(StandardCharsets.UTF_8), MOCK_BATCH_SIZE);
 
         ManagedCursor cursor = ledger.openCursor("c1");
 
-        ledger.addEntry("dummy-entry-2".getBytes(Encoding), MOCK_BATCH_SIZE);
+        ledger.addEntry("dummy-entry-2".getBytes(StandardCharsets.UTF_8), MOCK_BATCH_SIZE);
 
         assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex(), MOCK_BATCH_SIZE * 2 - 1);
 
@@ -141,7 +141,7 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
 
         long firstLedgerId = -1;
         for (int i = 0; i < maxEntriesPerLedger; i++) {
-            firstLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+            firstLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(StandardCharsets.UTF_8), MOCK_BATCH_SIZE)).getLedgerId();
         }
 
         assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex(), 9);
@@ -156,7 +156,7 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         // roll over ledger
         long secondLedgerId = -1;
         for (int i = 0; i < maxEntriesPerLedger; i++) {
-            secondLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+            secondLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(StandardCharsets.UTF_8), MOCK_BATCH_SIZE)).getLedgerId();
         }
         assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex(), 19);
         assertNotEquals(firstLedgerId, secondLedgerId);
@@ -174,7 +174,7 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
 
         long thirdLedgerId = -1;
         for (int i = 0; i < maxEntriesPerLedger; i++) {
-            thirdLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(Encoding), MOCK_BATCH_SIZE)).getLedgerId();
+            thirdLedgerId = ((PositionImpl) ledger.addEntry("dummy-entry".getBytes(StandardCharsets.UTF_8), MOCK_BATCH_SIZE)).getLedgerId();
         }
         assertEquals(((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex(), 29);
         assertNotEquals(secondLedgerId, thirdLedgerId);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiMessageIdImpl.java
@@ -23,7 +23,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import lombok.Getter;
 import org.apache.pulsar.client.api.MessageId;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * A MessageId implementation that contains a map of <partitionName, MessageId>.
@@ -42,7 +41,7 @@ public class MultiMessageIdImpl implements MessageId {
     //  https://github.com/apache/pulsar/issues/4940
     @Override
     public byte[] toByteArray() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
@@ -20,9 +20,6 @@ package org.apache.pulsar.common.stats;
 
 import com.google.common.collect.Maps;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
@@ -33,7 +30,7 @@ import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"restriction", "checkstyle:JavadocType"})
+@SuppressWarnings({"checkstyle:JavadocType"})
 public class JvmDefaultGCMetricsLogger implements JvmGCMetricsLogger {
 
     private static final Logger log = LoggerFactory.getLogger(JvmDefaultGCMetricsLogger.class);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
@@ -19,10 +19,17 @@
 package org.apache.pulsar.common.stats;
 
 import com.google.common.collect.Maps;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+
+import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,17 +43,44 @@ public class JvmDefaultGCMetricsLogger implements JvmGCMetricsLogger {
     private volatile long accumulatedFullGcTime = 0;
     private volatile long currentFullGcTime = 0;
 
-    @SuppressWarnings("restriction")
-    private static sun.management.HotspotRuntimeMBean runtime;
+    private static Object /*sun.management.HotspotRuntimeMBean*/ runtime;
+    private static Method getTotalSafepointTimeHandle;
+    private static Method getSafepointCountHandle;
 
     private Map<String, GCMetrics> gcMetricsMap = Maps.newHashMap();
 
     static {
         try {
-            runtime = sun.management.ManagementFactoryHelper.getHotspotRuntimeMBean();
-        } catch (Exception e) {
+            runtime = Class.forName("sun.management.ManagementFactoryHelper")
+                    .getMethod("getHotspotRuntimeMBean")
+                    .invoke(null);
+            getTotalSafepointTimeHandle = runtime.getClass().getMethod("getTotalSafepointTime");
+            getTotalSafepointTimeHandle.setAccessible(true);
+            getSafepointCountHandle = runtime.getClass().getMethod("getSafepointCount");
+            getSafepointCountHandle.setAccessible(true);
+
+            // try to use the methods
+            getTotalSafepointTimeHandle.invoke(runtime);
+            getSafepointCountHandle.invoke(runtime);
+        } catch (Throwable e) {
             log.warn("Failed to get Runtime bean", e);
         }
+    }
+
+    @SneakyThrows
+    static long getTotalSafepointTime() {
+        if (getTotalSafepointTimeHandle == null) {
+            return -1;
+        }
+        return (long) getTotalSafepointTimeHandle.invoke(runtime);
+    }
+
+    @SneakyThrows
+    static long getSafepointCount() {
+        if (getTotalSafepointTimeHandle == null) {
+            return -1;
+        }
+        return (long) getSafepointCountHandle.invoke(runtime);
     }
 
     /**
@@ -92,8 +126,8 @@ public class JvmDefaultGCMetricsLogger implements JvmGCMetricsLogger {
              * that the application has been stopped for safepoint operations.
              * http://www.docjar.com/docs/api/sun/management/HotspotRuntimeMBean.html
              */
-            long newSafePointTime = runtime.getTotalSafepointTime();
-            long newSafePointCount = runtime.getSafepointCount();
+            long newSafePointTime = getTotalSafepointTime();
+            long newSafePointCount = getSafepointCount();
             currentFullGcTime = newSafePointTime - accumulatedFullGcTime;
             currentFullGcCount = newSafePointCount - accumulatedFullGcCount;
             accumulatedFullGcTime = newSafePointTime;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLoggerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLoggerTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.stats;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotEquals;
+
+
+@Slf4j
+public class JvmDefaultGCMetricsLoggerTest {
+
+    @Test
+    public void testInvokeJVMInternals() {
+      long safePointCount = JvmDefaultGCMetricsLogger.getSafepointCount();
+      long totalSafePointTime = JvmDefaultGCMetricsLogger.getTotalSafepointTime();
+      log.info("safePointCount {} totalSafePointTime {}", safePointCount, totalSafePointTime);
+      assertNotEquals(safePointCount, -1);
+      assertNotEquals(totalSafePointTime, -1);
+    }
+}


### PR DESCRIPTION

Master Issue: #9578

### Motivation

If you try to build Pulsar on JDK11 and add the --release flag to javac (that is -Dmaven.compiler.release=8 in Maven terms) you see errors due to some internal APIs that have been hidden to the user at build time.

### Modifications

- Fix usages of internal JRE APIs that are still accessible at runtime even on JDK11 but they are not visible at build time in JDK8
- add tests
