### PR TITLE
[Java Client] Fix NPE in ClientCnx

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -855,7 +855,7 @@ public class ClientCnx extends PulsarHandler {
             ctx.writeAndFlush(requestMessage).addListener(writeFuture -> {
                 if (!writeFuture.isSuccess()) {
                     CompletableFuture<?> newFuture = pendingRequests.remove(requestId);
-                    if (!newFuture.isDone()) {
+                    if (newFuture != null && !newFuture.isDone()) {
                         log.warn("{} Failed to send {} to broker: {}", ctx.channel(),
                                 requestType.getDescription(), writeFuture.cause().getMessage());
                         future.completeExceptionally(writeFuture.cause());


### PR DESCRIPTION
Fixes #9760

### Motivation

There's a NPE on this line in logs when running ReplicatorTest:
https://github.com/apache/pulsar/blob/34ca8938ca13ea60b05d164c27d9755855caf87c/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L858

### Modifications

Add null check