### PR TITLE
[Common] Reduce duration of locks when processing items held in ConcurrentOpenHashMaps

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -397,7 +397,7 @@ public class ManagedLedgerOfflineBacklog {
 
         // go through ledgers where LAC was -1
         if (accurate && ledgerRetryMap.size() > 0) {
-            ledgerRetryMap.forEach((cursorName, ledgerId) -> {
+            ledgerRetryMap.forEachInSnapshot((cursorName, ledgerId) -> {
                 if (log.isDebugEnabled()) {
                     log.debug("Cursor {} Ledger {} Trying to obtain MD from BkAdmin", cursorName, ledgerId);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1090,7 +1090,7 @@ public class PersistentTopicsBase extends AdminResource {
             validateReadOperationOnTopic(authoritative);
             Topic topic = getTopicReference(topicName);
             final List<String> subscriptions = Lists.newArrayList();
-            topic.getSubscriptions().forEach((subName, sub) -> subscriptions.add(subName));
+            topic.getSubscriptions().forEachInSnapshot((subName, sub) -> subscriptions.add(subName));
             asyncResponse.resume(subscriptions);
         } catch (WebApplicationException wae) {
             if (log.isDebugEnabled()) {
@@ -1793,7 +1793,7 @@ public class PersistentTopicsBase extends AdminResource {
         }
         final AtomicReference<Throwable> exception = new AtomicReference<>();
 
-        topic.getReplicators().forEach((subName, replicator) -> {
+        topic.getReplicators().forEachInSnapshot((subName, replicator) -> {
             try {
                 internalExpireMessagesByTimestampForSinglePartition(subName, expireTimeInSeconds, authoritative);
             } catch (Throwable t) {
@@ -1801,7 +1801,7 @@ public class PersistentTopicsBase extends AdminResource {
             }
         });
 
-        topic.getSubscriptions().forEach((subName, subscriber) -> {
+        topic.getSubscriptions().forEachInSnapshot((subName, subscriber) -> {
             try {
                 internalExpireMessagesByTimestampForSinglePartition(subName, expireTimeInSeconds, authoritative);
             } catch (Throwable t) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -431,8 +431,8 @@ public class LoadManagerShared {
             final String antiAffinityGroup = policies.get().namespaceAntiAffinityGroup;
             final Map<String, Integer> brokerToAntiAffinityNamespaceCount = new ConcurrentHashMap<>();
             final List<CompletableFuture<Void>> futures = Lists.newArrayList();
-            brokerToNamespaceToBundleRange.forEach((broker, nsToBundleRange) -> {
-                nsToBundleRange.forEach((ns, bundleRange) -> {
+            brokerToNamespaceToBundleRange.forEachInSnapshot((broker, nsToBundleRange) -> {
+                nsToBundleRange.forEachInSnapshot((ns, bundleRange) -> {
                     if (bundleRange.isEmpty()) {
                         return;
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1224,7 +1224,7 @@ public class NamespaceService {
                                     .containsKey(namespaceName.toString())) {
                                 pulsar.getBrokerService().getMultiLayerTopicMap().get(namespaceName.toString()).values()
                                         .forEach(bundle -> {
-                                            bundle.forEach((topicName, topic) -> {
+                                            bundle.forEachInSnapshot((topicName, topic) -> {
                                                 if (topic instanceof NonPersistentTopic
                                                         && ((NonPersistentTopic) topic).isActive()) {
                                                     topics.add(topicName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -105,7 +105,7 @@ public class PulsarStats implements Closeable {
             // Json begin
             topicStatsStream.startObject();
 
-            topicsMap.forEach((namespaceName, bundles) -> {
+            topicsMap.forEachInSnapshot((namespaceName, bundles) -> {
                 if (bundles.isEmpty()) {
                     return;
                 }
@@ -115,7 +115,7 @@ public class PulsarStats implements Closeable {
 
                     nsStats.reset();
 
-                    bundles.forEach((bundle, topics) -> {
+                    bundles.forEachInSnapshot((bundle, topics) -> {
                         NamespaceBundleStats currentBundleStats = bundleStats.computeIfAbsent(bundle,
                                 k -> new NamespaceBundleStats());
                         currentBundleStats.reset();
@@ -126,7 +126,7 @@ public class PulsarStats implements Closeable {
                         tempNonPersistentTopics.clear();
                         // start persistent topic
                         topicStatsStream.startObject("persistent");
-                        topics.forEach((name, topic) -> {
+                        topics.forEachInSnapshot((name, topic) -> {
                             if (topic instanceof PersistentTopic) {
                                 try {
                                     topic.updateRates(nsStats, currentBundleStats, topicStatsStream,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -403,7 +403,7 @@ public class MessageDeduplication {
             log.debug("[{}] Taking snapshot of sequence ids map", topic.getName());
         }
         Map<String, Long> snapshot = new TreeMap<>();
-        highestSequencedPersisted.forEach((producerName, sequenceId) -> {
+        highestSequencedPersisted.forEachInSnapshot((producerName, sequenceId) -> {
             if (snapshot.size() < maxNumberOfProducers) {
                 snapshot.put(producerName, sequenceId);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -188,7 +188,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         cleanupTimedOutSnapshots();
 
         AtomicBoolean anyReplicatorDisconnected = new AtomicBoolean();
-        topic.getReplicators().forEach((cluster, replicator) -> {
+        topic.getReplicators().forEachInSnapshot((cluster, replicator) -> {
             if (!replicator.isConnected()) {
                 anyReplicatorDisconnected.set(true);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ClusterReplicationMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ClusterReplicationMetrics.java
@@ -69,7 +69,7 @@ public class ClusterReplicationMetrics {
     }
 
     private void generate() {
-        metricsMap.forEach((key, replicationMetrics) -> {
+        metricsMap.forEachInSnapshot((key, replicationMetrics) -> {
             int splitPoint = key.lastIndexOf(SEPARATOR);
             add(key.substring(0, splitPoint), key.substring(splitPoint + 1), replicationMetrics);
             replicationMetrics.reset();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -56,12 +56,12 @@ public class NamespaceStatsAggregator {
         printDefaultBrokerStats(stream, cluster);
 
         LongAdder topicsCount = new LongAdder();
-        pulsar.getBrokerService().getMultiLayerTopicMap().forEach((namespace, bundlesMap) -> {
+        pulsar.getBrokerService().getMultiLayerTopicMap().forEachInSnapshot((namespace, bundlesMap) -> {
             namespaceStats.reset();
             topicsCount.reset();
 
-            bundlesMap.forEach((bundle, topicsMap) -> {
-                topicsMap.forEach((name, topic) -> {
+            bundlesMap.forEachInSnapshot((bundle, topicsMap) -> {
+                topicsMap.forEachInSnapshot((name, topic) -> {
                     getTopicStats(topic, topicStats, includeConsumerMetrics, includeProducerMetrics,
                             pulsar.getConfiguration().isExposePreciseBacklogInPrometheus(),
                             pulsar.getConfiguration().isExposeSubscriptionBacklogSizeInPrometheus());
@@ -177,7 +177,7 @@ public class NamespaceStatsAggregator {
 
         // Consumer stats can be a lot if a subscription has many consumers
         if (includeConsumerMetrics) {
-            topic.getSubscriptions().forEach((name, subscription) -> {
+            topic.getSubscriptions().forEachInSnapshot((name, subscription) -> {
                 AggregatedSubscriptionStats subsStats = stats.subscriptionStats
                         .computeIfAbsent(name, k -> new AggregatedSubscriptionStats());
                 subscription.getConsumers().forEach(consumer -> {
@@ -198,7 +198,7 @@ public class NamespaceStatsAggregator {
             });
         }
 
-        topic.getReplicators().forEach((cluster, replicator) -> {
+        topic.getReplicators().forEachInSnapshot((cluster, replicator) -> {
             AggregatedReplicationStats aggReplStats = stats.replicationStats.computeIfAbsent(cluster,
                     k -> new AggregatedReplicationStats());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +50,7 @@ public class ReplicatorTlsTest extends ReplicatorTestBase {
     public void testReplicationClient() throws Exception {
         log.info("--- Starting ReplicatorTlsTest::testReplicationClient ---");
         for (BrokerService ns : Lists.newArrayList(ns1, ns2, ns3)) {
-            ns.getReplicationClients().forEach((cluster, client) -> {
+            ns.getReplicationClients().forEachInSnapshot((cluster, client) -> {
                 assertTrue(((PulsarClientImpl) client).getConfiguration().isUseTls());
                 assertEquals(((PulsarClientImpl) client).getConfiguration().getTlsTrustCertsFilePath(),
                         TLS_SERVER_CERT_FILE_PATH);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketProxyStatsBase.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketProxyStatsBase.java
@@ -96,17 +96,17 @@ public class WebSocketProxyStatsBase extends WebSocketWebResource {
 
         Map<String, ProxyTopicStat> statMap = Maps.newHashMap();
 
-        service().getProducers().forEach((topicName, handlers) -> {
+        service().getProducers().forEachInSnapshot((topicName, handlers) -> {
             ProxyTopicStat topicStat = statMap.computeIfAbsent(topicName, t -> new ProxyTopicStat());
             handlers.forEach(handler -> topicStat.producerStats.add(new ProducerStats(handler)));
             statMap.put(topicName, topicStat);
         });
-        service().getConsumers().forEach((topicName, handlers) -> {
+        service().getConsumers().forEachInSnapshot((topicName, handlers) -> {
             ProxyTopicStat topicStat = statMap.computeIfAbsent(topicName, t -> new ProxyTopicStat());
             handlers.forEach(handler -> topicStat.consumerStats.add(new ConsumerStats(handler)));
             statMap.put(topicName, topicStat);
         });
-        service().getReaders().forEach((topicName, handlers) -> {
+        service().getReaders().forEachInSnapshot((topicName, handlers) -> {
             ProxyTopicStat topicStat = statMap.computeIfAbsent(topicName, t -> new ProxyTopicStat());
             handlers.forEach(handler -> topicStat.consumerStats.add(new ConsumerStats(handler)));
             statMap.put(topicName, topicStat);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
@@ -68,7 +68,7 @@ public class ProxyStats {
 
         topicStats.clear();
 
-        service.getProducers().forEach((topic, handlers) -> {
+        service.getProducers().forEachInSnapshot((topic, handlers) -> {
             if (log.isDebugEnabled()) {
                 log.debug("Collect stats from {} producer handlers for topic {}", handlers.size(), topic);
             }
@@ -83,7 +83,7 @@ public class ProxyStats {
                 nsStat.publishMsgLatency.addAll(handler.getPublishLatencyStatsUSec());
             });
         });
-        service.getConsumers().forEach((topic, handlers) -> {
+        service.getConsumers().forEachInSnapshot((topic, handlers) -> {
             if (log.isDebugEnabled()) {
                 log.debug("Collect stats from {} consumer handlers for topic {}", handlers.size(), topic);
             }
@@ -98,7 +98,7 @@ public class ProxyStats {
         });
 
         tempMetricsCollection.clear();
-        topicStats.forEach((namespace, stats) -> {
+        topicStats.forEachInSnapshot((namespace, stats) -> {
             if (log.isDebugEnabled()) {
                 log.debug("Add ns-stats of namespace {} to metrics", namespace);
             }


### PR DESCRIPTION
### Motivation

Currently `ConcurrentOpenHashMap.forEach` keeps a read lock in each section for the duration of the processing. This can lead to various issues when I/O operations are done in the processing function. This is a common patter in Pulsar code base. The I/O usually happens to Zookeeper and it leads to threads piling up in waiting for locks in ConcurrentOpenHashMap when there are both reads and writes for the same section in concurrently executing threads. 
It is also possible that long living locks lead to dead locks.

This is the current implementation of `ConcurrentOpenHashMap.forEach`
https://github.com/apache/pulsar/blob/34ca8938ca13ea60b05d164c27d9755855caf87c/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java#L157-L161
and the referenced `Section.forEach`
https://github.com/apache/pulsar/blob/34ca8938ca13ea60b05d164c27d9755855caf87c/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java#L356-L395

### Modifications

- Add a new method `ConcurrentOpenHashMap.forEachInSnapshot` which makes a copy of the entries in each section before processing the entries. 
```java
    public void forEachInSnapshot(BiConsumer<? super K, ? super V> processor) {
        for (Section<K, V> s : sections) {
            List<Entry<K, V>> entries = new ArrayList<>(s.size);
            s.forEach((k, v) -> entries.add(new Entry<>(k, v)));
            entries.forEach(entry -> processor.accept(entry.key, entry.value));
        }
    }
```

- Replace all current usages of `forEach` with `forEachInSnapshot`

There are tradeoffs involved. Some memory allocations will have to be made to make a copy. However, allocations aren't a real issue. JVMs are really efficient for such short time allocations and the allocations aren't causing new bottlenecks or performance issues. 
The other tradeoff is a related to data consistency. The entry might have already been removed from the collection at the time it is processed. This is also a non-issue in most cases since it would be a bad solution in the first place to determine state based on the membership in the collection. 

Since the previous `forEach` implementation remains, it's possible to choose between the usage of `forEach` or `forEachInSnapshot` in each specific use case. If this feature isn't needed, it is possible to replace the `forEach` implemention with the snapshotting implemention completely.