### PR TITLE
Master branch rpm package failed to build

### DIFF
--- a/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
@@ -49,7 +49,7 @@ The devel package contains C++ and C API headers and `libpulsar.a`
 static library.
 
 %prep
-%setup -q -n apache-pulsar-%{pom_version}
+%setup -q -n apache-pulsar-%{pom_version}-src
 
 %build
 cd pulsar-client-cpp


### PR DESCRIPTION
**Motivation**

After #9184, we changed the source code directory name and
that makes the RPM package build fail.

```
centos-7: Pulling from apachepulsar/pulsar-build
Digest: sha256:5c90d7a1f30f603a049cf53dc04f730c989be9bf5eeb537ec20fc874d58f74cd
Status: Image is up to date for apachepulsar/pulsar-build:centos-7
docker.io/apachepulsar/pulsar-build:centos-7
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.eIzZ5F
+ umask 022
+ cd /pulsar/pulsar-client-cpp/pkg/rpm/BUILD
+ cd /pulsar/pulsar-client-cpp/pkg/rpm/BUILD
+ rm -rf apache-pulsar-2.8.0-SNAPSHOT
+ /usr/bin/gzip -dc /pulsar/pulsar-client-cpp/pkg/rpm/SOURCES/apache-pulsar-2.8.0-SNAPSHOT-src.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd apache-pulsar-2.8.0-SNAPSHOT
/var/tmp/rpm-tmp.eIzZ5F: line 35: cd: apache-pulsar-2.8.0-SNAPSHOT: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.eIzZ5F (%prep)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.eIzZ5F (%prep)
```

After this change, the RPM can build successfully

```
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.ScknI0
+ umask 022
+ cd /pulsar/pulsar-client-cpp/pkg/rpm/BUILD
+ cd /pulsar/pulsar-client-cpp/pkg/rpm/BUILD
+ rm -rf apache-pulsar-2.8.0-SNAPSHOT-src
+ /usr/bin/gzip -dc /pulsar/pulsar-client-cpp/pkg/rpm/SOURCES/apache-pulsar-2.8.0-SNAPSHOT-src.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd apache-pulsar-2.8.0-SNAPSHOT-src
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.NlLQD6
+ umask 022
+ cd /pulsar/pulsar-client-cpp/pkg/rpm/BUILD
+ cd apache-pulsar-2.8.0-SNAPSHOT-src
+ cd pulsar-client-cpp
+ cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON -DBUILD_PYTHON_WRAPPER=OFF
```