### PR TITLE
[Doc]Add namespace subscription-expiration-time operation doc on web page.

### DIFF
--- a/site2/website/versioned_docs/version-2.6.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-pulsar-admin.md
@@ -862,6 +862,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1349,6 +1351,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.6.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-pulsar-admin.md
@@ -1354,7 +1354,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1367,7 +1367,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash

--- a/site2/website/versioned_docs/version-2.6.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-pulsar-admin.md
@@ -862,6 +862,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1349,6 +1351,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.6.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-pulsar-admin.md
@@ -1354,7 +1354,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1367,7 +1367,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash

--- a/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
@@ -1363,7 +1363,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1376,7 +1376,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash

--- a/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-pulsar-admin.md
@@ -863,6 +863,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1358,6 +1360,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.6.3/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-pulsar-admin.md
@@ -1363,7 +1363,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1376,7 +1376,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash

--- a/site2/website/versioned_docs/version-2.6.3/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-pulsar-admin.md
@@ -863,6 +863,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1358,6 +1360,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
@@ -866,6 +866,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1362,6 +1364,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-pulsar-admin.md
@@ -1367,7 +1367,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1380,7 +1380,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash

--- a/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
@@ -869,6 +869,8 @@ Subcommands
 * `get-subscribe-rate`
 * `set-subscription-dispatch-rate`
 * `get-subscription-dispatch-rate`
+* `set-subscription-expiration-time`
+* `get-subscription-expiration-time`
 * `clear-backlog`
 * `unsubscribe`
 * `set-encryption-required`
@@ -1365,6 +1367,27 @@ Get subscription configured message-dispatch-rate for all topics of the namespac
 Usage
 ```bash
 $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
+```
+
+### `set-subscription-expiration-time`
+Set subscription expiration time in minutes for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces set-subscription-expiration-time tenant/namespace options
+```
+
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-t`, `--time`|Subscription expiration time in minutes|0|
+
+### `get-subscription-expiration-time`
+Get subscription expiration time for a namespace
+
+Usage
+```bash
+$ pulsar-admin namespaces get-subscription-expiration-time tenant/namespace
 ```
 
 ### `clear-backlog`

--- a/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-pulsar-admin.md
@@ -1370,7 +1370,7 @@ $ pulsar-admin namespaces get-subscription-dispatch-rate tenant/namespace
 ```
 
 ### `set-subscription-expiration-time`
-Set subscription expiration time in minutes for a namespace
+Set the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash
@@ -1383,7 +1383,7 @@ Options
 |`-t`, `--time`|Subscription expiration time in minutes|0|
 
 ### `get-subscription-expiration-time`
-Get subscription expiration time for a namespace
+Get the subscription expiration time for a namespace (in minutes).
 
 Usage
 ```bash


### PR DESCRIPTION
Fixes #9599 

### Motivation

Namespaces set-subscription-expiration-time and get-subscription-expiration-time operations are not documented on web page

### Modifications

Add namespace subscription-expiration-time operation doc on web page.
