### PR TITLE
[Issue 9622] Fix setting Bookie dbStorage_*CacheMaxSizeMb in pulsar-test-latest-version docker image

### DIFF
--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -22,6 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/bookie.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseG1GC",dbStorage_writeCacheMaxSizeMb="16",dbStorage_readAheadCacheMaxSizeMb="16"
+environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar bookie
 user=pulsar

--- a/tests/docker-images/latest-version-image/scripts/run-bookie.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-bookie.sh
@@ -18,6 +18,10 @@
 # under the License.
 #
 
+# sets dbStorage_writeCacheMaxSizeMb and dbStorage_readAheadCacheMaxSizeMb if not already defined
+export dbStorage_writeCacheMaxSizeMb="${dbStorage_writeCacheMaxSizeMb:-16}"
+export dbStorage_readAheadCacheMaxSizeMb="${dbStorage_readAheadCacheMaxSizeMb:-16}"
+
 bin/apply-config-from-env.py conf/bookkeeper.conf && \
     bin/apply-config-from-env.py conf/pulsar_env.sh
 


### PR DESCRIPTION
Fixes #9622

### Motivation

When using pulsar-test-latest-version docker image in integration tests, bookies run out of direct memory. This causes integration tests to fail and requiring retries to pass.

There has been intention to set `dbStorage_writeCacheMaxSizeMb=16` and `dbStorage_readAheadCacheMaxSizeMb=16`, however these didn't get applied because of misconfiguration.

See #9622 for long explanation.

### Modifications

Fix setting `dbStorage_writeCacheMaxSizeMb=16` and `dbStorage_readAheadCacheMaxSizeMb=16` when running bookies in pulsar-test-latest-version docker image.