### PR TITLE
Add mirror method for getPersistenceNamingEncoding

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -27,6 +27,8 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
@@ -317,6 +319,33 @@ public class TopicName implements ServiceUnitId {
             return String.format("%s/%s/%s/%s", tenant, namespacePortion, domain, getEncodedLocalName());
         } else {
             return String.format("%s/%s/%s/%s/%s", tenant, cluster, namespacePortion, domain, getEncodedLocalName());
+        }
+    }
+
+    public static TopicName fromPersistenceNamingEncoding(String name) throws Exception {
+        if (name == null) {
+            return null;
+        }
+        final String[] arr = name.split("/");
+
+        if (arr.length == 4) {
+            String tenant = arr[0];
+            String namespacePortion = arr[1];
+            String domain = arr[2];
+            String encodedLocalName = arr[3];
+            final String decodedName = Codec.decode(encodedLocalName);
+            return TopicName.get(domain, tenant, namespacePortion, decodedName);
+        } else if (arr.length == 5) {
+            String tenant = arr[0];
+            String cluster = arr[1];
+            String namespacePortion = arr[2];
+            String domain = arr[3];
+            String encodedLocalName = arr[4];
+            final String decodedName = Codec.decode(encodedLocalName);
+            return TopicName.get(domain, tenant, cluster, namespacePortion, decodedName);
+        } else {
+            log.error("arr.length = {}, arr = {}", arr.length, Stream.of(arr).collect(Collectors.toList()));
+            throw new Exception("not valid name: " + name);
         }
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
-
 import org.apache.pulsar.common.util.Codec;
 import org.testng.annotations.Test;
 
@@ -30,7 +29,7 @@ public class TopicNameTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void topic() {
+    public void topic() throws Exception {
         try {
             TopicName.get("://tenant.namespace:topic").getNamespace();
             fail("Should have thrown exception");
@@ -161,6 +160,9 @@ public class TopicNameTest {
 
         assertEquals(TopicName.get("persistent://tenant/cluster/namespace/topic")
                 .getPersistenceNamingEncoding(), "tenant/cluster/namespace/persistent/topic");
+
+        assertEquals(TopicName.fromPersistenceNamingEncoding("tenant/cluster/namespace/persistent/topic"),
+                TopicName.get("persistent://tenant/cluster/namespace/topic"));
 
         try {
             TopicName.get("://tenant.namespace");

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/naming/TopicNameTest.java
@@ -52,7 +52,7 @@ public class TopicNameTest {
                 "persistent://tenant/cluster/namespace/topic");
 
         assertNotEquals(TopicName.get("persistent://tenant/cluster/namespace/topic"),
-            "persistent://tenant/cluster/namespace/topic");
+                "persistent://tenant/cluster/namespace/topic");
 
         assertEquals(TopicName.get("persistent://tenant/cluster/namespace/topic").getDomain(),
                 TopicDomain.persistent);
@@ -162,6 +162,10 @@ public class TopicNameTest {
                 .getPersistenceNamingEncoding(), "tenant/cluster/namespace/persistent/topic");
 
         assertEquals(TopicName.fromPersistenceNamingEncoding("tenant/cluster/namespace/persistent/topic"),
+                TopicName.get("persistent://tenant/cluster/namespace/topic"));
+
+        assertEquals(TopicName.fromPersistenceNamingEncoding(
+                TopicName.get("persistent://tenant/cluster/namespace/topic").getPersistenceNamingEncoding()),
                 TopicName.get("persistent://tenant/cluster/namespace/topic"));
 
         try {


### PR DESCRIPTION
This method will be used for where we need to get Schema info from the persistent name in some plugins.