### PR TITLE
[Pulsar Transaction] Handle TC low water mark on pending ack handle.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -269,10 +269,12 @@ public class TransactionMetadataStoreService {
                 CompletableFuture<TxnID> actionFuture = new CompletableFuture<>();
                 if (TxnAction.COMMIT_VALUE == txnAction) {
                     actionFuture = tbClient.commitTxnOnSubscription(
-                            tbSub.getTopic(), tbSub.getSubscription(), txnID.getMostSigBits(), txnID.getLeastSigBits());
+                            tbSub.getTopic(), tbSub.getSubscription(), txnID.getMostSigBits(),
+                            txnID.getLeastSigBits(), lowWaterMark);
                 } else if (TxnAction.ABORT_VALUE == txnAction) {
                     actionFuture = tbClient.abortTxnOnSubscription(
-                            tbSub.getTopic(), tbSub.getSubscription(), txnID.getMostSigBits(), txnID.getLeastSigBits());
+                            tbSub.getTopic(), tbSub.getSubscription(), txnID.getMostSigBits(),
+                            txnID.getLeastSigBits(), lowWaterMark);
                 } else {
                     actionFuture.completeExceptionally(new Throwable("Unsupported txnAction " + txnAction));
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1885,7 +1885,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 }
 
                 CompletableFuture<Void> completableFuture =
-                        subscription.endTxn(txnidMostBits, txnidLeastBits, txnAction);
+                        subscription.endTxn(txnidMostBits, txnidLeastBits, txnAction,
+                                command.getTxnidLeastBitsOfLowWatermark());
                 completableFuture.whenComplete((ignored, throwable) -> {
                     if (throwable != null) {
                         log.error("Handle end txn on subscription failed for request {}", requestId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -105,7 +105,7 @@ public interface Subscription {
         // Default is no-op
     }
 
-    CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction);
+    CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction, long lowWaterMark);
 
     // Subscription utils
     static boolean isCumulativeAckMode(SubType subType) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -491,7 +491,7 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction) {
+    public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction, long lowWaterMark) {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         completableFuture.completeExceptionally(
                 new Exception("Unsupported operation end txn for NonPersistentSubscription"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1059,17 +1059,17 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
-    public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction) {
+    public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction, long lowWaterMark) {
         TxnID txnID = new TxnID(txnidMostBits, txnidLeastBits);
         if (TxnAction.COMMIT.getValue() == txnAction) {
-            return pendingAckHandle.commitTxn(txnID, Collections.emptyMap());
+            return pendingAckHandle.commitTxn(txnID, Collections.emptyMap(), lowWaterMark);
         } else if (TxnAction.ABORT.getValue() == txnAction) {
             Consumer redeliverConsumer = null;
             if (getDispatcher() instanceof PersistentDispatcherSingleActiveConsumer) {
                 redeliverConsumer = ((PersistentDispatcherSingleActiveConsumer)
                         getDispatcher()).getActiveConsumer();
             }
-            return pendingAckHandle.abortTxn(txnID, redeliverConsumer);
+            return pendingAckHandle.abortTxn(txnID, redeliverConsumer, lowWaterMark);
         } else {
             return FutureUtil.failedFuture(new NotAllowedException("Unsupported txnAction " + txnAction));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -60,16 +60,16 @@ public class TransactionBufferClientImpl implements TransactionBufferClient {
 
     @Override
     public CompletableFuture<TxnID> commitTxnOnSubscription(String topic, String subscription, long txnIdMostBits,
-                                                            long txnIdLeastBits) {
+                                                            long txnIdLeastBits, long lowWaterMark) {
         return tbHandler.endTxnOnSubscription(topic, subscription, txnIdMostBits, txnIdLeastBits,
-                TxnAction.COMMIT);
+                TxnAction.COMMIT, lowWaterMark);
     }
 
     @Override
     public CompletableFuture<TxnID> abortTxnOnSubscription(String topic, String subscription,
-                                                           long txnIdMostBits, long txnIdLeastBits) {
+                                                           long txnIdMostBits, long txnIdLeastBits, long lowWaterMark) {
         return tbHandler.endTxnOnSubscription(topic, subscription, txnIdMostBits, txnIdLeastBits,
-                TxnAction.ABORT);
+                TxnAction.ABORT, lowWaterMark);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -105,14 +105,14 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler, T
 
     @Override
     public CompletableFuture<TxnID> endTxnOnSubscription(String topic, String subscription, long txnIdMostBits,
-                                                         long txnIdLeastBits, TxnAction action) {
+                                                         long txnIdLeastBits, TxnAction action, long lowWaterMark) {
         CompletableFuture<TxnID> cb = new CompletableFuture<>();
         if (!canSendRequest(cb)) {
             return cb;
         }
         long requestId = requestIdGenerator.getAndIncrement();
         ByteBuf cmd = Commands.newEndTxnOnSubscription(requestId, txnIdLeastBits, txnIdMostBits,
-                topic, subscription, action);
+                topic, subscription, action, lowWaterMark);
         OpRequestSend op = OpRequestSend.create(requestId, topic, cmd, cb);
         pendingRequests.put(requestId, op);
         cmd.retain();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -86,18 +86,20 @@ public interface PendingAckHandle {
      * @param txnID      {@link TxnID} to identify the transaction.
      * @param properties Additional user-defined properties that can be
      *                   associated with a particular cursor position.
+     * @param lowWaterMark the low water mark of this transaction
      * @return the future of this operation.
      */
-    CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties);
+    CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties, long lowWaterMark);
 
     /**
      * Abort a transaction.
      *
      * @param txnId  {@link TxnID} to identify the transaction.
      * @param consumer {@link Consumer} which aborting transaction.
+     * @param lowWaterMark the low water mark of this transaction
      * @return the future of this operation.
      */
-    CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer);
+    CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer, long lowWaterMark);
 
     /**
      * Sync the position ack set, in order to clean up the cache of this position for pending ack handle.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -47,12 +47,12 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
     }
 
     @Override
-    public CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties) {
+    public CompletableFuture<Void> commitTxn(TxnID txnID, Map<String, Long> properties, long lowWaterMark) {
         return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
     }
 
     @Override
-    public CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer) {
+    public CompletableFuture<Void> abortTxn(TxnID txnId, Consumer consumer, long lowWaterMark) {
         return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -200,7 +200,7 @@ public class PersistentSubscriptionTest {
         persistentSubscription.transactionIndividualAcknowledge(txnID1, positionsPair);
 
         // Commit txn
-        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID1.getLeastSigBits(), TxnAction.COMMIT_VALUE).get();
+        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID1.getLeastSigBits(), TxnAction.COMMIT_VALUE, -1).get();
 
         List<PositionImpl> positions = new ArrayList<>();
         positions.add(new PositionImpl(3, 100));
@@ -216,7 +216,7 @@ public class PersistentSubscriptionTest {
         }).when(cursorMock).asyncMarkDelete(any(), any(), any(AsyncCallbacks.MarkDeleteCallback.class), any());
 
         // Commit txn
-        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID1.getLeastSigBits(), TxnAction.COMMIT_VALUE).get();
+        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID1.getLeastSigBits(), TxnAction.COMMIT_VALUE, -1).get();
     }
 
     @Test
@@ -283,7 +283,7 @@ public class PersistentSubscriptionTest {
         persistentSubscription.acknowledgeMessage(positionList, AckType.Individual, Collections.emptyMap());
 
         //Abort txn.
-        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID2.getLeastSigBits(), TxnAction.ABORT_VALUE);
+        persistentSubscription.endTxn(txnID1.getMostSigBits(), txnID2.getLeastSigBits(), TxnAction.ABORT_VALUE, -1);
 
         positions.clear();
         positions.add(new PositionImpl(2, 50));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -92,7 +92,8 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
         brokerServices = new BrokerService[pulsarServices.length];
         for (int i = 0; i < pulsarServices.length; i++) {
             Subscription mockSubscription = Mockito.mock(Subscription.class);
-            Mockito.when(mockSubscription.endTxn(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt()))
+            Mockito.when(mockSubscription.endTxn(Mockito.anyLong(),
+                    Mockito.anyLong(), Mockito.anyInt(), Mockito.anyLong()))
                     .thenReturn(CompletableFuture.completedFuture(null));
 
             Topic mockTopic = Mockito.mock(Topic.class);
@@ -143,7 +144,7 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
         List<CompletableFuture<TxnID>> futures = new ArrayList<>();
         for (int i = 0; i < partitions; i++) {
             String topic = partitionedTopicName.getPartition(i).toString();
-            futures.add(tbClient.commitTxnOnSubscription(topic, "test", 1L, i));
+            futures.add(tbClient.commitTxnOnSubscription(topic, "test", 1L, i, -1L));
         }
         for (int i = 0; i < futures.size(); i++) {
             Assert.assertEquals(futures.get(i).get().getMostSigBits(), 1L);
@@ -156,7 +157,7 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
         List<CompletableFuture<TxnID>> futures = new ArrayList<>();
         for (int i = 0; i < partitions; i++) {
             String topic = partitionedTopicName.getPartition(i).toString();
-            futures.add(tbClient.abortTxnOnSubscription(topic, "test", 1L, i));
+            futures.add(tbClient.abortTxnOnSubscription(topic, "test", 1L, i, -1L));
         }
         for (int i = 0; i < futures.size(); i++) {
             Assert.assertEquals(futures.get(i).get().getMostSigBits(), 1L);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -19,16 +19,29 @@
 package org.apache.pulsar.broker.transaction.buffer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.collections4.map.LinkedMap;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
+import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -37,6 +50,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -44,6 +58,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -91,7 +106,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
     }
 
     @Test
-    private void testLowWaterMark() throws Exception {
+    private void testTransactionBufferLowWaterMark() throws Exception {
         Transaction txn = pulsarClient.newTransaction()
                 .withTransactionTimeout(5, TimeUnit.SECONDS)
                 .build().get();
@@ -157,5 +172,117 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
             fail();
         }
 
+    }
+
+    @Test
+    private void testPendingAckLowWaterMark() throws Exception {
+        String subName = "test";
+        Transaction txn = pulsarClient.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.SECONDS)
+                .build().get();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer()
+                .topic(TOPIC)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .enableBatching(false)
+                .create();
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(TOPIC)
+                .subscriptionName(subName)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .enableBatchIndexAcknowledgment(true)
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+        final String TEST1 = "test1";
+        final String TEST2 = "test2";
+        final String TEST3 = "test3";
+
+        producer.send(TEST1.getBytes());
+        producer.send(TEST2.getBytes());
+        producer.send(TEST3.getBytes());
+
+        Message<byte[]> message = consumer.receive(2, TimeUnit.SECONDS);
+        assertEquals(new String(message.getData()), TEST1);
+        consumer.acknowledgeAsync(message.getMessageId(), txn).get();
+        LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction = null;
+
+        for (int i = 0; i < getPulsarServiceList().size(); i++) {
+            Field field = BrokerService.class.getDeclaredField("topics");
+            field.setAccessible(true);
+            ConcurrentOpenHashMap<String, CompletableFuture<Optional<Topic>>> topics =
+                    (ConcurrentOpenHashMap<String, CompletableFuture<Optional<Topic>>>) field
+                            .get(getPulsarServiceList().get(i).getBrokerService());
+            CompletableFuture<Optional<Topic>> completableFuture = topics.get("persistent://" + TOPIC);
+            if (completableFuture != null) {
+                Optional<Topic> topic = completableFuture.get();
+                if (topic.isPresent()) {
+                    PersistentSubscription persistentSubscription = (PersistentSubscription) topic.get()
+                            .getSubscription(subName);
+                    field = PersistentSubscription.class.getDeclaredField("pendingAckHandle");
+                    field.setAccessible(true);
+                    PendingAckHandleImpl pendingAckHandle = (PendingAckHandleImpl) field.get(persistentSubscription);
+                    field = PendingAckHandleImpl.class.getDeclaredField("individualAckOfTransaction");
+                    field.setAccessible(true);
+                    individualAckOfTransaction =
+                            (LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>>) field.get(pendingAckHandle);
+                }
+            }
+        }
+
+        assertTrue(individualAckOfTransaction.containsKey(new TxnID(((TransactionImpl) txn).getTxnIdMostBits(),
+                ((TransactionImpl) txn).getTxnIdLeastBits())));
+        txn.commit().get();
+        assertFalse(individualAckOfTransaction.containsKey(new TxnID(((TransactionImpl) txn).getTxnIdMostBits(),
+                ((TransactionImpl) txn).getTxnIdLeastBits())));
+
+        message = consumer.receive();
+        assertEquals(new String(message.getData()), TEST2);
+        consumer.acknowledgeAsync(message.getMessageId(), txn).get();
+        assertTrue(individualAckOfTransaction.containsKey(new TxnID(((TransactionImpl) txn).getTxnIdMostBits(),
+                ((TransactionImpl) txn).getTxnIdLeastBits())));
+
+        PartitionedTopicMetadata partitionedTopicMetadata =
+                ((PulsarClientImpl) pulsarClient).getLookup()
+                        .getPartitionedTopicMetadata(TopicName.TRANSACTION_COORDINATOR_ASSIGN).get();
+        Transaction lowWaterMarkTxn = null;
+        for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {
+            lowWaterMarkTxn = pulsarClient.newTransaction()
+                    .withTransactionTimeout(5, TimeUnit.SECONDS)
+                    .build().get();
+            if (((TransactionImpl) lowWaterMarkTxn).getTxnIdMostBits() == ((TransactionImpl) txn).getTxnIdMostBits()) {
+                break;
+            }
+        }
+
+        if (lowWaterMarkTxn != null &&
+                ((TransactionImpl) lowWaterMarkTxn).getTxnIdMostBits() == ((TransactionImpl) txn).getTxnIdMostBits()) {
+            producer.newMessage(lowWaterMarkTxn).value(TEST3.getBytes()).send();
+
+            message = consumer.receive(2, TimeUnit.SECONDS);
+            assertEquals(new String(message.getData()), TEST3);
+            consumer.acknowledgeAsync(message.getMessageId(), lowWaterMarkTxn).get();
+
+            assertTrue(individualAckOfTransaction.containsKey(new TxnID(((TransactionImpl) txn).getTxnIdMostBits(),
+                    ((TransactionImpl) txn).getTxnIdLeastBits())));
+
+            assertTrue(individualAckOfTransaction
+                    .containsKey(new TxnID(((TransactionImpl) lowWaterMarkTxn).getTxnIdMostBits(),
+                            ((TransactionImpl) lowWaterMarkTxn).getTxnIdLeastBits())));
+            lowWaterMarkTxn.commit().get();
+
+            assertFalse(individualAckOfTransaction.containsKey(new TxnID(((TransactionImpl) txn).getTxnIdMostBits(),
+                    ((TransactionImpl) txn).getTxnIdLeastBits())));
+
+            assertFalse(individualAckOfTransaction
+                    .containsKey(new TxnID(((TransactionImpl) lowWaterMarkTxn).getTxnIdMostBits(),
+                            ((TransactionImpl) lowWaterMarkTxn).getTxnIdLeastBits())));
+
+        } else {
+            fail();
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
@@ -51,9 +51,9 @@ public class TransactionCoordinatorClientTest extends TransactionMetaStoreTestBa
                     .thenReturn(CompletableFuture.completedFuture(null));
             Mockito.when(tbClient.abortTxnOnTopic(anyString(), anyLong(), anyLong(), anyLong()))
                     .thenReturn(CompletableFuture.completedFuture(null));
-            Mockito.when(tbClient.commitTxnOnSubscription(anyString(), anyString(), anyLong(), anyLong()))
+            Mockito.when(tbClient.commitTxnOnSubscription(anyString(), anyString(), anyLong(), anyLong(), anyLong()))
                     .thenReturn(CompletableFuture.completedFuture(null));
-            Mockito.when(tbClient.abortTxnOnSubscription(anyString(), anyString(), anyLong(), anyLong()))
+            Mockito.when(tbClient.abortTxnOnSubscription(anyString(), anyString(), anyLong(), anyLong(), anyLong()))
                     .thenReturn(CompletableFuture.completedFuture(null));
 
             TransactionMetadataStoreService metadataStoreService = pulsarService.getTransactionMetadataStoreService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
@@ -158,8 +159,8 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
                         PendingAckHandleImpl pendingAckHandle = (PendingAckHandleImpl) field.get(persistentSubscription);
                         field = PendingAckHandleImpl.class.getDeclaredField("individualAckOfTransaction");
                         field.setAccessible(true);
-                        HashMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction =
-                                (HashMap<TxnID, HashMap<PositionImpl, PositionImpl>>) field.get(pendingAckHandle);
+                        LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction =
+                                (LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>>) field.get(pendingAckHandle);
                         assertTrue(individualAckOfTransaction.isEmpty());
                         if (retryCnt == 0) {
                             //one message are not ack
@@ -202,7 +203,7 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
         PersistentSubscription persistentSubscription = null;
         PendingAckHandleImpl pendingAckHandle = null;
 
-        HashMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction = null;
+        LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction = null;
         ManagedCursorImpl managedCursor = null;
 
         ConcurrentSkipListMap<PositionImpl, BitSetRecyclable> batchDeletedIndexes = null;
@@ -251,7 +252,7 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
                         field = PendingAckHandleImpl.class.getDeclaredField("individualAckOfTransaction");
                         field.setAccessible(true);
                         individualAckOfTransaction =
-                                (HashMap<TxnID, HashMap<PositionImpl, PositionImpl>>) field.get(pendingAckHandle);
+                                (LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>>) field.get(pendingAckHandle);
                         assertTrue(individualAckOfTransaction.isEmpty());
                         managedCursor = (ManagedCursorImpl) persistentSubscription.getCursor();
                         field = ManagedCursorImpl.class.getDeclaredField("batchDeletedIndexes");

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClient.java
@@ -65,12 +65,14 @@ public interface TransactionBufferClient {
      * @param subscription subscription name
      * @param txnIdMostBits the most bits of txn id
      * @param txnIdLeastBits the least bits of txn id
+     * @param lowWaterMark the low water mark of this txn
      * @return the future represents the commit result
      */
     CompletableFuture<TxnID> commitTxnOnSubscription(String topic,
-                                                    String subscription,
-                                                    long txnIdMostBits,
-                                                    long txnIdLeastBits);
+                                                     String subscription,
+                                                     long txnIdMostBits,
+                                                     long txnIdLeastBits,
+                                                     long lowWaterMark);
 
     /**
      * Abort the transaction associated with the topic subscription.
@@ -79,12 +81,14 @@ public interface TransactionBufferClient {
      * @param subscription subscription name
      * @param txnIdMostBits the most bits of txn id
      * @param txnIdLeastBits the least bits of txn id
+     * @param lowWaterMark the low water mark of this txn
      * @return the future represents the abort result
      */
     CompletableFuture<TxnID> abortTxnOnSubscription(String topic,
-                                                   String subscription,
-                                                   long txnIdMostBits,
-                                                   long txnIdLeastBits);
+                                                    String subscription,
+                                                    long txnIdMostBits,
+                                                    long txnIdLeastBits,
+                                                    long lowWaterMark);
 
     void close();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBufferHandler.java
@@ -47,11 +47,12 @@ public interface TransactionBufferHandler {
      * @param subscription subscription name
      * @param txnIdMostBits txnIdMostBits
      * @param txnIdLeastBits txnIdLeastBits
+     * @param lowWaterMark low water mark of this transaction
      * @param action transaction action type
      * @return TxnId
      */
     CompletableFuture<TxnID> endTxnOnSubscription(String topic, String subscription, long txnIdMostBits,
-        long txnIdLeastBits, TxnAction action);
+        long txnIdLeastBits, TxnAction action, long lowWaterMark);
 
     /**
      * Handle response of end transaction on topic.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1321,13 +1321,14 @@ public class Commands {
     }
 
     public static ByteBuf newEndTxnOnSubscription(long requestId, long txnIdLeastBits, long txnIdMostBits, String topic,
-            String subscription, TxnAction txnAction) {
+            String subscription, TxnAction txnAction, long lowWaterMark) {
         BaseCommand cmd = localCmd(Type.END_TXN_ON_SUBSCRIPTION);
         cmd.setEndTxnOnSubscription()
                 .setRequestId(requestId)
                 .setTxnidLeastBits(txnIdLeastBits)
                 .setTxnidMostBits(txnIdMostBits)
                 .setTxnAction(txnAction)
+                .setTxnidLeastBitsOfLowWatermark(lowWaterMark)
                 .setSubscription()
                 .setTopic(topic)
                 .setSubscription(subscription);

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -844,6 +844,7 @@ message CommandEndTxnOnSubscription {
     optional uint64 txnid_most_bits = 3 [default = 0];
     optional Subscription subscription= 4;
     optional TxnAction txn_action = 5;
+    optional uint64 txnid_least_bits_of_low_watermark = 6;
 }
 
 message CommandEndTxnOnSubscriptionResponse {


### PR DESCRIPTION
## Motivation

Use the TC low watermark to clean the useless transaction individual acks such as the client uses a committed/aborted transaction to ack messages, the transaction can't commit or abort again, so the ongoing acks of the transaction can't be removed. 

## implement

end sub with transaction coordinator lowWaterMark
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

