### PR TITLE
Duplicate key __pfn_input_topic__ in presto server

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -85,7 +85,8 @@ public class RawMessageImpl implements RawMessage {
     public Map<String, String> getProperties() {
         if (singleMessageMetadata != null && singleMessageMetadata.getPropertiesCount() > 0) {
             return singleMessageMetadata.getPropertiesList().stream()
-                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+                      .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                              (oldValue,newValue) -> newValue));
         } else if (msgMetadata.getMetadata().getPropertiesCount() > 0) {
             return msgMetadata.getMetadata().getPropertiesList().stream()
                     .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
@@ -1,0 +1,32 @@
+package org.apache.pulsar.common.api.raw;
+
+import io.netty.buffer.ByteBuf;
+import junit.framework.TestCase;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class RawMessageImplTest extends TestCase {
+
+    private static final String HARD_CODE_KEY = "__pfn_input_topic__";
+    private static final String KEY_VALUE_FIRST= "persistent://first-tenant-value/first-namespace-value/first-topic-value";
+    private static final String KEY_VALUE_SECOND = "persistent://second-tenant-value/second-namespace-value/second-topic-value";
+    private static final String HARD_CODE_KEY_ID = "__pfn_input_msg_id__";
+    private static final String HARD_CODE_KEY_ID_VALUE  = "__pfn_input_msg_id_value__";
+    public void testGetProperties() {
+        ReferenceCountedMessageMetadata refCntMsgMetadata = ReferenceCountedMessageMetadata.get();
+        SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
+        singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_FIRST);
+        singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_SECOND);
+        singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY_ID).setValue(HARD_CODE_KEY_ID_VALUE);
+        RawMessage msg = RawMessageImpl.get(refCntMsgMetadata, singleMessageMetadata, null , 0, 0, 0);
+        Map<String, String> properties = msg.getProperties();
+        assertEquals(KEY_VALUE_SECOND, properties.get(HARD_CODE_KEY));
+        assertEquals(HARD_CODE_KEY_ID_VALUE, properties.get(HARD_CODE_KEY_ID));
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
@@ -1,15 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.common.api.raw;
 
-import io.netty.buffer.ByteBuf;
 import junit.framework.TestCase;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
-
-import static org.testng.Assert.assertEquals;
 
 public class RawMessageImplTest extends TestCase {
 


### PR DESCRIPTION
<!--
### Contribution Checklist

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation
When I query a topic with presto
`presto> select * from xxxTable from pulsar."xxxTenant/xxxNamespace"."last-topic-value";

Query 20210222_101426_00019_jvnf5, FAILED, 2 nodes
Splits: 18 total, 0 done (0.00%)
**0.79** [0 rows, 0B] [0 rows/s, 0B/s]

You can see it cast a long time, and will not stop.
And you can see many error messages in presto server:
Query 20210222_101426_00019_jvnf5 failed: Duplicate key __pfn_input_topic__ (attempted merging values persistent://first-tenant-value/first-namespace-value/first-topic-value and persistent://second-tenant-value/second-namespace-value/second-topic-valu)`
![image](https://user-images.githubusercontent.com/1859919/108883639-aa2d1d80-7640-11eb-9fea-c64dcd3c62ed.png)


**To Reproduce**
Steps to reproduce the behavior:
1. create 3 topics: first-topic-value, second-topic-value, last-topic-value
2. create 2 pulsar functions, f1 pulls messages from first-topic-value, writes to second-topic-value, f2 pulls messages from second-topic-value, writes to last-topic-value.
3. `presto> select * from xxxTable from pulsar."xxxTenant/xxxNamespace"."last-topic-value";
4. See these errors

**Expected behavior**
query successfully, and No error.

**Screenshots**
<img width="1288" alt="Screen Shot 2021-02-24 at 00 16 09" src="https://user-images.githubusercontent.com/1859919/108872874-9af4a280-7635-11eb-8ce5-04c88108b12b.png">

**Desktop (please complete the following information):**
 - OS: CentOS , pulsar 2.7.0
### Modifications
if key dumplicated, use new one.

### Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test in RawMessageImplTest.java*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)
  - The rest endpoints: (yes / **no**)
  - The admin cli options: (yes / **no**)
  - Anything that affects deployment: (yes / **no** / don't know)

### Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why? it is a bug
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
  - It is just like <#6390>, but it causes presto issue.
