### PR TITLE
Include pulsar-client-admin-api in the shaded version of pulsar-client-admin

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -66,6 +66,7 @@
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
+                  <include>org.apache.pulsar:pulsar-client-admin-api</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>


### PR DESCRIPTION
In the following PR:

https://github.com/apache/pulsar/pull/9246

The API of the pulsar-client-admin was separated into another module.  However, the api module was not added to be included in the shaded version of pulsar-client-admin.  This creates dependency issues such as

`java.lang.NoSuchMethodError: org.apache.pulsar.client.admin.PulsarAdminException.<init>(Lorg/apache/pulsar/shade/javax/ws/rs/ClientErrorException;)V`


