### PR TITLE
Revert "Avoid enable DLQ on Key_Shared subscription. (#9163)"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
@@ -33,15 +33,8 @@ public interface RawReader {
 
     static CompletableFuture<RawReader> create(PulsarClient client, String topic, String subscription) {
         CompletableFuture<Consumer<byte[]>> future = new CompletableFuture<>();
-        RawReader r = null;
-        try {
-            r = new RawReaderImpl((PulsarClientImpl) client, topic, subscription, future);
-        } catch (PulsarClientException.InvalidConfigurationException e) {
-            // Shouldn't happen, as exception was thrown if DLQ enabled for Key_Shared sub type, RawReader use
-            // Exclusive sub type so should be fine.
-        }
-        RawReader finalR = r;
-        return future.thenCompose((consumer) -> finalR.seekAsync(MessageId.earliest)).thenApply((ignore) -> finalR);
+        RawReader r = new RawReaderImpl((PulsarClientImpl) client, topic, subscription, future);
+        return future.thenCompose((consumer) -> r.seekAsync(MessageId.earliest)).thenApply((ignore) -> r);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
@@ -50,8 +49,7 @@ public class RawReaderImpl implements RawReader {
     private RawConsumerImpl consumer;
 
     public RawReaderImpl(PulsarClientImpl client, String topic, String subscription,
-                         CompletableFuture<Consumer<byte[]>> consumerFuture)
-            throws PulsarClientException.InvalidConfigurationException {
+                         CompletableFuture<Consumer<byte[]>> consumerFuture) {
         consumerConfiguration = new ConsumerConfigurationData<>();
         consumerConfiguration.getTopicNames().add(topic);
         consumerConfiguration.setSubscriptionName(subscription);
@@ -109,8 +107,7 @@ public class RawReaderImpl implements RawReader {
         final Queue<CompletableFuture<RawMessage>> pendingRawReceives;
 
         RawConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData<byte[]> conf,
-                CompletableFuture<Consumer<byte[]>> consumerFuture)
-                throws PulsarClientException.InvalidConfigurationException {
+                CompletableFuture<Consumer<byte[]>> consumerFuture) {
             super(client,
                     conf.getSingleTopic(),
                     conf,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -182,63 +182,6 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
     }
 
     @Test(timeOut = 30000)
-    public void testDLQDisabledForKeySharedSubtype() throws Exception {
-        final String topic = "persistent://my-property/my-ns/dead-letter-topic";
-
-        final int maxRedeliveryCount = 2;
-
-        final int sendMessages = 100;
-
-        Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
-                .topic(topic)
-                .subscriptionName("my-subscription")
-                .subscriptionType(SubscriptionType.Key_Shared)
-                .keySharedPolicy(KeySharedPolicy.autoSplitHashRange())
-                .ackTimeout(1, TimeUnit.SECONDS)
-                .deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(maxRedeliveryCount).build())
-                .receiverQueueSize(100)
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscribe();
-
-        PulsarClient newPulsarClient = newPulsarClient(lookupUrl.toString(), 0);
-        // Creates new client connection
-        Consumer<byte[]> deadLetterConsumer = newPulsarClient.newConsumer(Schema.BYTES)
-                .topic("persistent://my-property/my-ns/dead-letter-topic-my-subscription-DLQ")
-                .subscriptionName("my-subscription")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscribe();
-
-        Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
-                .topic(topic)
-                .create();
-
-        for (int i = 0; i < sendMessages; i++) {
-            producer.send(String.format("Hello Pulsar [%d]", i).getBytes());
-        }
-
-        producer.close();
-
-        int totalReceived = 0;
-        Message<byte[]> message;
-        do {
-            message = consumer.receive();
-            log.info("consumer received message : {} {}", message.getMessageId(), new String(message.getData()));
-            assertNotNull(message);
-            totalReceived++;
-        } while (totalReceived < sendMessages * (maxRedeliveryCount + 1));
-        // make sure message not acked sent to retry topic.
-        assertEquals(totalReceived, sendMessages * (maxRedeliveryCount + 1));
-
-        // make sure no message sent to dead letter topic.
-        Message dlqMessage = deadLetterConsumer.receive(5, TimeUnit.SECONDS);
-        assertNull(dlqMessage);
-
-        deadLetterConsumer.close();
-        consumer.close();
-        newPulsarClient.close();
-    }
-
-    @Test(timeOut = 30000)
     public void testDuplicatedMessageSendToDeadLetterTopic() throws Exception {
         final String topic = "persistent://my-property/my-ns/dead-letter-topic-DuplicatedMessage";
         final int maxRedeliveryCount = 1;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -20,16 +20,11 @@ package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.DeadLetterPolicy;
-import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
@@ -42,9 +37,6 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TopicMetadata;
-import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
-import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
@@ -59,7 +51,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,8 +65,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -487,47 +476,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Already subscribed to " + topicName);
             return null;
         }).get();
-    }
-
-    @Test
-    public void testSubscribeKeySharedWithDLQ() throws Exception{
-        final String topicName = "persistent://prop/use/ns-abc/testTopicNameValid";
-        TenantInfo tenantInfo = createDefaultTenantInfo();
-        admin.tenants().createTenant("prop", tenantInfo);
-        admin.topics().createPartitionedTopic(topicName, 3);
-        // Through builder
-        pulsarClient.newConsumer()
-                .topic(topicName)
-                .subscriptionName("subscriptionName")
-                .subscriptionType(SubscriptionType.Key_Shared)
-                .keySharedPolicy(KeySharedPolicy.autoSplitHashRange())
-                .deadLetterPolicy(DeadLetterPolicy.builder().deadLetterTopic("DLQ").build())
-                .receiverQueueSize(0)
-                .subscribeAsync().handle((res, exception) -> {
-                    assertTrue(exception instanceof PulsarClientException.InvalidConfigurationException);
-                    assertEquals(((PulsarClientException.InvalidConfigurationException) exception).getMessage(), "DeadLetterQueue is not supported for Key_Shared subscription type since DLQ can't guarantee message ordering.");
-                    return null;
-                }).get();
-
-        // Through constructor
-        PulsarClientImpl mockClient = mock(PulsarClientImpl.class);
-        ConsumerConfigurationData<Byte[]> consumerConfig = new ConsumerConfigurationData<>();
-        consumerConfig.setDeadLetterPolicy(DeadLetterPolicy.builder().deadLetterTopic("DLQ").build());
-        consumerConfig.setSubscriptionType(SubscriptionType.Key_Shared);
-        when(mockClient.newConsumerId()).thenReturn(1l);
-        when(mockClient.getConfiguration()).thenReturn(new ClientConfigurationData());
-        when(mockClient.timer()).thenReturn(new HashedWheelTimer());
-        when(mockClient.eventLoopGroup()).thenReturn(new NioEventLoopGroup());
-        try {
-            ConsumerImpl consumer = new ConsumerImpl(mockClient, "my-topic", consumerConfig,
-                    new ExecutorProvider(1, new DefaultThreadFactory("test")), 0,
-                    false, new CompletableFuture<>(),
-            MessageId.earliest, 100, Schema.BYTES,
-                    new ConsumerInterceptors(Collections.emptyList()), false);
-        } catch (Exception exception) {
-            assertTrue(exception instanceof PulsarClientException.InvalidConfigurationException);
-            assertEquals(exception.getMessage(), "Deadletter topic on Key_Shared subscription type is not supported.");
-        }
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -119,35 +119,25 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             return FutureUtil.failedFuture(
                     new InvalidConfigurationException("KeySharedPolicy must set with KeyShared subscription"));
         }
-        if (conf.isRetryEnable() && conf.getTopicNames().size() > 0 ) {
+        if(conf.isRetryEnable() && conf.getTopicNames().size() > 0 ) {
             TopicName topicFirst = TopicName.get(conf.getTopicNames().iterator().next());
             String retryLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
             String deadLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
             if(conf.getDeadLetterPolicy() == null) {
-                DeadLetterPolicy.DeadLetterPolicyBuilder dlpBuilder = DeadLetterPolicy.builder()
-                        .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)
-                        .retryLetterTopic(retryLetterTopic);
-                // Don't set DLQ for key shared subType since it requires msg to be ordered for key.
-                if (conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
-                    dlpBuilder.deadLetterTopic(deadLetterTopic);
-                }
-                conf.setDeadLetterPolicy(dlpBuilder.build());
+                conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
+                                        .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)
+                                        .retryLetterTopic(retryLetterTopic)
+                                        .deadLetterTopic(deadLetterTopic)
+                                        .build());
             } else {
                 if (StringUtils.isBlank(conf.getDeadLetterPolicy().getRetryLetterTopic())) {
                     conf.getDeadLetterPolicy().setRetryLetterTopic(retryLetterTopic);
                 }
-                if (StringUtils.isBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())
-                        && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
+                if (StringUtils.isBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
                     conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic);
                 }
             }
             conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
-        }
-        if (conf.getDeadLetterPolicy() != null && StringUtils.isNotBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())
-                && conf.getSubscriptionType() == SubscriptionType.Key_Shared) {
-            return FutureUtil
-                    .failedFuture(new InvalidConfigurationException("DeadLetterQueue is not supported for" +
-                            " Key_Shared subscription type since DLQ can't guarantee message ordering."));
         }
         return interceptorList == null || interceptorList.size() == 0 ?
                 client.subscribeAsync(conf, schema, null) :

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -195,8 +195,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                MessageId startMessageId,
                                                Schema<T> schema,
                                                ConsumerInterceptors<T> interceptors,
-                                               boolean createTopicIfDoesNotExist)
-            throws PulsarClientException.InvalidConfigurationException {
+                                               boolean createTopicIfDoesNotExist) {
         return newConsumerImpl(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer, subscribeFuture,
                 startMessageId, schema, interceptors, createTopicIfDoesNotExist, 0);
     }
@@ -212,8 +211,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                Schema<T> schema,
                                                ConsumerInterceptors<T> interceptors,
                                                boolean createTopicIfDoesNotExist,
-                                               long startMessageRollbackDurationInSec)
-            throws PulsarClientException.InvalidConfigurationException {
+                                               long startMessageRollbackDurationInSec) {
         if (conf.getReceiverQueueSize() == 0) {
             return new ZeroQueueConsumerImpl<>(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer,
                     subscribeFuture,
@@ -230,7 +228,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
            ExecutorProvider executorProvider, int partitionIndex, boolean hasParentConsumer,
            CompletableFuture<Consumer<T>> subscribeFuture, MessageId startMessageId,
            long startMessageRollbackDurationInSec, Schema<T> schema, ConsumerInterceptors<T> interceptors,
-           boolean createTopicIfDoesNotExist) throws PulsarClientException.InvalidConfigurationException {
+           boolean createTopicIfDoesNotExist) {
         super(client, topic, conf, conf.getReceiverQueueSize(), executorProvider, subscribeFuture, schema, interceptors);
         this.consumerId = client.newConsumerId();
         this.subscriptionMode = conf.getSubscriptionMode();
@@ -317,36 +315,26 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         if (conf.getDeadLetterPolicy() != null) {
-            // DLQ only supports non-ordered subscriptions, don't enable DLQ on Key_Shared subType since it require message ordering for given key.
-            if (conf.getSubscriptionType() == SubscriptionType.Key_Shared &&
-                    StringUtils.isNotBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
-                throw new PulsarClientException.InvalidConfigurationException("Deadletter topic on Key_Shared " +
-                        "subscription type is not supported.");
-            }
-
-            if (conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
-                possibleSendToDeadLetterTopicMessages = new ConcurrentHashMap<>();
-            } else {
-                possibleSendToDeadLetterTopicMessages = null;
-            }
-            DeadLetterPolicy.DeadLetterPolicyBuilder dlpBuilder = DeadLetterPolicy.builder()
-                    .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount());
-
+            possibleSendToDeadLetterTopicMessages = new ConcurrentHashMap<>();
             if (StringUtils.isNotBlank(conf.getDeadLetterPolicy().getDeadLetterTopic())) {
-                dlpBuilder.deadLetterTopic(conf.getDeadLetterPolicy().getDeadLetterTopic());
-            } else if (conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
-                // Not setting a default DLQ if it's Key_Shared subType.
-                dlpBuilder.deadLetterTopic(String.format("%s-%s" + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX,
-                        topic, subscription));
+                this.deadLetterPolicy = DeadLetterPolicy.builder()
+                        .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount())
+                        .deadLetterTopic(conf.getDeadLetterPolicy().getDeadLetterTopic())
+                        .build();
+            } else {
+                this.deadLetterPolicy = DeadLetterPolicy.builder()
+                        .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount())
+                        .deadLetterTopic(String.format("%s-%s" + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX, topic, subscription))
+                        .build();
             }
 
             if (StringUtils.isNotBlank(conf.getDeadLetterPolicy().getRetryLetterTopic())) {
-                dlpBuilder.retryLetterTopic(conf.getDeadLetterPolicy().getRetryLetterTopic());
+                this.deadLetterPolicy.setRetryLetterTopic(conf.getDeadLetterPolicy().getRetryLetterTopic());
             } else {
-                dlpBuilder.retryLetterTopic(String.format("%s-%s" + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX,
+                this.deadLetterPolicy.setRetryLetterTopic(String.format("%s-%s" + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX,
                         topic, subscription));
             }
-            this.deadLetterPolicy = dlpBuilder.build();
+
         } else {
             deadLetterPolicy = null;
             possibleSendToDeadLetterTopicMessages = null;
@@ -1070,8 +1058,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 // Enqueue the message so that it can be retrieved when application calls receive()
                 // if the conf.getReceiverQueueSize() is 0 then discard message if no one is waiting for it.
                 // if asyncReceive is waiting then notify callback without adding to incomingMessages queue
-                if (deadLetterPolicy != null && possibleSendToDeadLetterTopicMessages != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()
-                && StringUtils.isNotBlank(deadLetterPolicy.getDeadLetterTopic())) {
+                if (deadLetterPolicy != null && possibleSendToDeadLetterTopicMessages != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()) {
                     possibleSendToDeadLetterTopicMessages.put((MessageIdImpl)message.getMessageId(), Collections.singletonList(message));
                 }
                 if (peekPendingReceive() != null) {
@@ -1237,8 +1224,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         MessageIdImpl batchMessage = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(),
                 getPartitionIndex());
         List<MessageImpl<T>> possibleToDeadLetter = null;
-        // DLQ only supports non-ordered subscriptions, don't enable DLQ on Key_Shared subType since it require message ordering for given key.
-        if (deadLetterPolicy != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount() && StringUtils.isNotBlank(deadLetterPolicy.getDeadLetterTopic())) {
+        if (deadLetterPolicy != null && redeliveryCount >= deadLetterPolicy.getMaxRedeliverCount()) {
             possibleToDeadLetter = new ArrayList<>();
         }
 
@@ -1612,7 +1598,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         checkArgument(messageIds.stream().findFirst().get() instanceof MessageIdImpl);
 
         if (conf.getSubscriptionType() != SubscriptionType.Shared
-                && deadLetterPolicy != null && StringUtils.isNotBlank(deadLetterPolicy.getDeadLetterTopic())) {
+                && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
             // We cannot redeliver single messages if subscription type is not Shared
             redeliverUnacknowledgedMessages();
             return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -925,19 +925,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     partitionIndex -> {
                         String partitionName = TopicName.get(topicName).getPartition(partitionIndex).toString();
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
-                        ConsumerImpl<T> newConsumer = null;
-                        try {
-                            newConsumer = ConsumerImpl.newConsumerImpl(client, partitionName,
+                        ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(client, partitionName,
                                     configurationData, client.externalExecutorProvider(),
                                     partitionIndex, true, subFuture,
                                     startMessageId, schema, interceptors,
                                     createIfDoesNotExist, startMessageRollbackDurationInSec);
-                        } catch (PulsarClientException.InvalidConfigurationException e) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Deadletter topic on Key_Shared subscription type is not supported.");
-                            }
-                            subFuture.completeExceptionally(e);
-                        }
                         consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
                         return subFuture;
                     })
@@ -954,20 +946,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             allTopicPartitionsNumber.incrementAndGet();
 
             CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
-            ConsumerImpl<T> newConsumer = null;
-            try {
-                newConsumer = ConsumerImpl.newConsumerImpl(client, topicName, internalConfig,
+            ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(client, topicName, internalConfig,
                         client.externalExecutorProvider(), -1,
                         true, subFuture, null, schema, interceptors,
                         createIfDoesNotExist);
                 consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
-
-            } catch (PulsarClientException.InvalidConfigurationException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Deadletter topic on Key_Shared subscription type is not supported.");
-                }
-                subFuture.completeExceptionally(e);
-            }
 
             futureList = Collections.singletonList(subFuture);
         }
@@ -1239,19 +1222,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         int partitionIndex = TopicName.getPartitionIndex(partitionName);
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
-                        ConsumerImpl<T> newConsumer = null;
-                        try {
-                            newConsumer = ConsumerImpl.newConsumerImpl(
+                        ConsumerImpl<T> newConsumer = ConsumerImpl.newConsumerImpl(
                                 client, partitionName, configurationData,
                                 client.externalExecutorProvider(),
                                 partitionIndex, true, subFuture, null, schema, interceptors,
                                 true /* createTopicIfDoesNotExist */);
-                        } catch (PulsarClientException.InvalidConfigurationException e) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Deadletter topic on Key_Shared subscription type is not supported.");
-                            }
-                            subFuture.completeExceptionally(e);
-                        }
                         synchronized (pauseMutex) {
                             if (paused) {
                                 newConsumer.pause();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -39,8 +39,7 @@ public class ReaderImpl<T> implements Reader<T> {
     private final ConsumerImpl<T> consumer;
 
     public ReaderImpl(PulsarClientImpl client, ReaderConfigurationData<T> readerConfiguration,
-                      ExecutorProvider executorProvider, CompletableFuture<Consumer<T>> consumerFuture, Schema<T> schema)
-            throws PulsarClientException.InvalidConfigurationException {
+                      ExecutorProvider executorProvider, CompletableFuture<Consumer<T>> consumerFuture, Schema<T> schema) {
 
         String subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -52,7 +52,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
              ExecutorProvider executorProvider, int partitionIndex, boolean hasParentConsumer,
              CompletableFuture<Consumer<T>> subscribeFuture, MessageId startMessageId, Schema<T> schema,
              ConsumerInterceptors<T> interceptors,
-             boolean createTopicIfDoesNotExist) throws PulsarClientException.InvalidConfigurationException {
+             boolean createTopicIfDoesNotExist) {
         super(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer, subscribeFuture,
                 startMessageId, 0 /* startMessageRollbackDurationInSec */, schema, interceptors,
                 createTopicIfDoesNotExist);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
@@ -59,33 +58,6 @@ public class ConsumerBuilderImplTest {
         when(consumerBuilderImpl.subscribeAsync())
                 .thenReturn(CompletableFuture.completedFuture(consumer));
         assertNotNull(consumerBuilderImpl.topic(TOPIC_NAME).subscribe());
-    }
-
-    @Test(expectedExceptions = PulsarClientException.InvalidConfigurationException.class)
-    public void testConsumerBuilderImplDLQForKeySharedNotAllowed() throws PulsarClientException {
-        PulsarClientImpl client = mock(PulsarClientImpl.class);
-        ConsumerBuilderImpl consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic("my-topic")
-                .subscriptionName("my-sub")
-                .subscriptionType(SubscriptionType.Key_Shared)
-                .keySharedPolicy(KeySharedPolicy.autoSplitHashRange())
-                .deadLetterPolicy(DeadLetterPolicy.builder().deadLetterTopic("my-DLQ").build())
-                .subscribe();
-    }
-
-    @Test
-    public void testConsumerBuilderImplDLQForRetry() throws PulsarClientException {
-        PulsarClientImpl client = mock(PulsarClientImpl.class);
-        CompletableFuture future = new CompletableFuture<>();
-        future.complete(null);
-        when(client.subscribeAsync(any(), any(), any())).thenReturn(future);
-        ConsumerBuilderImpl consumerBuilderImpl = new ConsumerBuilderImpl(client, Schema.BYTES);
-        consumerBuilderImpl.topic("my-topic")
-                .subscriptionName("my-sub")
-                .enableRetry(true)
-                .subscriptionType(SubscriptionType.Key_Shared)
-                .keySharedPolicy(KeySharedPolicy.autoSplitHashRange())
-                .subscribe();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -50,7 +50,7 @@ public class ConsumerImplTest {
     private ConsumerConfigurationData consumerConf;
 
     @BeforeMethod
-    public void setUp() throws PulsarClientException.InvalidConfigurationException {
+    public void setUp() {
         consumerConf = new ConsumerConfigurationData<>();
         PulsarClientImpl client = ClientTestFixtures.createPulsarClientMock();
         ClientConfigurationData clientConf = client.getConfiguration();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ReaderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ReaderImplTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.impl;
 
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.testng.annotations.BeforeMethod;
@@ -35,7 +34,7 @@ public class ReaderImplTest {
     ReaderImpl<byte[]> reader;
 
     @BeforeMethod
-    void setupReader() throws PulsarClientException.InvalidConfigurationException {
+    void setupReader() {
         PulsarClientImpl mockedClient = ClientTestFixtures.createPulsarClientMockWithMockedClientCnx();
         ReaderConfigurationData<byte[]> readerConfiguration = new ReaderConfigurationData<>();
         readerConfiguration.setTopicName("topicName");

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -378,14 +378,8 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         if (queryParams.containsKey("maxRedeliverCount") || queryParams.containsKey("deadLetterTopic")) {
             DeadLetterPolicy.DeadLetterPolicyBuilder dlpBuilder = DeadLetterPolicy.builder();
             if (queryParams.containsKey("maxRedeliverCount")) {
-                dlpBuilder.maxRedeliverCount(Integer.parseInt(queryParams.get("maxRedeliverCount")));
-            }
-
-            // Don't provide a default DLQ to Key_Shared sub type as DLQ can't guarantee order.
-            if (!queryParams.containsKey("subscriptionType") ||
-                queryParams.containsKey("subscriptionType") &&
-                SubscriptionType.valueOf(queryParams.get("subscriptionType")) != SubscriptionType.Key_Shared) {
-                dlpBuilder.deadLetterTopic(String.format("%s-%s-DLQ", topic, subscription));
+                dlpBuilder.maxRedeliverCount(Integer.parseInt(queryParams.get("maxRedeliverCount")))
+                        .deadLetterTopic(String.format("%s-%s-DLQ", topic, subscription));
             }
 
             if (queryParams.containsKey("deadLetterTopic")) {

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -313,59 +313,6 @@ public class AbstractWebSocketHandlerTest {
         // the params are all different with the default value
         Map<String, String[]> queryParams = new HashMap<String, String>(){{
             put("ackTimeoutMillis", "1001");
-            put("subscriptionType", "Shared");
-            put("subscriptionMode", "NonDurable");
-            put("receiverQueueSize", "999");
-            put("consumerName", "my-consumer");
-            put("priorityLevel", "1");
-            put("maxRedeliverCount", "5");
-        }}.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> new String[]{ entry.getValue() }));
-
-        httpServletRequest = mock(HttpServletRequest.class);
-        when(httpServletRequest.getRequestURI()).thenReturn(consumerV2);
-        when(httpServletRequest.getParameterMap()).thenReturn(queryParams);
-
-        WebSocketService service = mock(WebSocketService.class);
-        when(service.isAuthenticationEnabled()).thenReturn(false);
-        when(service.isAuthorizationEnabled()).thenReturn(false);
-        when(service.getPulsarClient()).thenReturn(newPulsarClient());
-
-        MockedServletUpgradeResponse response = new MockedServletUpgradeResponse(null);
-
-        MockedConsumerHandler consumerHandler = new MockedConsumerHandler(service, httpServletRequest, response);
-        assertEquals(response.getStatusCode(), 500);
-        assertTrue(response.getMessage().contains("Connection refused"));
-        assertEquals(consumerHandler.getSubscriptionMode(), SubscriptionMode.NonDurable);
-        assertEquals(consumerHandler.getSubscriptionType(), SubscriptionType.Shared);
-
-        ConsumerConfigurationData<byte[]> conf = consumerHandler.getConf();
-        assertEquals(conf.getAckTimeoutMillis(), 1001);
-        assertEquals(conf.getSubscriptionType(), SubscriptionType.Shared);
-        assertEquals(conf.getSubscriptionMode(), SubscriptionMode.NonDurable);
-        assertEquals(conf.getReceiverQueueSize(), 999);
-        assertEquals(conf.getConsumerName(), "my-consumer");
-        assertEquals(conf.getPriorityLevel(), 1);
-        assertEquals(conf.getDeadLetterPolicy().getDeadLetterTopic(),
-                "persistent://my-property/my-ns/my-topic-my-subscription-DLQ");
-        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 5);
-
-        consumerHandler.clearQueryParams();
-        consumerHandler.putQueryParam("receiverQueueSize", "1001");
-        consumerHandler.putQueryParam("deadLetterTopic", "dead-letter-topic");
-
-        conf = consumerHandler.getConf();
-        // receive queue size is the minimum value of default value (1000) and user defined value(1001)
-        assertEquals(conf.getReceiverQueueSize(), 1000);
-        assertEquals(conf.getDeadLetterPolicy().getDeadLetterTopic(), "dead-letter-topic");
-        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 0);
-    }
-
-    @Test
-    public void consumerBuilderKeySharedTest() throws IOException {
-        String consumerV2 = "/ws/v2/consumer/persistent/my-property/my-ns/my-topic/my-subscription";
-        // the params are all different with the default value
-        Map<String, String[]> queryParams = new HashMap<String, String>(){{
-            put("ackTimeoutMillis", "1001");
             put("subscriptionType", "Key_Shared");
             put("subscriptionMode", "NonDurable");
             put("receiverQueueSize", "999");
@@ -385,20 +332,31 @@ public class AbstractWebSocketHandlerTest {
 
         MockedServletUpgradeResponse response = new MockedServletUpgradeResponse(null);
 
-        // Won't set DLQ by default
         MockedConsumerHandler consumerHandler = new MockedConsumerHandler(service, httpServletRequest, response);
         assertEquals(response.getStatusCode(), 500);
         assertTrue(response.getMessage().contains("Connection refused"));
         assertEquals(consumerHandler.getSubscriptionMode(), SubscriptionMode.NonDurable);
         assertEquals(consumerHandler.getSubscriptionType(), SubscriptionType.Key_Shared);
-        assertEquals(consumerHandler.getConf().getDeadLetterPolicy().getMaxRedeliverCount(), 5);
-        assertEquals(consumerHandler.getConf().getDeadLetterPolicy().getDeadLetterTopic(), null);
 
-        // Throw exception from consumer builder if client try to set DLQ for Key_Shared sub type.
-        queryParams.put("deadLetterTopic", new String[]{"dead-letter-topic"});
+        ConsumerConfigurationData<byte[]> conf = consumerHandler.getConf();
+        assertEquals(conf.getAckTimeoutMillis(), 1001);
+        assertEquals(conf.getSubscriptionType(), SubscriptionType.Key_Shared);
+        assertEquals(conf.getSubscriptionMode(), SubscriptionMode.NonDurable);
+        assertEquals(conf.getReceiverQueueSize(), 999);
+        assertEquals(conf.getConsumerName(), "my-consumer");
+        assertEquals(conf.getPriorityLevel(), 1);
+        assertEquals(conf.getDeadLetterPolicy().getDeadLetterTopic(),
+                "persistent://my-property/my-ns/my-topic-my-subscription-DLQ");
+        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 5);
 
-        new MockedConsumerHandler(service, httpServletRequest, response);
-        assertEquals(response.getStatusCode(), 500);
-        assertTrue(response.getMessage().contains("DeadLetterQueue is not supported for Key_Shared subscription type since DLQ can't guarantee message ordering."));
+        consumerHandler.clearQueryParams();
+        consumerHandler.putQueryParam("receiverQueueSize", "1001");
+        consumerHandler.putQueryParam("deadLetterTopic", "dead-letter-topic");
+
+        conf = consumerHandler.getConf();
+        // receive queue size is the minimum value of default value (1000) and user defined value(1001)
+        assertEquals(conf.getReceiverQueueSize(), 1000);
+        assertEquals(conf.getDeadLetterPolicy().getDeadLetterTopic(), "dead-letter-topic");
+        assertEquals(conf.getDeadLetterPolicy().getMaxRedeliverCount(), 0);
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/apache/pulsar/pull/9583, Key_Shared is not all about ordering, so we'll still enable use of DLQ but adding document to warn user about the consequence of using negative ack and DQL for ordered sub type.
This reverts commit 9af857781fc3d357834eaa13acf45005f8186875.