### PR TITLE
Add Java 11 to Pulsar Build image and upgrade dependencies

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN git clone https://github.com/google/protobuf.git /pulsar/protobuf && \
 # Installation
 ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_FILENAME="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+ARG MAVEN_HOME=/opt/maven
 ARG MAVEN_URL="http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_FILENAME}"
 ARG MAVEN_TMP="/tmp/${MAVEN_FILENAME}"
 RUN wget --no-verbose -O ${MAVEN_TMP} ${MAVEN_URL} 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -24,11 +24,14 @@ RUN mkdir /pulsar
 ADD protobuf.patch /pulsar
 
 RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:openjdk-r/ppa && \
+    apt-get update && \
     apt-get install -y tig g++ cmake libssl-dev libcurl4-openssl-dev \
                 liblog4cxx-dev libprotobuf-dev libboost-all-dev google-mock libgtest-dev \
                 libjsoncpp-dev libxml2-utils protobuf-compiler wget \
-                curl doxygen openjdk-8-jdk-headless clang-format-5.0 \
-                gnupg2 golang-1.10-go zip unzip libzstd-dev libsnappy-dev
+                curl doxygen openjdk-8-jdk-headless openjdk-11-jdk-headless clang-format-5.0 \
+                gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib
@@ -40,6 +43,7 @@ RUN cd /usr/src/gmock && cmake . && make && cp libgmock.a /usr/lib
 RUN git clone https://github.com/google/gtest-parallel.git
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV JAVA_HOME_11=/usr/lib/jvm/java-1.11.0-openjdk-amd64
 
 ## Website build dependencies
 
@@ -62,12 +66,11 @@ RUN wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
 RUN dpkg -i crowdin.deb
 
 # Install PIP and PDoc
-RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
-RUN pip install pdoc
+RUN pip3 install pdoc
 
 # Install Protobuf doc generator (requires Go)
 ENV GOPATH "$HOME/go"
-ENV PATH "/usr/lib/go-1.10/bin:$GOPATH/bin:$PATH"
+ENV PATH "/usr/lib/go-1.13/bin:$GOPATH/bin:$PATH"
 RUN go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 
 # Build the patched protoc
@@ -80,6 +83,7 @@ RUN git clone https://github.com/google/protobuf.git /pulsar/protobuf && \
     make
 
 # Installation
+ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_FILENAME="apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 ARG MAVEN_URL="http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_FILENAME}"
 ARG MAVEN_TMP="/tmp/${MAVEN_FILENAME}"


### PR DESCRIPTION
- add Java 11
- remove Java 8
- set Default Maven version to 3.6.3
- add Python3/Pip3
- upgrade Go to 1.13

I had to upgrade Go to 1.13, otherwise the build of the image would fail with this error
https://github.com/golang/go/issues/34202

I had to set the MAVEN_VERSION ARG in order to allow the build to pass
