### PR TITLE
Fix exception when force delete namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -377,9 +377,7 @@ public abstract class NamespacesBase extends AdminResource {
 
         List<String> topics;
         try {
-            topics = pulsar().getNamespaceService().getListOfPersistentTopics(namespaceName).join();
-            topics.addAll(getPartitionedTopicList(TopicDomain.persistent));
-            topics.addAll(getPartitionedTopicList(TopicDomain.non_persistent));
+            topics = pulsar().getNamespaceService().getFullListOfTopics(namespaceName).join();
         } catch (Exception e) {
             asyncResponse.resume(new RestException(e));
             return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -60,6 +60,7 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.admin.v1.Namespaces;
 import org.apache.pulsar.broker.admin.v1.PersistentTopics;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -1136,7 +1137,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
      */
     @Test
     public void testForceDeleteNamespace() throws Exception {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         String topic = namespace + "/topic";
         String non_persistent_topic = "non-persistent://" + topic;
 
@@ -1359,7 +1360,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testDeleteNonPartitionedTopicMultipleTimes() throws Exception {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         String topic = namespace + "/topic";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
@@ -1387,7 +1388,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testDeletePartitionedTopicMultipleTimes() throws Exception {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         String topic = namespace + "/topic";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
@@ -1416,7 +1417,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testRetentionPolicyValidation() throws Exception {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(testLocalCluster));
 
@@ -1595,7 +1596,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     public void testSubscriptionTypesEnabled() throws PulsarAdminException, PulsarClientException {
         pulsar.getConfiguration().setAuthorizationEnabled(false);
         pulsar.getConfiguration().setTopicLevelPoliciesEnabled(false);
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         String topic = namespace + "/test-subscription-enabled";
         admin.namespaces().createNamespace(namespace);
         Set<SubscriptionType> subscriptionTypes = new HashSet<>();
@@ -1665,7 +1666,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     private void assertValidRetentionPolicyAsPartOfAllPolicies(Policies policies, int retentionTimeInMinutes,
                                                                int retentionSizeInMB) throws PulsarAdminException {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         RetentionPolicies retention = new RetentionPolicies(retentionTimeInMinutes, retentionSizeInMB);
         policies.retention_policies = retention;
         admin.namespaces().createNamespace(namespace, policies);
@@ -1674,7 +1675,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     private void assertInvalidRetentionPolicyAsPartOfAllPolicies(Policies policies, int retentionTimeInMinutes,
                                                                  int retentionSizeInMB) {
-        String namespace = this.testTenant + "/namespace-" + System.nanoTime();
+        String namespace = BrokerTestUtil.newUniqueName(this.testTenant + "/namespace");
         try {
             RetentionPolicies retention = new RetentionPolicies(retentionTimeInMinutes, retentionSizeInMB);
             policies.retention_policies = retention;


### PR DESCRIPTION
### Motivation
 When force delete namespace, the partition topics to be deleted are list twice and a exception will happen when delete the topic second time.
![deletens](https://user-images.githubusercontent.com/65590138/108942063-3e26d580-7691-11eb-82f9-43c5f7217a08.png)


### Modifications
Correct the list of topics under the namespace to be delete.

### Verifying this change
This change is already covered by existing tests, such as testForceDeleteNamespace() 

