### PR TITLE
Disable negativeAck for Key_Shared sub type.

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -855,8 +855,10 @@ void ConsumerImpl::doAcknowledgeCumulative(const MessageId& messageId, ResultCal
 }
 
 void ConsumerImpl::negativeAcknowledge(const MessageId& messageId) {
-    unAckedMessageTrackerPtr_->remove(messageId);
-    negativeAcksTracker_.add(messageId);
+    if (config_.getConsumerType() != ConsumerKeyShared) {
+        unAckedMessageTrackerPtr_->remove(messageId);
+        negativeAcksTracker_.add(messageId);
+    }
 }
 
 void ConsumerImpl::disconnectConsumer() {


### PR DESCRIPTION
Fixes #9582

### Motivation
The message negative ack will break the message ordering dispatch guarantee, Key_Shared is an ordering dispatch guarantee subscription, so we should avoid the message negative ack for the Key_Shared subscription.

### Modifications
Check if it's Key_Shared subscription type before negativeAcking messages.

### Verifying this change

This change added tests and can be verified as follows:
  - *Added test case.*
