### PR TITLE
[CI][C++] Force CMake to find Python2

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -81,7 +81,7 @@ jobs:
         if: steps.docs.outputs.changed_only == 'no'
         run: |
           echo "Build C++ client library"
-          export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF"
+          export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so"
           pulsar-client-cpp/docker-build.sh
 
       - name: run c++ tests

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
                 liblog4cxx-dev libprotobuf-dev libboost-all-dev google-mock libgtest-dev \
                 libjsoncpp-dev libxml2-utils protobuf-compiler wget \
                 curl doxygen openjdk-8-jdk-headless openjdk-11-jdk-headless clang-format-5.0 \
-                gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip
+                gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip python-pip
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -28,10 +28,11 @@ RUN apt-get update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     apt-get install -y tig g++ cmake libssl-dev libcurl4-openssl-dev \
-                liblog4cxx-dev libprotobuf-dev libboost-all-dev google-mock libgtest-dev \
-                libjsoncpp-dev libxml2-utils protobuf-compiler wget \
+                liblog4cxx-dev libprotobuf-dev google-mock libgtest-dev \
+                libboost-dev libboost-program-options-dev libboost-system-dev libboost-python-dev \
+                libxml2-utils protobuf-compiler wget \
                 curl doxygen openjdk-8-jdk-headless openjdk-11-jdk-headless clang-format-5.0 \
-                gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip python-pip
+                gnupg2 golang-1.13-go zip unzip libzstd-dev libsnappy-dev python3-pip libpython-dev
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib
@@ -66,6 +67,7 @@ RUN wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
 RUN dpkg -i crowdin.deb
 
 # Install PIP and PDoc
+RUN wget https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py
 RUN pip3 install pdoc
 
 # Install Protobuf doc generator (requires Go)

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
 RUN dpkg -i crowdin.deb
 
 # Install PIP and PDoc
-RUN wget https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py
+RUN wget https://bootstrap.pypa.io/2.7/get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip3 install pdoc
 
 # Install Protobuf doc generator (requires Go)

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -26,7 +26,7 @@ set -e
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -26,8 +26,8 @@ set -e
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
-BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
+BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"
 

--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -33,8 +33,8 @@ fi
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
-BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
+BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"
 

--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -33,7 +33,7 @@ fi
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-bewaremypower/pulsar-build}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"


### PR DESCRIPTION
Fixes #9682 

### Motivation

Currently, ci-cpp-tests uses `pulsar-build` image that is from `ubuntu:16.04` to build C++/Python client. The image uses `libboost-all-dev` for CMake to find boost dependencies. However, the Boost.Python library from Ubuntu 16.04's apt source only supports Python 2.

### Modifications

- Specifying `PYTHON_INCLUDE_DIR` and `PYTHON_LIBRARY` could indicate the installation of Python to use. Since the `pulsar-build` image only contains Python binary but not the Python2 library (`libpython2.7so`), this PR installs `libpython-dev` to setup the Python2 library. Otherwise, CMake would still find the Python3 library(`libpython3.5.so`).
- Remove redundant C++ client dependencies like `libjsoncpp-dev` and replace `libboost-all-dev` with the specific `libboost-xxx-dev`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.