### PR TITLE
Fix cannot consume using older subscriptions if max subscription limi…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -258,6 +258,10 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected TopicName topicName;
 
+    protected void validateTopicOperation() {
+        checkTopicLevelPolicyEnable();
+    }
+
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -258,10 +258,6 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected TopicName topicName;
 
-    protected void validateTopicOperation() {
-        checkTopicLevelPolicyEnable();
-    }
-
     protected void validateTopicName(String property, String namespace, String encodedTopic) {
         String topic = Codec.decode(encodedTopic);
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -64,6 +64,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -785,8 +786,7 @@ public class PersistentTopic extends AbstractTopic
     private CompletableFuture<Subscription> getDurableSubscription(String subscriptionName,
             InitialPosition initialPosition, long startMessageRollbackDurationSec, boolean replicated) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
-
-        if (checkMaxSubscriptionsPerTopicExceed()) {
+        if (checkMaxSubscriptionsPerTopicExceed(subscriptionName)) {
             subscriptionFuture.completeExceptionally(new RestException(Response.Status.PRECONDITION_FAILED,
                     "Exceed the maximum number of subscriptions of the topic: " + topic));
             return subscriptionFuture;
@@ -831,7 +831,7 @@ public class PersistentTopic extends AbstractTopic
         log.info("[{}][{}] Creating non-durable subscription at msg id {}", topic, subscriptionName, startMessageId);
 
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
-        if (checkMaxSubscriptionsPerTopicExceed()) {
+        if (checkMaxSubscriptionsPerTopicExceed(subscriptionName)) {
             subscriptionFuture.completeExceptionally(new RestException(Response.Status.PRECONDITION_FAILED,
                     "Exceed the maximum number of subscriptions of the topic: " + topic));
             return subscriptionFuture;
@@ -2786,7 +2786,11 @@ public class PersistentTopic extends AbstractTopic
         return messageDeduplication;
     }
 
-    private boolean checkMaxSubscriptionsPerTopicExceed() {
+    private boolean checkMaxSubscriptionsPerTopicExceed(String subscriptionName) {
+        //Existing subscriptions are not affected
+        if (StringUtils.isNotEmpty(subscriptionName) && getSubscription(subscriptionName) != null) {
+            return false;
+        }
         TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
         Integer maxSubsPerTopic = null;
         if (topicPolicies != null && topicPolicies.isMaxSubscriptionsPerTopicSet()) {


### PR DESCRIPTION
Fixes #9755
### Motivation
If maxSubscriptionsPerTopic is set in the broker (or even as a namespace policy), once this limit is reached, broker does not allow consumers to be created for even older subscriptions.

### Modifications
Existing subscriptions are not restricted

### Verifying this change
TopicPoliciesTest#testMaxSubscriptionsPerTopicWithExistingSubs
