### PR TITLE
[C++] SinglePartition message router is always picking the same partition

### DIFF
--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <cstdlib>
 #include "PartitionedProducerImpl.h"
 #include "LogUtils.h"
 #include <lib/TopicName.h>
@@ -24,7 +23,6 @@
 #include "RoundRobinMessageRouter.h"
 #include "SinglePartitionMessageRouter.h"
 #include "TopicMetadataImpl.h"
-#include "MessageImpl.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -71,8 +69,7 @@ MessageRoutingPolicyPtr PartitionedProducerImpl::getMessageRouter() {
             return conf_.getMessageRouterPtr();
         case ProducerConfiguration::UseSinglePartition:
         default:
-            unsigned int random = rand();
-            return std::make_shared<SinglePartitionMessageRouter>(random % getNumPartitions(),
+            return std::make_shared<SinglePartitionMessageRouter>(getNumPartitions(),
                                                                   conf_.getHashingScheme());
     }
 }

--- a/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
+++ b/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
@@ -18,9 +18,22 @@
  */
 #include "SinglePartitionMessageRouter.h"
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <chrono>
+
 namespace pulsar {
 SinglePartitionMessageRouter::~SinglePartitionMessageRouter() {}
-SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int partitionIndex,
+
+SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int numberOfPartitions,
+                                                           ProducerConfiguration::HashingScheme hashingScheme)
+    : MessageRouterBase(hashingScheme) {
+    boost::random::mt19937 rng(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    boost::random::uniform_int_distribution<int> dist;
+    selectedSinglePartition_ = dist(rng) % numberOfPartitions;
+}
+
+SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int partitionIndex, const int numberOfPartitions,
                                                            ProducerConfiguration::HashingScheme hashingScheme)
     : MessageRouterBase(hashingScheme) {
     selectedSinglePartition_ = partitionIndex;

--- a/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
+++ b/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
@@ -18,9 +18,8 @@
  */
 #include "SinglePartitionMessageRouter.h"
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 #include <chrono>
+#include <random>
 
 namespace pulsar {
 SinglePartitionMessageRouter::~SinglePartitionMessageRouter() {}
@@ -28,9 +27,8 @@ SinglePartitionMessageRouter::~SinglePartitionMessageRouter() {}
 SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int numberOfPartitions,
                                                            ProducerConfiguration::HashingScheme hashingScheme)
     : MessageRouterBase(hashingScheme) {
-    boost::random::mt19937 rng(std::chrono::high_resolution_clock::now().time_since_epoch().count());
-    boost::random::uniform_int_distribution<int> dist;
-    selectedSinglePartition_ = dist(rng) % numberOfPartitions;
+    std::default_random_engine generator(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    selectedSinglePartition_ = generator() % numberOfPartitions;
 }
 
 SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int partitionIndex,

--- a/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
+++ b/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
@@ -33,7 +33,8 @@ SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int numberOfPar
     selectedSinglePartition_ = dist(rng) % numberOfPartitions;
 }
 
-SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int partitionIndex, const int numberOfPartitions,
+SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int partitionIndex,
+                                                           const int numberOfPartitions,
                                                            ProducerConfiguration::HashingScheme hashingScheme)
     : MessageRouterBase(hashingScheme) {
     selectedSinglePartition_ = partitionIndex;

--- a/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
+++ b/pulsar-client-cpp/lib/SinglePartitionMessageRouter.cc
@@ -27,7 +27,8 @@ SinglePartitionMessageRouter::~SinglePartitionMessageRouter() {}
 SinglePartitionMessageRouter::SinglePartitionMessageRouter(const int numberOfPartitions,
                                                            ProducerConfiguration::HashingScheme hashingScheme)
     : MessageRouterBase(hashingScheme) {
-    std::default_random_engine generator(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    std::default_random_engine generator(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
     selectedSinglePartition_ = generator() % numberOfPartitions;
 }
 

--- a/pulsar-client-cpp/lib/SinglePartitionMessageRouter.h
+++ b/pulsar-client-cpp/lib/SinglePartitionMessageRouter.h
@@ -30,7 +30,9 @@ namespace pulsar {
 
 class PULSAR_PUBLIC SinglePartitionMessageRouter : public MessageRouterBase {
    public:
-    SinglePartitionMessageRouter(const int partitionIndex,
+    SinglePartitionMessageRouter(const int partitionIndex, const int numberOfPartitions,
+                                 ProducerConfiguration::HashingScheme hashingScheme);
+    SinglePartitionMessageRouter(const int numberOfPartitions,
                                  ProducerConfiguration::HashingScheme hashingScheme);
     virtual ~SinglePartitionMessageRouter();
     virtual int getPartition(const Message& msg, const TopicMetadata& topicMetadata);

--- a/pulsar-client-cpp/tests/SinglePartitionMessageRouterTest.cc
+++ b/pulsar-client-cpp/tests/SinglePartitionMessageRouterTest.cc
@@ -38,7 +38,7 @@ using namespace pulsar;
 TEST(SinglePartitionMessageRouterTest, DISABLED_getPartitionWithoutPartitionKey) {
     const int selectedPartition = 1234;
 
-    SinglePartitionMessageRouter router(selectedPartition, ProducerConfiguration::BoostHash);
+    SinglePartitionMessageRouter router(selectedPartition, 10000, ProducerConfiguration::BoostHash);
 
     GMockMessage message;
     EXPECT_CALL(message, hasPartitionKey()).Times(1).WillOnce(Return(false));
@@ -50,7 +50,7 @@ TEST(SinglePartitionMessageRouterTest, DISABLED_getPartitionWithoutPartitionKey)
 TEST(SinglePartitionMessageRouterTest, DISABLED_getPartitionWithPartitionKey) {
     const int numPartitons = 1234;
 
-    SinglePartitionMessageRouter router(1, ProducerConfiguration::BoostHash);
+    SinglePartitionMessageRouter router(1, numPartitons, ProducerConfiguration::BoostHash);
 
     std::string partitionKey1 = "key1";
     std::string partitionKey2 = "key2";


### PR DESCRIPTION
### Motivation

The `SinglePartitionMessageRouter` is supposed to pick a random partition for a given producer and to stick with that. The problem is that the C `rand()` call is always using the seed 0 and that ends up having multiple processes to always deterministically pick the same partition.

