### PR TITLE
Issue-9402: [functions] Added ImmediateTrigger class and unit tests

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -111,6 +111,13 @@
       <artifactId>pulsar-transaction-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-batch-discovery-triggerers</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -313,6 +320,13 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-batch-data-generator</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-data-generator</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -428,6 +442,8 @@
                       tofile="${basedir}/src/test/resources/pulsar-functions-api-examples.jar"/>
                 <copy file="${basedir}/../pulsar-io/data-generator/target/pulsar-io-data-generator-${project.version}.nar"
                       tofile="${basedir}/src/test/resources/pulsar-io-data-generator.nar"/>
+                <copy file="${basedir}/../pulsar-io/batch-data-generator/target/pulsar-io-batch-data-generator-${project.version}.nar"
+                      tofile="${basedir}/src/test/resources/pulsar-io-batch-data-generator.nar"/>
               </target>
             </configuration>
           </execution>

--- a/pulsar-io/batch-discovery-triggerers/src/main/java/org/apache/pulsar/io/batchdiscovery/ImmediateTriggerer.java
+++ b/pulsar-io/batch-discovery-triggerers/src/main/java/org/apache/pulsar/io/batchdiscovery/ImmediateTriggerer.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.batchdiscovery;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.io.core.BatchSourceTriggerer;
+import org.apache.pulsar.io.core.SourceContext;
+
+@Slf4j
+public class ImmediateTriggerer implements BatchSourceTriggerer {
+	
+  @Override
+  public void init(Map<String, Object> map, SourceContext sourceContext) throws Exception {
+    log.info("Initialized ImmediateTrigger at: {}",  System.currentTimeMillis());
+  }
+
+  @Override
+  public void start(Consumer<String> consumer) {
+    consumer.accept("");
+  }
+
+  @Override
+  public void stop() {
+
+  }
+}

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -76,6 +76,7 @@
       <modules>
         <module>core</module>
         <module>batch-discovery-triggerers</module>
+        <module>batch-data-generator</module>
         <module>common</module>
         <module>twitter</module>
         <module>cassandra</module>


### PR DESCRIPTION
Fixes #9402

We needed a new type of triggerer for batch sources that is triggered exactly once, e.g. a S3 source that receives CDC notifications via an SQS topic. In this scenario, the discover phase only needs to run once to setup the SQS connection, etc.

Replaces PR: https://github.com/apache/pulsar/pull/9406 