### PR TITLE
[WIP][PIP-56] Migrate the python2.7 to python3.7

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 RUN apt-get install -y curl
 RUN cd /usr/src && curl -O -L https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz && \
     tar zxf boost_1_75_0.tar.gz && cd boost_1_75_0 && \
-    ./bootstrap.sh --with-python=/usr/bin/python3 --with-libraries=program_options,filesystem,regex,thread,system,python && \
+    ./bootstrap.sh --with-python=/usr/bin/python3 --with-libraries=program_options,python && \
     ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
     cd .. && rm -rf boost_1_75_0 boost_1_75_0.tar.gz
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -28,10 +28,18 @@ RUN apt-get update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     apt-get install -y tig g++ cmake libssl-dev libcurl4-openssl-dev \
-                liblog4cxx-dev libprotobuf-dev libboost-all-dev google-mock libgtest-dev \
+                liblog4cxx-dev libprotobuf-dev google-mock libgtest-dev \
                 libjsoncpp-dev libxml2-utils protobuf-compiler wget \
                 curl doxygen openjdk-8-jdk-headless openjdk-11-jdk-headless clang-format-5.0 \
                 gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip
+
+# Compile and install Boost because Boost.Python for Python3 is required
+RUN apt-get install -y curl
+RUN cd /usr/src && curl -O -L https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz && \
+    tar zxf boost_1_75_0.tar.gz && cd boost_1_75_0 && \
+    ./bootstrap.sh --with-python=/usr/bin/python3 --with-libraries=program_options,filesystem,regex,thread,system,python && \
+    ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
+    cd .. && rm -rf boost_1_75_0 boost_1_75_0.tar.gz
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -26,7 +26,7 @@ set -e
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"

--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -33,7 +33,7 @@ fi
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"

--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -90,7 +90,7 @@ class JsonSchema(Schema):
         return json.dumps(obj.__dict__, default=self._get_serialized_value, indent=True).encode('utf-8')
 
     def decode(self, data):
-        return self._record_cls(**json.loads(data))
+        return self._record_cls(**json.loads(data.decode()))
 
 
 class AvroSchema(Schema):

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -370,10 +370,10 @@ class PulsarTest(TestCase):
         producer = client.create_producer(topic=topic,
                                           encryption_key="client-rsa.pem",
                                           crypto_key_reader=crypto_key_reader)
-        producer.send('hello')
+        producer.send(b'hello')
         msg = consumer.receive(TM)
         self.assertTrue(msg)
-        self.assertEqual(msg.value(), 'hello')
+        self.assertEqual(msg.value(), b'hello')
         consumer.unsubscribe()
         client.close()
 

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -326,7 +326,7 @@ class SchemaTest(TestCase):
         s = JsonSchema(Example)
         r = Example(a=1, b=2)
         data = s.encode(r)
-        self.assertEqual(json.loads(data), {'a': 1, 'b': 2})
+        self.assertEqual(json.loads(data.decode()), {'a': 1, 'b': 2})
 
         r2 = s.decode(data)
         self.assertEqual(r2.__class__.__name__, 'Example')

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -45,10 +45,10 @@ popd
 if [ $RES -eq 0 ]; then
     pushd python
     echo "---- Build Python Wheel file"
-    python setup.py bdist_wheel
+    python3 setup.py bdist_wheel
 
     echo "---- Installing  Python Wheel file"
-    pip install dist/pulsar_client-*-linux_x86_64.whl
+    pip3 install dist/pulsar_client-*-linux_x86_64.whl
 
     echo "---- Running Python unit tests"
 
@@ -57,7 +57,7 @@ if [ $RES -eq 0 ]; then
     cp *_test.py /tmp
     pushd /tmp
 
-    python pulsar_test.py
+    python3 pulsar_test.py
     RES=$?
 
     echo "---- Running Python Function Instance unit tests"

--- a/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
+++ b/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
@@ -20,12 +20,12 @@
 
 
 # Make sure dependencies are installed
-pip install mock --user
-pip install protobuf --user
-pip install fastavro --user
+pip3 install mock --user
+pip3 install protobuf --user
+pip3 install fastavro --user
 
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PULSAR_HOME=$CUR_DIR/../../../../
 
 # run instance tests
-PULSAR_HOME=${PULSAR_HOME} PYTHONPATH=${PULSAR_HOME}/pulsar-functions/instance/target/python-instance python -m unittest discover -v ${PULSAR_HOME}/pulsar-functions/instance/target/python-instance/tests
+PULSAR_HOME=${PULSAR_HOME} PYTHONPATH=${PULSAR_HOME}/pulsar-functions/instance/target/python-instance python3 -m unittest discover -v ${PULSAR_HOME}/pulsar-functions/instance/target/python-instance/tests


### PR DESCRIPTION
Fixes #8622 

### Motivation

Currently, ci-cpp-tests uses `pulsar-build` image that is from `ubuntu:16.04` to build C++/Python client. The image uses `libboost-all-dev` for CMake to find boost dependencies. However, the Boost.Python library from Ubuntu 16.04's apt source only supports Python 2.

### Modifications

- Modify the related `Dockerfile` to install Boost dependency from source.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.