### PR TITLE
[build] Enable detailed Java compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1122,6 +1122,12 @@ flexible messaging model and an intuitive client API.</description>
           </annotationProcessorPaths>
           <compilerArgs>
             <arg>-parameters</arg>
+            <!-- enable 'all' lint warnings with some exclusions -->
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-options</arg>
+            <arg>-Xlint:-serial</arg>
+            <arg>-Xlint:-classfile</arg>
+            <arg>-Xlint:-processing</arg>
           </compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Motivation

- In many projects there's a convention that Java compiler warnings should be addressed by suppressing individual warnings or fixing the code. 
- To fix unchecked/unsafe warnings, it is necessary to see the detailed warning. This can be seen when there is `-Xlint:unchecked` or `-Xlint:all` in compiler arguments

### Modifications

Add `-Xlint:all -Xlint:-options -Xlint:-serial -Xlint:-classfile -Xlint:-processing` to the configuration of `maven-compiler-plugin`. This enables all javac lint warnings except 'options', 'serial' and 'classfile'.

