### PR TITLE
[Broker] Fix failing test LoadReportNetworkLimit

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -214,6 +214,10 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         }
     }
 
+    public int getNicCount() {
+        return getNics().size();
+    }
+
     private boolean isPhysicalNic(Path path) {
         if (!path.toString().contains("/virtual/")) {
             try {


### PR DESCRIPTION
### Motivation

The LoadReportNetworkLimit test fails on Linux when there are more than 1 nics.

### Modifications

Create a solution where the test queries the number of nics so that the assertion can be done correctly.