### PR TITLE
[WIP]Evict usage of ManagedLedgerImpl in ManagedLedgerFactoryImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -20,11 +20,9 @@ package org.apache.bookkeeper.mledger;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Range;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
@@ -233,6 +231,8 @@ public interface ManagedCursor {
      * @return true if there are pending entries to read, false otherwise
      */
     boolean hasMoreEntries();
+
+    boolean hasMoreEntries(PositionImpl position);
 
     /**
      * Return the number of messages that this cursor still has to read.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -393,6 +393,8 @@ public interface ManagedLedger {
 
     boolean ledgerExists(long ledgerId);
 
+    void asyncDeleteLedgerFromBookKeeper(long ledgerId);
+
     /**
      * Get the total number of active entries for this managed ledger.
      *

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger;
 
 import java.util.function.Supplier;
-
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -113,7 +112,9 @@ public interface ManagedLedgerFactory {
      * @param ctx
      */
     void asyncOpenReadOnlyCursor(String managedLedgerName, Position startPosition, ManagedLedgerConfig config,
-            OpenReadOnlyCursorCallback callback, Object ctx);
+                                 OpenReadOnlyCursorCallback callback, Object ctx);
+
+    void close(ManagedLedger ledger);
 
     /**
      * Get the current metadata info for a managed ledger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -76,6 +76,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.SkipEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedger.PositionBound;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -83,7 +84,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NoMoreEntriesToReadException;
-import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
@@ -582,7 +582,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     public void asyncReadEntries(int restNumOfEntries, long restMaxSizeBytes, ReadEntriesCallback callback,
                                  Object ctx, PositionImpl maxPosition, List<Entry> alreadyRead) {
-        checkArgument(restNumOfEntries > 0);
+        checkArgument(restNumOfEntries >= 0);
         if (isClosed()) {
             callback.readEntriesFailed(new ManagedLedgerException("Cursor was already closed"), ctx);
             return;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -482,7 +482,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         });
     }
 
-    void close(ManagedLedger ledger) {
+    public void close(ManagedLedger ledger) {
         // Remove the ledger from the internal factory cache
         ledgers.remove(ledger.getName());
         entryCacheManager.removeEntryCache(ledger.getName());

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2946,15 +2946,16 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                                                                        * identify offloader
                                                                                        */
             Map<String, String> offloadDriverMetadata, String cleanupReason) {
+        offloadDriverMetadata.put("ManagedLedgerName", name);
         Retries.run(Backoff.exponentialJittered(TimeUnit.SECONDS.toMillis(1), TimeUnit.SECONDS.toHours(1)).limit(10),
                 Retries.NonFatalPredicate,
                 () -> config.getLedgerOffloader().deleteOffloaded(ledgerId, uuid, offloadDriverMetadata),
                 scheduledExecutor, name).whenComplete((ignored, exception) -> {
-                    if (exception != null) {
-                        log.warn("Error cleaning up offload for {}, (cleanup reason: {})", ledgerId, cleanupReason,
-                                exception);
-                    }
-                });
+            if (exception != null) {
+                log.warn("Error cleaning up offload for {}, (cleanup reason: {})", ledgerId, cleanupReason,
+                        exception);
+            }
+        });
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2521,7 +2521,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    private void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
+    protected void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
         asyncDeleteLedger(ledgerId, DEFAULT_LEDGER_DELETE_RETRIES);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2521,7 +2521,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    protected void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
+    public void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
         asyncDeleteLedger(ledgerId, DEFAULT_LEDGER_DELETE_RETRIES);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -19,21 +19,21 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import com.google.common.base.Predicate;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
-
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-
+import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedger.PositionBound;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 
 @Slf4j
 class OpFindNewest implements ReadEntryCallback {
-    private final ManagedCursorImpl cursor;
-    private final ManagedLedgerImpl ledger;
+    private final ManagedCursor cursor;
+    private final ManagedLedger ledger;
     private final PositionImpl startPosition;
     private final FindEntryCallback callback;
     private final Predicate<Entry> condition;
@@ -49,10 +49,10 @@ class OpFindNewest implements ReadEntryCallback {
     Position lastMatchedPosition = null;
     State state;
 
-    public OpFindNewest(ManagedCursorImpl cursor, PositionImpl startPosition, Predicate<Entry> condition,
-            long numberOfEntries, FindEntryCallback callback, Object ctx) {
+    public OpFindNewest(ManagedCursor cursor, PositionImpl startPosition, Predicate<Entry> condition,
+                        long numberOfEntries, FindEntryCallback callback, Object ctx) {
         this.cursor = cursor;
-        this.ledger = cursor.ledger;
+        this.ledger = cursor.getManagedLedger();
         this.startPosition = startPosition;
         this.callback = callback;
         this.condition = condition;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -19,14 +19,12 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import com.google.common.collect.Range;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedLedger.PositionBound;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ReadOnlyCursor;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 
 @Slf4j

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -91,6 +90,11 @@ public class ManagedCursorContainerTest {
         @Override
         public boolean hasMoreEntries() {
             return true;
+        }
+
+        @Override
+        public boolean hasMoreEntries(PositionImpl position) {
+            return false;
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
@@ -19,22 +19,13 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.testng.Assert.assertEquals;
-
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo.CursorInfo;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo.MessageRangeInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
-import org.apache.bookkeeper.test.ZooKeeperUtil;
-import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class ManagedLedgerFactoryTest extends MockedBookKeeperTestCase {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -102,7 +102,15 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         };
 
         this.managedLedgerFactory =
-                new ManagedLedgerFactoryImpl(bkFactory, zkClient, managedLedgerFactoryConfig, statsLogger);
+                createManagedLedgerFactory(zkClient, managedLedgerFactoryConfig, statsLogger, bkFactory);
+    }
+
+    protected ManagedLedgerFactoryImpl
+    createManagedLedgerFactory(ZooKeeper zkClient,
+                               ManagedLedgerFactoryConfig managedLedgerFactoryConfig,
+                               StatsLogger statsLogger,
+                               BookkeeperFactoryForCustomEnsemblePlacementPolicy bkFactory) throws Exception {
+        return new ManagedLedgerFactoryImpl(bkFactory, zkClient, managedLedgerFactoryConfig, statsLogger);
     }
 
     public ManagedLedgerFactory getManagedLedgerFactory() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -53,12 +53,12 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerOfflineBacklog;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.StringUtils;
@@ -2193,7 +2193,7 @@ public class PersistentTopicsBase extends AdminResource {
                                    MessageIdImpl messageId, int batchIndex) {
         if (batchIndex >= 0) {
             try {
-                ManagedLedgerImpl ledger = (ManagedLedgerImpl) topic.getManagedLedger();
+                ManagedLedger ledger = topic.getManagedLedger();
                 ledger.asyncReadEntry(new PositionImpl(messageId.getLedgerId(),
                         messageId.getEntryId()), new AsyncCallbacks.ReadEntryCallback() {
                     @Override
@@ -2278,7 +2278,7 @@ public class PersistentTopicsBase extends AdminResource {
             // will redirect if the topic not owned by current broker
             validateReadOperationOnTopic(authoritative);
             PersistentTopic topic = (PersistentTopic) getTopicReference(topicName);
-            ManagedLedgerImpl ledger = (ManagedLedgerImpl) topic.getManagedLedger();
+            ManagedLedger ledger = topic.getManagedLedger();
             ledger.asyncReadEntry(new PositionImpl(ledgerId, entryId), new AsyncCallbacks.ReadEntryCallback() {
                 @Override
                 public void readEntryFailed(ManagedLedgerException exception, Object ctx) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -132,7 +132,7 @@ public class BacklogQuotaManager {
 
         // Get estimated unconsumed size for the managed ledger associated with this topic. Estimated size is more
         // useful than the actual storage size. Actual storage size gets updated only when managed ledger is trimmed.
-        ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedLedger mLedger = persistentTopic.getManagedLedger();
         long backlogSize = mLedger.getEstimatedBacklogSize();
 
         if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -48,9 +48,9 @@ import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.commons.lang3.StringUtils;
@@ -1604,7 +1604,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             String subscriptionName) {
 
         PersistentTopic persistentTopic = (PersistentTopic) topic;
-        ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedLedger ml = persistentTopic.getManagedLedger();
 
         // If it's not pointing to a valid entry, respond messageId of the current position.
         if (lastPosition.getEntryId() == -1) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -949,6 +949,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     }
 
                                     if (schema != null) {
+                                        log.info("subscribe with schema {}", schema);
                                         return topic.addSchemaIfIdleOrCheckCompatible(schema)
                                                 .thenCompose(v -> topic.subscribe(
                                                         ServerCnx.this, subscriptionName, consumerId,
@@ -957,6 +958,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                         readCompacted, initialPosition, startMessageRollbackDurationSec,
                                                         isReplicated, keySharedMeta));
                                     } else {
+                                        log.info("subscribe with out schema");
                                         return topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                             subType, priorityLevel, consumerName, isDurable,
                                             startMessageId, metadata, readCompacted, initialPosition,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -338,7 +337,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         PositionImpl mdp = (PositionImpl) cursor.getMarkDeletedPosition();
         if (mdp != null) {
             PositionImpl nextPositionOfTheMarkDeletePosition =
-                    ((ManagedLedgerImpl) cursor.getManagedLedger()).getNextValidPosition(mdp);
+                    cursor.getManagedLedger().getNextValidPosition(mdp);
             while (itr.hasNext()) {
                 Map.Entry<Consumer, PositionImpl> entry = itr.next();
                 if (entry.getValue().compareTo(nextPositionOfTheMarkDeletePosition) <= 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
@@ -26,7 +26,6 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.pulsar.broker.service.Consumer;
@@ -88,7 +87,7 @@ public class PersistentStreamingDispatcherMultipleConsumers extends PersistentDi
             log.debug("[{}] Distributing a messages to {} consumers", name, consumerList.size());
         }
 
-        cursor.seek(((ManagedLedgerImpl) cursor.getManagedLedger())
+        cursor.seek(cursor.getManagedLedger()
                 .getNextValidPosition((PositionImpl) entry.getPosition()));
         sendMessagesToConsumers(readType, Lists.newArrayList(entry));
         ctx.recycle();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherSingleActiveConsumer.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.pulsar.broker.service.Consumer;
@@ -163,7 +162,7 @@ public class PersistentStreamingDispatcherSingleActiveConsumer extends Persisten
             filterEntriesForConsumer(Lists.newArrayList(entry), batchSizes, sendMessageInfo, batchIndexesAcks,
                     cursor, false);
             // Update cursor's read position.
-            cursor.seek(((ManagedLedgerImpl) cursor.getManagedLedger())
+            cursor.seek(cursor.getManagedLedger()
                     .getNextValidPosition((PositionImpl) entry.getPosition()));
             dispatchEntriesToConsumer(currentConsumer, Lists.newArrayList(entry), batchSizes,
                     batchIndexesAcks, sendMessageInfo);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -36,12 +36,12 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ConcurrentFindCursorPositionException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.InvalidCursorPositionException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
@@ -380,7 +380,7 @@ public class PersistentSubscription implements Subscription {
 
     private void deleteTransactionMarker(PositionImpl position, AckType ackType, Map<String, Long> properties) {
         if (position != null) {
-            ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+            ManagedLedger managedLedger = cursor.getManagedLedger();
             PositionImpl nextPosition = managedLedger.getNextValidPosition(position);
             managedLedger.asyncReadEntry(nextPosition, new ReadEntryCallback() {
                 @Override
@@ -963,7 +963,7 @@ public class PersistentSubscription implements Subscription {
         }
         subStats.msgBacklog = getNumberOfEntriesInBacklog(getPreciseBacklog);
         if (subscriptionBacklogSize) {
-            subStats.backlogSize = ((ManagedLedgerImpl) topic.getManagedLedger())
+            subStats.backlogSize = topic.getManagedLedger()
                     .getEstimatedBacklogSize((PositionImpl) cursor.getMarkDeletedPosition());
         }
         subStats.msgBacklogNoDelayed = subStats.msgBacklog - subStats.msgDelayed;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -138,15 +138,18 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     @NotNull
     public CompletableFuture<SchemaVersion> putSchemaIfAbsent(String schemaId, SchemaData schema,
                                                               SchemaCompatibilityStrategy strategy) {
+        log.debug("call put schema if absent {} {} {}", schema, schema, strategy);
+
         return trimDeletedSchemaAndGetList(schemaId).thenCompose(schemaAndMetadataList ->
                 getSchemaVersionBySchemaData(schemaAndMetadataList, schema).thenCompose(schemaVersion -> {
-            if (schemaVersion != null) {
-                return CompletableFuture.completedFuture(schemaVersion);
-            }
-            CompletableFuture<Void> checkCompatibilityFuture = new CompletableFuture<>();
-            if (schemaAndMetadataList.size() != 0) {
-                if (isTransitiveStrategy(strategy)) {
-                    checkCompatibilityFuture = checkCompatibilityWithAll(schema, strategy, schemaAndMetadataList);
+                    if (schemaVersion != null) {
+                        return CompletableFuture.completedFuture(schemaVersion);
+                    }
+                    CompletableFuture<Void> checkCompatibilityFuture = new CompletableFuture<>();
+                    if (schemaAndMetadataList.size() != 0) {
+                        if (isTransitiveStrategy(strategy)) {
+                            checkCompatibilityFuture = checkCompatibilityWithAll(schema, strategy,
+                                    schemaAndMetadataList);
                 } else {
                     checkCompatibilityFuture = checkCompatibilityWithLatest(schemaId, schema, strategy);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
@@ -29,11 +29,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.WaitingEntryCallBack;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -95,7 +95,7 @@ public class StreamingEntryReader implements AsyncCallbacks.ReadEntryCallback, W
         }
 
         PositionImpl nextReadPosition = (PositionImpl) cursor.getReadPosition();
-        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) cursor.getManagedLedger();
+        ManagedLedger managedLedger = cursor.getManagedLedger();
         // Edge case, when a old ledger is full and new ledger is not yet opened, position can point to next
         // position of the last confirmed position, but it'll be an invalid position. So try to update the position.
         if (!managedLedger.isValidPosition(nextReadPosition)) {
@@ -272,9 +272,9 @@ public class StreamingEntryReader implements AsyncCallbacks.ReadEntryCallback, W
             // Jump again into dispatcher dedicated thread
             topic.getBrokerService().getTopicOrderedExecutor().executeOrdered(dispatcher.getName(),
                     SafeRun.safeRun(() -> {
-                ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) cursor.getManagedLedger();
-                managedLedger.asyncReadEntry(pendingReadEntryRequest.position, this, pendingReadEntryRequest);
-            }));
+                        ManagedLedger managedLedger = cursor.getManagedLedger();
+                        managedLedger.asyncReadEntry(pendingReadEntryRequest.position, this, pendingReadEntryRequest);
+                    }));
         }, delay, TimeUnit.MILLISECONDS);
     }
 
@@ -290,7 +290,7 @@ public class StreamingEntryReader implements AsyncCallbacks.ReadEntryCallback, W
             log.debug("[{}} Streaming entry reader get notification of newly added entries from managed ledger,"
                     + " trying to issued pending read requests.", cursor.getName());
         }
-        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) cursor.getManagedLedger();
+        ManagedLedger managedLedger = cursor.getManagedLedger();
         List<PendingReadEntryRequest> newlyIssuedRequests = new ArrayList<>();
         if (!pendingReads.isEmpty()) {
             // Edge case, when a old ledger is full and new ledger is not yet opened, position can point to next

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryMXBean;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -97,7 +97,7 @@ abstract class AbstractMetrics {
      *
      * @return
      */
-    protected Map<String, ManagedLedgerImpl> getManagedLedgers() {
+    protected Map<String, ManagedLedger> getManagedLedgers() {
         return ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getManagedLedgers();
     }
 
@@ -224,8 +224,8 @@ abstract class AbstractMetrics {
      * @param metrics
      * @param ledger
      */
-    protected void populateDimensionMap(Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimensionMap, Metrics metrics,
-            ManagedLedgerImpl ledger) {
+    protected void populateDimensionMap(Map<Metrics, List<ManagedLedger>> ledgersByDimensionMap, Metrics metrics,
+                                        ManagedLedger ledger) {
         if (!ledgersByDimensionMap.containsKey(metrics)) {
             // create new list
             ledgersByDimensionMap.put(metrics, Lists.newArrayList(ledger));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
@@ -25,9 +25,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
@@ -55,13 +54,12 @@ public class ManagedCursorMetrics extends AbstractMetrics {
      */
     private List<Metrics> aggregate() {
         metricsCollection.clear();
-        for (Map.Entry<String, ManagedLedgerImpl> e : getManagedLedgers().entrySet()) {
+        for (Map.Entry<String, ManagedLedger> e : getManagedLedgers().entrySet()) {
             String ledgerName = e.getKey();
-            ManagedLedgerImpl ledger = e.getValue();
+            ManagedLedger ledger = e.getValue();
             String namespace = parseNamespaceFromLedgerName(ledgerName);
 
-            ManagedCursorContainer cursorContainer = ledger.getCursors();
-            Iterator<ManagedCursor> cursorIterator = cursorContainer.iterator();
+            Iterator<ManagedCursor> cursorIterator = ledger.getCursors().iterator();
 
             while (cursorIterator.hasNext()) {
                 ManagedCursorImpl cursor = (ManagedCursorImpl) cursorIterator.next();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -23,16 +23,16 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
 public class ManagedLedgerMetrics extends AbstractMetrics {
 
     private List<Metrics> metricsCollection;
-    private Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimensionMap;
+    private Map<Metrics, List<ManagedLedger>> ledgersByDimensionMap;
     // temp map to prepare aggregation metrics
     private Map<String, Double> tempAggregatedMetricsMap;
 
@@ -57,20 +57,19 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
      * @param ledgersByDimension
      * @return
      */
-    private List<Metrics> aggregate(Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimension) {
-
+    private List<Metrics> aggregate(Map<Metrics, List<ManagedLedger>> ledgersByDimension) {
         metricsCollection.clear();
 
-        for (Entry<Metrics, List<ManagedLedgerImpl>> e : ledgersByDimension.entrySet()) {
+        for (Entry<Metrics, List<ManagedLedger>> e : ledgersByDimension.entrySet()) {
             Metrics metrics = e.getKey();
-            List<ManagedLedgerImpl> ledgers = e.getValue();
+            List<ManagedLedger> ledgers = e.getValue();
 
             // prepare aggregation map
             tempAggregatedMetricsMap.clear();
 
             // generate the collections by each metrics and then apply the aggregation
 
-            for (ManagedLedgerImpl ledger : ledgers) {
+            for (ManagedLedger ledger : ledgers) {
                 ManagedLedgerMXBean lStats = ledger.getStats();
 
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_AddEntryBytesRate",
@@ -134,17 +133,17 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
      *
      * @return
      */
-    private Map<Metrics, List<ManagedLedgerImpl>> groupLedgersByDimension() {
+    private Map<Metrics, List<ManagedLedger>> groupLedgersByDimension() {
 
         ledgersByDimensionMap.clear();
 
         // get the current topics statistics from StatsBrokerFilter
         // Map : topic-name->dest-stat
 
-        for (Entry<String, ManagedLedgerImpl> e : getManagedLedgers().entrySet()) {
+        for (Entry<String, ManagedLedger> e : getManagedLedgers().entrySet()) {
 
             String ledgerName = e.getKey();
-            ManagedLedgerImpl ledger = e.getValue();
+            ManagedLedger ledger = e.getValue();
 
             // we want to aggregate by NS dimension
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -21,9 +21,8 @@ package org.apache.pulsar.broker.stats;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
@@ -65,7 +64,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
             producer.send(message.getBytes());
         }
 
-        for (Entry<String, ManagedLedgerImpl> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+        for (Entry<String, ManagedLedger> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
                 .getManagedLedgers().entrySet()) {
             ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
             stats.refreshStats(1, TimeUnit.SECONDS);
@@ -78,7 +77,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        for (Entry<String, ManagedLedgerImpl> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+        for (Entry<String, ManagedLedger> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
                 .getManagedLedgers().entrySet()) {
             ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
             stats.refreshStats(1, TimeUnit.SECONDS);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -78,7 +78,7 @@ public class TopicName implements ServiceUnitId {
     }
 
     public static TopicName get(String domain, String tenant, String cluster, String namespace,
-            String topic) {
+                                String topic) {
         String name = domain + "://" + tenant + '/' + cluster + '/' + namespace + '/' + topic;
         return TopicName.get(name);
     }
@@ -113,11 +113,11 @@ public class TopicName implements ServiceUnitId {
                     completeTopicName = TopicDomain.persistent.name() + "://" + completeTopicName;
                 } else if (parts.length == 1) {
                     completeTopicName = TopicDomain.persistent.name() + "://"
-                        + PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE + "/" + parts[0];
+                            + PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE + "/" + parts[0];
                 } else {
                     throw new IllegalArgumentException(
-                        "Invalid short topic name '" + completeTopicName + "', it should be in the format of "
-                        + "<tenant>/<namespace>/<topic> or <topic>");
+                            "Invalid short topic name '" + completeTopicName + "', it should be in the format of "
+                                    + "<tenant>/<namespace>/<topic> or <topic>");
                 }
             }
 
@@ -169,11 +169,11 @@ public class TopicName implements ServiceUnitId {
         }
         if (isV2()) {
             this.completeTopicName = String.format("%s://%s/%s/%s",
-                                                   domain, tenant, namespacePortion, localName);
+                    domain, tenant, namespacePortion, localName);
         } else {
             this.completeTopicName = String.format("%s://%s/%s/%s/%s",
-                                                   domain, tenant, cluster,
-                                                   namespacePortion, localName);
+                    domain, tenant, cluster,
+                    namespacePortion, localName);
         }
     }
 
@@ -320,6 +320,32 @@ public class TopicName implements ServiceUnitId {
         }
     }
 
+    public static TopicName fromPersistenceNamingEncoding(String name) throws Exception {
+        if (name == null) {
+            return null;
+        }
+        final String[] arr = name.split("//");
+
+        if (arr.length == 4) {
+            String tenant = arr[0];
+            String namespacePortion = arr[1];
+            String domain = arr[2];
+            String encodedLocalName = arr[3];
+            final String decodedName = Codec.decode(encodedLocalName);
+            TopicName.get(domain, tenant, namespacePortion, decodedName);
+        } else if (arr.length == 5) {
+            String tenant = arr[0];
+            String cluster = arr[1];
+            String namespacePortion = arr[2];
+            String domain = arr[3];
+            String encodedLocalName = arr[4];
+            final String decodedName = Codec.decode(encodedLocalName);
+            TopicName.get(domain, tenant, cluster, namespacePortion, decodedName);
+        }
+
+        throw new Exception("not valid name: " + name);
+    }
+
     /**
      * Get a string suitable for completeTopicName lookup.
      *
@@ -344,8 +370,8 @@ public class TopicName implements ServiceUnitId {
 
     public String getSchemaName() {
         return getTenant()
-            + "/" + getNamespacePortion()
-            + "/" + TopicName.get(getPartitionedTopicName()).getEncodedLocalName();
+                + "/" + getNamespacePortion()
+                + "/" + TopicName.get(getPartitionedTopicName()).getEncodedLocalName();
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -27,6 +27,8 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
@@ -332,7 +334,7 @@ public class TopicName implements ServiceUnitId {
             String domain = arr[2];
             String encodedLocalName = arr[3];
             final String decodedName = Codec.decode(encodedLocalName);
-            TopicName.get(domain, tenant, namespacePortion, decodedName);
+            return TopicName.get(domain, tenant, namespacePortion, decodedName);
         } else if (arr.length == 5) {
             String tenant = arr[0];
             String cluster = arr[1];
@@ -340,10 +342,11 @@ public class TopicName implements ServiceUnitId {
             String domain = arr[3];
             String encodedLocalName = arr[4];
             final String decodedName = Codec.decode(encodedLocalName);
-            TopicName.get(domain, tenant, cluster, namespacePortion, decodedName);
+            return TopicName.get(domain, tenant, cluster, namespacePortion, decodedName);
+        } else {
+            log.error("arr.length = {}, arr = {}", arr.length, Stream.of(arr).collect(Collectors.toList()));
+            throw new Exception("not valid name: " + name);
         }
-
-        throw new Exception("not valid name: " + name);
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -324,7 +324,7 @@ public class TopicName implements ServiceUnitId {
         if (name == null) {
             return null;
         }
-        final String[] arr = name.split("//");
+        final String[] arr = name.split("/");
 
         if (arr.length == 4) {
             String tenant = arr[0];

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 import com.google.common.base.Predicate;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -31,12 +32,34 @@ import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.WaitingEntryCallBack;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 
 @Slf4j
 public class MockManagedLedger implements ManagedLedger {
+    @Override
+    public void initialize(ManagedLedgerInitializeLedgerCallback callback, Object ctx) {
+
+    }
+
+    @Override
+    public boolean isValidPosition(PositionImpl nextReadPosition) {
+        return false;
+    }
+
+    @Override
+    public boolean hasMoreEntries(PositionImpl nextReadPosition) {
+        return false;
+    }
+
+    @Override
+    public void addWaitingEntryCallBack(WaitingEntryCallBack streamingEntryReader) {
+
+    }
+
     @Override
     public String getName() {
         return null;
@@ -54,6 +77,11 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public void asyncAddEntry(byte[] data, AsyncCallbacks.AddEntryCallback callback, Object ctx) {
+
+    }
+
+    @Override
+    public void asyncReadEntry(PositionImpl position, AsyncCallbacks.ReadEntryCallback callback, Object ctx) {
 
     }
 
@@ -169,6 +197,52 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
+    public long getEntriesAddedCounter() {
+        return 0;
+    }
+
+    @Override
+    public long getLastLedgerCreatedTimestamp() {
+        return 0;
+    }
+
+    @Override
+    public long getLastLedgerCreationFailureTimestamp() {
+        return 0;
+    }
+
+    @Override
+    public int getWaitingCursorsCount() {
+        return 0;
+    }
+
+    @Override
+    public long getCurrentLedgerEntries() {
+        return 0;
+    }
+
+    @Override
+    public long getCurrentLedgerSize() {
+        return 0;
+    }
+
+
+    @Override
+    public NavigableMap<Long, LedgerInfo> getLedgersInfo() {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<String> getLedgerMetadata(long ledgerId) {
+        return null;
+    }
+
+    @Override
+    public boolean ledgerExists(long ledgerId) {
+        return false;
+    }
+
+    @Override
     public long getNumberOfActiveEntries() {
         return 0;
     }
@@ -180,6 +254,21 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public long getEstimatedBacklogSize() {
+        return 0;
+    }
+
+    @Override
+    public long getEstimatedBacklogSize(PositionImpl pos) {
+        return 0;
+    }
+
+    @Override
+    public int getPendingAddEntriesCount() {
+        return 0;
+    }
+
+    @Override
+    public long getCacheSize() {
         return 0;
     }
 
@@ -211,6 +300,11 @@ public class MockManagedLedger implements ManagedLedger {
     @Override
     public ManagedLedgerMXBean getStats() {
         return null;
+    }
+
+    @Override
+    public void doCacheEviction(long maxTimestamp) {
+
     }
 
     @Override
@@ -255,6 +349,11 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public Position getLastConfirmedEntry() {
+        return null;
+    }
+
+    @Override
+    public String getState() {
         return null;
     }
 
@@ -316,6 +415,21 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
+    public PositionImpl getPositionAfterN(PositionImpl startPosition, long n, PositionBound startRange) {
+        return null;
+    }
+
+    @Override
+    public PositionImpl getFirstPosition() {
+        return null;
+    }
+
+    @Override
+    public PositionImpl getLastPosition() {
+        return null;
+    }
+
+    @Override
     public ManagedLedgerInterceptor getManagedLedgerInterceptor() {
         return null;
     }
@@ -324,5 +438,10 @@ public class MockManagedLedger implements ManagedLedger {
     public CompletableFuture<LedgerInfo> getLedgerInfo(long ledgerId) {
         final LedgerInfo build = LedgerInfo.newBuilder().setLedgerId(ledgerId).setSize(100).setEntries(20).build();
         return CompletableFuture.completedFuture(build);
+    }
+
+    @Override
+    public PositionImpl getNextValidPosition(PositionImpl position) {
+        return null;
     }
 }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -243,6 +243,11 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
+    public void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
+
+    }
+
+    @Override
     public long getNumberOfActiveEntries() {
         return 0;
     }


### PR DESCRIPTION
Use `ManagedLedger` instead of `ManagedLedgerImpl` in `ManagedLedgerFactoryImpl` to make the `ManagedLedgerFactoryImpl` extendable.
As a result, some method declarations also moved from `ManagedLedgerImpl` to `ManagedLedger`. 
Next step of https://github.com/apache/pulsar/pull/9397 to allow supporting different storage implementations for Pulsar