### PR TITLE
Fix flaky test MultiTopicsConsumerImplTest#testConsumerCleanupOnSubscribeFailure

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -160,8 +160,8 @@ public class MultiTopicsConsumerImplTest {
         // indicating that closeAsync was called
         assertEquals(impl.getState(), HandlerState.State.Uninitialized);
         try {
-            completeFuture.get(15, TimeUnit.MILLISECONDS);
-        } catch (Throwable ex) {
+            completeFuture.get(2, TimeUnit.SECONDS);
+        } catch (Throwable ignore) {
             // just ignore the exception
         }
         assertTrue(completeFuture.isCompletedExceptionally());


### PR DESCRIPTION
### Modifications
The thread pool is used in the unit test to complete the delay failure, but the time left for the thread pool is only 5ms. The time of thread switching is uncontrollable, so failures often occur.

