### PR TITLE
Allow to disable producer max queue size

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.impl.ProducerImpl;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ProducerQueueSizeTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "matrix")
+    public Object[][] matrix() {
+        return new Object[][]{
+                {Boolean.FALSE, Boolean.FALSE},
+                {Boolean.FALSE, Boolean.TRUE},
+                {Boolean.TRUE, Boolean.FALSE},
+                {Boolean.TRUE, Boolean.TRUE},
+        };
+    }
+
+    @Test(dataProvider = "matrix")
+    public void testRemoveMaxQueueLimit(boolean blockIfQueueFull, boolean partitioned) throws Exception {
+        String topic = newTopicName();
+
+        if (partitioned) {
+            admin.topics().createPartitionedTopic(topic, 10);
+        }
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .memoryLimit(10, SizeUnit.KILO_BYTES)
+                .build();
+
+        @Cleanup
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(topic)
+                .blockIfQueueFull(blockIfQueueFull)
+                .maxPendingMessages(0)
+                .maxPendingMessagesAcrossPartitions(0)
+                .create();
+
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            futures.add(producer.sendAsync("hello"));
+        }
+
+        producer.flush();
+
+        for (CompletableFuture<?>f : futures) {
+            f.get();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -680,13 +680,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         try {
-            pulsarClient.newProducer().maxPendingMessages(0);
-            Assert.fail("should fail");
-        } catch (IllegalArgumentException e) {
-            // ok
-        }
-
-        try {
             pulsarClient.newProducer().topic("invalid://topic").create();
             Assert.fail("should fail");
         } catch (PulsarClientException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -426,13 +426,6 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         }
 
         try {
-            pulsarClient.newProducer().maxPendingMessages(0);
-            Assert.fail("should fail");
-        } catch (IllegalArgumentException e) {
-            // ok
-        }
-
-        try {
             pulsarClient.newProducer().topic("invalid://topic").create();
             Assert.fail("should fail");
         } catch (PulsarClientException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChecksumTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChecksumTest.java
@@ -136,7 +136,6 @@ public class MessageChecksumTest extends BrokerTestBase {
 
         // inject a CountDownLatch to the pending message callback of the PulsarTestClient
         CountDownLatch messageSendingProcessedLatch = new CountDownLatch(2);
-        pulsarTestClient.setPendingMessageCallback(__ -> messageSendingProcessedLatch.countDown());
 
         // WHEN
         // a message is sent, it should succeed
@@ -155,7 +154,6 @@ public class MessageChecksumTest extends BrokerTestBase {
 
         // And
         // until the message checksum has been calculated and it is pending
-        messageSendingProcessedLatch.await();
         pulsarTestClient.setPendingMessageCallback(null);
 
         // And

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -51,10 +51,12 @@ public class MemoryLimitController {
     }
 
     public void reserveMemory(long size) throws InterruptedException {
-        while (!tryReserveMemory(size)) {
+        if (!tryReserveMemory(size)) {
             mutex.lock();
             try {
-                condition.await();
+                while (!tryReserveMemory(size)) {
+                    condition.await();
+                }
             } finally {
                 mutex.unlock();
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -131,7 +131,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     }
 
     public void setMaxPendingMessages(int maxPendingMessages) {
-        checkArgument(maxPendingMessages > 0, "maxPendingMessages needs to be > 0");
+        checkArgument(maxPendingMessages >= 0, "maxPendingMessages needs to be >= 0");
         this.maxPendingMessages = maxPendingMessages;
     }
 


### PR DESCRIPTION
### Motivation

Allow to set the producer queue size to 0 and disable the limit, just relying on the `ClientBuilder.memoryLimit()` setting to apply the backpressure.

This will greatly simplify the producer configuration tuning to achieve high throughput on topics with many partitions.

### Modifications 
 
 * Set the producer semaphore as optional
 * Changed the queue into a non concurrent `ArrayDeque`, since we're using it always from within the producer 
 * Removed `pendingCallbacks` queue, which was there since forever but was completely useless.