### PR TITLE
[Tests] Use DiagnosticCommand JMX MBean to do the threaddump

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
@@ -29,6 +29,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+import javax.management.JMException;
+import javax.management.ObjectName;
 
 /**
  * Adapted from Hadoop TimedOutTestsListener
@@ -44,9 +46,6 @@ public class ThreadDumpUtil {
         StringWriter sw = new StringWriter();
         PrintWriter output = new PrintWriter(sw);
 
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
-        output.println(String.format("Timestamp: %s", dateFormat.format(new Date())));
-        output.println();
         output.println(buildThreadDump());
 
         String deadlocksInfo = buildDeadlockInfo();
@@ -60,7 +59,19 @@ public class ThreadDumpUtil {
     }
 
     static String buildThreadDump() {
+        try {
+            // first attempt to use jcmd to do the thread dump, similar output to jstack
+            return callDiagnosticCommand("threadPrint", "-l");
+        } catch (Exception ignore) {
+        }
+
+        // fallback to using JMX for creating the thread dump
         StringBuilder dump = new StringBuilder();
+
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        dump.append(String.format("Timestamp: %s", dateFormat.format(new Date())));
+        dump.append("\n\n");
+
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
         for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
             Thread thread = e.getKey();
@@ -77,6 +88,20 @@ public class ThreadDumpUtil {
             dump.append("\n");
         }
         return dump.toString();
+    }
+
+    /**
+     * Calls a diagnostic commands.
+     * The available operations are similar to what the jcmd commandline tool has,
+     * however the naming of the operations are different. The "help" operation can be used
+     * to find out the available operations. For example, the jcmd command "Thread.print" maps
+     * to "threadPrint" operation name.
+     */
+    static String callDiagnosticCommand(String operationName, String... args)
+            throws JMException {
+        return (String) ManagementFactory.getPlatformMBeanServer()
+                .invoke(new ObjectName("com.sun.management:type=DiagnosticCommand"),
+                        operationName, new Object[]{args}, new String[]{String[].class.getName()});
     }
 
     static String buildDeadlockInfo() {

--- a/buildtools/src/test/java/org/apache/pulsar/tests/ThreadDumpUtilTest.java
+++ b/buildtools/src/test/java/org/apache/pulsar/tests/ThreadDumpUtilTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import javax.management.JMException;
+import org.testng.annotations.Test;
+
+public class ThreadDumpUtilTest {
+
+    @Test
+    void testThreadDump() {
+        // simply verify that an exception isn't thrown
+        System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
+    }
+
+    @Test
+    void testHelp() throws JMException {
+        System.out.println(ThreadDumpUtil.callDiagnosticCommand("help"));
+    }
+}


### PR DESCRIPTION
### Motivation

When a tests times out, a thread dump will be printed using `org.apache.pulsar.tests.ThreadDumpUtil` . This class produces output that isn't 
as rich as the output of `jstack -l <pid>`. However it's possible to produce a similar thread dump in Java programmatically. The benefit of a richer and standard thread dump is that it's possible to analyse it using standard tooling such as https://jstack.review/

### Modifications

- Improve threaddump by using DiagnosticCommand JMX MBean to do the threaddump
  - include full information about locks in the output
  - output is similar to what `jstack -l <pid>` produces
- fallback to previous method if DiagnosticCommand MBean fails to produce
  the threaddump
