### PR TITLE
Fix writing/encoding of GenericJsonRecord

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonWriter.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonWriter.java
@@ -19,11 +19,10 @@
 package org.apache.pulsar.client.impl.schema.generic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaWriter;
-
-import java.io.IOException;
 
 public class GenericJsonWriter implements SchemaWriter<GenericRecord> {
 
@@ -36,7 +35,7 @@ public class GenericJsonWriter implements SchemaWriter<GenericRecord> {
     @Override
     public byte[] write(GenericRecord message) {
         try {
-            return objectMapper.writeValueAsBytes(((GenericJsonRecord)message).getJsonNode().toString());
+            return objectMapper.writeValueAsBytes(((GenericJsonRecord)message).getJsonNode());
         } catch (IOException ioe) {
             throw new SchemaSerializationException(ioe);
         }


### PR DESCRIPTION
Fixes #9605

### Motivation

See #9605 

### Modifications

- Pass the `JsonNode` object directly to Jackson's ObjectMapper.writeValueAsBytes method instead of calling `.toString()` on the `JsonNode` value.
- This bug was in GenericJsonWriter. However since there wasn't similar test coverage for JSONSchema.encode, some test coverage was added for JSONSchema.encode/decode in this same PR.