### PR TITLE
[Issue 9700][Admin API] Validate /offload param

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2442,6 +2442,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     @ApiOperation(value = "Offload a prefix of a topic to long term storage")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 400, message = "Message ID is null"),
             @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or"
                     + "subscriber is not authorized to access this operation"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
@@ -2461,6 +2462,9 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
                                MessageIdImpl messageId) {
+        if (messageId == null) {
+            throw new RestException(Response.Status.BAD_REQUEST, "messageId is null");
+        }
         validateTopicName(tenant, namespace, encodedTopic);
         internalTriggerOffload(authoritative, messageId);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -696,4 +696,17 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(new String(admin.topics().examineMessage(topicName + "-partition-0", "latest", 4).getData()), "message2");
         Assert.assertEquals(new String(admin.topics().examineMessage(topicName + "-partition-0", "latest", 5).getData()), "message1");
     }
+
+    @Test
+    public void testOffloadWithNullMessageId() {
+        final String topicName = "topic-123";
+        persistentTopics.createNonPartitionedTopic(testTenant, testNamespace, topicName, true);
+
+        try {
+            persistentTopics.triggerOffload(testTenant, testNamespace, topicName, true, null);
+            Assert.fail("should have failed");
+        } catch (RestException e) {
+            Assert.assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+        }
+    }
 }


### PR DESCRIPTION
If no `messageId` param is included in the PUT request, an NPE is thrown
down the stack. This change validates that `messageId` is non-null,
returning a 400 otherwise.

Fixes #9700

### Motivation

See commit message above.

### Modifications

Add null check on `messageId` param on admin v2 API handler for triggering an offload operation.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added test that passing a null `messageId` to this method results in a `RestException` with an HTTP 400 response.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: only added validation
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
  - If a feature is not applicable for documentation, explain why? this API is not documented
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (should I do this?)
