### PR TITLE
[Bookie] Fallback to PULSAR_GC if BOOKIE_GC is not defined

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -36,7 +36,7 @@ BOOKIE_CONF=${BOOKIE_CONF:-"$BK_HOME/conf/bookkeeper.conf"}
 BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"}}
 
 # Garbage collection options
-BOOKIE_GC=${BOOKIE_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"}
+BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"}}
 
 # Extra options to be passed to the jvm
 BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} ${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"


### PR DESCRIPTION
### Motivation

- Currently Bookies fall back to `PULSAR_MEM` when `BOOKIE_MEM` isn't set (#6201).
  For consistency, it's useful to fall back to `PULSAR_GC` if `BOOKIE_GC`
  isn't set.

### Modifications

Change `conf/bkenv.sh` to handle `BOOKIE_GC` similarly as `BOOKIE_MEM` is handled, falling back to `PULSAR_*`.