### PR TITLE
fix consumer receives duplicate messages when enable retry letter topic

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -358,7 +358,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * will be more efficient at the expense of a slight increase in message re-deliveries after a failure.
      *
      * @param delay
-     *            the max amount of time an acknowledgemnt can be delayed
+     *            the max amount of time an acknowledgement can be delayed
      * @param unit
      *            the time unit for the delay
      * @return the consumer builder instance
@@ -372,7 +372,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> replicateSubscriptionState(boolean replicateSubscriptionState);
 
     /**
-     * Set the max total receiver queue size across partitons.
+     * Set the max total receiver queue size across partitions.
      *
      * <p>This setting will be used to reduce the receiver queue size for individual partitions
      * {@link #receiverQueueSize(int)} if the total exceeds this value (default: 50000).
@@ -389,7 +389,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
     /**
      * Set the consumer name.
      *
-     * <p>Consumer name is informative and it can be used to indentify a particular consumer
+     * <p>Consumer name is informative and it can be used to identify a particular consumer
      * instance from the topic stats.
      *
      * @param consumerName
@@ -648,7 +648,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
 
     /**
      * If enabled, the consumer will auto retry message.
-     * default unabled.
+     * default disabled.
      *
      * @param retryEnable
      *            whether to auto retry message

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -121,8 +121,10 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         }
         if (conf.isRetryEnable() && conf.getTopicNames().size() > 0 ) {
             String topicName = TopicName.get(conf.getTopicNames().iterator().next()).getPartitionedTopicName();
-            String retryLetterTopic = topicName + "-" + conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
-            String deadLetterTopic = topicName + "-" + conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
+            String retryLetterTopic = topicName + "-" + conf.getSubscriptionName()
+                    + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
+            String deadLetterTopic = topicName + "-" + conf.getSubscriptionName()
+                    + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
             if(conf.getDeadLetterPolicy() == null) {
                 conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
                                         .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -119,10 +119,10 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             return FutureUtil.failedFuture(
                     new InvalidConfigurationException("KeySharedPolicy must set with KeyShared subscription"));
         }
-        if(conf.isRetryEnable() && conf.getTopicNames().size() > 0 ) {
-            TopicName topicFirst = TopicName.get(conf.getTopicNames().iterator().next());
-            String retryLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
-            String deadLetterTopic = topicFirst.getNamespace() + "/" + conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
+        if (conf.isRetryEnable() && conf.getTopicNames().size() > 0 ) {
+            String topicName = TopicName.get(conf.getTopicNames().iterator().next()).getPartitionedTopicName();
+            String retryLetterTopic = topicName + "-" + conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
+            String deadLetterTopic = topicName + "-" + conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
             if(conf.getDeadLetterPolicy() == null) {
                 conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
                                         .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)


### PR DESCRIPTION


Fixes #9742 
### Motivation
This PR fix Consumer receive extra messages when enableRetry and retryLetterTopic and deadLetterTopic are not set.


### Modifications

makes sure that generated retryLetterTopic and deadLetterTopic contain both subscriptionName and topicName
