### PR TITLE
Add NPE check for PulsarService#getAdminClient

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1166,7 +1166,13 @@ public class PulsarService implements AutoCloseable {
         if (this.adminClient == null) {
             try {
                 ServiceConfiguration conf = this.getConfiguration();
-                String adminApiUrl = conf.isBrokerClientTlsEnabled() ? webServiceAddressTls : webServiceAddress;
+                final String adminApiUrl = conf.isBrokerClientTlsEnabled() ? webServiceAddressTls : webServiceAddress;
+                if (adminApiUrl == null) {
+                    throw new IllegalArgumentException("adminApiUrl is null"
+                            + ", isBrokerClientTlsEnabled: " + conf.isBrokerClientTlsEnabled()
+                            + ", webServiceAddressTls: " + webServiceAddressTls
+                            + ", webServiceAddress: " + webServiceAddress);
+                }
                 PulsarAdminBuilder builder = PulsarAdmin.builder().serviceHttpUrl(adminApiUrl) //
                         .authentication(//
                                 conf.getBrokerClientAuthenticationPlugin(), //

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1168,7 +1168,7 @@ public class PulsarService implements AutoCloseable {
                 ServiceConfiguration conf = this.getConfiguration();
                 final String adminApiUrl = conf.isBrokerClientTlsEnabled() ? webServiceAddressTls : webServiceAddress;
                 if (adminApiUrl == null) {
-                    throw new IllegalArgumentException("Web service address does not set properly "
+                    throw new IllegalArgumentException("Web service address was not set properly "
                             + ", isBrokerClientTlsEnabled: " + conf.isBrokerClientTlsEnabled()
                             + ", webServiceAddressTls: " + webServiceAddressTls
                             + ", webServiceAddress: " + webServiceAddress);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1168,7 +1168,7 @@ public class PulsarService implements AutoCloseable {
                 ServiceConfiguration conf = this.getConfiguration();
                 final String adminApiUrl = conf.isBrokerClientTlsEnabled() ? webServiceAddressTls : webServiceAddress;
                 if (adminApiUrl == null) {
-                    throw new IllegalArgumentException("adminApiUrl is null"
+                    throw new IllegalArgumentException("Web service address does not set properly "
                             + ", isBrokerClientTlsEnabled: " + conf.isBrokerClientTlsEnabled()
                             + ", webServiceAddressTls: " + webServiceAddressTls
                             + ", webServiceAddress: " + webServiceAddress);


### PR DESCRIPTION
### Motivation

If user set incorrect `brokerClientTlsEnabled` config, the `PulsarService#getAdminClient` would throw NPE and the error logs is not clear. For example, start a standalone pulsar with `brokerClientTlsEnabled=true`, some admin APIs that don't involve `PulsarService#getAdminClient` work well, however some admin APIs like `GET /admin/v2/non-persistent/:tenant/:namespace` will throw NPE with following logs:

```
org.apache.pulsar.broker.PulsarServerException: java.lang.NullPointerException
	at org.apache.pulsar.broker.PulsarService.getAdminClient(PulsarService.java:1193)
	at org.apache.pulsar.broker.admin.v2.NonPersistentTopics.getList(NonPersistentTopics.java:273)
```

After this PR, the logs became:

```
org.apache.pulsar.broker.PulsarServerException: java.lang.IllegalArgumentException: adminApiUrl is null, isBrokerClientTlsEnabled: true, webServiceAddressTls: null, webServiceAddress: http://localhost:8080
```

### Modifications

- Check if `adminApiUrl` is null in `PulsarService#getAdminClient` and give a human readable error message.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.