### PR TITLE
[issue][improve] zookeeper connections monitor data

### DIFF
--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperServerAspect.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperServerAspect.java
@@ -72,12 +72,16 @@ public class ZooKeeperServerAspect {
                 .setChild(new Gauge.Child() {
                     @Override
                     public double get() {
+                        int connections = -1;
                         ServerCnxnFactory cnxFactory = zkServer.getServerCnxnFactory();
                         if (cnxFactory != null) {
-                            return cnxFactory.getNumAliveConnections();
-                        } else {
-                            return -1;
+                            connections += cnxFactory.getNumAliveConnections();
                         }
+                        ServerCnxnFactory secCnxFactory = zkServer.getSecureServerCnxnFactory();
+                        if (secCnxFactory != null) {
+                            connections += secCnxFactory.getNumAliveConnections();
+                        }
+                        return connections;
                     }
                 }).register();
 


### PR DESCRIPTION

Fixes #9777


### Motivation

The value of zookeeper_server_connections is incorrect when we open tls connection between client(broker、bookie) and zookeeper server

### Modifications

when zkServer.getSecureServerCnxnFactory() not null ,will plus the connections and return 

ServerCnxnFactory secCnxFactory = zkServer.getSecureServerCnxnFactory();
if (secCnxFactory != null) {
    connections += secCnxFactory.getNumAliveConnections();
}

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations:(no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature?(no)
