### PR TITLE
[broker] change getWorkerService method to throw UnsupportedOperationException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -958,8 +958,8 @@ public class PulsarService implements AutoCloseable {
     }
 
     public WorkerService getWorkerService() throws UnsupportedOperationException {
-        return functionWorkerService.orElseThrow(() -> new UnsupportedOperationException("Pulsar Functions worker " +
-                "service is disabled in the broker, When functionsWorkerEnabled is set to false"));
+        return functionWorkerService.orElseThrow(() -> new UnsupportedOperationException("Pulsar Function Worker is not " +
+                "enabled, probably functionsWorkerEnabled is set to false"));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -957,8 +957,9 @@ public class PulsarService implements AutoCloseable {
         return functionWorkerService;
     }
 
-    public WorkerService getWorkerService() {
-        return functionWorkerService.orElse(null);
+    public WorkerService getWorkerService() throws UnsupportedOperationException {
+        return functionWorkerService.orElseThrow(() -> new UnsupportedOperationException("Pulsar Functions worker " +
+                "service is disabled in the broker, When functionsWorkerEnabled is set to false"));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -958,8 +958,8 @@ public class PulsarService implements AutoCloseable {
     }
 
     public WorkerService getWorkerService() throws UnsupportedOperationException {
-        return functionWorkerService.orElseThrow(() -> new UnsupportedOperationException("Pulsar Function Worker is not " +
-                "enabled, probably functionsWorkerEnabled is set to false"));
+        return functionWorkerService.orElseThrow(() -> new UnsupportedOperationException("Pulsar Function Worker "
+                + "is not enabled, probably functionsWorkerEnabled is set to false"));
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import static org.mockito.Mockito.mock;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.functions.worker.WorkerConfig;
+import org.apache.pulsar.functions.worker.WorkerService;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class PulsarServiceTest {
+
+    @Test
+    public void testGetWorkerService() {
+        ServiceConfiguration configuration = new ServiceConfiguration();
+        configuration.setZookeeperServers("localhost");
+        configuration.setClusterName("clusterName");
+        configuration.setFunctionsWorkerEnabled(true);
+        PulsarService pulsarService = new PulsarService(configuration, new WorkerConfig(),
+                Optional.of(mock(WorkerService.class)), (exitCode) -> {});
+
+        pulsarService.getWorkerService();
+    }
+
+    /**
+     * Verifies that the getWorkerService throws {@link UnsupportedOperationException}
+     * when functionsWorkerEnabled is set to false .
+     */
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testGetWorkerServiceException() throws Exception {
+        ServiceConfiguration configuration = new ServiceConfiguration();
+        configuration.setZookeeperServers("localhost");
+        configuration.setClusterName("clusterName");
+        configuration.setFunctionsWorkerEnabled(false);
+        PulsarService pulsarService = new PulsarService(configuration, new WorkerConfig(),
+                Optional.empty(), (exitCode) -> {});
+
+        pulsarService.getWorkerService();
+    }
+}


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fix #9633 


### Motivation
When we set `functionsWorkerEnabled=false` in `broker.conf`, broker don't support management function of `functionWorker`.
But when we try to appy those method. Broker will throw NullPointerException  instead of throwing a more user friendly error that explain the problem.

This PR is trying to fix it.

### Modifications

* Throw an exception instead of returning null
* Add unit test for normal and abnormal conditions

### Documentation

  - Does this pull request introduce a new feature? ( no)
