### PR TITLE
[pulsar-functions] Add maximum allowed amount of resources setting for functions

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -40,7 +40,7 @@ zooKeeperOperationTimeoutSeconds: 30
 numFunctionPackageReplicas: 1
 downloadDirectory: download/pulsar_functions
 # Classname of Pluggable JVM GC metrics logger that can log GC specific metrics
-# jvmGCMetricsLoggerClassName: 
+# jvmGCMetricsLoggerClassName:
 
 #################################################################
 # Function metadata managment (assignment, scheduling, and etc)
@@ -225,6 +225,14 @@ functionRuntimeFactoryConfigs:
 #   ram: 1073741824
 #   disk: 10737418240
 
+## A set of the maximum amount of resources functions may request.
+## Support for this depends on function runtime.
+## Only kubernetes runtime currently supports this.
+# functionInstanceMaxResources:
+#   cpu: 16
+#   ram: 17179869184
+#   disk: 107374182400
+
 ## The full class-name of an instance of RuntimeCustomizer.
 ## This class receives the customRuntimeOptions string and can customize details of how the runtime operates.
 #runtimeCustomizerClassName: "org.apache.pulsar.functions.runtime.kubernetes.KubernetesManifestCustomizer"
@@ -259,22 +267,22 @@ authenticationProviders:
 # Authorization provider fully qualified class-name
 authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
 # Set of role names that are treated as "super-user", meaning they will be able to access any admin-api
-superUserRoles: 
+superUserRoles:
 
 #### tls configuration for worker service
 # Enable TLS
 tlsEnabled: false
 # Path for the TLS certificate file
-tlsCertificateFilePath: 
+tlsCertificateFilePath:
 # Path for the TLS private key file
-tlsKeyFilePath: 
-# Path for the trusted TLS certificate file 
+tlsKeyFilePath:
+# Path for the trusted TLS certificate file
 tlsTrustCertsFilePath:
-# Accept untrusted TLS certificate from client 
+# Accept untrusted TLS certificate from client
 tlsAllowInsecureConnection: false
 # Whether server hostname must match the common name of the certificate
 tlsEnableHostnameVerification: false
-# Tls cert refresh duration in seconds (set 0 to check on every new connection) 
+# Tls cert refresh duration in seconds (set 0 to check on every new connection)
 tlsCertRefreshCheckDurationSec: 300
 
 ########################

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
@@ -94,6 +94,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     private String pythonInstanceFile;
     private final String logDirectory = "logs/functions";
     private Resources functionInstanceMinResources;
+    private Resources functionInstanceMaxResources;
     private boolean authenticationEnabled;
     private Integer grpcPort;
     private Integer metricsPort;
@@ -208,6 +209,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         this.changeConfigMap = factoryConfig.getChangeConfigMap();
         this.changeConfigMapNamespace = factoryConfig.getChangeConfigMapNamespace();
         this.functionInstanceMinResources = workerConfig.getFunctionInstanceMinResources();
+        this.functionInstanceMaxResources = workerConfig.getFunctionInstanceMaxResources();
         this.secretsProviderConfigurator = secretsProviderConfigurator;
         this.authenticationEnabled = workerConfig.isAuthenticationEnabled();
         this.javaInstanceJarFile = this.pulsarRootDir + "/instances/java-instance.jar";
@@ -331,7 +333,8 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     	final String overriddenJobName = getOverriddenName(functionDetails);
         KubernetesRuntime.doChecks(functionDetails, overriddenJobName);
         validateMinResourcesRequired(functionDetails);
-        secretsProviderConfigurator.doAdmissionChecks(appsClient, coreClient, 
+        validateMaxResourcesRequired(functionDetails);
+        secretsProviderConfigurator.doAdmissionChecks(appsClient, coreClient,
         		getOverriddenNamespace(functionDetails), overriddenJobName, functionDetails);
     }
 
@@ -426,6 +429,25 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         }
     }
 
+    void validateMaxResourcesRequired(Function.FunctionDetails functionDetails) {
+        if (functionInstanceMaxResources != null) {
+            Double maxCpu = functionInstanceMaxResources.getCpu();
+            Long maxRam = functionInstanceMaxResources.getRam();
+
+            if (maxCpu != null && functionDetails.getResources().getCpu() > maxCpu) {
+                throw new IllegalArgumentException(
+                        String.format("Per instance CPU requested, %s, for function is greater than the maximum required, %s",
+                                functionDetails.getResources().getCpu(), maxCpu));
+            }
+
+            if (maxRam != null && functionDetails.getResources().getRam() > maxRam) {
+                throw new IllegalArgumentException(
+                        String.format("Per instance RAM requested, %s, for function is greater than the maximum required, %s",
+                                functionDetails.getResources().getRam(), maxRam));
+            }
+        }
+    }
+
     @Override
     public Optional<KubernetesFunctionAuthProvider> getAuthProvider() {
         return authProvider;
@@ -440,7 +462,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         Optional<KubernetesManifestCustomizer> manifestCustomizer = getRuntimeCustomizer();
         return manifestCustomizer.map((customizer) -> customizer.customizeNamespace(funcDetails, jobNamespace)).orElse(jobNamespace);
     }
-    
+
     private String getOverriddenName(Function.FunctionDetails funcDetails) {
         Optional<KubernetesManifestCustomizer> manifestCustomizer = getRuntimeCustomizer();
         return manifestCustomizer.map((customizer) -> customizer.customizeName(funcDetails, jobName)).orElse(jobName);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -462,6 +462,11 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             doc = "A set of the minimum amount of resources functions must request.  Support for this depends on function runtime."
     )
     private Resources functionInstanceMinResources;
+    @FieldContext(
+            category = CATEGORY_FUNC_RUNTIME_MNG,
+            doc = "A set of the maximum amount of resources functions may request.  Support for this depends on function runtime."
+    )
+    private Resources functionInstanceMaxResources;
 
     @FieldContext(
             category = CATEGORY_FUNC_RUNTIME_MNG,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
@@ -138,12 +138,14 @@ public class KubernetesRuntimeFactoryTest {
         }
     }
 
-    KubernetesRuntimeFactory createKubernetesRuntimeFactory(String extraDepsDir, Resources minResources) throws Exception {
-        return createKubernetesRuntimeFactory(extraDepsDir, minResources, Optional.empty(), Optional.empty());
+    KubernetesRuntimeFactory createKubernetesRuntimeFactory(String extraDepsDir, Resources minResources,
+                                                            Resources maxResources) throws Exception {
+        return createKubernetesRuntimeFactory(extraDepsDir, minResources, maxResources, Optional.empty(), Optional.empty());
     }
 
     KubernetesRuntimeFactory createKubernetesRuntimeFactory(String extraDepsDir,
                                                             Resources minResources,
+                                                            Resources maxResources,
                                                             Optional<FunctionAuthProvider> functionAuthProvider,
                                                             Optional<RuntimeCustomizer> manifestCustomizer) throws Exception {
         KubernetesRuntimeFactory factory = spy(new KubernetesRuntimeFactory());
@@ -179,6 +181,7 @@ public class KubernetesRuntimeFactoryTest {
                 ObjectMapperFactory.getThreadLocal().convertValue(kubernetesRuntimeFactoryConfig, Map.class));
 
         workerConfig.setFunctionInstanceMinResources(minResources);
+        workerConfig.setFunctionInstanceMaxResources(maxResources);
         workerConfig.setStateStorageServiceUrl(null);
         workerConfig.setAuthenticationEnabled(false);
 
@@ -198,14 +201,14 @@ public class KubernetesRuntimeFactoryTest {
 
     @Test
     public void testAdmissionChecks() throws Exception {
-        factory = createKubernetesRuntimeFactory(null, null);
+        factory = createKubernetesRuntimeFactory(null, null, null);
         FunctionDetails functionDetails = createFunctionDetails();
         factory.doAdmissionChecks(functionDetails);
     }
 
     @Test
     public void testValidateMinResourcesRequired() throws Exception {
-        factory = createKubernetesRuntimeFactory(null, null);
+        factory = createKubernetesRuntimeFactory(null, null, null);
 
         FunctionDetails functionDetailsBase = createFunctionDetails();
 
@@ -228,8 +231,48 @@ public class KubernetesRuntimeFactoryTest {
         testMinResource(null, 512L, true, "Per instance CPU requested, 0.0, for function is less than the minimum required, 0.1");
     }
 
+    @Test
+    public void testValidateMaxResourcesRequired() throws Exception {
+        factory = createKubernetesRuntimeFactory(null, null, null);
+
+        FunctionDetails functionDetailsBase = createFunctionDetails();
+
+        // max resources are not set
+        try {
+            factory.validateMaxResourcesRequired(functionDetailsBase);
+        } catch (Exception e) {
+            fail();
+        }
+
+        testMaxResource(0.2, 2048L, false, null);
+        testMaxResource(1.00, 2048L, false, null);
+        testMaxResource(1.01, 512L, true, "Per instance CPU requested, 1.01, for function is greater than the maximum required, 1.0");
+        testMaxResource(1.00, 2049L, true, "Per instance RAM requested, 2049, for function is greater than the maximum required, 2048");
+
+        testMaxResource(null, null, false, null);
+        testMaxResource(0.2, null, false, null);
+        testMaxResource(null, 2048L, false, null);
+        testMaxResource(1.05, null, true, "Per instance CPU requested, 1.05, for function is greater than the maximum required, 1.0");
+        testMaxResource(null, 3072L, true, "Per instance RAM requested, 3072, for function is greater than the maximum required, 2048");
+    }
+
+    @Test
+    public void testValidateMinMaxResourcesRequired() throws Exception {
+        testMinMaxResource(0.1, 1024L, false, null);
+        testMinMaxResource(0.2, 1536L, false, null);
+        testMinMaxResource(1.00, 2048L, false, null);
+
+        testMinMaxResource(1.01, 1024L, true, "Per instance CPU requested, 1.01, for function is greater than the maximum required, 1.0");
+        testMinMaxResource(1.00, 2049L, true, "Per instance RAM requested, 2049, for function is greater than the maximum required, 2048");
+        testMinMaxResource(0.05, 2048L, true, "Per instance CPU requested, 0.05, for function is less than the minimum required, 0.1");
+        testMinMaxResource(0.2, 512L, true, "Per instance RAM requested, 512, for function is less than the minimum required, 1024");
+
+        testMinMaxResource(null, null, true, "Per instance CPU requested, 0.0, for function is less than the minimum required, 0.1");
+        testMinMaxResource(0.2, null, true, "Per instance RAM requested, 0, for function is less than the minimum required, 1024");
+    }
+
     public void testAuthProvider(Optional<FunctionAuthProvider> authProvider) throws Exception {
-        factory = createKubernetesRuntimeFactory(null, null, authProvider, Optional.empty());
+        factory = createKubernetesRuntimeFactory(null, null, null, authProvider, Optional.empty());
     }
 
 
@@ -311,8 +354,22 @@ public class KubernetesRuntimeFactoryTest {
     }
 
     private void testMinResource(Double cpu, Long ram, boolean fail, String failError) throws Exception {
+        testResourceRestrictions(cpu, ram, Resources.builder().cpu(0.1).ram(1024L).build(), null, fail, failError);
+    }
 
-        factory = createKubernetesRuntimeFactory(null, Resources.builder().cpu(0.1).ram(1024L).build());
+    private void testMaxResource(Double cpu, Long ram, boolean fail, String failError) throws Exception {
+        testResourceRestrictions(cpu, ram, null, Resources.builder().cpu(1.0).ram(2048L).build(), fail, failError);
+    }
+
+    private void testMinMaxResource(Double cpu, Long ram, boolean fail, String failError) throws Exception {
+        testResourceRestrictions(cpu, ram, Resources.builder().cpu(0.1).ram(1024L).build(),
+                Resources.builder().cpu(1.0).ram(2048L).build(), fail, failError);
+    }
+
+    private void testResourceRestrictions(Double cpu, Long ram, Resources minResources, Resources maxResources,
+                                          boolean fail, String failError) throws Exception {
+
+        factory = createKubernetesRuntimeFactory(null, minResources, maxResources);
         FunctionDetails functionDetailsBase = createFunctionDetails();
 
         Function.Resources.Builder resources = Function.Resources.newBuilder();
@@ -330,7 +387,7 @@ public class KubernetesRuntimeFactoryTest {
         }
 
         try {
-            factory.validateMinResourcesRequired(functionDetails);
+            factory.doAdmissionChecks(functionDetails);
             if (fail) fail();
         } catch (IllegalArgumentException e) {
             if (!fail) fail();

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/worker/WorkerApiV2ResourceConfigTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/worker/WorkerApiV2ResourceConfigTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.worker;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import java.net.URL;
@@ -89,4 +90,23 @@ public class WorkerApiV2ResourceConfigTest {
         assertEquals(emptyOverrideWc.getFunctionAuthProviderClassName(),"org.apache.my.overridden.auth");
     }
 
+    @Test
+    public void testLoadResourceRestrictionsConfig() throws Exception {
+        URL emptyUrl = getClass().getClassLoader().getResource("test_worker_config.yml");
+        WorkerConfig emptyWc = WorkerConfig.load(emptyUrl.toURI().getPath());
+        assertNull(emptyWc.getFunctionInstanceMinResources());
+        assertNull(emptyWc.getFunctionInstanceMaxResources());
+
+        URL newK8SUrl = getClass().getClassLoader().getResource("test_worker_k8s_resource_config.yml");
+        WorkerConfig newK8SWc = WorkerConfig.load(newK8SUrl.toURI().getPath());
+        assertNotNull(newK8SWc.getFunctionInstanceMinResources());
+        assertEquals(newK8SWc.getFunctionInstanceMinResources().getCpu(), 0.5, 0.001);
+        assertEquals(newK8SWc.getFunctionInstanceMinResources().getRam().longValue(), 1073741824L);
+        assertEquals(newK8SWc.getFunctionInstanceMinResources().getDisk().longValue(), 10737418240L);
+
+        assertNotNull(newK8SWc.getFunctionInstanceMaxResources());
+        assertEquals(newK8SWc.getFunctionInstanceMaxResources().getCpu(), 16.0, 0.001);
+        assertEquals(newK8SWc.getFunctionInstanceMaxResources().getRam().longValue(), 17179869184L);
+        assertEquals(newK8SWc.getFunctionInstanceMaxResources().getDisk().longValue(), 107374182400L);
+    }
 }

--- a/pulsar-functions/runtime/src/test/resources/test_worker_k8s_resource_config.yml
+++ b/pulsar-functions/runtime/src/test/resources/test_worker_k8s_resource_config.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+workerId: test-worker
+workerPort: 7654
+pulsarServiceUrl: pulsar://localhost:6650
+functionMetadataTopicName: test-function-metadata-topic
+numFunctionPackageReplicas: 3
+functionRuntimeFactoryClassName: "org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory"
+
+functionInstanceMinResources:
+  cpu: 0.5
+  ram: 1073741824
+  disk: 10737418240
+
+functionInstanceMaxResources:
+  cpu: 16
+  ram: 17179869184
+  disk: 107374182400


### PR DESCRIPTION
### Motivation

The pulsar cluster may not allow users to request an arbitrary amount of resources for functions for various reasons, like quotas, limited physical resources, etc. And it's better to check the function creation requests and explicitly reject those of which the resources requested are greater than allowed.

### Modifications

Add a worker config to set the maximum amount of resource a function must request

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added unit tests to verify the configurations and checks.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

A sample configuration has been added to `conf/functions_worker.yml`.
