### PR TITLE
Clean up in pulsar-broker unit tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
@@ -210,11 +210,11 @@ public class BookKeeperClientFactoryImplTest {
         BookKeeperClientFactoryImpl factory = new BookKeeperClientFactoryImpl();
         ServiceConfiguration conf = new ServiceConfiguration();
         // default value
-        assertEquals(factory.createBkClientConfiguration(conf).getOpportunisticStriping(), false);
+        assertFalse(factory.createBkClientConfiguration(conf).getOpportunisticStriping());
         conf.getProperties().setProperty("bookkeeper_opportunisticStriping", "true");
-        assertEquals(factory.createBkClientConfiguration(conf).getOpportunisticStriping(), true);
+        assertTrue(factory.createBkClientConfiguration(conf).getOpportunisticStriping());
         conf.getProperties().setProperty("bookkeeper_opportunisticStriping", "false");
-        assertEquals(factory.createBkClientConfiguration(conf).getOpportunisticStriping(), false);
+        assertFalse(factory.createBkClientConfiguration(conf).getOpportunisticStriping());
 
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
@@ -72,7 +72,7 @@ public class MockedBookKeeperClientFactory implements BookKeeperClientFactory {
     public void close() {
         try {
             mockedBk.close();
-        } catch (BKException | InterruptedException e) {
+        } catch (BKException | InterruptedException ignored) {
         }
         executor.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -198,11 +198,11 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
         try {
             assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "sub1"));
             fail();
-        } catch (Exception e) {}
+        } catch (Exception ignored) {}
         try {
             assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "sub2"));
             fail();
-        } catch (Exception e) {}
+        } catch (Exception ignored) {}
 
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "role1-sub1"));
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "role2-sub2"));
@@ -216,7 +216,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     private static void waitForChange() {
         try {
             Thread.sleep(100);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException ignored) {
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
@@ -55,7 +55,7 @@ public class MockAuthentication implements Authentication {
             @Override
             public String getHttpAuthType() { return "mock"; }
             @Override
-            public Set<Map.Entry<String, String>> getHttpHeaders() throws Exception {
+            public Set<Map.Entry<String, String>> getHttpHeaders() {
                 return ImmutableMap.of("mockuser", user).entrySet();
             }
             @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MockAuthenticationProvider implements AuthenticationProvider {
-    private static Logger log = LoggerFactory.getLogger(MockAuthenticationProvider.class);
+    private static final Logger log = LoggerFactory.getLogger(MockAuthenticationProvider.class);
 
     @Override
     public void close() throws IOException {}
@@ -55,12 +55,13 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
 
         String[] parts = principal.split("\\.");
         if (parts.length == 2) {
-            if (parts[0].equals("pass")) {
-                return principal;
-            } else if (parts[0].equals("fail")) {
-                throw new AuthenticationException("Do not pass");
-            } else if (parts[0].equals("error")) {
-                throw new RuntimeException("Error in authn");
+            switch (parts[0]) {
+                case "pass":
+                    return principal;
+                case "fail":
+                    throw new AuthenticationException("Do not pass");
+                case "error":
+                    throw new RuntimeException("Error in authn");
             }
         }
         throw new IllegalArgumentException(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthorizationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthorizationProvider.java
@@ -275,12 +275,13 @@ public class MockAuthorizationProvider implements AuthorizationProvider {
     boolean roleAuthorized(String role) {
         String[] parts = role.split("\\.");
         if (parts.length == 2) {
-            if (parts[1].equals("pass")) {
-                return true;
-            } else if (parts[1].equals("fail")) {
-                return false;
-            } else if (parts[1].equals("error")) {
-                throw new RuntimeException("Error in authn");
+            switch (parts[1]) {
+                case "pass":
+                    return true;
+                case "fail":
+                    return false;
+                case "error":
+                    throw new RuntimeException("Error in authn");
             }
         }
         throw new IllegalArgumentException(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -284,9 +284,7 @@ public abstract class MockedPulsarServiceBaseTest {
         doReturn(sameThreadOrderedSafeExecutor).when(pulsar).getOrderedExecutor();
         doReturn(new CounterBrokerInterceptor()).when(pulsar).getBrokerInterceptor();
 
-        doAnswer((invocation) -> {
-                return spy(invocation.callRealMethod());
-            }).when(pulsar).newCompactor();
+        doAnswer((invocation) -> spy(invocation.callRealMethod())).when(pulsar).newCompactor();
     }
 
     protected void waitForZooKeeperWatchers() {
@@ -320,7 +318,7 @@ public abstract class MockedPulsarServiceBaseTest {
         return zk;
     }
 
-    public static MockZooKeeper createMockZooKeeperGlobal() throws Exception {
+    public static MockZooKeeper createMockZooKeeperGlobal() {
         return  MockZooKeeper.newInstanceForGlobalZK(MoreExecutors.newDirectExecutorService());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/ResourceQuotaCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/ResourceQuotaCacheTest.java
@@ -61,10 +61,10 @@ public class ResourceQuotaCacheTest {
 
         // set mock pulsar localzkcache
         LocalZooKeeperCacheService localZkCache = mock(LocalZooKeeperCacheService.class);
-        ZooKeeperDataCache<LocalPolicies> poilciesCache = mock(ZooKeeperDataCache.class);
+        ZooKeeperDataCache<LocalPolicies> policiesCache = mock(ZooKeeperDataCache.class);
         when(pulsar.getLocalZkCacheService()).thenReturn(localZkCache);
-        when(localZkCache.policiesCache()).thenReturn(poilciesCache);
-        doNothing().when(poilciesCache).registerListener(any());
+        when(localZkCache.policiesCache()).thenReturn(policiesCache);
+        doNothing().when(policiesCache).registerListener(any());
         bundleFactory = new NamespaceBundleFactory(pulsar, Hashing.crc32());
 
         doReturn(zkCache).when(pulsar).getLocalZkCache();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -135,7 +135,7 @@ public class LoadBalancerTest {
 
 
             ServiceConfiguration config = new ServiceConfiguration();
-            config.setBrokerServicePort(Optional.ofNullable(brokerNativeBrokerPorts[i]));
+            config.setBrokerServicePort(Optional.of(brokerNativeBrokerPorts[i]));
             config.setClusterName("use");
             config.setAdvertisedAddress(localhost);
             config.setAdvertisedAddress("localhost");
@@ -488,7 +488,7 @@ public class LoadBalancerTest {
             sru.setCpu(new ResourceUsage(200, 400));
             lr.setSystemResourceUsage(sru);
 
-            Map<String, NamespaceBundleStats> bundleStats = new HashMap<String, NamespaceBundleStats>();
+            Map<String, NamespaceBundleStats> bundleStats = new HashMap<>();
             for (int j = 0; j < 5; j++) {
                 String bundleName = String.format("pulsar/use/primary-ns-%d-%d/0x00000000_0xffffffff", i, j);
                 NamespaceBundleStats stats = new NamespaceBundleStats();
@@ -496,7 +496,7 @@ public class LoadBalancerTest {
                 stats.msgRateOut = 15 * (i + j);
                 stats.msgThroughputIn = 5000 * (i + j);
                 stats.msgThroughputOut = 15000 * (i + j);
-                stats.topics = 25 * (i + j);
+                stats.topics = 25L * (i + j);
                 stats.consumerCount = 50 * (i + j);
                 stats.producerCount = 50 * (i + j);
                 bundleStats.put(bundleName, stats);
@@ -942,7 +942,7 @@ public class LoadBalancerTest {
         zkCacheField.setAccessible(true);
         zkCacheField.set(pulsarServices[0], mockCache);
 
-        TreeMap<Long, Set<ResourceUnit>> sortedRankingsInstance = new TreeMap<Long, Set<ResourceUnit>>();
+        TreeMap<Long, Set<ResourceUnit>> sortedRankingsInstance = new TreeMap<>();
         for (int i = 1; i <= 3; i++) {
             PulsarResourceDescription rd = createResourceDescription(memoryMB * i, cpuPercent * i, bInMbps * i,
                     bOutMbps * 2, threads * i);
@@ -954,7 +954,7 @@ public class LoadBalancerTest {
                 // get the object set and put the rd in it
                 sortedRankingsInstance.get(rank).add(ru1);
             } else {
-                Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+                Set<ResourceUnit> rus = new HashSet<>();
                 rus.add(ru1);
                 sortedRankingsInstance.put(rank, rus);
             }
@@ -962,12 +962,12 @@ public class LoadBalancerTest {
         }
         Field sortedRankings = SimpleLoadManagerImpl.class.getDeclaredField("sortedRankings");
         sortedRankings.setAccessible(true);
-        AtomicReference<TreeMap<Long, Set<ResourceUnit>>> ar = new AtomicReference<TreeMap<Long, Set<ResourceUnit>>>();
+        AtomicReference<TreeMap<Long, Set<ResourceUnit>>> ar = new AtomicReference<>();
         ar.set(sortedRankingsInstance);
         sortedRankings.set(loadManager, ar);
 
         int totalNamespaces = 10;
-        Map<String, Integer> namespaceOwner = new HashMap<String, Integer>();
+        Map<String, Integer> namespaceOwner = new HashMap<>();
         for (int i = 0; i < totalNamespaces; i++) {
             ResourceUnit found = loadManager
                     .getLeastLoaded(TopicName.get("persistent://pulsar/use/primary-ns/topic" + i)).get();
@@ -1014,7 +1014,7 @@ public class LoadBalancerTest {
                 // get the object set and put the rd in it
                 sortedRankingsInstance.get(rank).add(ru1);
             } else {
-                Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+                Set<ResourceUnit> rus = new HashSet<>();
                 rus.add(ru1);
                 sortedRankingsInstance.put(rank, rus);
             }
@@ -1023,12 +1023,12 @@ public class LoadBalancerTest {
 
         Field sortedRankings = SimpleLoadManagerImpl.class.getDeclaredField("sortedRankings");
         sortedRankings.setAccessible(true);
-        AtomicReference<TreeMap<Long, Set<ResourceUnit>>> ar = new AtomicReference<TreeMap<Long, Set<ResourceUnit>>>();
+        AtomicReference<TreeMap<Long, Set<ResourceUnit>>> ar = new AtomicReference<>();
         ar.set(sortedRankingsInstance);
         sortedRankings.set(loadManager, ar);
 
         int totalNamespaces = 1000;
-        Map<String, Integer> namespaceOwner = new HashMap<String, Integer>();
+        Map<String, Integer> namespaceOwner = new HashMap<>();
         for (int i = 0; i < totalNamespaces; i++) {
             ResourceUnit found = loadManager
                     .getLeastLoaded(TopicName.get("persistent://pulsar/use/primary-ns/topic-" + i)).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -174,15 +174,15 @@ public class SimpleLoadManagerImplTest {
         NamespaceIsolationPolicies policies = new NamespaceIsolationPolicies();
         // set up policy that use this broker as primary
         NamespaceIsolationData policyData = new NamespaceIsolationData();
-        policyData.namespaces = new ArrayList<String>();
+        policyData.namespaces = new ArrayList<>();
         policyData.namespaces.add("pulsar/use/primary-ns.*");
-        policyData.primary = new ArrayList<String>();
+        policyData.primary = new ArrayList<>();
         policyData.primary.add(pulsar1.getAdvertisedAddress() + "*");
-        policyData.secondary = new ArrayList<String>();
+        policyData.secondary = new ArrayList<>();
         policyData.secondary.add("prod2-broker([78]).messaging.usw.example.co.*");
         policyData.auto_failover_policy = new AutoFailoverPolicyData();
         policyData.auto_failover_policy.policy_type = AutoFailoverPolicyType.min_available;
-        policyData.auto_failover_policy.parameters = new HashMap<String, String>();
+        policyData.auto_failover_policy.parameters = new HashMap<>();
         policyData.auto_failover_policy.parameters.put("min_limit", "1");
         policyData.auto_failover_policy.parameters.put("usage_threshold", "100");
         policies.setPolicy("primaryBrokerPolicy", policyData);
@@ -196,9 +196,9 @@ public class SimpleLoadManagerImplTest {
 
     }
 
-    @Test(enabled = true)
+    @Test
     public void testBasicBrokerSelection() throws Exception {
-        LoadManager loadManager = new SimpleLoadManagerImpl(pulsar1);
+        SimpleLoadManagerImpl loadManager = new SimpleLoadManagerImpl(pulsar1);
         PulsarResourceDescription rd = new PulsarResourceDescription();
         rd.put("memory", new ResourceUsage(1024, 4096));
         rd.put("cpu", new ResourceUsage(10, 100));
@@ -206,7 +206,7 @@ public class SimpleLoadManagerImplTest {
         rd.put("bandwidthOut", new ResourceUsage(550 * 1024, 1024 * 1024));
 
         ResourceUnit ru1 = new SimpleResourceUnit("http://prod2-broker7.messaging.usw.example.com:8080", rd);
-        Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+        Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         LoadRanker lr = new ResourceAvailabilityRanker();
         AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
@@ -216,7 +216,7 @@ public class SimpleLoadManagerImplTest {
         sortedRankings.setAccessible(true);
         sortedRankings.set(loadManager, sortedRankingsInstance);
 
-        Optional<ResourceUnit> res = ((SimpleLoadManagerImpl) loadManager)
+        Optional<ResourceUnit> res = loadManager
                 .getLeastLoaded(NamespaceName.get("pulsar/use/primary-ns.10"));
         // broker is not active so found should be null
         assertEquals(res, Optional.empty(), "found a broker when expected none to be found");
@@ -230,10 +230,10 @@ public class SimpleLoadManagerImplTest {
         field.set(objInstance, newValue);
     }
 
-    @Test(enabled = true)
+    @Test
     public void testPrimary() throws Exception {
         createNamespacePolicies(pulsar1);
-        LoadManager loadManager = new SimpleLoadManagerImpl(pulsar1);
+        SimpleLoadManagerImpl loadManager = new SimpleLoadManagerImpl(pulsar1);
         PulsarResourceDescription rd = new PulsarResourceDescription();
         rd.put("memory", new ResourceUsage(1024, 4096));
         rd.put("cpu", new ResourceUsage(10, 100));
@@ -242,7 +242,7 @@ public class SimpleLoadManagerImplTest {
 
         ResourceUnit ru1 = new SimpleResourceUnit(
                 "http://" + pulsar1.getAdvertisedAddress() + ":" + pulsar1.getConfiguration().getWebServicePort().get(), rd);
-        Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+        Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         LoadRanker lr = new ResourceAvailabilityRanker();
 
@@ -263,7 +263,7 @@ public class SimpleLoadManagerImplTest {
         sortedRankingsInstance.get().put(lr.getRank(rd), rus);
         setObjectField(SimpleLoadManagerImpl.class, loadManager, "sortedRankings", sortedRankingsInstance);
 
-        ResourceUnit found = ((SimpleLoadManagerImpl) loadManager)
+        ResourceUnit found = loadManager
                 .getLeastLoaded(NamespaceName.get("pulsar/use/primary-ns.10")).get();
         // broker is not active so found should be null
         assertNotEquals(found, null, "did not find a broker when expected one to be found");
@@ -300,7 +300,7 @@ public class SimpleLoadManagerImplTest {
         log.info("lzk mocked active brokers are {}",
                 availableActiveBrokers.get(SimpleLoadManagerImpl.LOADBALANCE_BROKERS_ROOT));
 
-        LoadManager loadManager = new SimpleLoadManagerImpl(pulsar1);
+        SimpleLoadManagerImpl loadManager = new SimpleLoadManagerImpl(pulsar1);
 
         PulsarResourceDescription rd = new PulsarResourceDescription();
         rd.put("memory", new ResourceUsage(1024, 4096));
@@ -309,7 +309,7 @@ public class SimpleLoadManagerImplTest {
         rd.put("bandwidthOut", new ResourceUsage(550 * 1024, 1024 * 1024));
 
         ResourceUnit ru1 = new SimpleResourceUnit("http://prod2-broker7.messaging.usw.example.com:8080", rd);
-        Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+        Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         LoadRanker lr = new ResourceAvailabilityRanker();
         AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRankingsInstance = new AtomicReference<>(Maps.newTreeMap());
@@ -319,7 +319,7 @@ public class SimpleLoadManagerImplTest {
         sortedRankings.setAccessible(true);
         sortedRankings.set(loadManager, sortedRankingsInstance);
 
-        ResourceUnit found = ((SimpleLoadManagerImpl) loadManager)
+        ResourceUnit found = loadManager
                 .getLeastLoaded(NamespaceName.get("pulsar/use/primary-ns.10")).get();
         assertEquals(found.getResourceId(), ru1.getResourceId());
 
@@ -372,7 +372,7 @@ public class SimpleLoadManagerImplTest {
 
     @Test(enabled = true)
     public void testDoLoadShedding() throws Exception {
-        LoadManager loadManager = spy(new SimpleLoadManagerImpl(pulsar1));
+        SimpleLoadManagerImpl loadManager = spy(new SimpleLoadManagerImpl(pulsar1));
         PulsarResourceDescription rd = new PulsarResourceDescription();
         rd.put("memory", new ResourceUsage(1024, 4096));
         rd.put("cpu", new ResourceUsage(10, 100));
@@ -381,7 +381,7 @@ public class SimpleLoadManagerImplTest {
 
         ResourceUnit ru1 = new SimpleResourceUnit("http://pulsar-broker1.com:8080", rd);
         ResourceUnit ru2 = new SimpleResourceUnit("http://pulsar-broker2.com:8080", rd);
-        Set<ResourceUnit> rus = new HashSet<ResourceUnit>();
+        Set<ResourceUnit> rus = new HashSet<>();
         rus.add(ru1);
         rus.add(ru2);
         LoadRanker lr = new ResourceAvailabilityRanker();
@@ -414,7 +414,7 @@ public class SimpleLoadManagerImplTest {
         loadReports.put(ru2, loadReport2);
         setObjectField(SimpleLoadManagerImpl.class, loadManager, "currentLoadReports", loadReports);
 
-        ((SimpleLoadManagerImpl) loadManager).doLoadShedding();
+        loadManager.doLoadShedding();
         verify(loadManager, atLeastOnce()).doLoadShedding();
     }
 
@@ -503,14 +503,14 @@ public class SimpleLoadManagerImplTest {
     @Test
     public void testUsage() {
         Map<String, Object> metrics = Maps.newHashMap();
-        metrics.put("brk_conn_cnt", new Long(1));
-        metrics.put("brk_repl_conn_cnt", new Long(1));
-        metrics.put("jvm_thread_cnt", new Long(1));
+        metrics.put("brk_conn_cnt", 1L);
+        metrics.put("brk_repl_conn_cnt", 1L);
+        metrics.put("jvm_thread_cnt", 1L);
         BrokerUsage brokerUsage = BrokerUsage.populateFrom(metrics);
         assertEquals(brokerUsage.getConnectionCount(), 1);
         assertEquals(brokerUsage.getReplicationConnectionCount(), 1);
-        JvmUsage jvmUage = JvmUsage.populateFrom(metrics);
-        assertEquals(jvmUage.getThreadCount(), 1);
+        JvmUsage jvmUsage = JvmUsage.populateFrom(metrics);
+        assertEquals(jvmUsage.getThreadCount(), 1);
         SystemResourceUsage usage = new SystemResourceUsage();
         double usageLimit = 10.0;
         usage.setBandwidthIn(new ResourceUsage(usageLimit, usageLimit));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
@@ -57,7 +57,7 @@ public class BookieClientsStatsGeneratorTest extends BrokerTestBase {
     }
 
     @Test
-    public void testJvmDirectMemoryUsedMetric() throws Exception {
+    public void testJvmDirectMemoryUsedMetric() {
         PooledByteBufAllocator allocator = new PooledByteBufAllocator( //
                 true, // preferDirect
                 0, // nHeapArenas,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -98,10 +98,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         Collection<Metric> metric = metrics.get("pulsar_topics_count");
-        metric.stream().forEach(item -> {
+        metric.forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
                 assertEquals(item.value, 6.0);
             }
@@ -141,7 +141,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
@@ -248,7 +248,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         // There should be 2 metrics with different tags for each topic
         List<Metric> cm = (List<Metric>) metrics.get("pulsar_subscription_last_expire_timestamp");
@@ -470,7 +470,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, true, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
@@ -550,7 +550,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
 
         Map<String, String> typeDefs = new HashMap<String, String>();
         Map<String, String> metricNames = new HashMap<String, String>();
@@ -636,7 +636,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
@@ -672,7 +672,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
@@ -721,13 +721,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         String ns = cm.get(0).tags.get("namespace");
-        assertEquals(ns.equals("my-property/use/my-ns") || ns.equals("my-property/use/my-ns2"), true);
+        assertTrue(ns.equals("my-property/use/my-ns") || ns.equals("my-property/use/my-ns2"));
 
         cm = (List<Metric>) metrics.get("pulsar_ml_AddEntryMessagesRate");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         ns = cm.get(0).tags.get("namespace");
-        assertEquals(ns.equals("my-property/use/my-ns") || ns.equals("my-property/use/my-ns2"), true);
+        assertTrue(ns.equals("my-property/use/my-ns") || ns.equals("my-property/use/my-ns2"));
 
         p1.close();
         p2.close();
@@ -747,7 +747,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
@@ -820,7 +820,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         List<Metric> cm = (List<Metric>) metrics.get("pulsar_authentication_success_count");
         boolean haveSucceed = false;
@@ -880,7 +880,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         List<Metric> cm = (List<Metric>) metrics.get("pulsar_expired_token_count");
         assertEquals(cm.size(), 1);
@@ -921,7 +921,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
-        String metricsStr = new String(statsOut.toByteArray());
+        String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
         Metric countMetric = ((List<Metric>) metrics.get("pulsar_expiring_token_minutes_count")).get(0);
         assertEquals(countMetric.value, tokenRemainTime.length);
@@ -979,7 +979,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             } else if (numericValue.equalsIgnoreCase("+Inf")) {
                 m.value = Double.POSITIVE_INFINITY;
             } else {
-                m.value = Double.valueOf(numericValue);
+                m.value = Double.parseDouble(numericValue);
             }
             String tags = matcher.group(2);
             Matcher tagsMatcher = tagsPattern.matcher(tags);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -53,7 +53,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
     }
 
     @Test
-    public void testInitialzation() throws InterruptedException, ExecutionException, PulsarAdminException {
+    public void testInitialization() throws InterruptedException, ExecutionException, PulsarAdminException {
 
         Properties properties = new Properties();
         properties.setProperty("serviceUrl", brokerUrl.toString());
@@ -91,7 +91,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 if(subscriptions.size() == 1){
                     break;
                 }
-            } catch (Exception e){
+            } catch (Exception ignored){
             }
             Thread.sleep(200);
         }
@@ -155,7 +155,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 if (subscriptions.size() == 0) {
                     break;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             Thread.sleep(200);
         }
@@ -192,7 +192,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
                 if (subscriptions.size() == 1) {
                     break;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             Thread.sleep(200);
         }
@@ -242,7 +242,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
             try {
                 List<String> subscriptions = admin.topics().getSubscriptions(topicName);
                 isCreated = (subscriptions.size() == 1);
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             return isCreated;
         });

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -35,8 +35,6 @@ import java.util.concurrent.Executors;
 
 
 public class PulsarClientToolWsTest extends BrokerTestBase {
-    private ProxyServer proxyServer;
-    private WebSocketService service;
 
     @BeforeMethod
     @Override
@@ -81,7 +79,7 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
                 if (subscriptions.size() == 1) {
                     break;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             Thread.sleep(200);
         }
@@ -100,7 +98,7 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
                 if (subscriptions.size() == 0) {
                     break;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             Thread.sleep(200);
         }
@@ -136,7 +134,7 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
                 if (subscriptions.size() == 1) {
                     break;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
             Thread.sleep(200);
         }


### PR DESCRIPTION
Collection of minor cleanup in pulsar-broker unit test cases.

* Fixing Usage of assert statements.
* Removing unused exceptions.
* Remove Unnecessary String creations.
