### PR TITLE
[Issue 9725][Transaction] - Fix deleteTransactionMarker memory leak

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -385,11 +385,15 @@ public class PersistentSubscription implements Subscription {
             managedLedger.asyncReadEntry(nextPosition, new ReadEntryCallback() {
                 @Override
                 public void readEntryComplete(Entry entry, Object ctx) {
-                    MessageMetadata messageMetadata = Commands.parseMessageMetadata(entry.getDataBuffer());
-                    isDeleteTransactionMarkerInProcess = false;
-                    if (Markers.isTxnCommitMarker(messageMetadata) || Markers.isTxnAbortMarker(messageMetadata)) {
-                        lastMarkDeleteForTransactionMarker = position;
-                        acknowledgeMessage(Collections.singletonList(nextPosition), ackType, properties);
+                    try {
+                        MessageMetadata messageMetadata = Commands.parseMessageMetadata(entry.getDataBuffer());
+                        isDeleteTransactionMarkerInProcess = false;
+                        if (Markers.isTxnCommitMarker(messageMetadata) || Markers.isTxnAbortMarker(messageMetadata)) {
+                            lastMarkDeleteForTransactionMarker = position;
+                            acknowledgeMessage(Collections.singletonList(nextPosition), ackType, properties);
+                        }
+                    } finally {
+                        entry.release();
                     }
                 }
 


### PR DESCRIPTION
Fixes (part of) #9725 (not sure if there are other leaks, though)

### Motivation

Fixes a memory leak for transactions.

### Modifications

The `ReadEntryCallback` should release the `entry` passed to it. I validated that other implementations of the `ReadEntryCallback` class release the `entry`. Further, the final stack trace referenced in #9725 has clear references to this stack. The only change is to call `entry.release()`. Because parsing could lead to an exception, I used a `finally` block.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage. (We must not have test coverage for this type of leak, though.)

### Cherry Pick

This PR fixes a memory leak in master (that is also in 2.7.0). We'll want to make sure this makes it into the `2.7.1` release.