### PR TITLE
Fix namespace-level MaxUnackedMessagesPerConsumer did not take effect and cannot be disabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -442,10 +442,6 @@ public abstract class AdminResource extends PulsarWebResource {
             policies.max_consumers_per_subscription = config.getMaxConsumersPerSubscription();
         }
 
-        if (policies.max_unacked_messages_per_consumer == -1) {
-            policies.max_unacked_messages_per_consumer = config.getMaxUnackedMessagesPerConsumer();
-        }
-
         if (policies.max_unacked_messages_per_subscription == -1) {
             policies.max_unacked_messages_per_subscription = config.getMaxUnackedMessagesPerSubscription();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2053,7 +2053,7 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected int internalGetMaxUnackedMessagesPerConsumer() {
+    protected Integer internalGetMaxUnackedMessagesPerConsumer() {
         validateNamespacePolicyOperation(namespaceName, PolicyName.MAX_UNACKED, PolicyOperation.READ);
         return getNamespacePolicies(namespaceName).max_unacked_messages_per_consumer;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -1095,7 +1095,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Get maxUnackedMessagesPerConsumer config on a namespace.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
-    public int getMaxUnackedMessagesPerConsumer(@PathParam("tenant") String tenant,
+    public Integer getMaxUnackedMessagesPerConsumer(@PathParam("tenant") String tenant,
                                        @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         return internalGetMaxUnackedMessagesPerConsumer();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -96,7 +96,7 @@ public abstract class AbstractTopic implements Topic {
     // schema validation enforced flag
     protected volatile boolean schemaValidationEnforced = false;
 
-    protected volatile int maxUnackedMessagesOnConsumer = -1;
+    protected volatile int maxUnackedMessagesOnConsumerAppilied = 0;
 
     protected volatile Integer maxSubscriptionsPerTopic = null;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessages.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessages.java
@@ -19,13 +19,22 @@
 package org.apache.pulsar.broker.admin;
 
 import com.google.common.collect.Sets;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.*;
 
@@ -48,13 +57,53 @@ public class AdminApiMaxUnackedMessages extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
+    @Test(timeOut = 30000)
+    public void testNamespacePolicy() throws Exception {
+        pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(3);
+        admin.namespaces().createNamespace("max-unacked-messages/policy-on-consumers");
+        final String namespace = "max-unacked-messages/policy-on-consumers";
+        final String topic = "persistent://" + namespace + "/testNamespacePolicy";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().receiverQueueSize(1)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub").topic(topic).subscribe();
+        //set namespace-level policy
+        admin.namespaces().setMaxUnackedMessagesPerConsumer(namespace, 1);
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.getSubscription("sub")
+                        .getConsumers().get(0).getMaxUnackedMessages(), 1));
+        //consumer-throttling should take effect
+        for (int i = 0; i < 20; i++) {
+            producer.send("msg".getBytes());
+        }
+        Message<byte[]> message = consumer.receive(500, TimeUnit.MILLISECONDS);
+        assertNotNull(message);
+        Message<byte[]> nullMsg = consumer.receive(500, TimeUnit.MILLISECONDS);
+        assertNull(nullMsg);
+
+        //disable limit check
+        admin.namespaces().setMaxUnackedMessagesPerConsumer(namespace, 0);
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.getSubscription("sub")
+                        .getConsumers().get(0).getMaxUnackedMessages(), 0));
+        consumer.acknowledge(message);
+        message = consumer.receive(500, TimeUnit.MILLISECONDS);
+        assertNotNull(message);
+    }
+
     @Test
     public void testMaxUnackedMessagesOnConsumers() throws Exception {
         admin.namespaces().createNamespace("max-unacked-messages/default-on-consumers");
         String namespace = "max-unacked-messages/default-on-consumers";
-        assertEquals(50000, admin.namespaces().getMaxUnackedMessagesPerConsumer(namespace));
+        assertNull(admin.namespaces().getMaxUnackedMessagesPerConsumer(namespace));
         admin.namespaces().setMaxUnackedMessagesPerConsumer(namespace, 2*50000);
-        assertEquals(2*50000, admin.namespaces().getMaxUnackedMessagesPerConsumer(namespace));
+        assertEquals(2*50000, admin.namespaces().getMaxUnackedMessagesPerConsumer(namespace).intValue());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -712,7 +712,6 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.subscriptionDispatchRate.put("test", ConfigHelper.subscriptionDispatchRate(conf));
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
         policies.max_unacked_messages_per_subscription = 200000;
-        policies.max_unacked_messages_per_consumer = 50000;
 
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
         assertEquals(admin.namespaces().getPermissions("prop-xyz/ns1"), policies.auth_policies.namespace_auth);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -650,7 +650,6 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         policies.clusterSubscribeRate.put("test", ConfigHelper.subscribeRate(conf));
 
         policies.max_unacked_messages_per_subscription = 200000;
-        policies.max_unacked_messages_per_consumer = 50000;
 
         assertEquals(admin.namespaces().getPolicies("prop-xyz/use/ns1"), policies);
         assertEquals(admin.namespaces().getPermissions("prop-xyz/use/ns1"), policies.auth_policies.namespace_auth);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -2879,7 +2879,7 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    int getMaxUnackedMessagesPerConsumer(String namespace) throws PulsarAdminException;
+    Integer getMaxUnackedMessagesPerConsumer(String namespace) throws PulsarAdminException;
 
     /**
      * Get the maxUnackedMessagesPerConsumer for a namespace asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -2437,7 +2437,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public int getMaxUnackedMessagesPerConsumer(String namespace) throws PulsarAdminException {
+    public Integer getMaxUnackedMessagesPerConsumer(String namespace) throws PulsarAdminException {
         try {
             return getMaxUnackedMessagesPerConsumerAsync(namespace).
                     get(this.readTimeoutMs, TimeUnit.MILLISECONDS);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -88,7 +88,7 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public int max_consumers_per_subscription = 0;
     @SuppressWarnings("checkstyle:MemberName")
-    public int max_unacked_messages_per_consumer = -1;
+    public Integer max_unacked_messages_per_consumer = null;
     @SuppressWarnings("checkstyle:MemberName")
     public int max_unacked_messages_per_subscription = -1;
     @SuppressWarnings("checkstyle:MemberName")
@@ -176,8 +176,8 @@ public class Policies {
                     && Objects.equals(subscription_auth_mode, other.subscription_auth_mode)
                     && Objects.equals(max_producers_per_topic, other.max_producers_per_topic)
                     && Objects.equals(max_consumers_per_topic, other.max_consumers_per_topic)
+                    && Objects.equals(max_unacked_messages_per_consumer, other.max_unacked_messages_per_consumer)
                     && max_consumers_per_subscription == other.max_consumers_per_subscription
-                    && max_unacked_messages_per_consumer == other.max_unacked_messages_per_consumer
                     && max_unacked_messages_per_subscription == other.max_unacked_messages_per_subscription
                     && compaction_threshold == other.compaction_threshold
                     && offload_threshold == other.offload_threshold


### PR DESCRIPTION
master issue #9146

### Motivation
Namespace-level `MaxUnackedMessagesPerConsumer` did not take effect and cannot be disabled.
The consumer will use the broker-level configuration when it is created, and this parameter is final and cannot be modified.

### Modifications
1) Change `int` to `Integer`, so that we can judge whether the namespace-level has a policy
2) The `maxUnackedMessages` in the consumer is changed to non-final, and this value is also updated when the policy is updated