### PR TITLE
[pulsar-functions] move metricsPort to InstanceConfig

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -43,6 +43,7 @@ public class InstanceConfig {
     // Whether the pulsar admin client exposed to function context, default is disabled.
     @Getter
     private boolean exposePulsarAdminClientEnabled = false;
+    private int metricsPort;
 
     /**
      * Get the string representation of {@link #getInstanceId()}.
@@ -55,5 +56,9 @@ public class InstanceConfig {
 
     public FunctionDetails getFunctionDetails() {
         return functionDetails;
+    }
+
+    public boolean hasValidMetricsPort() {
+        return metricsPort > 0 && metricsPort < 65536;
     }
 }

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -417,6 +417,7 @@ public class LocalRunner {
                 instanceConfig.setInstanceId(i + instanceIdOffset);
                 instanceConfig.setMaxBufferedTuples(1024);
                 instanceConfig.setPort(FunctionCommon.findAvailablePort());
+                instanceConfig.setMetricsPort(FunctionCommon.findAvailablePort());
                 instanceConfig.setClusterName("local");
                 if (functionConfig != null) {
                     instanceConfig.setMaxPendingAsyncRequests(functionConfig.getMaxPendingAsyncRequests());
@@ -499,6 +500,7 @@ public class LocalRunner {
             instanceConfig.setInstanceId(i + instanceIdOffset);
             instanceConfig.setMaxBufferedTuples(1024);
             instanceConfig.setPort(FunctionCommon.findAvailablePort());
+            instanceConfig.setMetricsPort(FunctionCommon.findAvailablePort());
             instanceConfig.setClusterName("local");
             if (functionConfig != null) {
                 instanceConfig.setMaxPendingAsyncRequests(functionConfig.getMaxPendingAsyncRequests());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
@@ -173,6 +173,7 @@ public class JavaInstanceStarter implements AutoCloseable {
         Function.FunctionDetails functionDetails = functionDetailsBuilder.build();
         instanceConfig.setFunctionDetails(functionDetails);
         instanceConfig.setPort(port);
+        instanceConfig.setMetricsPort(metrics_port);
 
         Map<String, String> secretsProviderConfigMap = null;
         if (!StringUtils.isEmpty(secretsProviderConfig)) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -70,7 +70,6 @@ public class RuntimeUtils {
                                           Boolean installUserCodeDependencies,
                                           String pythonDependencyRepository,
                                           String pythonExtraDependencyRepository,
-                                          int metricsPort,
                                           String narExtractionDirectory,
                                           String functionInstanceClassPath,
                                           String pulsarWebServiceUrl) throws Exception {
@@ -82,7 +81,7 @@ public class RuntimeUtils {
                 authConfig, shardId, grpcPort, expectedHealthCheckInterval,
                 logConfigFile, secretsProviderClassName, secretsProviderConfig,
                 installUserCodeDependencies, pythonDependencyRepository,
-                pythonExtraDependencyRepository, metricsPort, narExtractionDirectory,
+                pythonExtraDependencyRepository, narExtractionDirectory,
                 functionInstanceClassPath, false, pulsarWebServiceUrl));
         return cmd;
     }
@@ -120,8 +119,7 @@ public class RuntimeUtils {
     public static List<String> getGoInstanceCmd(InstanceConfig instanceConfig,
                                                 String originalCodeFileName,
                                                 String pulsarServiceUrl,
-                                                boolean k8sRuntime,
-                                                int metricsPort) throws IOException {
+                                                boolean k8sRuntime) throws IOException {
         final List<String> args = new LinkedList<>();
         GoInstanceConfig goInstanceConfig = new GoInstanceConfig();
 
@@ -221,8 +219,8 @@ public class RuntimeUtils {
             goInstanceConfig.setMaxMessageRetries(instanceConfig.getFunctionDetails().getRetryDetails().getMaxMessageRetries());
         }
 
-        if (metricsPort > 0 && metricsPort < 65536) {
-            goInstanceConfig.setMetricsPort(metricsPort);
+        if (instanceConfig.getMetricsPort() > 0 && instanceConfig.getMetricsPort() < 65536) {
+            goInstanceConfig.setMetricsPort(instanceConfig.getMetricsPort());
         }
 
         goInstanceConfig.setKillAfterIdleMs(0);
@@ -260,7 +258,6 @@ public class RuntimeUtils {
                                       Boolean installUserCodeDependencies,
                                       String pythonDependencyRepository,
                                       String pythonExtraDependencyRepository,
-                                      int metricsPort,
                                       String narExtractionDirectory,
                                       String functionInstanceClassPath,
                                       boolean k8sRuntime,
@@ -268,7 +265,7 @@ public class RuntimeUtils {
         final List<String> args = new LinkedList<>();
 
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.GO) {
-            return getGoInstanceCmd(instanceConfig, originalCodeFileName, pulsarServiceUrl, k8sRuntime, metricsPort);
+            return getGoInstanceCmd(instanceConfig, originalCodeFileName, pulsarServiceUrl, k8sRuntime);
         }
 
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {
@@ -398,7 +395,7 @@ public class RuntimeUtils {
         args.add(String.valueOf(grpcPort));
 
         args.add("--metrics_port");
-        args.add(String.valueOf(metricsPort));
+        args.add(String.valueOf(instanceConfig.getMetricsPort()));
 
         // state storage configs
         if (null != stateStorageServiceUrl) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -219,7 +219,7 @@ public class RuntimeUtils {
             goInstanceConfig.setMaxMessageRetries(instanceConfig.getFunctionDetails().getRetryDetails().getMaxMessageRetries());
         }
 
-        if (instanceConfig.getMetricsPort() > 0 && instanceConfig.getMetricsPort() < 65536) {
+        if (instanceConfig.hasValidMetricsPort()) {
             goInstanceConfig.setMetricsPort(instanceConfig.getMetricsPort());
         }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -189,7 +189,6 @@ public class KubernetesRuntime implements Runtime {
                       Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider,
                       boolean authenticationEnabled,
                       Integer grpcPort,
-                      Integer metricsPort,
                       String narExtractionDirectory,
                       Optional<KubernetesManifestCustomizer> manifestCustomizer,
                       String functinoInstanceClassPath,
@@ -238,7 +237,7 @@ public class KubernetesRuntime implements Runtime {
         this.functionAuthDataCacheProvider = functionAuthDataCacheProvider;
 
         this.grpcPort = grpcPort;
-        this.metricsPort = metricsPort;
+        this.metricsPort = instanceConfig.hasValidMetricsPort() ? instanceConfig.getMetricsPort() : null;
         this.narExtractionDirectory = narExtractionDirectory;
 
         this.processArgs = new LinkedList<>();
@@ -275,7 +274,6 @@ public class KubernetesRuntime implements Runtime {
                         installUserCodeDependencies,
                         pythonDependencyRepository,
                         pythonExtraDependencyRepository,
-                        metricsPort,
                         narExtractionDirectory,
                         functinoInstanceClassPath,
                         true,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
@@ -317,7 +317,6 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             authProvider,
             authenticationEnabled,
             grpcPort,
-            metricsPort,
             narExtractionDirectory,
             manifestCustomizer,
             functionInstanceClassPath,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -91,7 +91,7 @@ class ProcessRuntime implements Runtime {
                    String pulsarWebServiceUrl) throws Exception {
         this.instanceConfig = instanceConfig;
         this.instancePort = instanceConfig.getPort();
-        this.metricsPort = FunctionCommon.findAvailablePort();
+        this.metricsPort = instanceConfig.getMetricsPort();
         this.expectedHealthCheckInterval = expectedHealthCheckInterval;
         this.secretsProviderConfigurator = secretsProviderConfigurator;
         this.funcLogDir = RuntimeUtils.genFunctionLogFolder(logDirectory, instanceConfig);
@@ -134,7 +134,6 @@ class ProcessRuntime implements Runtime {
             false,
             null,
             null,
-                this.metricsPort,
                 narExtractionDirectory,
                 null,
                 pulsarWebServiceUrl);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -65,6 +65,7 @@ public class RuntimeUtilsTest {
         instanceConfig.setFunctionVersion("1.0.0");
         instanceConfig.setMaxBufferedTuples(5);
         instanceConfig.setPort(1337);
+        instanceConfig.setMetricsPort(60000);
 
 
         JSONObject userConfig = new JSONObject();
@@ -108,7 +109,7 @@ public class RuntimeUtilsTest {
 
         instanceConfig.setFunctionDetails(functionDetails);
 
-        List<String> commands = RuntimeUtils.getGoInstanceCmd(instanceConfig, "config", "pulsar://localhost:6650", k8sRuntime, 60000);
+        List<String> commands = RuntimeUtils.getGoInstanceCmd(instanceConfig, "config", "pulsar://localhost:6650", k8sRuntime);
         if (k8sRuntime) {
             goInstanceConfig = new ObjectMapper().readValue(commands.get(2).replaceAll("^\'|\'$", ""), HashMap.class);
         } else {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -876,6 +876,7 @@ public class KubernetesRuntimeTest {
         config.setInstanceId(0);
         config.setMaxBufferedTuples(1024);
         config.setClusterName("standalone");
+        config.setMetricsPort(4331);
 
         return config;
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -184,6 +184,7 @@ public class FunctionActioner {
         instanceConfig.setInstanceId(instanceId);
         instanceConfig.setMaxBufferedTuples(1024);
         instanceConfig.setPort(FunctionCommon.findAvailablePort());
+        instanceConfig.setMetricsPort(FunctionCommon.findAvailablePort());
         instanceConfig.setClusterName(clusterName);
         instanceConfig.setFunctionAuthenticationSpec(functionAuthSpec);
         instanceConfig.setMaxPendingAsyncRequests(workerConfig.getMaxPendingAsyncRequests());


### PR DESCRIPTION
Master Issue: #9177

### Motivation

As discussed in #9318, both @zymap and @wolfstudy suggested, to add `metricsPort` as a field of `InstanceConfig`.

### Modifications

- add `metricsPort` to `InstanceConfig`
- add `hasValidMetricsPort` to `InstanceConfig` to check if metrics port is valid
- applied changes to k8s runtime & process runtime

### Verifying this change

- [x] Make sure that the change passes the CI checks.