### PR TITLE
[Issue 8340] [pulsar-testclient] Fix to support to specify topics and subscriptions

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -71,8 +71,8 @@ public class PerformanceConsumer {
         @Parameter(names = { "--conf-file" }, description = "Configuration file")
         public String confFile;
 
-        @Parameter(description = "A list of topics to consume from (e.g. persistent://prop/ns/topic1 persistent://prop/ns/topic2)", required = true)
-        public List<String> topics;
+        @Parameter(description = "persistent://prop/ns/my-topic", required = true)
+        public List<String> topic;
 
         @Parameter(names = { "-t", "--num-topics" }, description = "Number of topics")
         public int numTopics = 1;
@@ -188,7 +188,7 @@ public class PerformanceConsumer {
             System.exit(-1);
         }
 
-        if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
+        if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
             System.out.println("The size of topics list should be equal to --num-topics");
             jc.usage();
             System.exit(-1);
@@ -322,7 +322,7 @@ public class PerformanceConsumer {
         }
 
         for (int i = 0; i < arguments.numTopics; i++) {
-            final TopicName topicName = TopicName.get(arguments.topics.get(i));
+            final TopicName topicName = TopicName.get(arguments.topic.get(i));
 
             log.info("Adding {} consumers per subscription on topic {}", arguments.numConsumers, topicName);
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -22,10 +22,9 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.FileInputStream;
-import java.nio.file.Paths;
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -72,8 +71,8 @@ public class PerformanceConsumer {
         @Parameter(names = { "--conf-file" }, description = "Configuration file")
         public String confFile;
 
-        @Parameter(description = "persistent://prop/ns/my-topic", required = true)
-        public List<String> topic;
+        @Parameter(description = "A list of topics to consume from (e.g. persistent://prop/ns/topic1 persistent://prop/ns/topic2)", required = true)
+        public List<String> topics;
 
         @Parameter(names = { "-t", "--num-topics" }, description = "Number of topics")
         public int numTopics = 1;
@@ -84,8 +83,12 @@ public class PerformanceConsumer {
         @Parameter(names = { "-ns", "--num-subscriptions" }, description = "Number of subscriptions (per topic)")
         public int numSubscriptions = 1;
 
-        @Parameter(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix")
+        @Deprecated
+        @Parameter(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix", hidden = true)
         public String subscriberName = "sub";
+
+        @Parameter(names = { "-ss", "--subscriptions" }, description = "A list of subscriptions to consume on (e.g. sub1,sub2)")
+        public List<String> subscriptions = Collections.singletonList("sub");
 
         @Parameter(names = { "-st", "--subscription-type" }, description = "Subscription type")
         public SubscriptionType subscriptionType = SubscriptionType.Exclusive;
@@ -105,7 +108,7 @@ public class PerformanceConsumer {
         @Parameter(names = { "--replicated" }, description = "Whether the subscription status should be replicated")
         public boolean replicatedSubscription = false;
 
-        @Parameter(names = { "--acks-delay-millis" }, description = "Acknowlegments grouping delay in millis")
+        @Parameter(names = { "--acks-delay-millis" }, description = "Acknowledgements grouping delay in millis")
         public int acknowledgmentsGroupingDelayMillis = 100;
 
         @Parameter(names = { "-c",
@@ -185,14 +188,22 @@ public class PerformanceConsumer {
             System.exit(-1);
         }
 
-        if (arguments.topic.size() != 1) {
-            System.out.println("Only one topic name is allowed");
+        if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
+            System.out.println("The size of topics list should be equal to --num-topics");
             jc.usage();
             System.exit(-1);
         }
 
         if (arguments.subscriptionType == SubscriptionType.Exclusive && arguments.numConsumers > 1) {
             System.out.println("Only one consumer is allowed when subscriptionType is Exclusive");
+            jc.usage();
+            System.exit(-1);
+        }
+
+        if (arguments.subscriptionType != SubscriptionType.Exclusive &&
+                arguments.subscriptions != null &&
+                arguments.subscriptions.size() != arguments.numConsumers) {
+            System.out.println("The size of subscriptions list should be equal to --num-consumers when subscriptionType isn't Exclusive");
             jc.usage();
             System.exit(-1);
         }
@@ -236,8 +247,6 @@ public class PerformanceConsumer {
         ObjectMapper m = new ObjectMapper();
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
         log.info("Starting Pulsar performance consumer with config: {}", w.writeValueAsString(arguments));
-
-        final TopicName prefixTopicName = TopicName.get(arguments.topic.get(0));
 
         final RateLimiter limiter = arguments.rate > 0 ? RateLimiter.create(arguments.rate) : null;
         long startTime = System.nanoTime();
@@ -313,18 +322,12 @@ public class PerformanceConsumer {
         }
 
         for (int i = 0; i < arguments.numTopics; i++) {
-            final TopicName topicName = (arguments.numTopics == 1) ? prefixTopicName
-                    : TopicName.get(String.format("%s-%d", prefixTopicName, i));
+            final TopicName topicName = TopicName.get(arguments.topics.get(i));
+
             log.info("Adding {} consumers per subscription on topic {}", arguments.numConsumers, topicName);
 
             for (int j = 0; j < arguments.numSubscriptions; j++) {
-                String subscriberName;
-                if (arguments.numSubscriptions > 1) {
-                    subscriberName = String.format("%s-%d", arguments.subscriberName, j);
-                } else {
-                    subscriberName = arguments.subscriberName;
-                }
-
+                String subscriberName = arguments.subscriptions.get(j);
                 for (int k = 0; k < arguments.numConsumers; k++) {
                     futures.add(consumerBuilder.clone().topic(topicName.toString()).subscriptionName(subscriberName)
                             .subscribeAsync());

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -96,7 +96,7 @@ public class PerformanceProducer {
         @Parameter(names = { "--conf-file" }, description = "Configuration file")
         public String confFile;
 
-        @Parameter(description = "A list of topics to produce messages to (e.g. persistent://prop/ns/topic1 persistent://prop/ns/topic2)", required = true)
+        @Parameter(description = "persistent://prop/ns/my-topic", required = true)
         public List<String> topics;
 
         @Parameter(names = { "-threads", "--num-test-threads" }, description = "Number of test threads")
@@ -108,7 +108,7 @@ public class PerformanceProducer {
         @Parameter(names = { "-s", "--size" }, description = "Message size (bytes)")
         public int msgSize = 1024;
 
-        @Parameter(names = { "-t", "--num-topics" }, description = "Number of topics")
+        @Parameter(names = { "-t", "--num-topic" }, description = "Number of topics")
         public int numTopics = 1;
 
         @Parameter(names = { "-n", "--num-producers" }, description = "Number of producers (per topic)")
@@ -238,7 +238,7 @@ public class PerformanceProducer {
         }
 
         if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
-            System.out.println("The size of topics list should be equal to --num-topics");
+            System.out.println("The size of topics list should be equal to --num-topic");
             jc.usage();
             System.exit(-1);
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -42,7 +42,6 @@ import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -97,7 +96,7 @@ public class PerformanceProducer {
         @Parameter(names = { "--conf-file" }, description = "Configuration file")
         public String confFile;
 
-        @Parameter(description = "persistent://prop/ns/my-topic", required = true)
+        @Parameter(description = "A list of topics to produce messages to (e.g. persistent://prop/ns/topic1 persistent://prop/ns/topic2)", required = true)
         public List<String> topics;
 
         @Parameter(names = { "-threads", "--num-test-threads" }, description = "Number of test threads")
@@ -109,7 +108,7 @@ public class PerformanceProducer {
         @Parameter(names = { "-s", "--size" }, description = "Message size (bytes)")
         public int msgSize = 1024;
 
-        @Parameter(names = { "-t", "--num-topic" }, description = "Number of topics")
+        @Parameter(names = { "-t", "--num-topics" }, description = "Number of topics")
         public int numTopics = 1;
 
         @Parameter(names = { "-n", "--num-producers" }, description = "Number of producers (per topic)")
@@ -238,8 +237,8 @@ public class PerformanceProducer {
             System.exit(-1);
         }
 
-        if (arguments.topics.size() != 1) {
-            System.out.println("Only one topic name is allowed");
+        if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
+            System.out.println("The size of topics list should be equal to --num-topics");
             jc.usage();
             System.exit(-1);
         }
@@ -400,7 +399,6 @@ public class PerformanceProducer {
         PulsarClient client = null;
         try {
             // Now processing command line arguments
-            String prefixTopicName = arguments.topics.get(0);
             List<Future<Producer<byte[]>>> futures = Lists.newArrayList();
 
             ClientBuilder clientBuilder = PulsarClient.builder() //
@@ -454,7 +452,7 @@ public class PerformanceProducer {
             }
 
             for (int i = 0; i < arguments.numTopics; i++) {
-                String topic = (arguments.numTopics == 1) ? prefixTopicName : String.format("%s-%d", prefixTopicName, i);
+                String topic = arguments.topics.get(i);
                 log.info("Adding {} publishers on topic {}", arguments.numProducers, topic);
 
                 for (int j = 0; j < arguments.numProducers; j++) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -59,8 +59,8 @@ public class PerformanceReader {
         @Parameter(names = { "--conf-file" }, description = "Configuration file")
         public String confFile;
 
-        @Parameter(description = "A list of topics to read on (e.g. persistent://prop/ns/topic1 persistent://prop/ns/topic2)", required = true)
-        public List<String> topics;
+        @Parameter(description = "persistent://prop/ns/my-topic", required = true)
+        public List<String> topic;
 
         @Parameter(names = { "-t", "--num-topics" }, description = "Number of topics")
         public int numTopics = 1;
@@ -138,7 +138,7 @@ public class PerformanceReader {
             System.exit(-1);
         }
 
-        if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
+        if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
             System.out.println("The size of topics list should be equal to --num-topics");
             jc.usage();
             System.exit(-1);
@@ -246,7 +246,7 @@ public class PerformanceReader {
                 .startMessageId(startMessageId);
 
         for (int i = 0; i < arguments.numTopics; i++) {
-            final TopicName topicName = TopicName.get(arguments.topics.get(i));
+            final TopicName topicName = TopicName.get(arguments.topic.get(i));
 
             futures.add(readerBuilder.clone().topic(topicName.toString()).createAsync());
         }
@@ -255,7 +255,7 @@ public class PerformanceReader {
 
         log.info("Start reading from {} topics", arguments.numTopics);
 
-         long oldTime = System.nanoTime();
+        long oldTime = System.nanoTime();
 
         while (true) {
             try {

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -429,19 +429,19 @@ Options
 |`--auth_params`|Authentication parameters, whose format is determined by the implementation of method `configure` in authentication plugin class, for example "key1:val1,key2:val2" or "{"key1":"val1","key2":"val2"}.||
 |`--auth_plugin`|Authentication plugin class name||
 |`--listener-name`|Listener name for the broker||
-|`--acks-delay-millis`|Acknowlegments grouping delay in millis|100|
+|`--acks-delay-millis`|Acknowledgements grouping delay in millis|100|
 |`-k`, `--encryption-key-name`|The private key name to decrypt payload||
 |`-v`, `--encryption-key-value-file`|The file which contains the private key to decrypt payload||
 |`-h`, `--help`|Help message|false|
 |`--conf-file`|Configuration file||
 |`-c`, `--max-connections`|Max number of TCP connections to a single broker|100|
 |`-n`, `--num-consumers`|Number of consumers (per topic)|1|
-|`-t`, `--num-topic`|The number of topics|1|
+|`-t`, `--num-topics`|The number of topics|1|
 |`-r`, `--rate`|Simulate a slow message consumer (rate in msg/s)|0|
 |`-q`, `--receiver-queue-size`|Size of the receiver queue|1000|
 |`-u`, `--service-url`|Pulsar service URL||
 |`-i`, `--stats-interval-seconds`|Statistics interval seconds. If 0, statistics will be disabled|0|
-|`-s`, `--subscriber-name`|Subscriber name prefix|sub|
+|`-ss`, `--subscriptions`|A list of subscriptions to consume on (e.g. sub1,sub2)|sub|
 |`-st`, `--subscription-type`|Subscriber type. Possible values are Exclusive, Shared, Failover, Key_Shared.|Exclusive|
 |`-sp`, `--subscription-position`|Subscriber position. Possible values are Latest, Earliest.|Latest|
 |`--trust-cert-file`|Path for the trusted TLS certificate file||
@@ -474,7 +474,7 @@ Options
 |`-p`, `--max-outstanding-across-partitions`|Max number of outstanding messages across partitions|50000|
 |`-m`, `--num-messages`|Number of messages to publish in total. If set to 0, it will keep publishing.|0|
 |`-n`, `--num-producers`|The number of producers (per topic)|1|
-|`-t`, `--num-topic`|The number of topics|1|
+|`-t`, `--num-topics`|The number of topics|1|
 |`-f`, `--payload-file`|Use payload from an UTF-8 encoded text file and a payload will be randomly selected when publishing messages||
 |`-e`, `--payload-delimiter`|The delimiter used to split lines when using payload from a file|\n|
 |`-r`, `--rate`|Publish rate msg/s across topics|100|
@@ -504,7 +504,7 @@ Options
 |`--conf-file`|Configuration file||
 |`-h`, `--help`|Help message|false|
 |`-c`, `--max-connections`|Max number of TCP connections to a single broker|100|
-|`-t`, `--num-topic`|The number of topics|1|
+|`-t`, `--num-topics`|The number of topics|1|
 |`-r`, `--rate`|Simulate a slow message reader (rate in msg/s)|0|
 |`-q`, `--receiver-queue-size`|Size of the receiver queue|1000|
 |`-u`, `--service-url`|Pulsar service URL||

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -474,7 +474,7 @@ Options
 |`-p`, `--max-outstanding-across-partitions`|Max number of outstanding messages across partitions|50000|
 |`-m`, `--num-messages`|Number of messages to publish in total. If set to 0, it will keep publishing.|0|
 |`-n`, `--num-producers`|The number of producers (per topic)|1|
-|`-t`, `--num-topics`|The number of topics|1|
+|`-t`, `--num-topic`|The number of topics|1|
 |`-f`, `--payload-file`|Use payload from an UTF-8 encoded text file and a payload will be randomly selected when publishing messages||
 |`-e`, `--payload-delimiter`|The delimiter used to split lines when using payload from a file|\n|
 |`-r`, `--rate`|Publish rate msg/s across topics|100|


### PR DESCRIPTION
### Motivation

Fixes #8340

### Modifications

- Fix option `main parameter` for CLI `pulsar-perf produce/consume/read` to specify multi topics.
- Add option `--subscriptions` for CLI `pulsar-perf` consume to specify multi subscriptions.
- Deprecate and hide the option `--subscriber-name`.
- Modify the corresponding doc.
