### PR TITLE
[Branch-2.7] Pulsar sql key-value schema separated model support.

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/AvroSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/AvroSchemaHandler.java
@@ -45,9 +45,10 @@ public class AvroSchemaHandler implements SchemaHandler {
     AvroSchemaHandler(TopicName topicName,
                       PulsarConnectorConfig pulsarConnectorConfig,
                       SchemaInfo schemaInfo,
-                      List<PulsarColumnHandle> columnHandles) throws PulsarClientException {
+                      List<PulsarColumnHandle> columnHandles,
+                      PulsarSqlSchemaInfoProvider.Type type) throws PulsarClientException {
         this(new PulsarSqlSchemaInfoProvider(topicName,
-                                pulsarConnectorConfig.getPulsarAdmin()), schemaInfo, columnHandles);
+                                pulsarConnectorConfig.getPulsarAdmin(), type), schemaInfo, columnHandles);
     }
 
     AvroSchemaHandler(PulsarSqlSchemaInfoProvider pulsarSqlSchemaInfoProvider,

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/KeyValueSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/KeyValueSchemaHandler.java
@@ -52,9 +52,9 @@ public class KeyValueSchemaHandler implements SchemaHandler {
         this.columnHandles = columnHandles;
         KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo);
         keySchemaHandler = PulsarSchemaHandlers.newPulsarSchemaHandler(topicName, pulsarConnectorConfig,
-                kvSchemaInfo.getKey(), columnHandles);
+                kvSchemaInfo.getKey(), columnHandles, PulsarSqlSchemaInfoProvider.Type.Key);
         valueSchemaHandler = PulsarSchemaHandlers.newPulsarSchemaHandler(topicName, pulsarConnectorConfig,
-                kvSchemaInfo.getValue(), columnHandles);
+                kvSchemaInfo.getValue(), columnHandles, PulsarSqlSchemaInfoProvider.Type.Value);
         keyValueEncodingType = KeyValueSchemaInfo.decodeKeyValueEncodingType(schemaInfo);
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -156,7 +156,8 @@ public class PulsarRecordCursor implements RecordCursor {
 
         this.schemaHandler = PulsarSchemaHandlers
                 .newPulsarSchemaHandler(this.topicName,
-                        this.pulsarConnectorConfig, pulsarSplit.getSchemaInfo(), columnHandles);
+                        this.pulsarConnectorConfig, pulsarSplit.getSchemaInfo(),
+                        columnHandles, PulsarSqlSchemaInfoProvider.Type.NONE);
 
         log.info("Initializing split with parameters: %s", pulsarSplit);
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSchemaHandlers.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSchemaHandlers.java
@@ -33,7 +33,8 @@ class PulsarSchemaHandlers {
     static SchemaHandler newPulsarSchemaHandler(TopicName topicName,
                                                 PulsarConnectorConfig pulsarConnectorConfig,
                                                 SchemaInfo schemaInfo,
-                                                List<PulsarColumnHandle> columnHandles) throws RuntimeException{
+                                                List<PulsarColumnHandle> columnHandles,
+                                                PulsarSqlSchemaInfoProvider.Type type) throws RuntimeException{
         if (schemaInfo.getType().isPrimitive()) {
             return new PulsarPrimitiveSchemaHandler(schemaInfo);
         } else if (schemaInfo.getType().isStruct()) {
@@ -42,7 +43,7 @@ class PulsarSchemaHandlers {
                     case JSON:
                         return new JSONSchemaHandler(columnHandles);
                     case AVRO:
-                        return new AvroSchemaHandler(topicName, pulsarConnectorConfig, schemaInfo, columnHandles);
+                        return new AvroSchemaHandler(topicName, pulsarConnectorConfig, schemaInfo, columnHandles, type);
                     default:
                         throw new PrestoException(NOT_SUPPORTED, "Not supported schema type: " + schemaInfo.getType());
                 }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSqlSchemaInfoProvider.java
@@ -29,7 +29,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -45,9 +47,17 @@ public class PulsarSqlSchemaInfoProvider implements SchemaInfoProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(PulsarSqlSchemaInfoProvider.class);
 
+    public enum Type{
+        NONE,
+        Key,
+        Value,
+    }
+
     private final TopicName topicName;
 
     private final PulsarAdmin pulsarAdmin;
+
+    private final Type type;
 
     private final LoadingCache<BytesSchemaVersion, SchemaInfo> cache = CacheBuilder.newBuilder().maximumSize(100000)
             .expireAfterAccess(30, TimeUnit.MINUTES).build(new CacheLoader<BytesSchemaVersion, SchemaInfo>() {
@@ -57,9 +67,10 @@ public class PulsarSqlSchemaInfoProvider implements SchemaInfoProvider {
                 }
             });
 
-    PulsarSqlSchemaInfoProvider(TopicName topicName, PulsarAdmin pulsarAdmin) {
+    PulsarSqlSchemaInfoProvider(TopicName topicName, PulsarAdmin pulsarAdmin, Type type) {
         this.topicName = topicName;
         this.pulsarAdmin = pulsarAdmin;
+        this.type = type;
     }
 
     @Override
@@ -94,8 +105,19 @@ public class PulsarSqlSchemaInfoProvider implements SchemaInfoProvider {
     }
 
     private SchemaInfo loadSchema(BytesSchemaVersion bytesSchemaVersion) throws PulsarAdminException {
-        return pulsarAdmin.schemas()
+        SchemaInfo schemaInfo = pulsarAdmin.schemas()
                 .getSchemaInfo(topicName.toString(), ByteBuffer.wrap(bytesSchemaVersion.get()).getLong());
+        switch (type) {
+            case NONE:
+                return schemaInfo;
+            case Key:
+                return KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo).getKey();
+            case Value:
+                return KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo).getValue();
+            default:
+                throw new PulsarAdminException(new PulsarClientException
+                        .NotSupportedException("PulsarSqlSchemaInfoProvider don't support this Type : " + type));
+        }
     }
 
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarPrimitiveSchemaHandler.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarPrimitiveSchemaHandler.java
@@ -141,7 +141,7 @@ public class TestPulsarPrimitiveSchemaHandler {
                 null,
                 null,
                 StringSchema.utf8().getSchemaInfo(),
-                null);
+                null, PulsarSqlSchemaInfoProvider.Type.NONE);
 
         String stringValue = "test";
         when(rawMessage.getData()).thenReturn(ByteBufAllocator.DEFAULT.buffer().writeBytes(StringSchema.utf8().encode(stringValue)));

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -22,11 +22,21 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 public class TestBasicPresto extends TestPulsarSQLBase {
@@ -55,6 +65,62 @@ public class TestBasicPresto extends TestPulsarSQLBase {
     public void testSimpleSQLQueryNonBatched() throws Exception {
         TopicName topicName = TopicName.get("public/default/stocks_nonbatched_" + randomName(5));
         pulsarSQLBasicTest(topicName, false, false);
+    }
+
+    @DataProvider(name = "keyValueEncodingType")
+    public Object[][] keyValueEncodingType() {
+        return new Object[][] { { KeyValueEncodingType.INLINE }, { KeyValueEncodingType.SEPARATED } };
+    }
+
+    @Test(dataProvider = "keyValueEncodingType")
+    public void testKeyValueSchema(KeyValueEncodingType type) throws Exception {
+        waitPulsarSQLReady();
+        TopicName topicName = TopicName.get("public/default/stocks" + randomName(20));
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
+                .build();
+
+        @Cleanup
+        Producer<KeyValue<Stock,Stock>> producer = pulsarClient.newProducer(Schema
+                .KeyValue(Schema.AVRO(Stock.class), Schema.AVRO(Stock.class), type))
+                .topic(topicName.toString())
+                .create();
+
+        for (int i = 0 ; i < NUM_OF_STOCKS; ++i) {
+            int j = 100 * i;
+            final Stock stock1 = new Stock(j, "STOCK_" + j , 100.0 + j * 10);
+            final Stock stock2 = new Stock(i, "STOCK_" + i , 100.0 + i * 10);
+            producer.send(new KeyValue<>(stock1, stock2));
+        }
+
+        producer.flush();
+
+        validateMetadata(topicName);
+
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                () -> {
+                    ContainerExecResult containerExecResult = execQuery(
+                            String.format("select * from pulsar.\"%s\".\"%s\" order by entryid;",
+                                    topicName.getNamespace(), topicName.getLocalName()));
+                    assertThat(containerExecResult.getExitCode()).isEqualTo(0);
+                    log.info("select sql query output \n{}", containerExecResult.getStdout());
+                    String[] split = containerExecResult.getStdout().split("\n");
+                    assertThat(split.length).isEqualTo(NUM_OF_STOCKS);
+                    String[] split2 = containerExecResult.getStdout().split("\n|,");
+                    for (int i = 0; i < NUM_OF_STOCKS; ++i) {
+                        int j = 100 * i;
+                        assertThat(split2).contains("\"" + i + "\"");
+                        assertThat(split2).contains("\"" + "STOCK_" + i + "\"");
+                        assertThat(split2).contains("\"" + (100.0 + i * 10) + "\"");
+
+                        assertThat(split2).contains("\"" + j + "\"");
+                        assertThat(split2).contains("\"" + "STOCK_" + j + "\"");
+                        assertThat(split2).contains("\"" + (100.0 + j * 10) + "\"");
+                    }
+                }
+        );
+
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -57,7 +57,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
         validateData(topic, messageCnt);
     }
 
-    private void waitPulsarSQLReady() throws Exception {
+    public void waitPulsarSQLReady() throws Exception {
         // wait until presto worker started
         ContainerExecResult result;
         do {
@@ -102,7 +102,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
         throw new Exception("Unsupported operation prepareData.");
     }
 
-    private void validateMetadata(TopicName topicName) throws Exception {
+    public void validateMetadata(TopicName topicName) throws Exception {
         ContainerExecResult result = execQuery("show schemas in pulsar;");
         assertThat(result.getExitCode()).isEqualTo(0);
         assertThat(result.getStdout()).contains(topicName.getNamespace());
@@ -122,7 +122,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
         );
     }
 
-    private void validateData(TopicName topicName, int messageNum) throws Exception {
+    public void validateData(TopicName topicName, int messageNum) throws Exception {
         String namespace = topicName.getNamespace();
         String topic = topicName.getLocalName();
 


### PR DESCRIPTION
## Motivation
Pulsar sql key-value schema separated model support in branch-2.7
## implement
Add the test
### Verifying this change
Add the test for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

