### PR TITLE
pulsar-perf: Dump JVM information

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.testclient.PerfClientUtils;
 import org.apache.pulsar.testclient.utils.PaddingDecimalFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -324,6 +325,7 @@ public class PerformanceClient {
     public static void main(String[] args) throws Exception {
         PerformanceClient test = new PerformanceClient();
         Arguments arguments = test.loadArguments(args);
+        PerfClientUtils.printJVMInformation(log);
         test.runPerformanceTest(arguments.numMessages, arguments.msgRate, arguments.numTopics, arguments.msgSize,
                 arguments.proxyURL, arguments.topics.get(0), arguments.authPluginClassName, arguments.authParams);
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -344,6 +344,7 @@ public class LoadSimulationClient {
             jc.usage();
             System.exit(-1);
         }
+        PerfClientUtils.printJVMInformation(log);
         (new LoadSimulationClient(mainArguments)).run();
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -122,6 +122,7 @@ public class ManagedLedgerWriter {
     }
 
     public static void main(String[] args) throws Exception {
+
         final Arguments arguments = new Arguments();
         JCommander jc = new JCommander(arguments);
         jc.setProgramName("pulsar-perf managed-ledger");

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -122,7 +122,6 @@ public class ManagedLedgerWriter {
     }
 
     public static void main(String[] args) throws Exception {
-
         final Arguments arguments = new Arguments();
         JCommander jc = new JCommander(arguments);
         jc.setProgramName("pulsar-perf managed-ledger");
@@ -143,6 +142,7 @@ public class ManagedLedgerWriter {
         arguments.testTime = TimeUnit.SECONDS.toMillis(arguments.testTime);
 
         // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
         ObjectMapper m = new ObjectMapper();
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
         log.info("Starting Pulsar managed-ledger perf writer with config: {}", w.writeValueAsString(arguments));

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.testclient;
+
+import com.google.common.collect.ImmutableSet;
+import io.netty.util.internal.PlatformDependent;
+import lombok.experimental.UtilityClass;
+import org.slf4j.Logger;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Collection;
+
+/**
+ * Utility for test clients
+ */
+@UtilityClass
+public class PerfClientUtils {
+
+    private static final Collection<String> USELESS_PROPERTIES = ImmutableSet
+            .<String>builder()
+            .add("java.class.path")
+            .build();
+    /**
+     * Print useful JVM information, you need this information in order to be able
+     * to compare the results of executions in different environments.
+     * @param log
+     */
+    public static void printJVMInformation(Logger log) {
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        log.info("Java Runtime Info");
+        System.getProperties().forEach( (k,v)-> {
+            String key = k.toString();
+            if (!USELESS_PROPERTIES.contains(key)
+                && (key.startsWith("java.") || key.startsWith("os."))) {
+                log.info("{} = {}", key, v);
+            }
+        });
+        log.info("JVM args {}", runtimeMXBean.getInputArguments());
+        log.info("Netty max memory (PlatformDependent.maxDirectMemory()) {}", PlatformDependent.maxDirectMemory());
+        log.info("JVM max heap memory (Runtime.getRuntime().maxMemory()) {}", Runtime.getRuntime().maxMemory());
+    }
+}

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pulsar.testclient;
 
-import com.google.common.collect.ImmutableSet;
 import io.netty.util.internal.PlatformDependent;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.util.Collection;
 
 /**
  * Utility for test clients
@@ -32,27 +30,14 @@ import java.util.Collection;
 @UtilityClass
 public class PerfClientUtils {
 
-    private static final Collection<String> USELESS_PROPERTIES = ImmutableSet
-            .<String>builder()
-            .add("java.class.path")
-            .build();
     /**
      * Print useful JVM information, you need this information in order to be able
      * to compare the results of executions in different environments.
      * @param log
      */
     public static void printJVMInformation(Logger log) {
-        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-        log.info("Java Runtime Info");
-        System.getProperties().forEach( (k,v)-> {
-            String key = k.toString();
-            if (!USELESS_PROPERTIES.contains(key)
-                && (key.startsWith("java.") || key.startsWith("os."))) {
-                log.info("{} = {}", key, v);
-            }
-        });
-        log.info("JVM args {}", runtimeMXBean.getInputArguments());
-        log.info("Netty max memory (PlatformDependent.maxDirectMemory()) {}", PlatformDependent.maxDirectMemory());
-        log.info("JVM max heap memory (Runtime.getRuntime().maxMemory()) {}", Runtime.getRuntime().maxMemory());
+        log.info("JVM args {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
+        log.info("Netty max memory (PlatformDependent.maxDirectMemory()) {}", FileUtils.byteCountToDisplaySize(PlatformDependent.maxDirectMemory()));
+        log.info("JVM max heap memory (Runtime.getRuntime().maxMemory()) {}", FileUtils.byteCountToDisplaySize(Runtime.getRuntime().maxMemory()));
     }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -233,6 +233,7 @@ public class PerformanceConsumer {
         }
 
         // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
         ObjectMapper m = new ObjectMapper();
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
         log.info("Starting Pulsar performance consumer with config: {}", w.writeValueAsString(arguments));

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -282,6 +282,7 @@ public class PerformanceProducer {
         }
 
         // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
         ObjectMapper m = new ObjectMapper();
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
         log.info("Starting Pulsar perf producer with config: {}", w.writeValueAsString(arguments));

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -184,6 +184,7 @@ public class PerformanceReader {
         }
 
         // Dump config variables
+        PerfClientUtils.printJVMInformation(log);
         ObjectMapper m = new ObjectMapper();
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
         log.info("Starting Pulsar performance reader with config: {}", w.writeValueAsString(arguments));


### PR DESCRIPTION
Relates to  #9721

### Motivation
Is it really useful to have a summary of JVM configuration when you are working with pulsar-perf.
This is because that configuration may affect the execution of the test, but also with that piece of information you can easily troubleshot problems like #9721  

### Modifications

Log JVM configuration at boot:
- Netty max memory
- JVM command line arguments
- Actual max heap size

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
