### PR TITLE
[Build] Reduce pulsar-test-latest-version docker image size

### DIFF
--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -17,6 +17,36 @@
 # under the License.
 #
 
+# build go lang examples first in a separate layer
+
+FROM apachepulsar/pulsar-all:latest as pulsar-function-go
+
+USER root
+
+RUN rm -rf /var/lib/apt/lists/* && apt-get update
+RUN apt-get install -y procps curl git
+
+ENV GOLANG_VERSION 1.13.3
+
+RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
+		| tar -v -C /usr/local -xz
+
+# RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
+# RUN export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+# RUN echo "export GOROOT=/usr/local/go" >> ~/.profile && echo "export GOPATH=$HOME/go" >> ~/.profile && echo "export PATH=$GOPATH/bin:$GOROOT/bin:$PATH" >> ~/.profile
+
+ENV PATH /usr/local/go/bin:$PATH
+
+RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+
+COPY target/pulsar-function-go/ /go/src/github.com/apache/pulsar/pulsar-function-go
+RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go && go install ./...
+RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
+RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
+
 FROM apachepulsar/pulsar-all:latest
 
 # Switch to run as the root user to simplify building container and then running
@@ -27,7 +57,7 @@ USER root
 
 RUN rm -rf /var/lib/apt/lists/* && apt update
 
-RUN apt-get clean && apt-get update && apt-get install -y supervisor vim procps curl git
+RUN apt-get clean && apt-get update && apt-get install -y supervisor vim procps curl
 
 RUN mkdir -p /var/log/pulsar && mkdir -p /var/run/supervisor/ && mkdir -p /pulsar/ssl
 
@@ -48,25 +78,7 @@ COPY scripts/init-cluster.sh scripts/run-global-zk.sh scripts/run-local-zk.sh \
      /pulsar/bin/
 
 # copy python test examples
-
 RUN mkdir -p /pulsar/instances/deps
-
-ENV GOLANG_VERSION 1.13.3
-
-RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
-		| tar -v -C /usr/local -xz
-
-# RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
-# RUN export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-# RUN echo "export GOROOT=/usr/local/go" >> ~/.profile && echo "export GOPATH=$HOME/go" >> ~/.profile && echo "export PATH=$GOPATH/bin:$GOROOT/bin:$PATH" >> ~/.profile
-
-ENV PATH /usr/local/go/bin:$PATH
-
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
-ENV GOROOT /usr/local/go
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-
 COPY python-examples/exclamation_lib.py /pulsar/instances/deps/
 COPY python-examples/exclamation_with_extra_deps.py /pulsar/examples/python-examples/
 COPY python-examples/exclamation.zip /pulsar/examples/python-examples/
@@ -74,10 +86,24 @@ COPY python-examples/producer_schema.py /pulsar/examples/python-examples/
 COPY python-examples/consumer_schema.py /pulsar/examples/python-examples/
 COPY python-examples/exception_function.py /pulsar/examples/python-examples/
 
-COPY target/pulsar-function-go/ /go/src/github.com/apache/pulsar/pulsar-function-go
-RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go && go install ./...
-RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
-RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
-
+# copy java test examples
 COPY target/java-test-functions.jar /pulsar/examples/
-RUN cp -a /go/bin/. /pulsar/examples/go-examples/
+
+# copy go test examples
+COPY --from=pulsar-function-go /go/bin /pulsar/examples/go-examples
+
+# change ownership of files
+RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar
+
+# remove static libpulsar*.a libraries to reduce image size
+RUN rm /usr/lib/libpulsar*.a
+# remove gcc
+RUN apt-get -y remove --autoremove --purge build-essential
+
+# cleanup
+RUN apt-get -y autoremove \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD bash


### PR DESCRIPTION
### Motivation

Smaller `pulsar-test-latest-version` docker image size makes it feasible to build the image once and share it between the different parallel integration test build jobs. This will help improve the Pulsar CI in the future since it opens up new possibilities to save build system resources (GitHub Actions Runner VM time).

### Modifications

- Build go-lang examples in a separate temporary layer. This reduces the final size of the image by at least 600MB.

- Cleanup files as last steps
  - Cleaning up files doesn't reduce the size of the image yet since it requires docker build squashing. The cleanup step is preparation for future changes.
  - To actually reduce the final image size, it would require `-Ddockerfile.build.squash=true` (uses `docker build --squash`). This is not part of this change since the image size isn't important until images are transferred over  the network. Squashing the image would just add overhead to the current build.
  - Remove Pulsar CPP library's static libraries `/usr/lib/libpulsar*.a` (since no tests use it)
  - Remove gcc compiler (since no tests use it)
  