### PR TITLE
[Doc]Update document to indicating effect of negative acking message for order sube type like exclusive, failover and key_shared.

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -128,7 +128,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -128,6 +128,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/docs/reference-terminology.md
+++ b/site2/docs/reference-terminology.md
@@ -80,7 +80,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order. 
 
 #### Unacknowledged
 

--- a/site2/docs/reference-terminology.md
+++ b/site2/docs/reference-terminology.md
@@ -80,8 +80,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order. 
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
@@ -90,7 +90,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 ### Acknowledgement timeout
 

--- a/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.0/concepts-messaging.md
@@ -90,6 +90,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 ### Acknowledgement timeout
 
 When a message is not consumed successfully, and you want to trigger the broker to redeliver the message automatically, you can adopt the unacknowledged message automatic re-delivery mechanism. Client will track the unacknowledged messages within the entire `acktimeout` time range, and send a `redeliver unacknowledged messages` request to the broker automatically when the acknowledgement timeout is specified.

--- a/site2/website/versioned_docs/version-2.5.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.1/concepts-messaging.md
@@ -99,7 +99,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > Note
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.

--- a/site2/website/versioned_docs/version-2.5.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.1/concepts-messaging.md
@@ -99,6 +99,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > Note
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.
 

--- a/site2/website/versioned_docs/version-2.5.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.2/concepts-messaging.md
@@ -99,7 +99,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > Note
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.

--- a/site2/website/versioned_docs/version-2.5.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.5.2/concepts-messaging.md
@@ -99,6 +99,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > Note
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.
 

--- a/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
@@ -105,6 +105,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.
 

--- a/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
@@ -105,7 +105,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages in the same batch may be redelivered to the consumer as well as the negatively acknowledged messages.

--- a/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
@@ -129,6 +129,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
@@ -129,7 +129,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
@@ -129,6 +129,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
@@ -129,7 +129,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
@@ -129,6 +129,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
@@ -129,7 +129,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
@@ -129,6 +129,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
@@ -129,7 +129,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
@@ -129,6 +129,8 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
+Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.
 

--- a/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
@@ -129,7 +129,7 @@ In the exclusive and failover subscription modes, consumers only negatively ackn
 
 In the shared and Key_Shared subscription modes, you can negatively acknowledge messages individually.
 
-Be aware that doing negative ack on ordered subscription type like Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+Be aware that negative acknowledgment on ordered subscription types, such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 > **Note**
 > If batching is enabled, other messages and the negatively acknowledged messages in the same batch are redelivered to the consumer.

--- a/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
@@ -81,8 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
-Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
+replayed after a 1 minute delay). Be aware that negative acknowledgment on ordered subscription types,
+such as Exclusive, Failover and Key_Shared, can cause failed messages to arrive consumers out of the original order.
 
 #### Unacknowledged
 

--- a/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
@@ -81,7 +81,8 @@ if no acknowledgement, then the message will be retained until it's processed.
 
 When an application fails to process a particular message, it can sends a "negative ack" to Pulsar
 to signal that the message should be replayed at a later timer. (By default, failed messages are
-replayed after a 1 minute delay)
+replayed after a 1 minute delay). Be aware that doing negative ack on ordered subscription type like
+Exclusive, Failover and Key_Share can cause failed messages arrive consumer out of original order.
 
 #### Unacknowledged
 


### PR DESCRIPTION
Fixes #9582

### Motivation

Originally try to disable negative acknowledgement for Key_Shared, but after discussion it's more like document problem that user should be aware that negative acks are going to trigger the out of order delivery of a particular message.

### Modifications

Update document for negative acknowledgement to warn user that it might break message ordering.
