### PR TITLE
[pulsar-broker] Added support to force deleting tenant

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -30,11 +30,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -42,6 +44,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -226,7 +229,8 @@ public class TenantsBase extends PulsarWebResource {
             @ApiResponse(code = 404, message = "Tenant does not exist"),
             @ApiResponse(code = 409, message = "The tenant still has active namespaces") })
     public void deleteTenant(@Suspended final AsyncResponse asyncResponse,
-            @PathParam("tenant") @ApiParam(value = "The tenant name") String tenant) {
+            @PathParam("tenant") @ApiParam(value = "The tenant name") String tenant,
+            @QueryParam("force") @DefaultValue("false") boolean force) {
         try {
             validateSuperUserAccess();
             validatePoliciesReadOnlyAccess();
@@ -234,8 +238,19 @@ public class TenantsBase extends PulsarWebResource {
             asyncResponse.resume(e);
             return;
         }
+        internalDeleteTenant(asyncResponse, tenant, force);
+    }
 
-        tenantResources().existsAsync(path(POLICIES, tenant)).thenApply(exists ->{
+    protected void internalDeleteTenant(AsyncResponse asyncResponse, String tenant, boolean force) {
+        if (force) {
+            internalDeleteTenantForcefully(asyncResponse, tenant);
+        } else {
+            internalDeleteTenant(asyncResponse, tenant);
+        }
+    }
+
+    protected void internalDeleteTenant(AsyncResponse asyncResponse, String tenant) {
+        tenantResources().existsAsync(path(POLICIES, tenant)).thenApply(exists -> {
             if (!exists) {
                 asyncResponse.resume(new RestException(Status.NOT_FOUND, "Tenant doesn't exist"));
                 return null;
@@ -271,6 +286,44 @@ public class TenantsBase extends PulsarWebResource {
                 asyncResponse.resume(new RestException(ex));
                 return null;
             });
+        });
+    }
+
+    protected void internalDeleteTenantForcefully(AsyncResponse asyncResponse, String tenant) {
+        List<String> namespaces;
+        try {
+            namespaces = getListOfNamespaces(tenant);
+        } catch (Exception e) {
+            log.error("[{}] Failed to get namespaces list of {}", clientAppId(), tenant, e);
+            asyncResponse.resume(new RestException(e));
+            return;
+        }
+
+        final List<CompletableFuture<Void>> futures = Lists.newArrayList();
+        try {
+            for (String namespace : namespaces) {
+                futures.add(pulsar().getAdminClient().namespaces().deleteNamespaceAsync(namespace, true));
+            }
+        } catch (Exception e) {
+            log.error("[{}] Failed to force delete namespaces {}", clientAppId(), namespaces, e);
+            asyncResponse.resume(new RestException(e));
+        }
+
+        FutureUtil.waitForAll(futures).handle((result, exception) -> {
+            if (exception != null) {
+                if (exception.getCause() instanceof PulsarAdminException) {
+                    asyncResponse.resume(new RestException((PulsarAdminException) exception.getCause()));
+                } else {
+                    log.error("[{}] Failed to force delete namespaces {}", clientAppId(), namespaces, exception);
+                    asyncResponse.resume(new RestException(exception.getCause()));
+                }
+                return null;
+            }
+            // delete tenant normally
+            internalDeleteTenant(asyncResponse, tenant);
+
+            asyncResponse.resume(Response.noContent().build());
+            return null;
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1138,7 +1138,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             // Expected: cannot delete non-empty tenant
         }
 
-        //
+        // delete tenant forcefully
         admin.tenants().deleteTenant(tenant, true);
         assertFalse(admin.tenants().getTenants().contains(tenant));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1109,6 +1109,46 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testDeleteTenantForcefully() throws Exception {
+        String tenant = "my-tenant";
+        assertFalse(admin.tenants().getTenants().contains(tenant));
+
+        // create tenant
+        admin.tenants().createTenant(tenant,
+                new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test")));
+
+        assertTrue(admin.tenants().getTenants().contains(tenant));
+
+        // create namespace
+        String namespace = tenant + "/my-ns";
+        admin.namespaces().createNamespace("my-tenant/my-ns", Sets.newHashSet("test"));
+
+        assertEquals(admin.namespaces().getNamespaces(tenant), Lists.newArrayList("my-tenant/my-ns"));
+
+        // create topic
+        String topic = namespace + "/my-topic";
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        assertFalse(admin.topics().getList(namespace).isEmpty());
+
+        try {
+            admin.tenants().deleteTenant(tenant, false);
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            // Expected: cannot delete non-empty tenant
+        }
+
+        //
+        admin.tenants().deleteTenant(tenant, true);
+        assertFalse(admin.tenants().getTenants().contains(tenant));
+
+        admin.tenants().createTenant(tenant,
+                new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test")));
+        assertTrue(admin.tenants().getTenants().contains(tenant));
+        assertTrue(admin.namespaces().getNamespaces(tenant).isEmpty());
+    }
+
+    @Test
     public void testNamespaceSplitBundle() throws Exception {
         // Force to create a topic
         final String namespace = "prop-xyz/ns1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -462,7 +462,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         // Check deleting non-existing property
         try {
-            response = asynRequests(ctx -> properties.deleteTenant(ctx, "non-existing"));
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "non-existing", false));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
@@ -521,7 +521,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         try {
             cache.invalidateAll();
             store.invalidateAll();
-            response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property"));
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property", false));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -533,14 +533,14 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
             return op == MockZooKeeper.Op.DELETE && path.equals("/admin/policies/error-property");
         });
         try {
-            response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property"));
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property", false));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
-        response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property"));
-        response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property"));
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "test-property", false));
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "error-property", false));
         response = Lists.newArrayList();
         response = asynRequests(ctx -> properties.getTenants(ctx));
         assertEquals(response, Lists.newArrayList());
@@ -552,7 +552,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         namespaces.createNamespace("my-tenant", "use", "my-namespace", new BundlesData());
 
         try {
-            response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant"));
+            response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant", false));
             fail("should have failed");
         } catch (RestException e) {
             // Ok
@@ -601,7 +601,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
         verify(response2, timeout(5000).times(1)).resume(captor.capture());
         assertEquals(captor.getValue().getStatus(), Status.NO_CONTENT.getStatusCode());
-        response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant"));
+        response = asynRequests(ctx -> properties.deleteTenant(ctx, "my-tenant", false));
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Tenants.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Tenants.java
@@ -173,6 +173,27 @@ public interface Tenants {
     void deleteTenant(String tenant) throws PulsarAdminException;
 
     /**
+     * Delete an existing tenant.
+     * <p/>
+     * Force flag delete a tenant forcefully and all namespaces and topics under it.
+     *
+     * @param tenant
+     *            Tenant name
+     * @param force
+     *            Delete tenant forcefully
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             The tenant does not exist
+     * @throws ConflictException
+     *             The tenant still has active namespaces
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void deleteTenant(String tenant, boolean force) throws PulsarAdminException;
+
+    /**
      * Delete an existing tenant asynchronously.
      * <p/>
      * Delete a tenant and all namespaces and topics under it.
@@ -181,4 +202,16 @@ public interface Tenants {
      *            Tenant name
      */
     CompletableFuture<Void> deleteTenantAsync(String tenant);
+
+    /**
+     * Delete an existing tenant asynchronously.
+     * <p/>
+     * Force flag delete a tenant forcefully and all namespaces and topics under it.
+     *
+     * @param tenant
+     *            Tenant name
+     * @param force
+     *            Delete tenant forcefully
+     */
+    CompletableFuture<Void> deleteTenantAsync(String tenant, boolean force);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TenantsImpl.java
@@ -163,8 +163,28 @@ public class TenantsImpl extends BaseResource implements Tenants, Properties {
     }
 
     @Override
+    public void deleteTenant(String tenant, boolean force) throws PulsarAdminException {
+        try {
+            deleteTenantAsync(tenant, force).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
     public CompletableFuture<Void> deleteTenantAsync(String tenant) {
+        return deleteTenantAsync(tenant, false);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteTenantAsync(String tenant, boolean force) {
         WebTarget path = adminTenants.path(tenant);
+        path = path.queryParam("force", force);
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -236,7 +236,7 @@ public class PulsarAdminToolTest {
         verify(mockTenants).getTenantInfo("my-tenant");
 
         tenants.run(split("delete my-tenant"));
-        verify(mockTenants).deleteTenant("my-tenant");
+        verify(mockTenants).deleteTenant("my-tenant", false);
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
@@ -119,10 +119,14 @@ public class CmdTenants extends CmdBase {
         @Parameter(description = "tenant-name", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = { "-f",
+                "--force" }, description = "Delete tenant by force deleting all namespaces under it")
+        private boolean force = false;
+
         @Override
         void run() throws PulsarAdminException {
             String tenant = getOneArgument(params);
-            getAdmin().tenants().deleteTenant(tenant);
+            getAdmin().tenants().deleteTenant(tenant, force);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
@@ -120,7 +120,7 @@ public class CmdTenants extends CmdBase {
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
-                "--force" }, description = "Delete tenant by force deleting all namespaces under it")
+                "--force" }, description = "Delete a tenant forcefully by deleting all namespaces under it.")
         private boolean force = false;
 
         @Override

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2454,7 +2454,7 @@ $ pulsar-admin tenants delete tenant-name
 Options
 |Flag|Description|Default|
 |----|---|---|
-|`-f`, `--force`|Delete tenant forcefully by force deleting all namespaces under it|false|
+|`-f`, `--force`|Delete a tenant forcefully by deleting all namespaces under it.|false|
 
 
 ## `resource-quotas`

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -2451,6 +2451,11 @@ Usage
 $ pulsar-admin tenants delete tenant-name
 ```
 
+Options
+|Flag|Description|Default|
+|----|---|---|
+|`-f`, `--force`|Delete tenant forcefully by force deleting all namespaces under it|false|
+
 
 ## `resource-quotas`
 Operations for managing resource quotas


### PR DESCRIPTION
### Motivation

Some users expect an option to force deleting tenant for simplicity, it can be useful in some situations.

### Modifications

Add a optional field to force the deletion of all stuffs related to tenant and a related unit test.