### PR TITLE
Issue-9430 [pulsar-io]: Added delete methods to ConnectorContext

### DIFF
--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -331,6 +331,16 @@ public class IOConfigUtilsTest {
         public CompletableFuture<ByteBuffer> getStateAsync(String key) {
             return null;
         }
+        
+        @Override
+        public void deleteState(String key) {
+        	
+        }
+        
+        @Override
+        public CompletableFuture<Void> deleteStateAsync(String key) {
+        	return null;
+        }
     }
 
     @Test

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -183,6 +183,16 @@ public class IOConfigUtilsTest {
         public CompletableFuture<ByteBuffer> getStateAsync(String key) {
             return null;
         }
+        
+        @Override
+        public void deleteState(String key) {
+        	
+        }
+        
+        @Override
+        public CompletableFuture<Void> deleteStateAsync(String key) {
+        	return null;
+        }
 
         @Override
         public <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException {

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
@@ -162,4 +162,18 @@ public interface ConnectorContext {
      * @return the state value for the key.
      */
     CompletableFuture<ByteBuffer> getStateAsync(String key);
+
+    /**
+     * Delete the state value for the key.
+     *
+     * @param key   name of the key
+     */
+    void deleteState(String key);
+
+    /**
+     * Delete the state value for the key, but don't wait for the operation to be completed
+     *
+     * @param key   name of the key
+     */
+    CompletableFuture<Void> deleteStateAsync(String key);
 }

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -157,6 +157,16 @@ public class KafkaAbstractSinkTest {
             public CompletableFuture<ByteBuffer> getStateAsync(String key) {
                 return null;
             }
+            
+            @Override
+            public void deleteState(String key) {
+            	
+            }
+            
+            @Override
+            public CompletableFuture<Void> deleteStateAsync(String key) {
+            	return null;
+            }
         };
         ThrowingRunnable openAndClose = ()->{
             try {

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -162,6 +162,16 @@ public class KafkaAbstractSourceTest {
             public CompletableFuture<ByteBuffer> getStateAsync(String key) {
                 return null;
             }
+            
+            @Override
+            public void deleteState(String key) {
+            	
+            }
+            
+            @Override
+            public CompletableFuture<Void> deleteStateAsync(String key) {
+            	return null;
+            }
 
             @Override
             public <O> TypedMessageBuilder<O> newOutputMessage(String topicName, Schema<O> schema) throws PulsarClientException {


### PR DESCRIPTION
Fixes #9430

### Motivation

We wanted to add the capability of to delete items from the state store inside the IO connector framework. You can currently put/get items to the state store but not delete them. This will bring the Pulsar IO connectors to feature parity with the Pulsar Functions that can (put/get/delete) from the state store.

### Modifications

Added two method signatures to the ConnectorContext object. 

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: (yes), it exposes two new methods in the ConnectorContext API


### Documentation

This feature is documented via JavaDoc comments on the newly added methods
