### PR TITLE
[broker] Fix NPE that occurs in PersistentStickyKeyDispatcherMultipleConsumers when debug log is enabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -181,7 +181,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     maxMessagesForC, readType);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] select consumer {} with messages num {}, read type is {}",
-                        name, consumer.consumerName(), messagesForC, readType);
+                        name, consumer == null ? "null" : consumer.consumerName(), messagesForC, readType);
             }
 
             if (messagesForC < entriesWithSameKeyCount) {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/8969 fixed an issue where NPE could occur in `PersistentStickyKeyDispatcherMultipleConsumers`. However, if the log level is debug, I think NPE will occur in the following part as well:
https://github.com/apache/pulsar/blob/2fd878a8f4bfdd5cffa7fa6450714ec1ad25f514/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L183-L184

### Modifications

If `consumer` is null, "null" will be output to the log as the consumer name.