### PR TITLE
PIP-74: Implemented memory limit in C++ producer

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
@@ -34,6 +34,19 @@ class PULSAR_PUBLIC ClientConfiguration {
     ClientConfiguration& operator=(const ClientConfiguration&);
 
     /**
+     * Configure a limit on the amount of memory that will be allocated by this client instance.
+     * Setting this to 0 will disable the limit. By default this is disabled.
+     *
+     * @param memoryLimitBytes the memory limit
+     */
+    ClientConfiguration& setMemoryLimit(uint64_t memoryLimitBytes);
+
+    /**
+     * @return the client memory limit in bytes
+     */
+    uint64_t getMemoryLimit() const;
+
+    /**
      * Set the authentication method to be used with the broker
      *
      * @param authentication the authentication data to use

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -86,6 +86,8 @@ enum Result
     ResultTransactionConflict,                       /// Transaction ack conflict
     ResultTransactionNotFound,                       /// Transaction not found
     ResultProducerFenced,                            /// Producer was fenced by broker
+
+    ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
 };
 
 // Return string representation of result code

--- a/pulsar-client-cpp/lib/BatchMessageContainer.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainer.cc
@@ -34,8 +34,8 @@ BatchMessageContainer::BatchMessageContainer(const ProducerImpl& producer)
 
 BatchMessageContainer::~BatchMessageContainer() {
     LOG_DEBUG(*this << " destructed");
-    LOG_INFO("[numberOfBatchesSent = " << numberOfBatchesSent_
-                                       << "] [averageBatchSize_ = " << averageBatchSize_ << "]");
+    LOG_DEBUG("[numberOfBatchesSent = " << numberOfBatchesSent_
+                                        << "] [averageBatchSize_ = " << averageBatchSize_ << "]");
 }
 
 bool BatchMessageContainer::add(const Message& msg, const SendCallback& callback) {

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
@@ -36,6 +36,9 @@ Result BatchMessageContainerBase::createOpSendMsgHelper(OpSendMsg& opSendMsg,
                                                         const FlushCallback& flushCallback,
                                                         const MessageAndCallbackBatch& batch) const {
     opSendMsg.sendCallback_ = batch.createSendCallback();
+    opSendMsg.messagesCount_ = batch.messagesCount();
+    opSendMsg.messagesSize_ = batch.messagesSize();
+
     if (flushCallback) {
         auto sendCallback = opSendMsg.sendCallback_;
         opSendMsg.sendCallback_ = [sendCallback, flushCallback](Result result, const MessageId& id) {

--- a/pulsar-client-cpp/lib/ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/ClientConfiguration.cc
@@ -31,6 +31,13 @@ ClientConfiguration& ClientConfiguration::operator=(const ClientConfiguration& x
     return *this;
 }
 
+ClientConfiguration& ClientConfiguration::setMemoryLimit(uint64_t memoryLimitBytes) {
+    impl_->memoryLimit = memoryLimitBytes;
+    return *this;
+}
+
+uint64_t ClientConfiguration::getMemoryLimit() const { return impl_->memoryLimit; }
+
 ClientConfiguration& ClientConfiguration::setAuth(const AuthenticationPtr& authentication) {
     impl_->authenticationPtr = authentication;
     return *this;

--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -25,6 +25,7 @@ namespace pulsar {
 
 struct ClientConfigurationImpl {
     AuthenticationPtr authenticationPtr;
+    uint64_t memoryLimit;
     int ioThreads;
     int operationTimeoutSeconds;
     int messageListenerThreads;
@@ -41,6 +42,7 @@ struct ClientConfigurationImpl {
 
     ClientConfigurationImpl()
         : authenticationPtr(AuthFactory::Disabled()),
+          memoryLimit(0ull),
           ioThreads(1),
           operationTimeoutSeconds(30),
           messageListenerThreads(1),

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -82,6 +82,7 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
       state_(Open),
       serviceUrl_(serviceUrl),
       clientConfiguration_(detectTls(serviceUrl, clientConfiguration)),
+      memoryLimitController_(clientConfiguration.getMemoryLimit()),
       ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getIOThreads())),
       listenerExecutorProvider_(
           std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
@@ -124,6 +125,8 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
 ClientImpl::~ClientImpl() { shutdown(); }
 
 const ClientConfiguration& ClientImpl::conf() const { return clientConfiguration_; }
+
+MemoryLimitController& ClientImpl::getMemoryLimitController() { return memoryLimitController_; }
 
 ExecutorServiceProviderPtr ClientImpl::getIOExecutorProvider() { return ioExecutorProvider_; }
 

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -22,6 +22,7 @@
 #include <pulsar/Client.h>
 #include "ExecutorService.h"
 #include "BinaryProtoLookupService.h"
+#include "MemoryLimitController.h"
 #include "ConnectionPool.h"
 #include "LookupDataResult.h"
 #include <mutex>
@@ -75,6 +76,8 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
 
     void closeAsync(CloseCallback callback);
     void shutdown();
+
+    MemoryLimitController& getMemoryLimitController();
 
     uint64_t newProducerId();
     uint64_t newConsumerId();
@@ -130,6 +133,7 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
     State state_;
     std::string serviceUrl_;
     ClientConfiguration clientConfiguration_;
+    MemoryLimitController memoryLimitController_;
 
     ExecutorServiceProviderPtr ioExecutorProvider_;
     ExecutorServiceProviderPtr listenerExecutorProvider_;

--- a/pulsar-client-cpp/lib/MemoryLimitController.cc
+++ b/pulsar-client-cpp/lib/MemoryLimitController.cc
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "MemoryLimitController.h"
+
+namespace pulsar {
+
+MemoryLimitController::MemoryLimitController(uint64_t memoryLimit)
+    : memoryLimit_(memoryLimit), currentUsage_(0), mutex_(), condition_() {}
+
+bool MemoryLimitController::tryReserveMemory(uint64_t size) {
+    while (true) {
+        uint64_t current = currentUsage_;
+        uint64_t newUsage = current + size;
+
+        // We allow one request to go over the limit, to make the notification
+        // path simpler and more efficient
+        if (current > memoryLimit_ && memoryLimit_ > 0) {
+            return false;
+        }
+
+        if (currentUsage_.compare_exchange_strong(current, newUsage)) {
+            return true;
+        }
+    }
+}
+
+void MemoryLimitController::reserveMemory(uint64_t size) {
+    while (!tryReserveMemory(size)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        condition_.wait(lock);
+    }
+}
+
+void MemoryLimitController::releaseMemory(uint64_t size) {
+    uint64_t oldUsage = currentUsage_.fetch_sub(size);
+    uint64_t newUsage = oldUsage - size;
+
+    if (newUsage + size > memoryLimit_ && newUsage <= memoryLimit_) {
+        // We just crossed the limit. Now we have more space
+        std::unique_lock<std::mutex> lock(mutex_);
+        condition_.notify_all();
+    }
+}
+
+uint64_t MemoryLimitController::currentUsage() const { return currentUsage_; }
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/MemoryLimitController.cc
+++ b/pulsar-client-cpp/lib/MemoryLimitController.cc
@@ -54,7 +54,7 @@ void MemoryLimitController::releaseMemory(uint64_t size) {
 
     if (newUsage + size > memoryLimit_ && newUsage <= memoryLimit_) {
         // We just crossed the limit. Now we have more space
-        std::unique_lock<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         condition_.notify_all();
     }
 }

--- a/pulsar-client-cpp/lib/MemoryLimitController.h
+++ b/pulsar-client-cpp/lib/MemoryLimitController.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
 

--- a/pulsar-client-cpp/lib/MemoryLimitController.h
+++ b/pulsar-client-cpp/lib/MemoryLimitController.h
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace pulsar {
+
+class MemoryLimitController {
+   public:
+    explicit MemoryLimitController(uint64_t memoryLimit);
+    bool tryReserveMemory(uint64_t size);
+    void reserveMemory(uint64_t size);
+    void releaseMemory(uint64_t size);
+    uint64_t currentUsage() const;
+
+   private:
+    const uint64_t memoryLimit_;
+    std::atomic<uint64_t> currentUsage_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.cc
@@ -36,11 +36,16 @@ void MessageAndCallbackBatch::add(const Message& msg, const SendCallback& callba
                                                                      ClientConnection::getMaxMessageSize());
     LOG_DEBUG(" After serialization payload size in bytes = " << msgImpl_->payload.readableBytes());
     callbacks_.emplace_back(callback);
+
+    ++messagesCount_;
+    messagesSize_ += msg.getLength();
 }
 
 void MessageAndCallbackBatch::clear() {
     msgImpl_.reset();
     callbacks_.clear();
+    messagesCount_ = 0;
+    messagesSize_ = 0;
 }
 
 static void completeSendCallbacks(const std::vector<SendCallback>& callbacks, Result result,

--- a/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
+++ b/pulsar-client-cpp/lib/MessageAndCallbackBatch.h
@@ -71,10 +71,16 @@ class MessageAndCallbackBatch : public boost::noncopyable {
     const MessageImplPtr& msgImpl() const { return msgImpl_; }
     uint64_t sequenceId() const noexcept { return sequenceId_; }
 
+    uint32_t messagesCount() const { return messagesCount_; }
+    uint64_t messagesSize() const { return messagesSize_; }
+
    private:
     MessageImplPtr msgImpl_;
     std::vector<SendCallback> callbacks_;
     std::atomic<uint64_t> sequenceId_{static_cast<uint64_t>(-1L)};
+
+    uint32_t messagesCount_{0};
+    uint64_t messagesSize_{0ull};
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -34,18 +34,20 @@ struct OpSendMsg {
     uint64_t producerId_;
     uint64_t sequenceId_;
     boost::posix_time::ptime timeout_;
+    uint32_t messagesCount_;
+    uint64_t messagesSize_;
 
     OpSendMsg() = default;
 
     OpSendMsg(const Message& msg, const SendCallback& sendCallback, uint64_t producerId, uint64_t sequenceId,
-              int sendTimeoutMs)
+              int sendTimeoutMs, uint32_t messagesCount, uint64_t messagesSize)
         : msg_(msg),
           sendCallback_(sendCallback),
           producerId_(producerId),
           sequenceId_(sequenceId),
-          timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)) {}
-
-    uint32_t num_messages_in_batch() const { return msg_.impl_->metadata.num_messages_in_batch(); }
+          timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)),
+          messagesCount_(messagesCount),
+          messagesSize_(messagesSize) {}
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -68,8 +68,8 @@ ProducerConfiguration& ProducerConfiguration::setCompressionType(CompressionType
 CompressionType ProducerConfiguration::getCompressionType() const { return impl_->compressionType; }
 
 ProducerConfiguration& ProducerConfiguration::setMaxPendingMessages(int maxPendingMessages) {
-    if (maxPendingMessages <= 0) {
-        throw std::invalid_argument("maxPendingMessages needs to be greater than 0");
+    if (maxPendingMessages < 0) {
+        throw std::invalid_argument("maxPendingMessages needs to be >= 0");
     }
     impl_->maxPendingMessages = maxPendingMessages;
     return *this;
@@ -78,8 +78,8 @@ ProducerConfiguration& ProducerConfiguration::setMaxPendingMessages(int maxPendi
 int ProducerConfiguration::getMaxPendingMessages() const { return impl_->maxPendingMessages; }
 
 ProducerConfiguration& ProducerConfiguration::setMaxPendingMessagesAcrossPartitions(int maxPendingMessages) {
-    if (maxPendingMessages <= 0) {
-        throw std::invalid_argument("maxPendingMessages needs to be greater than 0");
+    if (maxPendingMessages < 0) {
+        throw std::invalid_argument("maxPendingMessages needs to be >=0");
     }
     impl_->maxPendingMessagesAcrossPartitions = maxPendingMessages;
     return *this;

--- a/pulsar-client-cpp/lib/Result.cc
+++ b/pulsar-client-cpp/lib/Result.cc
@@ -156,6 +156,9 @@ const char* strResult(Result result) {
 
         case ResultProducerFenced:
             return "ResultProducerFenced";
+
+        case ResultMemoryBufferIsFull:
+            return "ResultMemoryBufferIsFull";
     };
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding

--- a/pulsar-client-cpp/lib/Semaphore.cc
+++ b/pulsar-client-cpp/lib/Semaphore.cc
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "Semaphore.h"
+
+namespace pulsar {
+
+Semaphore::Semaphore(uint32_t limit) : limit_(limit), currentUsage_(0), mutex_(), condition_() {}
+
+bool Semaphore::tryAcquire(int n) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    if (currentUsage_ + n > limit_) {
+        return false;
+    } else {
+        currentUsage_ += n;
+        return true;
+    }
+}
+
+void Semaphore::acquire(int n) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    while (currentUsage_ + n > limit_) {
+        condition_.wait(lock);
+    }
+
+    currentUsage_ += n;
+}
+
+void Semaphore::release(int n) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    currentUsage_ += n;
+    if (n == 1) {
+        condition_.notify_one();
+    } else {
+        condition_.notify_all();
+    }
+}
+
+uint32_t Semaphore::currentUsage() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return currentUsage_;
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/Semaphore.cc
+++ b/pulsar-client-cpp/lib/Semaphore.cc
@@ -24,7 +24,7 @@ namespace pulsar {
 Semaphore::Semaphore(uint32_t limit) : limit_(limit), currentUsage_(0), mutex_(), condition_() {}
 
 bool Semaphore::tryAcquire(int n) {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
 
     if (currentUsage_ + n > limit_) {
         return false;
@@ -45,8 +45,8 @@ void Semaphore::acquire(int n) {
 }
 
 void Semaphore::release(int n) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    currentUsage_ += n;
+    std::lock_guard<std::mutex> lock(mutex_);
+    currentUsage_ -= n;
     if (n == 1) {
         condition_.notify_one();
     } else {
@@ -55,7 +55,7 @@ void Semaphore::release(int n) {
 }
 
 uint32_t Semaphore::currentUsage() const {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return currentUsage_;
 }
 

--- a/pulsar-client-cpp/lib/Semaphore.h
+++ b/pulsar-client-cpp/lib/Semaphore.h
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace pulsar {
+
+class Semaphore {
+   public:
+    explicit Semaphore(uint32_t limit);
+
+    bool tryAcquire(int n = 1);
+    void acquire(int n = 1);
+    void release(int n = 1);
+    uint32_t currentUsage() const;
+
+   private:
+    const uint32_t limit_;
+    uint32_t currentUsage_;
+    mutable std::mutex mutex_;
+    std::condition_variable condition_;
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/Semaphore.h
+++ b/pulsar-client-cpp/lib/Semaphore.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
 

--- a/pulsar-client-cpp/perf/PerfProducer.cc
+++ b/pulsar-client-cpp/perf/PerfProducer.cc
@@ -48,6 +48,7 @@ struct Arguments {
     bool isTlsAllowInsecureConnection;
     std::string tlsTrustCertsFilePath;
     std::string topic;
+    int memoryLimitMb;
     double rate;
     int msgSize;
     int numTopics;
@@ -220,6 +221,8 @@ int main(int argc, char** argv) {
     desc.add_options()                         //
         ("help,h", "Print this help message")  //
 
+        ("memory-limit,ml", po::value<int>(&args.memoryLimitMb)->default_value(64), "Memory limit (MB)")  //
+
         ("auth-params,v", po::value<std::string>(&args.authParams)->default_value(""),
          "Authentication parameters, e.g., \"key1:val1,key2:val2\"")  //
 
@@ -367,6 +370,7 @@ int main(int argc, char** argv) {
     producerConf.setPartitionsRoutingMode(ProducerConfiguration::RoundRobinDistribution);
 
     pulsar::ClientConfiguration conf;
+    conf.setMemoryLimit(args.memoryLimitMb * 1024 * 1024);
     conf.setUseTls(args.isUseTls);
     conf.setTlsAllowInsecureConnection(args.isTlsAllowInsecureConnection);
     if (!args.tlsTrustCertsFilePath.empty()) {

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -59,11 +59,11 @@ std::mutex mutex_;
 static int globalTestBatchMessagesCounter = 0;
 static int globalCount = 0;
 static long globalResendMessageCount = 0;
-static std::string lookupUrl = "pulsar://localhost:6650";
+std::string lookupUrl = "pulsar://localhost:6650";
 static std::string adminUrl = "http://localhost:8080/";
 static int uniqueCounter = 0;
 
-static std::string unique_str() {
+std::string unique_str() {
     long nanos = std::chrono::duration_cast<std::chrono::milliseconds>(
                      std::chrono::steady_clock::now().time_since_epoch())
                      .count();
@@ -603,10 +603,6 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
     ASSERT_EQ(ResultOk, result);
-
-    for (const auto &q : PulsarFriend::getProducerMessageQueue(producer, NonPartitioned)) {
-        ASSERT_EQ(0, q->reservedSpots());
-    }
 
     delete[] content;
 }

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -928,10 +928,6 @@ TEST(BatchMessageTest, testPartitionedTopics) {
 
     // Number of messages consumed
     ASSERT_EQ(i, numOfMessages - globalPublishCountQueueFull);
-
-    for (const auto& q : PulsarFriend::getProducerMessageQueue(producer, Partitioned)) {
-        ASSERT_EQ(0, q->reservedSpots());
-    }
 }
 
 TEST(BatchMessageTest, producerFailureResult) {
@@ -1040,10 +1036,6 @@ TEST(BatchMessageTest, testSendCallback) {
 
     latch.wait();
     ASSERT_EQ(sentIdSet, receivedIdSet);
-
-    for (const auto& q : PulsarFriend::getProducerMessageQueue(producer, NonPartitioned)) {
-        ASSERT_EQ(0, q->reservedSpots());
-    }
 
     consumer.close();
     producer.close();

--- a/pulsar-client-cpp/tests/MemoryLimitControllerTest.cc
+++ b/pulsar-client-cpp/tests/MemoryLimitControllerTest.cc
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "../lib/MemoryLimitController.h"
+#include "../lib/Latch.h"
+
+using namespace pulsar;
+
+TEST(MemoryLimitControllerTest, testLimit) {
+    MemoryLimitController mlc(100);
+
+    for (int i = 0; i < 101; i++) {
+        mlc.reserveMemory(1);
+    }
+
+    ASSERT_EQ(mlc.currentUsage(), 101);
+    ASSERT_FALSE(mlc.tryReserveMemory(1));
+    mlc.releaseMemory(1);
+    ASSERT_EQ(mlc.currentUsage(), 100);
+
+    ASSERT_TRUE(mlc.tryReserveMemory(1));
+    ASSERT_EQ(mlc.currentUsage(), 101);
+}
+
+TEST(MemoryLimitControllerTest, testBlocking) {
+    MemoryLimitController mlc(100);
+
+    for (int i = 0; i < 101; i++) {
+        mlc.reserveMemory(1);
+    }
+
+    Latch l1(1);
+    std::thread t1([&]() {
+        mlc.reserveMemory(1);
+        l1.countdown();
+    });
+
+    Latch l2(1);
+    std::thread t2([&]() {
+        mlc.reserveMemory(1);
+        l2.countdown();
+    });
+
+    Latch l3(1);
+    std::thread t3([&]() {
+        mlc.reserveMemory(1);
+        l3.countdown();
+    });
+
+    // The threads are blocked since the quota is full
+    ASSERT_FALSE(l1.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l2.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l3.wait(std::chrono::milliseconds(100)));
+
+    ASSERT_EQ(mlc.currentUsage(), 101);
+    mlc.releaseMemory(3);
+
+    ASSERT_TRUE(l1.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l2.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l3.wait(std::chrono::seconds(1)));
+    ASSERT_EQ(mlc.currentUsage(), 101);
+
+    t1.join();
+    t2.join();
+    t3.join();
+}
+
+TEST(MemoryLimitControllerTest, testStepRelease) {
+    MemoryLimitController mlc(100);
+
+    for (int i = 0; i < 101; i++) {
+        mlc.reserveMemory(1);
+    }
+
+    Latch l1(1);
+    std::thread t1([&]() {
+        mlc.reserveMemory(1);
+        l1.countdown();
+    });
+
+    Latch l2(1);
+    std::thread t2([&]() {
+        mlc.reserveMemory(1);
+        l2.countdown();
+    });
+
+    Latch l3(1);
+    std::thread t3([&]() {
+        mlc.reserveMemory(1);
+        l3.countdown();
+    });
+
+    // The threads are blocked since the quota is full
+    ASSERT_FALSE(l1.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l2.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l3.wait(std::chrono::milliseconds(100)));
+
+    ASSERT_EQ(mlc.currentUsage(), 101);
+    mlc.releaseMemory(1);
+    mlc.releaseMemory(1);
+    mlc.releaseMemory(1);
+
+    ASSERT_TRUE(l1.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l2.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l3.wait(std::chrono::seconds(1)));
+    ASSERT_EQ(mlc.currentUsage(), 101);
+
+    t1.join();
+    t2.join();
+    t3.join();
+}

--- a/pulsar-client-cpp/tests/MemoryLimitTest.cc
+++ b/pulsar-client-cpp/tests/MemoryLimitTest.cc
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <array>
+#include <thread>
+
+#include "../lib/MemoryLimitController.h"
+#include "../lib/Latch.h"
+#include "../lib/Future.h"
+#include "../lib/Utils.h"
+
+#include <pulsar/Client.h>
+
+using namespace pulsar;
+
+extern std::string lookupUrl;
+extern std::string unique_str();
+
+TEST(MemoryLimitTest, testRejectMessages) {
+    std::string topic = "topic-" + unique_str();
+
+    ClientConfiguration config;
+    config.setMemoryLimit(100 * 1024);
+    Client client(lookupUrl, config);
+
+    ProducerConfiguration producerConf;
+    producerConf.setBlockIfQueueFull(false);
+    Producer producer;
+    Result res = client.createProducer(topic, producerConf, producer);
+    ASSERT_EQ(res, ResultOk);
+
+    const int n = 101;
+    Latch latch(n);
+
+    std::array<char, 1024> buffer;
+
+    for (int i = 0; i < n; i++) {
+        producer.sendAsync(MessageBuilder().setContent(buffer.data(), buffer.size()).build(),
+                           [&](Result res, const MessageId& msgId) {
+                               ASSERT_EQ(res, ResultOk);
+                               latch.countdown();
+                           });
+    }
+
+    res = producer.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultMemoryBufferIsFull);
+
+    latch.wait();
+
+    // We should now be able to send again
+    res = producer.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultOk);
+}
+
+TEST(MemoryLimitTest, testRejectMessagesOnMultipleTopics) {
+    std::string t1 = "topic-1-" + unique_str();
+    std::string t2 = "topic-2-" + unique_str();
+
+    ClientConfiguration config;
+    config.setMemoryLimit(100 * 1024);
+    Client client(lookupUrl, config);
+
+    ProducerConfiguration producerConf;
+    producerConf.setBlockIfQueueFull(false);
+    producerConf.setBatchingMaxPublishDelayMs(10000);
+
+    Producer p1;
+    Result res = client.createProducer(t1, producerConf, p1);
+    ASSERT_EQ(res, ResultOk);
+
+    Producer p2;
+    res = client.createProducer(t2, producerConf, p2);
+    ASSERT_EQ(res, ResultOk);
+
+    const int n = 101;
+    Latch latch(n);
+
+    std::array<char, 1024> buffer;
+
+    for (int i = 0; i < n / 2; i++) {
+        p1.sendAsync(MessageBuilder().setContent(buffer.data(), buffer.size()).build(),
+                     [&](Result res, const MessageId& msgId) {
+                         ASSERT_EQ(res, ResultOk);
+                         latch.countdown();
+                     });
+
+        p2.sendAsync(MessageBuilder().setContent(buffer.data(), buffer.size()).build(),
+                     [&](Result res, const MessageId& msgId) {
+                         ASSERT_EQ(res, ResultOk);
+                         latch.countdown();
+                     });
+    }
+
+    // Last message in order to reach the limit
+    p1.sendAsync(MessageBuilder().setContent(buffer.data(), buffer.size()).build(),
+                 [&](Result res, const MessageId& msgId) {
+                     ASSERT_EQ(res, ResultOk);
+                     latch.countdown();
+                 });
+
+    res = p1.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultMemoryBufferIsFull);
+
+    res = p2.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultMemoryBufferIsFull);
+
+    latch.wait();
+
+    // We should now be able to send again
+    res = p1.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultOk);
+
+    res = p2.send(MessageBuilder().setContent(buffer.data(), buffer.size()).build());
+    ASSERT_EQ(res, ResultOk);
+}
+
+TEST(MemoryLimitTest, testNoProducerQueueSize) {
+    std::string topic = "topic-" + unique_str();
+
+    ClientConfiguration config;
+    config.setMemoryLimit(10 * 1024);
+    Client client(lookupUrl, config);
+
+    ProducerConfiguration producerConf;
+    producerConf.setBlockIfQueueFull(true);
+    producerConf.setMaxPendingMessages(0);
+    producerConf.setMaxPendingMessagesAcrossPartitions(0);
+    Producer producer;
+    Result res = client.createProducer(topic, producerConf, producer);
+    ASSERT_EQ(res, ResultOk);
+
+    std::array<Promise<Result, MessageId>, 100> promises;
+
+    for (int i = 0; i < 100; i++) {
+        producer.sendAsync(MessageBuilder().setContent("hello").build(),
+                           WaitForCallbackValue<MessageId>(promises[i]));
+    }
+
+    producer.flush();
+
+    for (auto& p : promises) {
+        MessageId id;
+        Result res = p.getFuture().get(id);
+        ASSERT_EQ(res, ResultOk);
+    }
+}

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -42,21 +42,6 @@ class PulsarFriend {
         return std::static_pointer_cast<ProducerStatsImpl>(producerImpl->producerStatsBasePtr_);
     }
 
-    static std::vector<ProducerImpl::MessageQueue*> getProducerMessageQueue(Producer producer,
-                                                                            ConsumerTopicType type) {
-        ProducerImplBasePtr producerBaseImpl = producer.impl_;
-        if (type == Partitioned) {
-            std::vector<ProducerImpl::MessageQueue*> queues;
-            for (const auto& producer :
-                 std::static_pointer_cast<PartitionedProducerImpl>(producerBaseImpl)->producers_) {
-                queues.emplace_back(&producer->pendingMessagesQueue_);
-            }
-            return queues;
-        } else {
-            return {&std::static_pointer_cast<ProducerImpl>(producerBaseImpl)->pendingMessagesQueue_};
-        }
-    }
-
     template <typename T>
     static unsigned long sum(std::map<T, unsigned long> m) {
         unsigned long sum = 0;

--- a/pulsar-client-cpp/tests/SemaphoreTest.cc
+++ b/pulsar-client-cpp/tests/SemaphoreTest.cc
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "../lib/Semaphore.h"
+#include "../lib/Latch.h"
+
+using namespace pulsar;
+
+TEST(SemaphoreTest, testLimit) {
+    Semaphore s(100);
+
+    for (int i = 0; i < 100; i++) {
+        s.acquire();
+    }
+
+    ASSERT_EQ(s.currentUsage(), 100);
+    ASSERT_FALSE(s.tryAcquire());
+    s.release();
+    ASSERT_EQ(s.currentUsage(), 99);
+
+    ASSERT_TRUE(s.tryAcquire());
+    ASSERT_EQ(s.currentUsage(), 100);
+}
+
+TEST(SemaphoreTest, testStepRelease) {
+    Semaphore s(100);
+
+    for (int i = 0; i < 100; i++) {
+        s.acquire();
+    }
+
+    Latch l1(1);
+    std::thread t1([&]() {
+        s.acquire();
+        l1.countdown();
+    });
+
+    Latch l2(1);
+    std::thread t2([&]() {
+        s.acquire();
+        l2.countdown();
+    });
+
+    Latch l3(1);
+    std::thread t3([&]() {
+        s.acquire();
+        l3.countdown();
+    });
+
+    // The threads are blocked since the quota is full
+    ASSERT_FALSE(l1.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l2.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l3.wait(std::chrono::milliseconds(100)));
+
+    ASSERT_EQ(s.currentUsage(), 100);
+    s.release();
+    s.release();
+    s.release();
+
+    ASSERT_TRUE(l1.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l2.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l3.wait(std::chrono::seconds(1)));
+    ASSERT_EQ(s.currentUsage(), 100);
+
+    t1.join();
+    t2.join();
+    t3.join();
+}
+
+TEST(SemaphoreTest, testSingleRelease) {
+    Semaphore s(100);
+
+    s.acquire(100);
+    ASSERT_EQ(s.currentUsage(), 100);
+
+    Latch l1(1);
+    std::thread t1([&]() {
+        s.acquire();
+        l1.countdown();
+    });
+
+    Latch l2(1);
+    std::thread t2([&]() {
+        s.acquire();
+        l2.countdown();
+    });
+
+    Latch l3(1);
+    std::thread t3([&]() {
+        s.acquire();
+        l3.countdown();
+    });
+
+    // The threads are blocked since the quota is full
+    ASSERT_FALSE(l1.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l2.wait(std::chrono::milliseconds(100)));
+    ASSERT_FALSE(l3.wait(std::chrono::milliseconds(100)));
+
+    ASSERT_EQ(s.currentUsage(), 100);
+    s.release(3);
+
+    ASSERT_TRUE(l1.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l2.wait(std::chrono::seconds(1)));
+    ASSERT_TRUE(l3.wait(std::chrono::seconds(1)));
+    ASSERT_EQ(s.currentUsage(), 100);
+
+    t1.join();
+    t2.join();
+    t3.join();
+}


### PR DESCRIPTION
### Motivation

Similar to what already implemented in Java client, adding a client-wide memory limit for messages produced on all the C++ producers.

### Modifications

Refactored the `pendingMessagesQueue` handling code to be similar to the Java implementation, using a "Deque" and a semaphore, rather that having all the logic collapsed into the queue implementation. 