### PR TITLE
[Metrics] Reduce CPU consumption of metrics creation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -59,6 +59,52 @@ abstract class AbstractMetrics {
         }
     }
 
+    // simple abstract for the buckets, their boundaries and pre-calculated keys
+    // pre-calculating the keys avoids a lot of object allocations during metric collection
+    static class Buckets {
+        private final double[] boundaries;
+        private final String[] bucketKeys;
+
+        Buckets(String metricKey, double[] boundaries) {
+            this.boundaries = boundaries;
+            this.bucketKeys = generateBucketKeys(metricKey, boundaries);
+        }
+
+        private static String[] generateBucketKeys(String mkey, double[] boundaries) {
+            String[] keys = new String[boundaries.length + 1];
+            for (int i = 0; i < boundaries.length + 1; i++) {
+                String bucketKey;
+                double value;
+
+                // example of key : "<metric_key>_0.0_0.5"
+                if (i == 0 && boundaries.length > 0) {
+                    bucketKey = String.format("%s_0.0_%1.1f", mkey, boundaries[i]);
+                } else if (i < boundaries.length) {
+                    bucketKey = String.format("%s_%1.1f_%1.1f", mkey, boundaries[i - 1], boundaries[i]);
+                } else {
+                    bucketKey = String.format("%s_OVERFLOW", mkey);
+                }
+                keys[i] = bucketKey;
+            }
+            return keys;
+        }
+
+        public void populateBucketEntries(Map<String, Double> map, long[] bucketValues, int period) {
+            // bucket values should be one more that the boundaries to have the last element as OVERFLOW
+            if (bucketValues != null && bucketValues.length != boundaries.length + 1) {
+                throw new RuntimeException("Bucket boundary and value array length mismatch");
+            }
+
+            for (int i = 0; i < boundaries.length + 1; i++) {
+                double value = (bucketValues == null) ? 0.0D : ((double) bucketValues[i] / (period > 0 ? period : 1));
+                String bucketKey = bucketKeys[i];
+                Double val = map.getOrDefault(bucketKey, 0.0);
+                map.put(bucketKey, val + value);
+            }
+        }
+    }
+
+
     protected final PulsarService pulsar;
 
     abstract List<Metrics> generate();
@@ -167,34 +213,6 @@ abstract class AbstractMetrics {
         dimensionMap.put("to_cluster", toClusterName);
 
         return createMetrics(dimensionMap);
-    }
-
-    protected void populateBucketEntries(Map<String, Double> map, String mkey, double[] boundaries,
-            long[] bucketValues, int period) {
-
-        // bucket values should be one more that the boundaries to have the last element as OVERFLOW
-        if (bucketValues != null && bucketValues.length != boundaries.length + 1) {
-            throw new RuntimeException("Bucket boundary and value array length mismatch");
-        }
-
-        for (int i = 0; i < boundaries.length + 1; i++) {
-            String bucketKey;
-            double value;
-
-            // example of key : "<metric_key>_0.0_0.5"
-            if (i == 0 && boundaries.length > 0) {
-                bucketKey = String.format("%s_0.0_%1.1f", mkey, boundaries[i]);
-            } else if (i < boundaries.length) {
-                bucketKey = String.format("%s_%1.1f_%1.1f", mkey, boundaries[i - 1], boundaries[i]);
-            } else {
-                bucketKey = String.format("%s_OVERFLOW", mkey);
-            }
-
-            value = (bucketValues == null) ? 0.0D : ((double) bucketValues[i] / (period > 0 ? period : 1));
-
-            Double val = map.getOrDefault(bucketKey, 0.0);
-            map.put(bucketKey, val + value);
-        }
     }
 
     protected void populateAggregationMap(Map<String, List<Double>> map, String mkey, double value) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -97,9 +97,7 @@ abstract class AbstractMetrics {
 
             for (int i = 0; i < boundaries.length + 1; i++) {
                 double value = (bucketValues == null) ? 0.0D : ((double) bucketValues[i] / (period > 0 ? period : 1));
-                String bucketKey = bucketKeys[i];
-                Double val = map.getOrDefault(bucketKey, 0.0);
-                map.put(bucketKey, val + value);
+                map.compute(bucketKeys[i], (key, currentValue) -> (currentValue == null ? 0.0d : currentValue) + value);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -35,6 +35,16 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
     private Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimensionMap;
     // temp map to prepare aggregation metrics
     private Map<String, Double> tempAggregatedMetricsMap;
+    private static final Buckets
+            BRK_ML_ADDENTRYLATENCYBUCKETS = new Buckets("brk_ml_AddEntryLatencyBuckets",
+            ENTRY_LATENCY_BUCKETS_MS);
+    private static final Buckets BRK_ML_LEDGERADDENTRYLATENCYBUCKETS = new Buckets(
+            "brk_ml_LedgerAddEntryLatencyBuckets", ENTRY_LATENCY_BUCKETS_MS);
+    private static final Buckets BRK_ML_LEDGERSWITCHLATENCYBUCKETS = new Buckets(
+            "brk_ml_LedgerSwitchLatencyBuckets", ENTRY_LATENCY_BUCKETS_MS);
+
+    private static final Buckets
+            BRK_ML_ENTRYSIZEBUCKETS = new Buckets("brk_ml_EntrySizeBuckets", ENTRY_SIZE_BUCKETS_BYTES);
 
     public ManagedLedgerMetrics(PulsarService pulsar) {
         super(pulsar);
@@ -98,18 +108,17 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
                         (double) lStats.getStoredMessagesSize());
 
                 // handle bucket entries initialization here
-                populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_AddEntryLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getAddEntryLatencyBuckets(),
+                BRK_ML_ADDENTRYLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        lStats.getAddEntryLatencyBuckets(),
                         ManagedLedgerFactoryImpl.StatsPeriodSeconds);
-                populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_LedgerAddEntryLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerAddEntryLatencyBuckets(),
+                BRK_ML_LEDGERADDENTRYLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        lStats.getLedgerAddEntryLatencyBuckets(),
                         ManagedLedgerFactoryImpl.StatsPeriodSeconds);
-                populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_LedgerSwitchLatencyBuckets",
-                        ENTRY_LATENCY_BUCKETS_MS, lStats.getLedgerSwitchLatencyBuckets(),
+                BRK_ML_LEDGERSWITCHLATENCYBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        lStats.getLedgerSwitchLatencyBuckets(),
                         ManagedLedgerFactoryImpl.StatsPeriodSeconds);
-
-                populateBucketEntries(tempAggregatedMetricsMap, "brk_ml_EntrySizeBuckets",
-                        ENTRY_SIZE_BUCKETS_BYTES, lStats.getEntrySizeBuckets(),
+                BRK_ML_ENTRYSIZEBUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        lStats.getEntrySizeBuckets(),
                         ManagedLedgerFactoryImpl.StatsPeriodSeconds);
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_MarkDeleteRate",
                         lStats.getMarkDeleteRate());


### PR DESCRIPTION
### Motivation

`String.format` is consuming most CPU when generating metrics:
![image](https://user-images.githubusercontent.com/66864/109286532-05226880-782b-11eb-9074-a578b1a83284.png)
([Flamegraph from Pulsar user, using Pulsar 2.7.0](https://apache-pulsar.slack.com/archives/C5Z4T36F7/p1614331656110600?thread_ts=1614293057.103600&cid=C5Z4T36F7))

Besides direct CPU consumption, it creates a lot of garbage which then causes more CPU being spent in GC.

### Modifications

It is possible to get rid of the key creation and avoid String.format calls and String object allocation, by using a similar approach as @rdhabalia used in NamespaceStats: https://github.com/apache/pulsar/blob/cc64889abe94d47f048e2f8e8fb10d6c37e695ec/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/NamespaceStats.java#L46-L63 .
Since there are multiple sets of buckets, there is a need for a class that handles the logic.