### PR TITLE
[Docs] Fix url scheme typo

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -673,7 +673,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/docs/security-oauth2.md
+++ b/site2/docs/security-oauth2.md
@@ -128,7 +128,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```
@@ -149,7 +149,7 @@ params = '''
 }
 '''
 
-client = Client("puslar://my-cluster:6650", authentication=AuthenticationOauth2(params))
+client = Client("pulsar://my-cluster:6650", authentication=AuthenticationOauth2(params))
 ```
 
 ## CLI configuration

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-go.md
@@ -674,7 +674,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.1/security-oauth2.md
@@ -129,7 +129,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-go.md
@@ -674,7 +674,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.2/security-oauth2.md
@@ -129,7 +129,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-go.md
@@ -674,7 +674,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.6.3/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.6.3/security-oauth2.md
@@ -129,7 +129,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-go.md
@@ -674,7 +674,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.0/security-oauth2.md
@@ -129,7 +129,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```
@@ -150,7 +150,7 @@ params = '''
 }
 '''
 
-client = Client("puslar://my-cluster:6650", authentication=AuthenticationOauth2(params))
+client = Client("pulsar://my-cluster:6650", authentication=AuthenticationOauth2(params))
 ```
 
 ## CLI configuration

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-go.md
@@ -674,7 +674,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```

--- a/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
+++ b/site2/website/versioned_docs/version-2.7.1/security-oauth2.md
@@ -129,7 +129,7 @@ oauth := pulsar.NewAuthenticationOAuth2(map[string]string{
 		"clientId":   "0Xx...Yyxeny",
 	})
 client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL:              "puslar://my-cluster:6650",
+		URL:              "pulsar://my-cluster:6650",
 		Authentication:   oauth,
 })
 ```
@@ -150,7 +150,7 @@ params = '''
 }
 '''
 
-client = Client("puslar://my-cluster:6650", authentication=AuthenticationOauth2(params))
+client = Client("pulsar://my-cluster:6650", authentication=AuthenticationOauth2(params))
 ```
 
 ## CLI configuration


### PR DESCRIPTION
Fixes a typo in the docs, `puslar://` vs `pulsar://`, in the URL of some examples with the Go client library.

I verified the changes with `yarn install && yarn start` for 2.6.x and 2.7.x series.