### PR TITLE
Consistently pass "alwaysRun = true" to all TestNG @After* annotations

### DIFF
--- a/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
+++ b/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
@@ -54,7 +54,7 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
         super.init();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -120,7 +120,7 @@ public abstract class BookKeeperClusterTestCase {
         return "";
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         // stop bookkeeper service
         stopBKCluster();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -105,7 +105,7 @@ public abstract class MockedBookKeeperTestCase {
         cachedExecutor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass() {
         executor.shutdown();
         cachedExecutor.shutdown();

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/ProxySaslAuthenticationTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/ProxySaslAuthenticationTest.java
@@ -160,7 +160,7 @@ public class ProxySaslAuthenticationTest extends ProducerConsumerBase {
 		log.info("created AuthenticationSasl");
 	}
 
-	@AfterClass
+	@AfterClass(alwaysRun = true)
 	public static void stopMiniKdc() {
 		System.clearProperty("java.security.auth.login.config");
 		System.clearProperty("java.security.krb5.conf");
@@ -206,7 +206,7 @@ public class ProxySaslAuthenticationTest extends ProducerConsumerBase {
 	}
 
 	@Override
-	@AfterMethod
+	@AfterMethod(alwaysRun = true)
 	protected void cleanup() throws Exception {
 		super.internalCleanup();
 	}

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -147,7 +147,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         log.info("created AuthenticationSasl");
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public static void stopMiniKdc() {
         System.clearProperty("java.security.auth.login.config");
         System.clearProperty("java.security.krb5.conf");
@@ -200,7 +200,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         super.producerBaseSetup();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderListTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderListTest.java
@@ -125,7 +125,7 @@ public class AuthenticationProviderListTest {
             Optional.of(new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(3))));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         this.authProvider.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -49,7 +49,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         //No-op
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -61,7 +61,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         resetConfig();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -47,7 +47,7 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
         super.producerBaseSetup();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -89,7 +89,7 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
         Thread.sleep(1000 * 3);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() {
         super.internalCleanup();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -71,7 +71,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
@@ -39,7 +39,7 @@ public class IOUtilsTest {
     InputStream stdin = System.in;
     PrintStream stdout = System.out;
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown() {
         System.setIn(stdin);
         System.setOut(stdout);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -44,7 +44,7 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
         super.internalSetup();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.resetConfig();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
@@ -72,7 +72,7 @@ public class AcknowledgementsGroupingTrackerTest {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardown() {
         eventLoopGroup.shutdownGracefully();
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxRequestTimeoutQueueTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxRequestTimeoutQueueTest.java
@@ -66,7 +66,7 @@ public class ClientCnxRequestTimeoutQueueTest {
         requestMessage = mock(ByteBuf.class);
     }
 
-    @AfterTest
+    @AfterTest(alwaysRun = true)
     void cleanupClientCnx() {
         eventLoop.shutdownNow();
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
@@ -40,7 +40,7 @@ public class MemoryLimitControllerTest {
         executor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     void teardown() {
         executor.shutdownNow();
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/DefaultSchemasTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/DefaultSchemasTest.java
@@ -79,7 +79,7 @@ public class DefaultSchemasTest {
         assertEquals(stringSchemaUtf16.encode(testString), bytes2);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown() throws PulsarClientException {
         client.close();
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
@@ -53,7 +53,7 @@ public class ChannelFuturesTest {
         eventLoop = new DefaultEventLoop();
     }
 
-    @AfterTest
+    @AfterTest(alwaysRun = true)
     public void shutdownEventLoop() throws InterruptedException {
         eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).await(100);
     }

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
@@ -88,7 +88,7 @@ public class DiscoveryServiceWebTest extends BaseZKStarterTest{
         start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     private void cleanup() throws Exception {
         close();
     }

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/web/ZookeeperCacheLoaderTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/web/ZookeeperCacheLoaderTest.java
@@ -47,7 +47,7 @@ public class ZookeeperCacheLoaderTest extends BaseZKStarterTest {
         start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     private void cleanup() throws Exception {
         close();
     }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryTest.java
@@ -131,7 +131,7 @@ public class KubernetesRuntimeFactoryTest {
         this.logDirectory = "logs/functions";
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() {
         if (null != this.factory) {
             this.factory.close();

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -174,7 +174,7 @@ public class KubernetesRuntimeTest {
         System.setProperty(FUNCTIONS_INSTANCE_CLASSPATH, "/pulsar/lib/*");
     }
     
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() {
         if (null != this.factory) {
             this.factory.close();

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -138,7 +138,7 @@ public class ProcessRuntimeTest {
         System.setProperty(FUNCTIONS_INSTANCE_CLASSPATH, "/pulsar/lib/*");
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() {
         if (null != this.factory) {
             this.factory.close();

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/ClusterServiceCoordinatorTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/ClusterServiceCoordinatorTest.java
@@ -75,7 +75,7 @@ public class ClusterServiceCoordinatorTest {
     }
 
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown() {
         coordinator.close();
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataTopicTailerTest.java
@@ -64,7 +64,7 @@ public class FunctionMetaDataTopicTailerTest {
                 ErrorNotifier.getDefaultImpl());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         fsc.close();
         verify(reader, times(1)).close();

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -137,7 +137,7 @@ public class SchedulerManagerTest {
         schedulerManager.setLeaderService(leaderService);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void stop() {
         this.executor.shutdown();
     }

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -61,7 +61,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         this.history = new PulsarDatabaseHistory();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -88,7 +88,7 @@ public class ElasticSearchSinkTests {
             }});
     }
     
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public final void tearDown() throws Exception {
         sink.close();
     }

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
@@ -68,7 +68,7 @@ public abstract class AbstractFileTests {
         executor = Executors.newFixedThreadPool(10);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         // Shutdown all of the processing threads
         stopThreads();

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/sink/StringSinkTests.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/sink/StringSinkTests.java
@@ -103,7 +103,7 @@ public class StringSinkTests extends AbstractFlumeTests {
         });
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         source.stop();
     }

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/source/StringSourceTests.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/source/StringSourceTests.java
@@ -71,7 +71,7 @@ public class StringSourceTests extends AbstractFlumeTests {
         mockSourceContext = mock(SourceContext.class);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         sink.stop();
         sink = null;

--- a/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkTest.java
+++ b/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBGenericRecordSinkTest.java
@@ -100,7 +100,7 @@ public class InfluxDBGenericRecordSinkTest {
         when(influxSink.influxDBBuilder.build(any())).thenReturn(influxDB);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         influxSink.close();
         verify(influxDB, times(1)).close();

--- a/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/JdbcUtilsTest.java
+++ b/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/JdbcUtilsTest.java
@@ -45,7 +45,7 @@ public class JdbcUtilsTest {
         sqliteUtils.setUp();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws IOException, SQLException {
         sqliteUtils.tearDown();
     }

--- a/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
+++ b/pulsar-io/jdbc/sqlite/src/test/java/org/apache/pulsar/io/jdbc/SqliteJdbcSinkTest.java
@@ -104,7 +104,7 @@ public class SqliteJdbcSinkTest {
 
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         sqliteUtils.tearDown();
         jdbcSink.close();

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -71,7 +71,7 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
 
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         tempFile.delete();

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
@@ -66,7 +66,7 @@ public class PulsarOffsetBackingStoreTest extends ProducerConsumerBase {
         this.offsetBackingStore.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         if (null != offsetBackingStore) {

--- a/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkTest.java
+++ b/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkTest.java
@@ -126,7 +126,7 @@ public class MongoSinkTest {
         }).when(mockPublisher).subscribe(any());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         sink.close();
         verify(mockMongoClient, times(1)).close();

--- a/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
+++ b/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
@@ -107,7 +107,7 @@ public class MongoSourceTest {
         }).when(mockPublisher).subscribe(any());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         source.close();
         verify(mockMongoClient, times(1)).close();

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -40,7 +40,7 @@ public class RabbitMQSinkTest {
         rabbitMQBrokerManager.startBroker();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         rabbitMQBrokerManager.stopBroker();
     }

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -37,7 +37,7 @@ public class RabbitMQSourceTest {
         rabbitMQBrokerManager.startBroker();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         rabbitMQBrokerManager.stopBroker();
     }

--- a/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkTest.java
+++ b/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkTest.java
@@ -45,7 +45,7 @@ public class RedisSinkTest {
         embeddedRedisUtils.setUp();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         embeddedRedisUtils.tearDown();
     }

--- a/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
+++ b/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrGenericRecordSinkTest.java
@@ -64,7 +64,7 @@ public class SolrGenericRecordSinkTest {
         solrServerUtil.startStandaloneSolr();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         solrServerUtil.stopStandaloneSolr();
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -34,7 +34,7 @@ public abstract class BaseMetadataStoreTest {
         zks = new TestZKServer();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     void teardown() throws Exception {
         zks.close();
     }

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageTest.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageTest.java
@@ -60,7 +60,7 @@ public class BookKeeperPackagesStorageTest extends BookKeeperClusterTestCase {
         storage.initialize();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
         if (storage != null) {
             storage.closeAsync().get();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLInputStreamTest.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLInputStreamTest.java
@@ -59,7 +59,7 @@ public class DLInputStreamTest {
         when(reader.asyncClose()).thenReturn(CompletableFuture.completedFuture(null));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown() throws IOException {
         if (dlm != null) {
             dlm.close();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStreamTest.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStreamTest.java
@@ -57,7 +57,7 @@ public class DLOutputStreamTest {
         when(writer.writeBulk(any(List.class)))
             .thenReturn(CompletableFuture.completedFuture(Collections.singletonList(DLSN.InitialDLSN))); }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown() throws IOException {
         if (dlm != null) {
             dlm.close();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -112,7 +112,7 @@ public abstract class BookKeeperClusterTestCase {
         }
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         // stop bookkeeper service
         stopBKCluster();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -105,7 +105,7 @@ public abstract class MockedBookKeeperTestCase {
         cachedExecutor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass() {
         executor.shutdown();
         cachedExecutor.shutdown();

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
@@ -30,10 +30,10 @@ import org.apache.pulsar.packages.management.core.PackagesStorageProvider;
 import org.apache.pulsar.packages.management.core.common.PackageMetadata;
 import org.apache.pulsar.packages.management.core.common.PackageName;
 import org.apache.pulsar.packages.management.core.exceptions.PackagesManagementException;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class PackagesManagementImplTest {
     private static PackagesStorage storage;

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/impl/PackagesManagementImplTest.java
@@ -49,7 +49,7 @@ public class PackagesManagementImplTest {
         packagesManagement.initialize(storage);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public static void teardown() throws ExecutionException, InterruptedException {
         storage.closeAsync().get();
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
@@ -111,7 +111,7 @@ public class AuthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
         webServer.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         webServer.stop();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
@@ -169,7 +169,7 @@ public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
@@ -128,7 +128,7 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         proxyService.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
@@ -183,7 +183,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 	}
 
 	@Override
-	@AfterMethod
+	@AfterMethod(alwaysRun = true)
 	protected void cleanup() throws Exception {
 		super.internalCleanup();
 	}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionThrottlingTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConnectionThrottlingTest.java
@@ -64,7 +64,7 @@ public class ProxyConnectionThrottlingTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
         proxyService.close();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyEnableHAProxyProtocolTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyEnableHAProxyProtocolTest.java
@@ -67,7 +67,7 @@ public class ProxyEnableHAProxyProtocolTest extends MockedPulsarServiceBaseTest 
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -76,7 +76,7 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
     }
 
     @Override
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
@@ -137,7 +137,7 @@ public class ProxyIsAHttpProxyTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithAuth.java
@@ -111,7 +111,7 @@ public class ProxyKeyStoreTlsTestWithAuth extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithoutAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithoutAuth.java
@@ -116,7 +116,7 @@ public class ProxyKeyStoreTlsTestWithoutAuth extends MockedPulsarServiceBaseTest
     }
 
     @Override
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
         proxyService.close();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyLookupThrottlingTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyLookupThrottlingTest.java
@@ -65,7 +65,7 @@ public class ProxyLookupThrottlingTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
         proxyService.close();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
@@ -85,7 +85,7 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
@@ -170,7 +170,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
     }
 
     @Override
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
@@ -91,7 +91,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -101,7 +101,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
@@ -71,7 +71,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
@@ -79,7 +79,7 @@ public class ProxyTlsTestWithAuth extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
@@ -135,7 +135,7 @@ public class ProxyWithAuthorizationNegTest extends ProducerConsumerBase {
         proxyService.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -203,7 +203,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                                                    PulsarConfigurationLoader.convertFrom(proxyConfig))));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -126,7 +126,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         proxyService.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SuperUserAuthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SuperUserAuthedAdminProxyHandlerTest.java
@@ -108,7 +108,7 @@ public class SuperUserAuthedAdminProxyHandlerTest extends MockedPulsarServiceBas
         webServer.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         webServer.stop();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
@@ -90,7 +90,7 @@ public class UnauthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
         webServer.stop();

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -686,7 +686,7 @@ public abstract class TestPulsarConnector {
         }
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void cleanup() {
         completedBytes = 0L;
     }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -50,7 +50,7 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
@@ -105,7 +105,7 @@ public abstract class MockedBookKeeperTestCase {
         cachedExecutor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass() {
         executor.shutdown();
         cachedExecutor.shutdown();

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
@@ -127,7 +127,7 @@ public class WebSocketWebResourceTest {
         topicName = TopicName.get("persistent://tenant/cluster/ns/dest");
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
         this.webResource = null;
     }

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/DeserializersTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/DeserializersTest.java
@@ -33,7 +33,7 @@ public class DeserializersTest {
     void setup() throws Exception {
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
     }
 

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -37,7 +37,7 @@ public class LocalBookkeeperEnsembleTest {
     void setup() throws Exception {
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
     }
 

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -62,7 +62,7 @@ public class ZkBookieRackAffinityMappingTest {
         BOOKIE3 = new BookieSocketAddress("127.0.0.3:3181");
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         localZkS.close();
     }

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
@@ -87,7 +87,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         isolationGroups.add("group1");
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         writableBookies.clear();
         isolationGroups.clear();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZooKeeperSessionWatcherTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZooKeeperSessionWatcherTest.java
@@ -70,7 +70,7 @@ public class ZooKeeperSessionWatcherTest {
         });
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         sessionWatcher.close();
         zkClient.shutdown();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperBkClientFactoryImplTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperBkClientFactoryImplTest.java
@@ -48,7 +48,7 @@ public class ZookeeperBkClientFactoryImplTest {
         localZkS.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         localZkS.close();
         executor.shutdown();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -79,7 +79,7 @@ public class ZookeeperCacheTest {
         zkClient = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         zkClient.shutdown();
     }
@@ -90,7 +90,7 @@ public class ZookeeperCacheTest {
         scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     void classTeardown() throws Exception {
         executor.shutdown();
         scheduledExecutor.shutdown();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperClientFactoryImplTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperClientFactoryImplTest.java
@@ -45,7 +45,7 @@ public class ZookeeperClientFactoryImplTest {
         localZkS.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         localZkS.close();
     }

--- a/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -72,7 +72,7 @@ public class SmokeTest {
 
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -72,7 +72,7 @@ public class SmokeTest {
 
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tests/bc_2_6_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_6_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -72,7 +72,7 @@ public class SmokeTest {
 
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/admin/PackagesOpsWithAuthTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/admin/PackagesOpsWithAuthTest.java
@@ -100,7 +100,7 @@ public class PackagesOpsWithAuthTest {
         pulsarCluster.start();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardown() {
         if (cmdContainer != null) {
             cmdContainer.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
@@ -134,7 +134,7 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
         log.info("Cluster {} is setup", spec.clusterName());
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_2.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_2.java
@@ -31,7 +31,7 @@ public class PulsarStandaloneTestSuite2_2 extends PulsarStandaloneTestBase imple
         super.startCluster(PulsarContainer.PULSAR_2_2_IMAGE_NAME);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_3.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_3.java
@@ -31,7 +31,7 @@ public class PulsarStandaloneTestSuite2_3 extends PulsarStandaloneTestBase imple
         super.startCluster(PulsarContainer.PULSAR_2_3_IMAGE_NAME);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_4.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_4.java
@@ -31,7 +31,7 @@ public class PulsarStandaloneTestSuite2_4 extends PulsarStandaloneTestBase imple
         super.startCluster(PulsarContainer.PULSAR_2_4_IMAGE_NAME);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
@@ -31,7 +31,7 @@ public class PulsarStandaloneTestSuite2_5 extends PulsarStandaloneTestBase imple
         super.startCluster(PulsarContainer.PULSAR_2_5_IMAGE_NAME);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/AdminMultiHostTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/AdminMultiHostTest.java
@@ -47,7 +47,7 @@ public class AdminMultiHostTest {
         pulsarCluster.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDownCluster() {
         if (pulsarCluster != null) {
             pulsarCluster.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
@@ -98,7 +98,7 @@ public class ClusterMetadataTearDownTest {
         admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() {
         try {
             ledgerManager.close();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
@@ -62,7 +62,7 @@ public class HealthCheckTest {
         pulsarCluster.start();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDownCluster() {
         if (pulsarCluster != null) {
             pulsarCluster.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
@@ -50,7 +50,7 @@ public class PackagesCliTest {
         pulsarCluster.start();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardown() {
         if (pulsarCluster != null) {
             pulsarCluster.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
@@ -59,7 +59,7 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
         log.info("{} function workers has started", numFunctionWorkers);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardownFunctionWorkers() {
         log.info("Tearing down function workers ...");
         pulsarCluster.stopWorkers();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestS3Offload.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestS3Offload.java
@@ -46,7 +46,7 @@ public class TestS3Offload extends TestBaseOffload {
         log.info("s3 container start finish.");
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardownS3() {
         if (null != s3Container) {
             s3Container.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestUniversalConfigurations.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestUniversalConfigurations.java
@@ -45,7 +45,7 @@ public class TestUniversalConfigurations extends TestBaseOffload {
         log.info("s3 container start finish.");
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardownS3() {
         if (null != s3Container) {
             s3Container.stop();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -39,7 +39,7 @@ public class TestBasicPresto extends TestPulsarSQLBase {
         pulsarCluster.startPrestoWorker();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardownPresto() {
         log.info("[TestBasicPresto] tearing down...");
         pulsarCluster.stopPrestoWorker();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPrestoQueryTieredStorage.java
@@ -92,7 +92,7 @@ public class TestPrestoQueryTieredStorage extends TestPulsarSQLBase {
         return sb.toString();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardownPresto() {
         log.info("[TestPrestoQueryTieredStorage] tearing down...");
         if (null != s3Container) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
@@ -31,7 +31,7 @@ public class PulsarStandaloneTestSuite extends PulsarStandaloneTestBase implemen
         super.startCluster(PulsarContainer.DEFAULT_IMAGE_NAME);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
@@ -33,7 +33,7 @@ public class PulsarTestSuite extends PulsarClusterTestBase implements ITest {
         super.setupCluster();
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTieredStorageTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTieredStorageTestSuite.java
@@ -52,7 +52,7 @@ public abstract class PulsarTieredStorageTestSuite extends PulsarClusterTestBase
         setupCluster(spec);
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/upgrade/PulsarZKDowngradeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/upgrade/PulsarZKDowngradeTest.java
@@ -74,7 +74,7 @@ public class PulsarZKDowngradeTest extends PulsarClusterTestBase {
         log.info("Cluster {} is setup", spec.clusterName());
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();

--- a/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -84,7 +84,7 @@ public class SimpleProducerConsumerTest {
         admin.close();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup() throws PulsarClientException {
         pulsarClient.close();
         pulsarContainer.stop();

--- a/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -85,7 +85,7 @@ public class SmokeTest {
         Assert.assertEquals(admin.namespaces().getNamespaces("public"), expectedNamespacesList);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -79,7 +79,7 @@ public class SimpleProducerConsumerTest {
         admin.close();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup() throws PulsarClientException {
         pulsarClient.close();
         pulsarContainer.stop();

--- a/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -85,7 +85,7 @@ public class SmokeTest {
         Assert.assertEquals(admin.namespaces().getNamespaces("public"), expectedNamespacesList);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -83,7 +83,7 @@ public class SimpleProducerConsumerTest {
         admin.close();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup() throws PulsarClientException {
         pulsarClient.close();
         pulsarContainer.stop();

--- a/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -72,7 +72,7 @@ public class SmokeTest {
 
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void cleanup(){
         pulsarContainer.stop();
     }

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
@@ -53,7 +53,7 @@ public class FileStoreTestBase {
                 scheduler, hdfsURI, basePath);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() {
         hdfsCluster.shutdown(true, true);
         hdfsCluster.close();

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
@@ -69,7 +69,7 @@ public class BlobStoreTestBase {
         }
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() {
         if (blobStore != null &&
             (!Boolean.parseBoolean(System.getProperty("testRealAWS", "false")) &&


### PR DESCRIPTION
### Motivation

TestNG doesn't run `@AfterMethod`/`@AfterClass`/`@AfterTest`/`@AfterSuite` annotations by default when the test execution fails or skipped. [By setting the `alwaysRun = true` attribute](https://testng.org/doc/documentation-main.html#annotations) for the annotation, TestNG will run the after method. TestNG documentation for alwaysRun: "For after methods (afterSuite, afterClass, ...): If set to true, this configuration method will be run even if one or more methods invoked previously failed or was skipped."

In most locations, `alwaysRun` is set to `true`. This motivation of this PR is to set `alwaysRun = true` consistently for all TestNG `@After*` annotations.

### Modifications

- Set `alwaysRun = true` consistently for all TestNG `@After*` annotations.
- One Junit 4 was detected. It was converted to a TestNG test.