### PR TITLE
[Testing] Add debugging feature which leaves integration test containers running after test completes

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -22,8 +22,10 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.utils.DockerUtils;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
@@ -48,6 +50,16 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
     public static final String PULSAR_2_1_IMAGE_NAME = "apachepulsar/pulsar:2.1.0";
     public static final String PULSAR_2_0_IMAGE_NAME = "apachepulsar/pulsar:2.0.0";
 
+    /**
+     * For debugging purposes, it is useful to have the ability to leave containers running.
+     * This mode can be activated by setting environment variables
+     * PULSAR_CONTAINERS_LEAVE_RUNNING=true and TESTCONTAINERS_REUSE_ENABLE=true
+     * After debugging, one can use this command to kill all containers that were left running:
+     * docker kill $(docker ps -q --filter "label=pulsarcontainer=true")
+     */
+    public static final boolean PULSAR_CONTAINERS_LEAVE_RUNNING =
+            Boolean.parseBoolean(System.getenv("PULSAR_CONTAINERS_LEAVE_RUNNING"));
+
     private final String hostname;
     private final String serviceName;
     private final String serviceEntryPoint;
@@ -71,13 +83,8 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
                            int servicePort,
                            int httpPort,
                            String httpPath) {
-        super(clusterName, DEFAULT_IMAGE_NAME);
-        this.hostname = hostname;
-        this.serviceName = serviceName;
-        this.serviceEntryPoint = serviceEntryPoint;
-        this.servicePort = servicePort;
-        this.httpPort = httpPort;
-        this.httpPath = httpPath;
+        this(clusterName, hostname, serviceName, serviceEntryPoint, servicePort, httpPort, httpPath,
+                DEFAULT_IMAGE_NAME);
     }
 
     public PulsarContainer(String clusterName,
@@ -95,6 +102,20 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
         this.servicePort = servicePort;
         this.httpPort = httpPort;
         this.httpPath = httpPath;
+
+        configureLeaveContainerRunning(this);
+    }
+
+    public static void configureLeaveContainerRunning(
+            GenericContainer<?> container) {
+        if (PULSAR_CONTAINERS_LEAVE_RUNNING) {
+            // use Testcontainers reuse containers feature to leave the container running
+            container.withReuse(true);
+            // add label that can be used to find containers that are left running.
+            container.withLabel("pulsarcontainer", "true");
+            // add a random label to prevent reuse of containers
+            container.withLabel("pulsarcontainer.random", UUID.randomUUID().toString());
+        }
     }
 
     @Override
@@ -107,6 +128,15 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
                 "/var/log/pulsar"
             );
         }
+    }
+
+    @Override
+    public void stop() {
+        if (PULSAR_CONTAINERS_LEAVE_RUNNING) {
+            log.warn("Ignoring stop due to PULSAR_CONTAINERS_LEAVE_RUNNING=true.");
+            return;
+        }
+        super.stop();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

For debugging purposes, it is useful to have the ability to leave the integration test containers running after the test completes. For example, this feature was necessary in investigating the issue #9622 . It was possible to view the log files and find out the issue. If the containers are killed, this options is lost.

### Modifications

Adds handling to the initialization and stopping of Pulsar containers and Pulsar cluster so that containers get configured using Testcontainers "reuse mode" which leaves containers running after the test JVM stops. Normally the Testcontainers automatic container cleanup feature stops all containers which weren't explicitly stopped during the tests.
Testcontainers reuse mode must be enabled by setting environment variable `TESTCONTAINERS_REUSE_ENABLE=true` (or by setting `testcontainers.reuse.enable=true` in `~/.testcontainers.properties`).

The modifications in this PR skip stopping PulsarContainer and PulsarCluster instances if environment variable `PULSAR_CONTAINERS_LEAVE_RUNNING=true`  .

### Usage example

In unix shells, one can pass environment variables by prepending the command with the variables, for example:
```
PULSAR_CONTAINERS_LEAVE_RUNNING=true TESTCONTAINERS_REUSE_ENABLE=true mvn -B -f tests/pom.xml test -DintegrationTests -DredirectTestOutputToFile=false -DtestRetryCount=0 -DfailIfNoTests=false -Dtest=CLITest#testCreateSubscriptionCommand
```

After the test run, one can use `docker ps` and `docker exec -it [container_name] bash` to get a shell in the running container that was left behind the test run when this feature introduced by this PR is active. 

After debugging, one can use this command to kill all containers that were left running:
```
docker kill $(docker ps -q --filter "label=pulsarcontainer=true")
```
(the solution in this PR labels the containers with "pulsarcontainer=true")
