### PR TITLE
[Pulsar SQL] Add max split entry queue size bytes limitation

### DIFF
--- a/conf/presto/catalog/pulsar.properties
+++ b/conf/presto/catalog/pulsar.properties
@@ -31,6 +31,8 @@ pulsar.target-num-splits=2
 pulsar.max-split-message-queue-size=10000
 # max entry queue size
 pulsar.max-split-entry-queue-size=1000
+# max entry queue size bytes, the entry queue shouldn't exceed this value, but it's not strict
+# pulsar.max-split-entry-queue-cache-size=400000
 # Rewrite namespace delimiter
 # Warn: avoid using symbols allowed by Namespace (a-zA-Z_0-9 -=:%)
 # to prevent erroneous rewriting

--- a/conf/presto/catalog/pulsar.properties
+++ b/conf/presto/catalog/pulsar.properties
@@ -31,8 +31,9 @@ pulsar.target-num-splits=2
 pulsar.max-split-message-queue-size=10000
 # max entry queue size
 pulsar.max-split-entry-queue-size=1000
-# max entry queue size bytes, the entry queue shouldn't exceed this value, but it's not strict
-# pulsar.max-split-entry-queue-cache-size=400000
+# half of this value is used as max entry queue size bytes and the left is used as max message queue size bytes,
+# the queue size bytes shouldn't exceed this value, but it's not strict, the default value -1 indicate no limit.
+pulsar.max-split-queue-cache-size=-1
 # Rewrite namespace delimiter
 # Warn: avoid using symbols allowed by Namespace (a-zA-Z_0-9 -=:%)
 # to prevent erroneous rewriting

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -308,7 +308,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         }
     }
 
-    public TenantInfo createDefaultTenantInfo() throws PulsarAdminException {
+    protected TenantInfo createDefaultTenantInfo() throws PulsarAdminException {
         // create local cluster if not exist
         if (!admin.clusters().getClusters().contains(configClusterName)) {
             admin.clusters().createCluster(configClusterName, new ClusterData());

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -121,6 +121,35 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-broker</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-broker</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+          <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>testmocks</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+          <version>${jetty.version}</version>
+          <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/CacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/CacheSizeAllocator.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.jetty.util.AtomicBiInteger;
+
+/**
+ * Cache size allocator.
+ */
+public class CacheSizeAllocator {
+
+    private final long maxCacheSize;
+    private final AtomicLong availableCacheSize;
+
+    public CacheSizeAllocator(long maxCacheSize) {
+        this.maxCacheSize = maxCacheSize;
+        this.availableCacheSize = new AtomicBiInteger(maxCacheSize);
+    }
+
+    public long getAvailableCacheSize() {
+        return availableCacheSize.get();
+    }
+
+    /**
+     * This operation will cost available cache size.
+     * if the request size exceed the available size, it's should be allowed,
+     * because maybe one entry size exceed the size and
+     * the query must be finished, the available size will become invalid.
+     *
+     * @param size allocate size
+     */
+    public void allocate(long size) {
+        availableCacheSize.addAndGet(-size);
+    }
+
+    /**
+     * This method used to release used cache size and add available cache size.
+     * in normal case, the available size shouldn't exceed max cache size.
+     *
+     * @param size release size
+     */
+    public void release(long size) {
+        if (availableCacheSize.addAndGet(size) > maxCacheSize) {
+            availableCacheSize.set(maxCacheSize);
+        }
+    }
+
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
@@ -47,7 +47,7 @@ public class PulsarConnectorConfig implements AutoCloseable {
     private int targetNumSplits = 2;
     private int maxSplitMessageQueueSize = 10000;
     private int maxSplitEntryQueueSize = 1000;
-    private long maxSplitEntryQueueSizeBytes = -1;
+    private long maxSplitQueueSizeBytes = -1;
     private int maxMessageSize = Commands.DEFAULT_MAX_MESSAGE_SIZE;
     private String statsProvider = NullStatsProvider.class.getName();
 
@@ -161,13 +161,13 @@ public class PulsarConnectorConfig implements AutoCloseable {
     }
 
     @NotNull
-    public long getMaxSplitEntryQueueSizeBytes() {
-        return this.maxSplitEntryQueueSizeBytes;
+    public long getMaxSplitQueueSizeBytes() {
+        return this.maxSplitQueueSizeBytes;
     }
 
-    @Config("pulsar.max-split-entry-queue-cache-size")
-    public PulsarConnectorConfig setMaxSplitEntryQueueSizeBytes(long maxSplitEntryQueueSizeBytes) {
-        this.maxSplitEntryQueueSizeBytes = maxSplitEntryQueueSizeBytes;
+    @Config("pulsar.max-split-queue-cache-size")
+    public PulsarConnectorConfig setMaxSplitQueueSizeBytes(long maxSplitQueueSizeBytes) {
+        this.maxSplitQueueSizeBytes = maxSplitQueueSizeBytes;
         return this;
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
@@ -47,6 +47,7 @@ public class PulsarConnectorConfig implements AutoCloseable {
     private int targetNumSplits = 2;
     private int maxSplitMessageQueueSize = 10000;
     private int maxSplitEntryQueueSize = 1000;
+    private long maxSplitEntryQueueSizeBytes = -1;
     private int maxMessageSize = Commands.DEFAULT_MAX_MESSAGE_SIZE;
     private String statsProvider = NullStatsProvider.class.getName();
 
@@ -156,6 +157,17 @@ public class PulsarConnectorConfig implements AutoCloseable {
     @Config("pulsar.max-split-entry-queue-size")
     public PulsarConnectorConfig setMaxSplitEntryQueueSize(int maxSplitEntryQueueSize) {
         this.maxSplitEntryQueueSize = maxSplitEntryQueueSize;
+        return this;
+    }
+
+    @NotNull
+    public long getMaxSplitEntryQueueSizeBytes() {
+        return this.maxSplitEntryQueueSizeBytes;
+    }
+
+    @Config("pulsar.max-split-entry-queue-cache-size")
+    public PulsarConnectorConfig setMaxSplitEntryQueueSizeBytes(long maxSplitEntryQueueSizeBytes) {
+        this.maxSplitEntryQueueSizeBytes = maxSplitEntryQueueSizeBytes;
         return this;
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -422,12 +422,17 @@ public class PulsarRecordCursor implements RecordCursor {
         }
     }
 
+    /**
+     * Check the queue has available cache size quota or not.
+     * 1. If the CacheSizeAllocator is NullCacheSizeAllocator, return true.
+     * 2. If the available cache size > 0, return true.
+     * 3. If the available cache size is invalid and the queue size == 0, return true, ensure not block the query.
+     */
     private boolean haveAvailableCacheSize(CacheSizeAllocator cacheSizeAllocator, SpscArrayQueue queue) {
         if (cacheSizeAllocator instanceof NullCacheSizeAllocator) {
             return true;
         }
-        return cacheSizeAllocator.getAvailableCacheSize() > 0
-                || cacheSizeAllocator.getAvailableCacheSize() == 0 && queue.size() == 0;
+        return cacheSizeAllocator.getAvailableCacheSize() > 0 || queue.size() == 0;
     }
 
     @Override
@@ -687,13 +692,13 @@ public class PulsarRecordCursor implements RecordCursor {
     }
 
     private void initEntryCacheSizeAllocator(PulsarConnectorConfig connectorConfig) {
-        if (connectorConfig.getMaxSplitEntryQueueSizeBytes() >= 0) {
+        if (connectorConfig.getMaxSplitQueueSizeBytes() >= 0) {
             this.entryQueueCacheSizeAllocator = new NoStrictCacheSizeAllocator(
-                    connectorConfig.getMaxSplitEntryQueueSizeBytes() / 2);
+                    connectorConfig.getMaxSplitQueueSizeBytes() / 2);
             this.messageQueueCacheSizeAllocator = new NoStrictCacheSizeAllocator(
-                    connectorConfig.getMaxSplitEntryQueueSizeBytes() / 2);
+                    connectorConfig.getMaxSplitQueueSizeBytes() / 2);
             log.info("Init cacheSizeAllocator with maxSplitEntryQueueSizeBytes {}.",
-                    connectorConfig.getMaxSplitEntryQueueSizeBytes());
+                    connectorConfig.getMaxSplitQueueSizeBytes());
         } else {
             this.entryQueueCacheSizeAllocator = new NullCacheSizeAllocator();
             this.messageQueueCacheSizeAllocator = new NullCacheSizeAllocator();

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/CacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/CacheSizeAllocator.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto.util;
+
+/**
+ * Cache size allocator.
+ */
+public interface CacheSizeAllocator {
+
+    /**
+     * Get available cache size.
+     *
+     * @return available cache size
+     */
+    public long getAvailableCacheSize();
+
+    /**
+     * Cost available cache.
+     *
+     * @param size allocate size
+     */
+    public void allocate(long size);
+
+    /**
+     * Release allocated cache size.
+     *
+     * @param size release size
+     */
+    public void release(long size);
+
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/NullCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/NullCacheSizeAllocator.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto.util;
+
+/**
+ * Null cache size allocator.
+ */
+public class NullCacheSizeAllocator implements CacheSizeAllocator {
+
+    @Override
+    public long getAvailableCacheSize() {
+        return -1;
+    }
+
+    @Override
+    public void allocate(long size) {
+        // no op
+    }
+
+    @Override
+    public void release(long size) {
+        // no op
+    }
+}

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/package-info.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/util/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto.util;

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import io.prestosql.spi.connector.ConnectorContext;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.testing.TestingConnectorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.jctools.queues.SpscArrayQueue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+
+@Slf4j
+public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+
+        admin.clusters().createCluster("test", new ClusterData(brokerUrl.toString()));
+
+        // so that clients can test short names
+        admin.tenants().createTenant("public",
+                new TenantInfo(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("public/default");
+        admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void cacheSizeAllocatorTest() throws Exception {
+        TopicName topicName = TopicName.get("public/default/cache-size-test");
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName.toString())
+                .create();
+
+        int entrySize = 100;
+        MessageIdImpl firstMessageId = null;
+        MessageIdImpl lastMessageId = null;
+        for (int i = 0; i < entrySize; i++) {
+            MessageIdImpl messageId = (MessageIdImpl) producer.send(generateBytesData(100));
+            if (firstMessageId == null) {
+                firstMessageId = messageId;
+            }
+            lastMessageId = messageId;
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        PulsarSplit pulsarSplit = new PulsarSplit(
+                0,
+                "connector-id",
+                topicName.getNamespace(),
+                topicName.getLocalName(),
+                topicName.getLocalName(),
+                1,
+                new String(Schema.BYTES.getSchemaInfo().getSchema()),
+                Schema.BYTES.getSchemaInfo().getType(),
+                firstMessageId.getEntryId(),
+                lastMessageId.getEntryId(),
+                firstMessageId.getLedgerId(),
+                lastMessageId.getLedgerId(),
+                TupleDomain.all(),
+                objectMapper.writeValueAsString(new HashMap<>()),
+                null);
+
+        List<PulsarColumnHandle> pulsarColumnHandles = TestPulsarConnector.getColumnColumnHandles(
+                topicName, Schema.BYTES.getSchemaInfo(), PulsarColumnHandle.HandleKeyValueType.NONE, true);
+
+        PulsarConnectorConfig connectorConfig = new PulsarConnectorConfig();
+
+        ConnectorContext prestoConnectorContext = new TestingConnectorContext();
+        PulsarRecordCursor pulsarRecordCursor = new PulsarRecordCursor(
+                pulsarColumnHandles, pulsarSplit, connectorConfig, pulsar.getManagedLedgerFactory(),
+                new ManagedLedgerConfig(), new PulsarConnectorMetricsTracker(new NullStatsProvider()),
+                new PulsarDispatchingRowDecoderFactory(prestoConnectorContext.getTypeManager()));
+
+        Class<PulsarRecordCursor> recordCursorClass = PulsarRecordCursor.class;
+        Field entryQueueField = recordCursorClass.getDeclaredField("entryQueue");
+
+        for (int i = 0; i < entrySize; i++) {
+            pulsarRecordCursor.advanceNextPosition();
+            SpscArrayQueue queue = (SpscArrayQueue) entryQueueField.get(pulsarRecordCursor);
+            log.info("queue size: {}", queue.size());
+        }
+    }
+
+    private byte[] generateBytesData(int size) {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = 1;
+        }
+        return bytes;
+    }
+
+}

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -26,7 +26,6 @@ import io.prestosql.testing.TestingConnectorContext;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -38,10 +37,10 @@ import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.api.raw.RawMessageImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.apache.pulsar.sql.presto.util.NullCacheSizeAllocator;
 import org.jctools.queues.SpscArrayQueue;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -84,20 +83,19 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
         };
     }
 
-    @Test(dataProvider = "cacheSizeProvider")
+    @Test(dataProvider = "cacheSizeProvider", timeOut = 1000 * 20)
     public void cacheSizeAllocatorTest(long entryQueueSizeBytes) throws Exception {
         TopicName topicName = TopicName.get(
                 "public/default/cache-size-" + entryQueueSizeBytes + "test_" + + RandomUtils.nextInt()) ;
-        int splitSize = 21;
-        MessageIdImpl firstMessageId = prepareData(topicName, splitSize);
+        int totalMsgCnt = 1000;
+        MessageIdImpl firstMessageId = prepareData(topicName, totalMsgCnt);
 
-        PositionImpl lastPosition = null;
         ReadOnlyCursor readOnlyCursor = pulsar.getManagedLedgerFactory().openReadOnlyCursor(
                 topicName.getPersistenceNamingEncoding(),
                 PositionImpl.get(firstMessageId.getLedgerId(), firstMessageId.getEntryId()),
                 new ManagedLedgerConfig());
-        readOnlyCursor.skipEntries(splitSize);
-        lastPosition = (PositionImpl) readOnlyCursor.getReadPosition();
+        readOnlyCursor.skipEntries(totalMsgCnt);
+        PositionImpl lastPosition = (PositionImpl) readOnlyCursor.getReadPosition();
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -107,7 +105,7 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
                 topicName.getNamespace(),
                 topicName.getLocalName(),
                 topicName.getLocalName(),
-                splitSize,
+                totalMsgCnt,
                 new String(Schema.BYTES.getSchemaInfo().getSchema()),
                 Schema.BYTES.getSchemaInfo().getType(),
                 firstMessageId.getEntryId(),
@@ -133,110 +131,30 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
         Class<PulsarRecordCursor> recordCursorClass = PulsarRecordCursor.class;
         Field entryQueueField = recordCursorClass.getDeclaredField("entryQueue");
         entryQueueField.setAccessible(true);
-        SpscArrayQueue<Entry> queue = (SpscArrayQueue<Entry>) entryQueueField.get(pulsarRecordCursor);
+        SpscArrayQueue<Entry> entryQueue = (SpscArrayQueue<Entry>) entryQueueField.get(pulsarRecordCursor);
 
-        Field entriesProcessedField = recordCursorClass.getDeclaredField("entriesProcessed");
-        entriesProcessedField.setAccessible(true);
+        Field messageQueueField = recordCursorClass.getDeclaredField("messageQueue");
+        messageQueueField.setAccessible(true);
+        SpscArrayQueue<RawMessageImpl> messageQueue =
+                (SpscArrayQueue<RawMessageImpl>) messageQueueField.get(pulsarRecordCursor);
 
-        Class<PulsarRecordCursor.ReadEntries> readEntriesClass = PulsarRecordCursor.ReadEntries.class;
-        Field readEntriesField = recordCursorClass.getDeclaredField("readEntries");
-        readEntriesField.setAccessible(true);
-        PulsarRecordCursor.ReadEntries readEntries = (PulsarRecordCursor.ReadEntries)
-                readEntriesClass.getDeclaredConstructors()[0].newInstance(pulsarRecordCursor);
-        readEntriesField.set(pulsarRecordCursor, readEntries);
-
-        Class<PulsarRecordCursor.DeserializeEntries> deserializeEntriesClass =
-                PulsarRecordCursor.DeserializeEntries.class;
-        Field deserializeEntriesField = recordCursorClass.getDeclaredField("deserializeEntries");
-        deserializeEntriesField.setAccessible(true);
-        PulsarRecordCursor.DeserializeEntries deserializeEntries = (PulsarRecordCursor.DeserializeEntries)
-                deserializeEntriesClass.getDeclaredConstructors()[0].newInstance(pulsarRecordCursor);
-        deserializeEntriesField.set(pulsarRecordCursor, deserializeEntries);
-
-        Field isRunningField = deserializeEntriesClass.getDeclaredField("isRunning");
-        isRunningField.setAccessible(true);
-
-        Field outstandingReadsRequestsField = readEntriesClass.getDeclaredField("outstandingReadsRequests");
-        outstandingReadsRequestsField.setAccessible(true);
-        AtomicLong outstandingReadRequests = (AtomicLong) outstandingReadsRequestsField.get(readEntries);
-
-        int receiveNum = 0;
-
-        readEntries.run();
+        long maxQueueSize = 0;
         if (entryQueueSizeBytes == -1) {
-            // use NullCacheSizeAllocator
-            checkQueueSize(outstandingReadRequests, queue, splitSize);
-            deserializeEntries(queue, isRunningField, deserializeEntries);
-        } else {
-            // first read only one entry
-            checkQueueSize(outstandingReadRequests, queue, 1);
-            receiveNum += 1;
-            deserializeEntries(queue, isRunningField, deserializeEntries);
+            maxQueueSize = Long.MAX_VALUE;
+        } else if (entryQueueSizeBytes == 0) {
+            maxQueueSize = 1;
+        } else if (entryQueueSizeBytes > 0) {
+            maxQueueSize = entryQueueSizeBytes / 2 / singleEntrySize + 1;
+        }
 
-            while (receiveNum != splitSize) {
-                long maxQueueSize = entryQueueSizeBytes / (singleEntrySize + 46) + 1;
-                if (maxQueueSize > (splitSize - receiveNum)) {
-                    maxQueueSize = splitSize - receiveNum;
-                }
-
-                int num = readAndCheck(readEntries, outstandingReadRequests, queue, (int) maxQueueSize);
-                receiveNum += num;
-                deserializeEntries(queue, isRunningField, deserializeEntries);
+        int receiveCnt = 0;
+        while (receiveCnt != totalMsgCnt) {
+            if (pulsarRecordCursor.advanceNextPosition()) {
+                receiveCnt ++;
             }
+            Assert.assertTrue(entryQueue.size() <= maxQueueSize);
+            Assert.assertTrue(messageQueue.size() <= maxQueueSize);
         }
-
-        while (pulsarRecordCursor.advanceNextPosition()) {
-            for (int i = 0; i < pulsarColumnHandles.size(); i++) {
-                if (pulsarColumnHandles.get(i).getName().equals("__value__")) {
-                    Assert.assertEquals(pulsarRecordCursor.getSlice(i).getBytes().length, 500);
-                }
-            }
-        }
-
-        Assert.assertTrue(readEntries.hasFinished());
-        readEntries.run();
-        checkQueueSize(outstandingReadRequests, queue, 0);
-    }
-
-    private int readAndCheck(PulsarRecordCursor.ReadEntries readEntries,
-                             AtomicLong outstandingReadsRequests,
-                             SpscArrayQueue<Entry> queue,
-                             int maxQueueSize) throws Exception {
-        int receiveNum = 0;
-
-        // read twice to make sure queue size reach max queue size
-        readEntries.run();
-        waitReadComplete(outstandingReadsRequests);
-        readEntries.run();
-        checkQueueSize(outstandingReadsRequests, queue, maxQueueSize);
-        receiveNum += maxQueueSize;
-
-        // read again to make sure don't read any more entries
-        readEntries.run();
-        checkQueueSize(outstandingReadsRequests, queue, maxQueueSize);
-        return receiveNum;
-    }
-
-    private void checkQueueSize(AtomicLong outstandingReadRequests,
-                                SpscArrayQueue<Entry> queue, int expectedNum) throws Exception {
-        waitReadComplete(outstandingReadRequests);
-        Assert.assertEquals(queue.size(), expectedNum);
-    }
-
-    private void waitReadComplete(AtomicLong outstandingReadRequests) throws InterruptedException {
-        while (outstandingReadRequests.get() < 1) {
-            Thread.sleep(500);
-        }
-    }
-
-    private void deserializeEntries(SpscArrayQueue<Entry> queue,
-                                    Field isRunningField,
-                                    PulsarRecordCursor.DeserializeEntries deserializeEntries) throws Exception {
-        new Thread(deserializeEntries::run).start();
-        while (queue.size() > 0) {
-            Thread.sleep(100);
-        }
-        isRunningField.set(deserializeEntries, false);
     }
 
     private MessageIdImpl prepareData(TopicName topicName, int messageNum) throws Exception {

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -120,7 +120,7 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
                 topicName, Schema.BYTES.getSchemaInfo(), PulsarColumnHandle.HandleKeyValueType.NONE, true);
 
         PulsarConnectorConfig connectorConfig = new PulsarConnectorConfig();
-        connectorConfig.setMaxSplitEntryQueueSizeBytes(entryQueueSizeBytes);
+        connectorConfig.setMaxSplitQueueSizeBytes(entryQueueSizeBytes);
 
         ConnectorContext prestoConnectorContext = new TestingConnectorContext();
         PulsarRecordCursor pulsarRecordCursor = new PulsarRecordCursor(

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -23,9 +23,17 @@ import com.google.common.collect.Sets;
 import io.prestosql.spi.connector.ConnectorContext;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.testing.TestingConnectorContext;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ReadOnlyCursor;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
@@ -33,17 +41,21 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.sql.presto.util.NullCacheSizeAllocator;
 import org.jctools.queues.SpscArrayQueue;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.List;
-
+/**
+ * Test cache size allocator.
+ */
 @Slf4j
 public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
+
+    private final int singleEntrySize = 500;
 
     @BeforeClass
     @Override
@@ -65,23 +77,27 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
-    @Test
-    public void cacheSizeAllocatorTest() throws Exception {
-        TopicName topicName = TopicName.get("public/default/cache-size-test");
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic(topicName.toString())
-                .create();
+    @DataProvider(name = "cacheSizeProvider")
+    private Object[][] dataProvider() {
+        return new Object[][] {
+                {-1}, {0}, {2000}, {5000}
+        };
+    }
 
-        int entrySize = 100;
-        MessageIdImpl firstMessageId = null;
-        MessageIdImpl lastMessageId = null;
-        for (int i = 0; i < entrySize; i++) {
-            MessageIdImpl messageId = (MessageIdImpl) producer.send(generateBytesData(100));
-            if (firstMessageId == null) {
-                firstMessageId = messageId;
-            }
-            lastMessageId = messageId;
-        }
+    @Test(dataProvider = "cacheSizeProvider")
+    public void cacheSizeAllocatorTest(long entryQueueSizeBytes) throws Exception {
+        TopicName topicName = TopicName.get(
+                "public/default/cache-size-" + entryQueueSizeBytes + "test_" + + RandomUtils.nextInt()) ;
+        int splitSize = 21;
+        MessageIdImpl firstMessageId = prepareData(topicName, splitSize);
+
+        PositionImpl lastPosition = null;
+        ReadOnlyCursor readOnlyCursor = pulsar.getManagedLedgerFactory().openReadOnlyCursor(
+                topicName.getPersistenceNamingEncoding(),
+                PositionImpl.get(firstMessageId.getLedgerId(), firstMessageId.getEntryId()),
+                new ManagedLedgerConfig());
+        readOnlyCursor.skipEntries(splitSize);
+        lastPosition = (PositionImpl) readOnlyCursor.getReadPosition();
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -91,13 +107,13 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
                 topicName.getNamespace(),
                 topicName.getLocalName(),
                 topicName.getLocalName(),
-                1,
+                splitSize,
                 new String(Schema.BYTES.getSchemaInfo().getSchema()),
                 Schema.BYTES.getSchemaInfo().getType(),
                 firstMessageId.getEntryId(),
-                lastMessageId.getEntryId(),
+                lastPosition.getEntryId(),
                 firstMessageId.getLedgerId(),
-                lastMessageId.getLedgerId(),
+                lastPosition.getLedgerId(),
                 TupleDomain.all(),
                 objectMapper.writeValueAsString(new HashMap<>()),
                 null);
@@ -106,6 +122,7 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
                 topicName, Schema.BYTES.getSchemaInfo(), PulsarColumnHandle.HandleKeyValueType.NONE, true);
 
         PulsarConnectorConfig connectorConfig = new PulsarConnectorConfig();
+        connectorConfig.setMaxSplitEntryQueueSizeBytes(entryQueueSizeBytes);
 
         ConnectorContext prestoConnectorContext = new TestingConnectorContext();
         PulsarRecordCursor pulsarRecordCursor = new PulsarRecordCursor(
@@ -115,20 +132,126 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
 
         Class<PulsarRecordCursor> recordCursorClass = PulsarRecordCursor.class;
         Field entryQueueField = recordCursorClass.getDeclaredField("entryQueue");
+        entryQueueField.setAccessible(true);
+        SpscArrayQueue<Entry> queue = (SpscArrayQueue<Entry>) entryQueueField.get(pulsarRecordCursor);
 
-        for (int i = 0; i < entrySize; i++) {
-            pulsarRecordCursor.advanceNextPosition();
-            SpscArrayQueue queue = (SpscArrayQueue) entryQueueField.get(pulsarRecordCursor);
-            log.info("queue size: {}", queue.size());
+        Field entriesProcessedField = recordCursorClass.getDeclaredField("entriesProcessed");
+        entriesProcessedField.setAccessible(true);
+
+        Class<PulsarRecordCursor.ReadEntries> readEntriesClass = PulsarRecordCursor.ReadEntries.class;
+        Field readEntriesField = recordCursorClass.getDeclaredField("readEntries");
+        readEntriesField.setAccessible(true);
+        PulsarRecordCursor.ReadEntries readEntries = (PulsarRecordCursor.ReadEntries)
+                readEntriesClass.getDeclaredConstructors()[0].newInstance(pulsarRecordCursor);
+        readEntriesField.set(pulsarRecordCursor, readEntries);
+
+        Class<PulsarRecordCursor.DeserializeEntries> deserializeEntriesClass =
+                PulsarRecordCursor.DeserializeEntries.class;
+        Field deserializeEntriesField = recordCursorClass.getDeclaredField("deserializeEntries");
+        deserializeEntriesField.setAccessible(true);
+        PulsarRecordCursor.DeserializeEntries deserializeEntries = (PulsarRecordCursor.DeserializeEntries)
+                deserializeEntriesClass.getDeclaredConstructors()[0].newInstance(pulsarRecordCursor);
+        deserializeEntriesField.set(pulsarRecordCursor, deserializeEntries);
+
+        Field isRunningField = deserializeEntriesClass.getDeclaredField("isRunning");
+        isRunningField.setAccessible(true);
+
+        Field outstandingReadsRequestsField = readEntriesClass.getDeclaredField("outstandingReadsRequests");
+        outstandingReadsRequestsField.setAccessible(true);
+        AtomicLong outstandingReadRequests = (AtomicLong) outstandingReadsRequestsField.get(readEntries);
+
+        int receiveNum = 0;
+
+        readEntries.run();
+        if (entryQueueSizeBytes == -1) {
+            // use NullCacheSizeAllocator
+            checkQueueSize(outstandingReadRequests, queue, splitSize);
+            deserializeEntries(queue, isRunningField, deserializeEntries);
+        } else {
+            // first read only one entry
+            checkQueueSize(outstandingReadRequests, queue, 1);
+            receiveNum += 1;
+            deserializeEntries(queue, isRunningField, deserializeEntries);
+
+            while (receiveNum != splitSize) {
+                long maxQueueSize = entryQueueSizeBytes / (singleEntrySize + 46) + 1;
+                if (maxQueueSize > (splitSize - receiveNum)) {
+                    maxQueueSize = splitSize - receiveNum;
+                }
+
+                int num = readAndCheck(readEntries, outstandingReadRequests, queue, (int) maxQueueSize);
+                receiveNum += num;
+                deserializeEntries(queue, isRunningField, deserializeEntries);
+            }
+        }
+
+        while (pulsarRecordCursor.advanceNextPosition()) {
+            for (int i = 0; i < pulsarColumnHandles.size(); i++) {
+                if (pulsarColumnHandles.get(i).getName().equals("__value__")) {
+                    Assert.assertEquals(pulsarRecordCursor.getSlice(i).getBytes().length, 500);
+                }
+            }
+        }
+
+        Assert.assertTrue(readEntries.hasFinished());
+        readEntries.run();
+        checkQueueSize(outstandingReadRequests, queue, 0);
+    }
+
+    private int readAndCheck(PulsarRecordCursor.ReadEntries readEntries,
+                             AtomicLong outstandingReadsRequests,
+                             SpscArrayQueue<Entry> queue,
+                             int maxQueueSize) throws Exception {
+        int receiveNum = 0;
+
+        // read twice to make sure queue size reach max queue size
+        readEntries.run();
+        waitReadComplete(outstandingReadsRequests);
+        readEntries.run();
+        checkQueueSize(outstandingReadsRequests, queue, maxQueueSize);
+        receiveNum += maxQueueSize;
+
+        // read again to make sure don't read any more entries
+        readEntries.run();
+        checkQueueSize(outstandingReadsRequests, queue, maxQueueSize);
+        return receiveNum;
+    }
+
+    private void checkQueueSize(AtomicLong outstandingReadRequests,
+                                SpscArrayQueue<Entry> queue, int expectedNum) throws Exception {
+        waitReadComplete(outstandingReadRequests);
+        Assert.assertEquals(queue.size(), expectedNum);
+    }
+
+    private void waitReadComplete(AtomicLong outstandingReadRequests) throws InterruptedException {
+        while (outstandingReadRequests.get() < 1) {
+            Thread.sleep(500);
         }
     }
 
-    private byte[] generateBytesData(int size) {
-        byte[] bytes = new byte[size];
-        for (int i = 0; i < size; i++) {
-            bytes[i] = 1;
+    private void deserializeEntries(SpscArrayQueue<Entry> queue,
+                                    Field isRunningField,
+                                    PulsarRecordCursor.DeserializeEntries deserializeEntries) throws Exception {
+        new Thread(deserializeEntries::run).start();
+        while (queue.size() > 0) {
+            Thread.sleep(100);
         }
-        return bytes;
+        isRunningField.set(deserializeEntries, false);
+    }
+
+    private MessageIdImpl prepareData(TopicName topicName, int messageNum) throws Exception {
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName.toString())
+                .create();
+
+        MessageIdImpl firstMessageId = null;
+        for (int i = 0; i < messageNum; i++) {
+            MessageIdImpl messageId = (MessageIdImpl) producer.send(new byte[singleEntrySize]);
+            if (firstMessageId == null) {
+                firstMessageId = messageId;
+            }
+        }
+        return firstMessageId;
     }
 
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Cache size allocator test.
+ */
+public class TestCacheSizeAllocator {
+
+    @Test
+    public void allocatorTest() {
+        CacheSizeAllocator cacheSizeAllocator = new CacheSizeAllocator(1000);
+        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+
+        cacheSizeAllocator.allocate(500);
+        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000 - 500);
+
+        cacheSizeAllocator.allocate(600);
+        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000 - 500 - 600);
+
+        cacheSizeAllocator.release(500 + 600);
+        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+
+        cacheSizeAllocator.release(100);
+        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+    }
+
+}

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestNoStrictCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestNoStrictCacheSizeAllocator.java
@@ -18,30 +18,31 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import org.apache.pulsar.sql.presto.util.NoStrictCacheSizeAllocator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * Cache size allocator test.
  */
-public class TestCacheSizeAllocator {
+public class TestNoStrictCacheSizeAllocator {
 
     @Test
     public void allocatorTest() {
-        CacheSizeAllocator cacheSizeAllocator = new CacheSizeAllocator(1000);
-        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+        NoStrictCacheSizeAllocator noStrictCacheSizeAllocator = new NoStrictCacheSizeAllocator(1000);
+        Assert.assertEquals(noStrictCacheSizeAllocator.getAvailableCacheSize(), 1000);
 
-        cacheSizeAllocator.allocate(500);
-        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000 - 500);
+        noStrictCacheSizeAllocator.allocate(500);
+        Assert.assertEquals(noStrictCacheSizeAllocator.getAvailableCacheSize(), 1000 - 500);
 
-        cacheSizeAllocator.allocate(600);
-        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000 - 500 - 600);
+        noStrictCacheSizeAllocator.allocate(600);
+        Assert.assertEquals(noStrictCacheSizeAllocator.getAvailableCacheSize(), 0);
 
-        cacheSizeAllocator.release(500 + 600);
-        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+        noStrictCacheSizeAllocator.release(500 + 600);
+        Assert.assertEquals(noStrictCacheSizeAllocator.getAvailableCacheSize(), 1000);
 
-        cacheSizeAllocator.release(100);
-        Assert.assertEquals(cacheSizeAllocator.getAvailableCacheSize(), 1000);
+        noStrictCacheSizeAllocator.release(100);
+        Assert.assertEquals(noStrictCacheSizeAllocator.getAvailableCacheSize(), 1000);
     }
 
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -67,6 +67,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -569,8 +570,8 @@ public abstract class TestPulsarConnector {
                     public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                         Object[] args = invocationOnMock.getArguments();
                         Integer readEntries = (Integer) args[0];
-                        AsyncCallbacks.ReadEntriesCallback callback = (AsyncCallbacks.ReadEntriesCallback) args[1];
-                        Object ctx = args[2];
+                        AsyncCallbacks.ReadEntriesCallback callback = (AsyncCallbacks.ReadEntriesCallback) args[2];
+                        Object ctx = args[3];
 
                         new Thread(new Runnable() {
                             @Override
@@ -622,7 +623,7 @@ public abstract class TestPulsarConnector {
 
                         return null;
                     }
-                }).when(readOnlyCursor).asyncReadEntries(anyInt(), any(), any(), any());
+                }).when(readOnlyCursor).asyncReadEntries(anyInt(), anyLong(), any(), any(), any());
 
                 when(readOnlyCursor.hasMoreEntries()).thenAnswer(new Answer<Boolean>() {
                     @Override

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
@@ -67,7 +67,7 @@ public class TestPulsarConnectorConfig {
         Assert.assertEquals(0L, connectorConfig.getManagedLedgerCacheSizeMB());
         Assert.assertEquals(availableProcessors, connectorConfig.getManagedLedgerNumWorkerThreads());
         Assert.assertEquals(availableProcessors, connectorConfig.getManagedLedgerNumSchedulerThreads());
-        Assert.assertEquals(connectorConfig.getMaxSplitEntryQueueSizeBytes(), -1);
+        Assert.assertEquals(connectorConfig.getMaxSplitQueueSizeBytes(), -1);
     }
 
     @Test

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
@@ -67,6 +67,7 @@ public class TestPulsarConnectorConfig {
         Assert.assertEquals(0L, connectorConfig.getManagedLedgerCacheSizeMB());
         Assert.assertEquals(availableProcessors, connectorConfig.getManagedLedgerNumWorkerThreads());
         Assert.assertEquals(availableProcessors, connectorConfig.getManagedLedgerNumSchedulerThreads());
+        Assert.assertEquals(connectorConfig.getMaxSplitEntryQueueSizeBytes(), -1);
     }
 
     @Test

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -311,8 +312,8 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
                     public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                         Object[] args = invocationOnMock.getArguments();
                         Integer readEntries = (Integer) args[0];
-                        AsyncCallbacks.ReadEntriesCallback callback = (AsyncCallbacks.ReadEntriesCallback) args[1];
-                        Object ctx = args[2];
+                        AsyncCallbacks.ReadEntriesCallback callback = (AsyncCallbacks.ReadEntriesCallback) args[2];
+                        Object ctx = args[3];
 
                         new Thread(new Runnable() {
                             @Override
@@ -349,7 +350,7 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
 
                         return null;
                     }
-                }).when(readOnlyCursor).asyncReadEntries(anyInt(), any(), any(), any());
+                }).when(readOnlyCursor).asyncReadEntries(anyInt(), anyLong(), any(), any(), any());
 
                 when(readOnlyCursor.hasMoreEntries()).thenAnswer(new Answer<Boolean>() {
                     @Override


### PR DESCRIPTION
### Motivation

In Pulsar SQL, there are two configurations `pulsar.max-split-entry-queue-size` and `pulsar.max-split-message-queue-size` to control the entry queue and message queue capacity, but some entries are so big some are small, it's hard to control the queue size bytes and the message queue size bytes.

### Modifications

Add a new configuration `pulsar.max-split-queue-cache-size` to control the entry queue size bytes and the message queue size bytes. Half of this configuration will assign to entry queue size bytes and the left quota assign to message queue size bytes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
