### PR TITLE
[Broker/Proxy] Prevent invalid broker or proxy configuration for authorization

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -481,6 +481,11 @@ public class PulsarService implements AutoCloseable {
                 throw new IllegalArgumentException("brokerServicePort/brokerServicePortTls must be present");
             }
 
+            if (config.isAuthorizationEnabled() && !config.isAuthenticationEnabled()) {
+                throw new IllegalStateException("Invalid broker configuration. Authentication must be enabled with "
+                        + "authenticationEnabled=true when authorization is enabled with authorizationEnabled=true.");
+            }
+
             localMetadataStore = createLocalMetadataStore();
             coordinationService = new CoordinationServiceImpl(localMetadataStore);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -123,12 +123,12 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
     public AdminTest() {
         super();
-        conf.setClusterName(configClusterName);
     }
 
     @Override
     @BeforeMethod
     public void setup() throws Exception {
+        conf.setClusterName(configClusterName);
         super.internalSetup();
 
         configurationCache = pulsar.getConfigurationCache();
@@ -194,6 +194,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
         super.internalCleanup();
+        conf.setClusterName(configClusterName);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -126,7 +126,6 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     public NamespacesTest() {
         super();
-        conf.setClusterName(testLocalCluster);
     }
 
     @BeforeClass
@@ -149,6 +148,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @Override
     @BeforeMethod
     public void setup() throws Exception {
+        conf.setClusterName(testLocalCluster);
         super.internalSetup();
 
         namespaces = spy(new Namespaces());
@@ -191,6 +191,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
         super.internalCleanup();
+        conf.setClusterName(testLocalCluster);
     }
 
     @Test
@@ -1439,7 +1440,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testMaxTopicsPerNamespace() throws Exception {
-        super.internalCleanup();
+        cleanup();
         conf.setMaxTopicsPerNamespace(15);
         super.internalSetup();
 
@@ -1488,7 +1489,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
 
         // check producer/consumer auto create partitioned topic
-        super.internalCleanup();
+        cleanup();
         conf.setMaxTopicsPerNamespace(0);
         conf.setDefaultNumPartitions(3);
         conf.setAllowAutoTopicCreationType("partitioned");
@@ -1518,7 +1519,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         }
 
         // check producer/consumer auto create non-partitioned topic
-        super.internalCleanup();
+        cleanup();
         conf.setMaxTopicsPerNamespace(0);
         conf.setDefaultNumPartitions(1);
         conf.setAllowAutoTopicCreationType("non-partitioned");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -125,9 +125,9 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testTopicPolicyDisabled() throws Exception {
+        super.internalCleanup();
         this.conf.setSystemTopicEnabled(true);
         this.conf.setTopicLevelPoliciesEnabled(false);
-        super.internalCleanup();
         super.internalSetup();
 
         admin.clusters().createCluster("test", new ClusterData(pulsar.getWebServiceAddress()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.fail;
 import java.util.EnumSet;
 
 import org.apache.pulsar.broker.authorization.AuthorizationService;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -46,10 +47,18 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     @Override
     public void setup() throws Exception {
         conf.setClusterName("c1");
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.auth.MockAuthenticationProvider"));
         conf.setAuthorizationEnabled(true);
         conf.setAuthorizationAllowWildcardsMatching(true);
-        conf.setSuperUserRoles(Sets.newHashSet("pulsar.super_user"));
+        conf.setSuperUserRoles(Sets.newHashSet("pulsar.super_user", "pass.pass"));
         internalSetup();
+    }
+
+    @Override
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
+        pulsarAdminBuilder.authentication(new MockAuthentication("pass.pass"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.auth;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.testng.annotations.Test;
+
+public class InvalidBrokerConfigForAuthorizationTest extends MockedPulsarServiceBaseTest {
+
+    @Test
+    void startupShouldFailWhenAuthorizationIsEnabledWithoutAuthentication() throws Exception {
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(false);
+        try {
+            internalSetup();
+            fail("An exception should have been thrown");
+        } catch (Exception e) {
+            assertEquals(e.getClass(), PulsarServerException.class);
+            assertEquals(e.getCause().getClass(), IllegalStateException.class);
+            assertEquals(e.getCause().getMessage(), "Invalid broker configuration. Authentication must be "
+                    + "enabled with authenticationEnabled=true when authorization is enabled with "
+                    + "authorizationEnabled=true.");
+        }
+    }
+
+    @Override
+    protected void setup() throws Exception {
+
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        internalCleanup();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -188,6 +189,7 @@ public abstract class MockedPulsarServiceBaseTest {
             stopBroker();
             pulsar = null;
         }
+        resetConfig();
         if (mockBookKeeper != null) {
             mockBookKeeper.reallyShutdown();
             mockBookKeeper = null;
@@ -220,7 +222,6 @@ public abstract class MockedPulsarServiceBaseTest {
             }
             bkExecutor = null;
         }
-
     }
 
     protected abstract void setup() throws Exception;
@@ -253,16 +254,18 @@ public abstract class MockedPulsarServiceBaseTest {
         if (admin != null) {
             admin.close();
         }
-        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).build());
+        PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString());
+        customizeNewPulsarAdminBuilder(pulsarAdminBuilder);
+        admin = spy(pulsarAdminBuilder.build());
+    }
+
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
+
     }
 
     protected PulsarService startBroker(ServiceConfiguration conf) throws Exception {
 
-        boolean isAuthorizationEnabled = conf.isAuthorizationEnabled();
-        // enable authorization to initialize authorization service which is used by grant-permission
-        conf.setAuthorizationEnabled(true);
         PulsarService pulsar = startBrokerWithoutAuthorization(conf);
-        conf.setAuthorizationEnabled(isAuthorizationEnabled);
 
         return pulsar;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -911,9 +911,9 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         int topicMessageTTLSecs = 2;
         String namespaceName = "prop/expiry-check-2";
 
+        cleanup();
         this.conf.setSystemTopicEnabled(true);
         this.conf.setTopicLevelPoliciesEnabled(true);
-        cleanup();
         setup();
 
         admin.namespaces().createNamespace(namespaceName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -55,7 +55,6 @@ public class ResendRequestTest extends BrokerTestBase {
     @Override
     public void cleanup() throws Exception {
         super.internalCleanup();
-        ;
     }
 
     @Test(timeOut = testTimeout)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
@@ -224,6 +224,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
 
     @Test(timeOut = 30000)
     public void testTopicPolicyTakeSnapshot() throws Exception {
+        super.internalCleanup();
         resetConfig();
         conf.setSystemTopicEnabled(true);
         conf.setTopicLevelPoliciesEnabled(true);
@@ -231,7 +232,6 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         conf.setBrokerDeduplicationSnapshotFrequencyInSeconds(1);
         conf.setBrokerDeduplicationSnapshotIntervalSeconds(7);
         conf.setBrokerDeduplicationEntriesInterval(20000);
-        super.internalCleanup();
         super.internalSetup();
         super.producerBaseSetup();
 
@@ -335,12 +335,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
     }
 
     private void testTakeSnapshot(boolean enabledSnapshot) throws Exception {
+        super.internalCleanup();
         resetConfig();
         conf.setBrokerDeduplicationEnabled(true);
         conf.setBrokerDeduplicationSnapshotFrequencyInSeconds(enabledSnapshot ? 1 : 0);
         conf.setBrokerDeduplicationSnapshotIntervalSeconds(1);
         conf.setBrokerDeduplicationEntriesInterval(20000);
-        super.internalCleanup();
         super.internalSetup();
         super.producerBaseSetup();
 
@@ -412,12 +412,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
 
     @Test(timeOut = 30000)
     public void testNamespacePolicyTakeSnapshot() throws Exception {
+        super.internalCleanup();
         resetConfig();
         conf.setBrokerDeduplicationEnabled(true);
         conf.setBrokerDeduplicationSnapshotFrequencyInSeconds(1);
         conf.setBrokerDeduplicationSnapshotIntervalSeconds(3);
         conf.setBrokerDeduplicationEntriesInterval(20000);
-        super.internalCleanup();
         super.internalSetup();
         super.producerBaseSetup();
 
@@ -464,12 +464,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
 
     @Test(timeOut = 30000)
     public void testDisableNamespacePolicyTakeSnapshot() throws Exception {
+        super.internalCleanup();
         resetConfig();
         conf.setBrokerDeduplicationEnabled(true);
         conf.setBrokerDeduplicationSnapshotFrequencyInSeconds(1);
         conf.setBrokerDeduplicationSnapshotIntervalSeconds(1);
         conf.setBrokerDeduplicationEntriesInterval(20000);
-        super.internalCleanup();
         super.internalSetup();
         super.producerBaseSetup();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -55,9 +55,9 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
+        this.conf.setClusterName("test");
         super.internalSetup();
         super.producerBaseSetup();
-        this.conf.setClusterName("test");
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -48,11 +48,11 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        super.internalSetup();
-        super.producerBaseSetup();
         this.conf.setClusterName("test");
         this.conf.setTopicPublisherThrottlingTickTimeMillis(1);
         this.conf.setBrokerPublisherThrottlingTickTimeMillis(1);
+        super.internalSetup();
+        super.producerBaseSetup();
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -163,6 +163,11 @@ public class ProxyService implements Closeable {
     }
 
     public void start() throws Exception {
+        if (proxyConfig.isAuthorizationEnabled() && !proxyConfig.isAuthenticationEnabled()) {
+            throw new IllegalStateException("Invalid proxy configuration. Authentication must be enabled with "
+                    + "authenticationEnabled=true when authorization is enabled with authorizationEnabled=true.");
+        }
+
         if (!isBlank(proxyConfig.getZookeeperServers()) && !isBlank(proxyConfig.getConfigurationStoreServers())) {
             localMetadataStore = createLocalMetadataStore();
             configMetadataStore = createConfigurationMetadataStore();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/InvalidProxyConfigForAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/InvalidProxyConfigForAuthorizationTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class InvalidProxyConfigForAuthorizationTest {
+
+    @Test
+    void startupShouldFailWhenAuthorizationIsEnabledWithoutAuthentication() throws Exception {
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setAuthorizationEnabled(true);
+        proxyConfiguration.setAuthenticationEnabled(false);
+        try (ProxyService proxyService = new ProxyService(proxyConfiguration,
+                Mockito.mock(AuthenticationService.class))) {
+            proxyService.start();
+            fail("An exception should have been thrown");
+        } catch (Exception e) {
+            assertEquals(e.getClass(), IllegalStateException.class);
+            assertEquals(e.getMessage(), "Invalid proxy configuration. Authentication must be "
+                    + "enabled with authenticationEnabled=true when authorization is enabled with "
+                    + "authorizationEnabled=true.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9709

### Motivation

Enabling authorization without enabling authentication leads to inconsistent behavior.

In some parts of the code, authorization is enforced only when both authorization is enabled and authentication is enabled. In a few places, it's enforced if authorization is enabled without checking for authentication. 

To prevent misleading behavior, it's better to check at startup time that authentication is enabled when authorization is enabled.

There's also changes to make Pulsar configuration more consistent in tests by resetting the configuration in the cleanup method.

### Modifications

- check the configuration before starting the Pulsar broker or Pulsar proxy
- fix AuthorizationTest where authentication configuration was missing
  - add the necessary authentication configuration for the test
- reset Pulsar configuration in MockedPulsarServiceBaseTest.internalCleanup method
  - this helps prevent inconsistent state in tests. Currently Pulsar configuration is inconsistent since it depends on the execution of previous test methods. Some test methods mutate the configuration and the next test method will use the configuration unless it's resetted explicitly.
 

### About the fix to flaky test AuthorizationTest.simple

This change fixes the flaky test #9709, but it remains unclear why the test was passing in some cases. 
It seems that the test is picking up state from some other test run. There are interesting observations in PR #9740 about the reasons why it passes in some cases.
Some effort was put into checking if the usage of [Jersey / JAX RS `@Context` annotation](https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/jaxrs-resources.html#d0e2871) on the PulsarWebResource's httpRequest field could be causing some concurrency issue, but that verification didn't reveal issues.