### PR TITLE
[Testing] Improve integration test base classes

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -33,5 +33,6 @@
         <Logger name="org.apache.pulsar" level="info"/>
         <Logger name="org.apache.bookkeeper" level="info"/>
         <Logger name="org.apache.kafka" level="info"/>
+        <Logger name="org.testcontainers" level="info"/>
     </Loggers>
 </Configuration>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
@@ -21,12 +21,12 @@ package org.apache.pulsar.tests.integration.auth.token;
 import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
-
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.Consumer;
@@ -35,8 +35,6 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.impl.ProducerImpl;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -48,17 +46,13 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
 import org.testcontainers.containers.Network;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
-public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTestBase implements ITest {
+public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTestBase {
 
     protected String superUserAuthToken;
     protected String proxyAuthToken;
@@ -76,7 +70,7 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
 
     protected ZKContainer<?> cmdContainer;
 
-    @BeforeSuite
+    @BeforeClass
     @Override
     public void setupCluster() throws Exception {
         // Before starting the cluster, generate the secret key and the token
@@ -134,16 +128,11 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
         log.info("Cluster {} is setup", spec.clusterName());
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();
         cmdContainer.close();
-    }
-
-    @Override
-    public String getTestName() {
-        return "token-auth-test-suite";
     }
 
     @Test

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_2.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_2.java
@@ -20,24 +20,19 @@ package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarStandaloneTestSuite2_2 extends PulsarStandaloneTestBase implements ITest {
+public class PulsarStandaloneTestSuite2_2 extends PulsarStandaloneTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     public void setUpCluster() throws Exception {
         super.startCluster(PulsarContainer.PULSAR_2_2_IMAGE_NAME);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }
 
-    @Override
-    public String getTestName() {
-        return "pulsar-standalone-suite";
-    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_3.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_3.java
@@ -20,23 +20,19 @@ package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarStandaloneTestSuite2_3 extends PulsarStandaloneTestBase implements ITest {
+public class PulsarStandaloneTestSuite2_3 extends PulsarStandaloneTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     public void setUpCluster() throws Exception {
         super.startCluster(PulsarContainer.PULSAR_2_3_IMAGE_NAME);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }
-    @Override
-    public String getTestName() {
-        return "pulsar-standalone-suite";
-    }
+
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_4.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_4.java
@@ -20,23 +20,19 @@ package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarStandaloneTestSuite2_4 extends PulsarStandaloneTestBase implements ITest {
+public class PulsarStandaloneTestSuite2_4 extends PulsarStandaloneTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     public void setUpCluster() throws Exception {
         super.startCluster(PulsarContainer.PULSAR_2_4_IMAGE_NAME);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }
-    @Override
-    public String getTestName() {
-        return "pulsar-standalone-suite";
-    }
+
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/PulsarStandaloneTestSuite2_5.java
@@ -20,23 +20,19 @@ package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarStandaloneTestSuite2_5 extends PulsarStandaloneTestBase implements ITest {
+public class PulsarStandaloneTestSuite2_5 extends PulsarStandaloneTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     public void setUpCluster() throws Exception {
         super.startCluster(PulsarContainer.PULSAR_2_5_IMAGE_NAME);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }
-    @Override
-    public String getTestName() {
-        return "pulsar-standalone-suite";
-    }
+
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_2.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_2.java
@@ -32,9 +32,4 @@ public class SmokeTest2_2 extends PulsarStandaloneTestSuite2_2 {
     public void testBatchMessagePublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {
         super.testBatchMessagePublishAndConsume(serviceUrl, isPersistent);
     }
-
-    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
-    public void testBatchIndexAckDisabled(String serviceUrl, boolean isPersistent) throws Exception {
-        super.testBatchIndexAckDisabled(serviceUrl);
-    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_3.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/SmokeTest2_3.java
@@ -32,9 +32,4 @@ public class SmokeTest2_3 extends PulsarStandaloneTestSuite2_3 {
     public void testBatchMessagePublishAndConsume(String serviceUrl, boolean isPersistent) throws Exception {
         super.testBatchMessagePublishAndConsume(serviceUrl, isPersistent);
     }
-
-    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
-    public void testBatchIndexAckDisabled(String serviceUrl, boolean isPersistent) throws Exception {
-        super.testBatchIndexAckDisabled(serviceUrl);
-    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClusterMetadataTearDownTest.java
@@ -18,6 +18,20 @@
  */
 package org.apache.pulsar.tests.integration.cli;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -39,25 +53,9 @@ import org.apache.pulsar.tests.integration.containers.ChaosContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.apache.zookeeper.ZooKeeper;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @Slf4j
 public class ClusterMetadataTearDownTest {
@@ -81,7 +79,7 @@ public class ClusterMetadataTearDownTest {
     private PulsarClient client;
     private PulsarAdmin admin;
 
-    @BeforeSuite
+    @BeforeClass
     public void setupCluster() throws Exception {
         pulsarCluster.start();
         metadataServiceUri = "zk+null://" + pulsarCluster.getZKConnString() + "/ledgers";
@@ -98,7 +96,7 @@ public class ClusterMetadataTearDownTest {
         admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build();
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() {
         try {
             ledgerManager.close();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1661,7 +1661,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
     }
 
-    private static void submitExclamationFunction(Runtime runtime,
+    private void submitExclamationFunction(Runtime runtime,
                                                   String inputTopicName,
                                                   String outputTopicName,
                                                   String functionName,
@@ -1680,7 +1680,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             schema);
     }
 
-    private static <T> void submitFunction(Runtime runtime,
+    private <T> void submitFunction(Runtime runtime,
                                            String inputTopicName,
                                            String outputTopicName,
                                            String functionName,
@@ -1708,7 +1708,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         submitFunction(runtime, inputTopicName, outputTopicName, functionName, file, functionClass, inputTopicSchema);
     }
 
-    private static <T> void submitFunction(Runtime runtime,
+    private <T> void submitFunction(Runtime runtime,
                                            String inputTopicName,
                                            String outputTopicName,
                                            String functionName,
@@ -1718,7 +1718,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         submitFunction(runtime, inputTopicName, outputTopicName, functionName, functionFile, functionClass, inputTopicSchema, null);
     }
 
-    private static <T> void submitFunction(Runtime runtime,
+    private <T> void submitFunction(Runtime runtime,
                                            String inputTopicName,
                                            String outputTopicName,
                                            String functionName,
@@ -1767,7 +1767,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         ensureSubscriptionCreated(inputTopicName, String.format("public/default/%s", functionName), inputTopicSchema);
     }
 
-    private static void updateFunctionParallelism(String functionName, int parallelism) throws Exception {
+    private void updateFunctionParallelism(String functionName, int parallelism) throws Exception {
 
         CommandGenerator generator = new CommandGenerator();
         generator.setFunctionName(functionName);
@@ -1783,7 +1783,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertTrue(result.getStdout().contains("\"Updated successfully\""));
     }
 
-    private static <T> void submitFunction(Runtime runtime,
+    private <T> void submitFunction(Runtime runtime,
                                            String inputTopicName,
                                            String outputTopicName,
                                            String functionName,
@@ -1826,7 +1826,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertTrue(result.getStdout().contains("\"Created successfully\""));
     }
 
-    private static <T> void ensureSubscriptionCreated(String inputTopicName,
+    private <T> void ensureSubscriptionCreated(String inputTopicName,
                                                       String subscriptionName,
                                                       Schema<T> inputTopicSchema)
             throws Exception {
@@ -1843,7 +1843,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
     }
 
-    private static void getFunctionInfoSuccess(String functionName) throws Exception {
+    private void getFunctionInfoSuccess(String functionName) throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",
@@ -1857,7 +1857,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertTrue(result.getStdout().contains("\"name\": \"" + functionName + "\""));
     }
 
-    private static void getFunctionStatsEmpty(String functionName) throws Exception {
+    private void getFunctionStatsEmpty(String functionName) throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "functions",
@@ -1897,7 +1897,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertEquals(functionStats.instances.get(0).getMetrics().oneMin.getAvgProcessLatency(), null);
     }
 
-    private static void getFunctionStats(String functionName, int numMessages) throws Exception {
+    private void getFunctionStats(String functionName, int numMessages) throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "functions",
@@ -1937,7 +1937,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertTrue(functionStats.instances.get(0).getMetrics().oneMin.getAvgProcessLatency() > 0);
     }
 
-    private static void getFunctionInfoNotFound(String functionName) throws Exception {
+    private void getFunctionInfoNotFound(String functionName) throws Exception {
         retryStrategically(aVoid -> {
             try {
                 pulsarCluster.getAnyWorker().execCmd(
@@ -1959,7 +1959,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }, 5, 100, true);
     }
 
-    private static void checkSubscriptionsCleanup(String topic) throws Exception {
+    private void checkSubscriptionsCleanup(String topic) throws Exception {
         try {
             ContainerExecResult result = pulsarCluster.getAnyBroker().execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
@@ -1974,7 +1974,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
     }
 
-    private static void checkPublisherCleanup(String topic) throws Exception {
+    private void checkPublisherCleanup(String topic) throws Exception {
         try {
             ContainerExecResult result = pulsarCluster.getAnyBroker().execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
@@ -1989,11 +1989,11 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
     }
 
-    private static void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts) throws Exception {
+    private void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts) throws Exception {
         getFunctionStatus(functionName, numMessages, checkRestarts, 1);
     }
 
-    private static void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts, int parallelism)
+    private void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts, int parallelism)
         throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
             PulsarCluster.ADMIN_SCRIPT,
@@ -2037,7 +2037,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         assertEquals(totalMessagesSuccessfullyProcessed, numMessages);
     }
 
-    private static void publishAndConsumeMessages(String inputTopic,
+    private void publishAndConsumeMessages(String inputTopic,
                                                   String outputTopic,
                                                   int numMessages) throws Exception {
         @Cleanup PulsarClient client = PulsarClient.builder()
@@ -2089,7 +2089,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
     }
 
-    private static void publishAndConsumeMessagesBytes(String inputTopic,
+    private void publishAndConsumeMessagesBytes(String inputTopic,
                                                        String outputTopic,
                                                        int numMessages) throws Exception {
         @Cleanup PulsarClient client = PulsarClient.builder()
@@ -2142,7 +2142,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         }
     }
 
-    private static void deleteFunction(String functionName) throws Exception {
+    private void deleteFunction(String functionName) throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",
@@ -2196,7 +2196,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         getFunctionInfoNotFound(functionName);
     }
 
-    private static void publishAndConsumeAvroMessages(String inputTopic,
+    private void publishAndConsumeAvroMessages(String inputTopic,
                                                       String outputTopic,
                                                       int numMessages) throws Exception {
 
@@ -2660,7 +2660,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             super.setupCluster();
             super.setupFunctionWorkers();
         }
-        
+
         Schema<?> schema;
         if (Runtime.JAVA == runtime) {
             schema = Schema.STRING;
@@ -2709,7 +2709,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
     }
 
-    private static void submitJavaLoggingFunction(String inputTopicName,
+    private void submitJavaLoggingFunction(String inputTopicName,
                                                   String logTopicName,
                                                   String functionName,
                                                   Schema<?> schema) throws Exception {
@@ -2737,7 +2737,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         ensureSubscriptionCreated(inputTopicName, String.format("public/default/%s", functionName), schema);
     }
 
-    private static void publishAndConsumeMessages(String inputTopic,
+    private void publishAndConsumeMessages(String inputTopic,
                                                   String outputTopic,
                                                   int numMessages,
                                                   String messagePostfix) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -226,7 +226,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 result.getStdout());
     }
 
-    private static void submitExclamationFunction(Runtime runtime,
+    private void submitExclamationFunction(Runtime runtime,
                                                   String inputTopicName,
                                                   String outputTopicName,
                                                   String functionName) throws Exception {
@@ -247,7 +247,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         }
     }
 
-    private static <T> void submitFunction(Runtime runtime,
+    private <T> void submitFunction(Runtime runtime,
                                            String inputTopicName,
                                            String outputTopicName,
                                            String functionName,
@@ -276,7 +276,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         ensureSubscriptionCreated(inputTopicName, String.format("public/default/%s", functionName), inputTopicSchema);
     }
 
-    private static <T> void ensureSubscriptionCreated(String inputTopicName,
+    private <T> void ensureSubscriptionCreated(String inputTopicName,
                                                       String subscriptionName,
                                                       Schema<T> inputTopicSchema)
             throws Exception {
@@ -293,7 +293,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         }
     }
 
-    private static void getSinkInfoSuccess(String sinkName) throws Exception {
+    private void getSinkInfoSuccess(String sinkName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sinks",
@@ -305,7 +305,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"name\": \"" + sinkName + "\""));
     }
 
-    private static void getSourceInfoSuccess(String sourceName) throws Exception {
+    private void getSourceInfoSuccess(String sourceName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sources",
@@ -317,7 +317,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"name\": \"" + sourceName + "\""));
     }
 
-    private static void getFunctionInfoSuccess(String functionName) throws Exception {
+    private void getFunctionInfoSuccess(String functionName) throws Exception {
         ContainerExecResult result = container.execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",
@@ -329,7 +329,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"name\": \"" + functionName + "\""));
     }
 
-    private static void getFunctionInfoNotFound(String functionName) throws Exception {
+    private void getFunctionInfoNotFound(String functionName) throws Exception {
         try {
             container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
@@ -344,7 +344,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         }
     }
 
-    private static void getSinkStatus(String sinkName) throws Exception {
+    private void getSinkStatus(String sinkName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sinks",
@@ -356,7 +356,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"running\" : true"));
     }
 
-    private static void getSourceStatus(String sourceName) throws Exception {
+    private void getSourceStatus(String sourceName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sources",
@@ -368,7 +368,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"running\" : true"));
     }
 
-    private static void getFunctionStatus(String functionName, int numMessages) throws Exception {
+    private void getFunctionStatus(String functionName, int numMessages) throws Exception {
         ContainerExecResult result = container.execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",
@@ -381,7 +381,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"numSuccessfullyProcessed\" : " + numMessages));
     }
 
-    private static void queryState(String functionName, String key, int amount)
+    private void queryState(String functionName, String key, int amount)
         throws Exception {
         ContainerExecResult result = container.execCmd(
             PulsarCluster.ADMIN_SCRIPT,
@@ -395,7 +395,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"numberValue\": " + amount));
     }
 
-    private static void publishAndConsumeMessages(String inputTopic,
+    private void publishAndConsumeMessages(String inputTopic,
                                                   String outputTopic,
                                                   int numMessages) throws Exception {
         @Cleanup PulsarClient client = PulsarClient.builder()
@@ -420,7 +420,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         }
     }
 
-    private static void deleteFunction(String functionName) throws Exception {
+    private void deleteFunction(String functionName) throws Exception {
         ContainerExecResult result = container.execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",
@@ -433,7 +433,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStderr().isEmpty());
     }
 
-    private static void deleteSource(String sourceName) throws Exception {
+    private void deleteSource(String sourceName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sources",
@@ -446,7 +446,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStderr().isEmpty());
     }
 
-    private static void deleteSink(String sinkName) throws Exception {
+    private void deleteSink(String sinkName) throws Exception {
         ContainerExecResult result = container.execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "sinks",
@@ -459,7 +459,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStderr().isEmpty());
     }
 
-    private static void getSourceInfoNotFound(String sourceName) throws Exception {
+    private void getSourceInfoNotFound(String sourceName) throws Exception {
         try {
             container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,
@@ -474,7 +474,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         }
     }
 
-    private static void getSinkInfoNotFound(String sinkName) throws Exception {
+    private void getSinkInfoNotFound(String sinkName) throws Exception {
         try {
             container.execCmd(
                     PulsarCluster.ADMIN_SCRIPT,

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -216,7 +216,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
         assertThat(returnedTimestamps.size()).isEqualTo(0);
     }
 
-    public static ContainerExecResult execQuery(final String query) throws Exception {
+    public ContainerExecResult execQuery(final String query) throws Exception {
         ContainerExecResult containerExecResult;
 
         containerExecResult = pulsarCluster.getPrestoWorkerContainer()

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
@@ -25,7 +25,6 @@ import org.apache.pulsar.tests.integration.containers.BrokerContainer;
 import org.apache.pulsar.tests.integration.containers.S3Container;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 
-
 @Slf4j
 public abstract class PulsarSQLTestSuite extends PulsarTestSuite {
 
@@ -33,11 +32,6 @@ public abstract class PulsarSQLTestSuite extends PulsarTestSuite {
     public final static String OFFLOAD_DRIVER = "aws-s3";
     public final static String BUCKET = "pulsar-integtest";
     public final static String ENDPOINT = "http://" + S3Container.NAME + ":9090";
-
-    @Override
-    public String getTestName() {
-        return "pulsar-sql-test-suite";
-    }
 
     @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(String clusterName, PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
@@ -20,24 +20,19 @@ package org.apache.pulsar.tests.integration.suites;
 
 import org.apache.pulsar.tests.integration.containers.PulsarContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarStandaloneTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarStandaloneTestSuite extends PulsarStandaloneTestBase implements ITest {
+public class PulsarStandaloneTestSuite extends PulsarStandaloneTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     public void setUpCluster() throws Exception {
         super.startCluster(PulsarContainer.DEFAULT_IMAGE_NAME);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDownCluster() throws Exception {
         super.stopCluster();
     }
 
-    @Override
-    public String getTestName() {
-        return "pulsar-standalone-suite";
-    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTestSuite.java
@@ -18,36 +18,28 @@
  */
 package org.apache.pulsar.tests.integration.suites;
 
-import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-
 import java.util.function.Predicate;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
-public class PulsarTestSuite extends PulsarClusterTestBase implements ITest {
+public class PulsarTestSuite extends PulsarClusterTestBase {
 
-    @BeforeSuite
+    @BeforeClass
     @Override
     public void setupCluster() throws Exception {
         super.setupCluster();
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();
     }
 
-    @Override
-    public String getTestName() {
-        return "pulsar-test-suite";
-    }
-
     public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis) throws Exception {
         retryStrategically(predicate, retryCount, intSleepTimeInMillis, false);
     }
-
 
     public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis, boolean throwException)
             throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTieredStorageTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarTieredStorageTestSuite.java
@@ -18,25 +18,22 @@
  */
 package org.apache.pulsar.tests.integration.suites;
 
+import static java.util.stream.Collectors.joining;
+import java.util.Map;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.containers.BrokerContainer;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
-import org.testng.ITest;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-
-import java.util.Map;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.joining;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 @Slf4j
-public abstract class PulsarTieredStorageTestSuite extends PulsarClusterTestBase implements ITest {
+public abstract class PulsarTieredStorageTestSuite extends PulsarClusterTestBase {
 
     protected static final int ENTRIES_PER_LEDGER = 1024;
 
-    @BeforeSuite
+    @BeforeClass
     @Override
     public void setupCluster() throws Exception {
         final String clusterName = Stream.of(this.getClass().getSimpleName(), randomName(5))
@@ -52,15 +49,10 @@ public abstract class PulsarTieredStorageTestSuite extends PulsarClusterTestBase
         setupCluster(spec);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();
-    }
-
-    @Override
-    public String getTestName() {
-        return "tiered-storage-test-suite";
     }
 
     protected abstract Map<String, String> getEnv();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterTestBase.java
@@ -29,7 +29,7 @@ import static java.util.stream.Collectors.joining;
 public abstract class PulsarClusterTestBase extends PulsarTestBase {
 
     @DataProvider(name = "ServiceUrlAndTopics")
-    public static Object[][] serviceUrlAndTopics() {
+    public Object[][] serviceUrlAndTopics() {
         return new Object[][] {
                 // plain text, persistent topic
                 {
@@ -45,7 +45,7 @@ public abstract class PulsarClusterTestBase extends PulsarTestBase {
     }
 
     @DataProvider(name = "ServiceUrls")
-    public static Object[][] serviceUrls() {
+    public Object[][] serviceUrls() {
         return new Object[][] {
                 // plain text
                 {
@@ -55,7 +55,7 @@ public abstract class PulsarClusterTestBase extends PulsarTestBase {
     }
 
     @DataProvider(name = "ServiceAndAdminUrls")
-    public static Object[][] serviceAndAdminUrls() {
+    public Object[][] serviceAndAdminUrls() {
         return new Object[][] {
                 // plain text
                 {
@@ -65,7 +65,7 @@ public abstract class PulsarClusterTestBase extends PulsarTestBase {
         };
     }
 
-    protected static PulsarCluster pulsarCluster;
+    protected PulsarCluster pulsarCluster;
 
     public void setupCluster() throws Exception {
         this.setupCluster("");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -38,7 +38,7 @@ import org.testng.annotations.DataProvider;
 public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
 
     @DataProvider(name = "StandaloneServiceUrlAndTopics")
-    public static Object[][] serviceUrlAndTopics() {
+    public Object[][] serviceUrlAndTopics() {
         return new Object[][] {
                 // plain text, persistent topic
                 {
@@ -54,7 +54,7 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
     }
 
     @DataProvider(name = "StandaloneServiceUrlAndHttpUrl")
-    public static Object[][] serviceUrlAndHttpUrl() {
+    public Object[][] serviceUrlAndHttpUrl() {
         return new Object[][] {
                 {
                         container.getPlainTextServiceUrl(),
@@ -63,8 +63,8 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
         };
     }
 
-    protected static Network network;
-    protected static StandaloneContainer container;
+    protected Network network;
+    protected StandaloneContainer container;
 
     protected void startCluster(final String pulsarImageName) throws Exception {
         network = Network.newNetwork();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -86,8 +86,14 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
     }
 
     protected void stopCluster() throws Exception {
-        container.stop();
-        network.close();
+        if (container != null) {
+            container.stop();
+            container = null;
+        }
+        if (network != null) {
+            network.close();
+            network = null;
+        }
     }
 
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/upgrade/PulsarZKDowngradeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/upgrade/PulsarZKDowngradeTest.java
@@ -20,14 +20,10 @@ package org.apache.pulsar.tests.integration.upgrade;
 
 import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertEquals;
-
 import com.google.common.collect.ImmutableMap;
-
 import java.util.stream.Stream;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -36,8 +32,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterTestBase;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -48,7 +44,7 @@ public class PulsarZKDowngradeTest extends PulsarClusterTestBase {
 
     protected static final int ENTRIES_PER_LEDGER = 1024;
 
-    @BeforeSuite
+    @BeforeClass
     @Override
     public void setupCluster() throws Exception {
         final String clusterName = Stream.of(this.getClass().getSimpleName(), randomName(5))
@@ -74,7 +70,7 @@ public class PulsarZKDowngradeTest extends PulsarClusterTestBase {
         log.info("Cluster {} is setup", spec.clusterName());
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     public void tearDownCluster() {
         super.tearDownCluster();


### PR DESCRIPTION
### Motivation

Integration test classes misuse BeforeSuite and AfterSuite annotations. When AfterSuite is used to cleanup resources, it results in resources piling up for the duration of the complete test suite run. It's like a memory leak since resources aren't properly cleaned up during test execution. 

Some test classes implemented ITest, which caused misleading error messages from TestNG. There shouldn't be a need to implement ITest.

Besides the annotation issue, some resources were using static fields without a real reason. 

The usage of BeforeSuite & static fields leads to issues such as the one described [in the comment](https://github.com/apache/pulsar/pull/9672#issuecomment-784122330). For example for the backwards compatibility tests, the last container to get initialized will be used for all tests in the suite and the backwards compatibility isn't tested at all for other than the last container version.

### Modifications

- replace BeforeSuite -> BeforeClass and AfterSuite -> AfterClass
- remove `implements ITest`
- use instance fields instead of static fields. drop "static" from the methods that reference these fields.