### PR TITLE
[MINOR] fix pulsar-io maven build configuration in pom.xml to avoid WARNING log

### DIFF
--- a/pulsar-io/aerospike/pom.xml
+++ b/pulsar-io/aerospike/pom.xml
@@ -66,6 +66,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -75,13 +78,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/aws/pom.xml
+++ b/pulsar-io/aws/pom.xml
@@ -63,6 +63,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -72,13 +75,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/batch-data-generator/pom.xml
+++ b/pulsar-io/batch-data-generator/pom.xml
@@ -75,6 +75,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+                </configuration>
                 <executions>
                     <execution>
                         <id>spotbugs</id>
@@ -84,13 +87,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pulsar-io/batch-discovery-triggerers/pom.xml
+++ b/pulsar-io/batch-discovery-triggerers/pom.xml
@@ -58,6 +58,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -67,13 +70,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -56,6 +56,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+                </configuration>
                 <executions>
                     <execution>
                         <id>spotbugs</id>
@@ -65,13 +68,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pulsar-io/core/pom.xml
+++ b/pulsar-io/core/pom.xml
@@ -44,6 +44,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -53,13 +56,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/docs/pom.xml
+++ b/pulsar-io/docs/pom.xml
@@ -125,6 +125,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -134,13 +137,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/netty/pom.xml
+++ b/pulsar-io/netty/pom.xml
@@ -88,6 +88,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
+                </configuration>
                 <executions>
                     <execution>
                         <id>spotbugs</id>
@@ -97,13 +100,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
there is always WARNING log in maven build log like following：

2021-02-20T15:39:58.6034609Z + echo -n 'Test Group : BROKER_GROUP_2'
2021-02-20T15:39:58.6035074Z + case $TEST_GROUP in
2021-02-20T15:39:58.6035488Z + broker_group_2
2021-02-20T15:39:58.6036948Z + build/retry.sh mvn -B -ntp test -pl pulsar-broker '-Dinclude=**/MessagePublishBufferThrottleTest.java' -DtestForkCount=1 -DtestReuseFork=true
2021-02-20T15:39:59.6481733Z Test Group : BROKER_GROUP_2[INFO] Scanning for projects...
2021-02-20T15:40:02.8370210Z [WARNING] 
2021-02-20T15:40:02.8374144Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-core:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8376090Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 57, column 15
2021-02-20T15:40:02.8377234Z [WARNING] 
2021-02-20T15:40:02.8450898Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-batch-discovery-triggerers:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8463439Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 71, column 15
2021-02-20T15:40:02.8464777Z [WARNING] 
2021-02-20T15:40:02.8470179Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-batch-data-generator:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8475823Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 88, column 21
2021-02-20T15:40:02.8476977Z [WARNING] 
2021-02-20T15:40:02.8478130Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-common:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8483317Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 69, column 21
2021-02-20T15:40:02.8487566Z [WARNING] 
2021-02-20T15:40:02.8490101Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-docs:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8492048Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 138, column 15
2021-02-20T15:40:02.8493180Z [WARNING] 
2021-02-20T15:40:02.8494298Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-aws:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8496227Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 76, column 15
2021-02-20T15:40:02.8523187Z [WARNING] 
2021-02-20T15:40:02.8524658Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-aerospike:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8526649Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 79, column 15
2021-02-20T15:40:02.8527775Z [WARNING] 
2021-02-20T15:40:02.8528910Z [WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-io-netty:jar:2.8.0-SNAPSHOT
2021-02-20T15:40:02.8531178Z [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.github.spotbugs:spotbugs-maven-plugin @ line 101, column 21
2021-02-20T15:40:02.8532305Z [WARNING] 
2021-02-20T15:40:02.8533005Z [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
2021-02-20T15:40:02.8533715Z [WARNING] 
2021-02-20T15:40:02.8534410Z [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
2021-02-20T15:40:02.8535122Z [WARNING] 
2021-02-20T15:40:02.8764319Z [INFO] ------------------------------------------------------------------------
2021-02-20T15:40:02.8766196Z [INFO] Detecting the operating system and CPU architecture
2021-02-20T15:40:02.8773375Z [INFO] ------------------------------------------------------------------------
2021-02-20T15:40:02.8774528Z [INFO] os.detected.name: linux
2021-02-20T15:40:02.8776403Z [INFO] os.detected.arch: x86_64
2021-02-20T15:40:02.8813515Z [INFO] os.detected.release: ubuntu
2021-02-20T15:40:02.8814927Z [INFO] os.detected.release.version: 16.04
2021-02-20T15:40:02.8815805Z [INFO] os.detected.release.like.ubuntu: true
2021-02-20T15:40:02.8816722Z [INFO] os.detected.release.like.debian: true
2021-02-20T15:40:02.8817899Z [INFO] os.detected.classifier: linux-x86_64
2021-02-20T15:40:02.8894526Z [INFO] 
2021-02-20T15:40:02.8958527Z [INFO] ------------------< org.apache.pulsar:pulsar-broker >-------------------