### PR TITLE
Ensure read-lock is not continuously held on a section while iterating over concurrent maps

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -423,9 +423,13 @@ public class ConcurrentLongHashMap<V> {
                     // Fallback to acquiring read lock
                     stamp = readLock();
 
-                    storedKey = keys[bucket];
-                    storedValue = values[bucket];
-                    unlockRead(stamp);
+                    try {
+                        storedKey = keys[bucket];
+                        storedValue = values[bucket];
+                    } finally {
+                        unlockRead(stamp);
+                    }
+
                     stamp = 0;
                 }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -153,14 +153,14 @@ public class ConcurrentLongHashMap<V> {
     }
 
     public void clear() {
-        for (Section<V> s : sections) {
-            s.clear();
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].clear();
         }
     }
 
     public void forEach(EntryProcessor<V> processor) {
-        for (Section<V> s : sections) {
-            s.forEach(processor);
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].forEach(processor);
         }
     }
 
@@ -393,46 +393,44 @@ public class ConcurrentLongHashMap<V> {
         public void forEach(EntryProcessor<V> processor) {
             long stamp = tryOptimisticRead();
 
+            // We need to make sure that we read these 3 variables in a consistent way
             int capacity = this.capacity;
             long[] keys = this.keys;
             V[] values = this.values;
 
-            boolean acquiredReadLock = false;
+            // Validate no rehashing
+            if (!validate(stamp)) {
+                // Fallback to read lock
+                stamp = readLock();
 
-            try {
+                capacity = this.capacity;
+                keys = this.keys;
+                values = this.values;
+                unlockRead(stamp);
+            }
 
-                // Validate no rehashing
+            // Go through all the buckets for this section. We try to renew the stamp only after a validation
+            // error, otherwise we keep going with the same.
+            for (int bucket = 0; bucket < capacity; bucket++) {
+                if (stamp == 0) {
+                    stamp = tryOptimisticRead();
+                }
+
+                long storedKey = keys[bucket];
+                V storedValue = values[bucket];
+
                 if (!validate(stamp)) {
-                    // Fallback to read lock
+                    // Fallback to acquiring read lock
                     stamp = readLock();
-                    acquiredReadLock = true;
 
-                    capacity = this.capacity;
-                    keys = this.keys;
-                    values = this.values;
-                }
-
-                // Go through all the buckets for this section
-                for (int bucket = 0; bucket < capacity; bucket++) {
-                    long storedKey = keys[bucket];
-                    V storedValue = values[bucket];
-
-                    if (!acquiredReadLock && !validate(stamp)) {
-                        // Fallback to acquiring read lock
-                        stamp = readLock();
-                        acquiredReadLock = true;
-
-                        storedKey = keys[bucket];
-                        storedValue = values[bucket];
-                    }
-
-                    if (storedValue != DeletedValue && storedValue != EmptyValue) {
-                        processor.accept(storedKey, storedValue);
-                    }
-                }
-            } finally {
-                if (acquiredReadLock) {
+                    storedKey = keys[bucket];
+                    storedValue = values[bucket];
                     unlockRead(stamp);
+                    stamp = 0;
+                }
+
+                if (storedValue != DeletedValue && storedValue != EmptyValue) {
+                    processor.accept(storedKey, storedValue);
                 }
             }
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -415,9 +415,13 @@ public class ConcurrentLongPairSet implements LongPairSet {
                     // Fallback to acquiring read lock
                     stamp = readLock();
 
-                    storedItem1 = table[bucket];
-                    storedItem2 = table[bucket + 1];
-                    unlockRead(stamp);
+                    try {
+                        storedItem1 = table[bucket];
+                        storedItem2 = table[bucket + 1];
+                    } finally {
+                        unlockRead(stamp);
+                    }
+
                     stamp = 0;
                 }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.common.util.collections;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -149,14 +149,14 @@ public class ConcurrentOpenHashMap<K, V> {
     }
 
     public void clear() {
-        for (Section<K, V> s : sections) {
-            s.clear();
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].clear();
         }
     }
 
     public void forEach(BiConsumer<? super K, ? super V> processor) {
-        for (Section<K, V> s : sections) {
-            s.forEach(processor);
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].forEach(processor);
         }
     }
 
@@ -164,13 +164,13 @@ public class ConcurrentOpenHashMap<K, V> {
      * @return a new list of all keys (makes a copy)
      */
     public List<K> keys() {
-        List<K> keys = Lists.newArrayList();
+        List<K> keys = new ArrayList<>((int) size());
         forEach((key, value) -> keys.add(key));
         return keys;
     }
 
     public List<V> values() {
-        List<V> values = Lists.newArrayList();
+        List<V> values = new ArrayList<>((int) size());
         forEach((key, value) -> values.add(value));
         return values;
     }
@@ -354,42 +354,33 @@ public class ConcurrentOpenHashMap<K, V> {
         }
 
         public void forEach(BiConsumer<? super K, ? super V> processor) {
-            long stamp = tryOptimisticRead();
-
+            // Take a reference to the data table, if there is a rehashing event, we'll be
+            // simply iterating over a snapshot of the data.
             Object[] table = this.table;
-            boolean acquiredReadLock = false;
 
-            try {
+            // Go through all the buckets for this section. We try to renew the stamp only after a validation
+            // error, otherwise we keep going with the same.
+            long stamp = 0;
+            for (int bucket = 0; bucket < table.length; bucket += 2) {
+                if (stamp == 0) {
+                    stamp = tryOptimisticRead();
+                }
 
-                // Validate no rehashing
+                K storedKey = (K) table[bucket];
+                V storedValue = (V) table[bucket + 1];
+
                 if (!validate(stamp)) {
-                    // Fallback to read lock
+                    // Fallback to acquiring read lock
                     stamp = readLock();
-                    acquiredReadLock = true;
-                    table = this.table;
-                }
 
-                // Go through all the buckets for this section
-                for (int bucket = 0; bucket < table.length; bucket += 2) {
-                    K storedKey = (K) table[bucket];
-                    V storedValue = (V) table[bucket + 1];
-
-                    if (!acquiredReadLock && !validate(stamp)) {
-                        // Fallback to acquiring read lock
-                        stamp = readLock();
-                        acquiredReadLock = true;
-
-                        storedKey = (K) table[bucket];
-                        storedValue = (V) table[bucket + 1];
-                    }
-
-                    if (storedKey != DeletedKey && storedKey != EmptyKey) {
-                        processor.accept(storedKey, storedValue);
-                    }
-                }
-            } finally {
-                if (acquiredReadLock) {
+                    storedKey = (K) table[bucket];
+                    storedValue = (V) table[bucket + 1];
                     unlockRead(stamp);
+                    stamp = 0;
+                }
+
+                if (storedKey != DeletedKey && storedKey != EmptyKey) {
+                    processor.accept(storedKey, storedValue);
                 }
             }
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -373,9 +373,13 @@ public class ConcurrentOpenHashMap<K, V> {
                     // Fallback to acquiring read lock
                     stamp = readLock();
 
-                    storedKey = (K) table[bucket];
-                    storedValue = (V) table[bucket + 1];
-                    unlockRead(stamp);
+                    try {
+                        storedKey = (K) table[bucket];
+                        storedValue = (V) table[bucket + 1];
+                    } finally {
+                        unlockRead(stamp);
+                    }
+
                     stamp = 0;
                 }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -75,23 +75,23 @@ public class ConcurrentOpenHashSet<V> {
 
     public long size() {
         long size = 0;
-        for (Section<V> s : sections) {
-            size += s.size;
+        for (int i = 0; i < sections.length; i++) {
+            size += sections[i].size;
         }
         return size;
     }
 
     public long capacity() {
         long capacity = 0;
-        for (Section<V> s : sections) {
-            capacity += s.capacity;
+        for (int i = 0; i < sections.length; i++) {
+            capacity += sections[i].capacity;
         }
         return capacity;
     }
 
     public boolean isEmpty() {
-        for (Section<V> s : sections) {
-            if (s.size != 0) {
+        for (int i = 0; i < sections.length; i++) {
+            if (sections[i].size != 0) {
                 return false;
             }
         }
@@ -124,14 +124,14 @@ public class ConcurrentOpenHashSet<V> {
     }
 
     public void clear() {
-        for (Section<V> s : sections) {
-            s.clear();
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].clear();
         }
     }
 
     public void forEach(Consumer<? super V> processor) {
-        for (Section<V> s : sections) {
-            s.forEach(processor);
+        for (int i = 0; i < sections.length; i++) {
+            sections[i].forEach(processor);
         }
     }
 
@@ -139,8 +139,8 @@ public class ConcurrentOpenHashSet<V> {
         checkNotNull(filter);
 
         int removedCount = 0;
-        for (Section<V> s : sections) {
-            removedCount += s.removeIf(filter);
+        for (int i = 0; i < sections.length; i++) {
+            removedCount += sections[i].removeIf(filter);
         }
 
         return removedCount;
@@ -371,44 +371,28 @@ public class ConcurrentOpenHashSet<V> {
         }
 
         public void forEach(Consumer<? super V> processor) {
-            long stamp = tryOptimisticRead();
-
-            int capacity = this.capacity;
             V[] values = this.values;
 
-            boolean acquiredReadLock = false;
+            // Go through all the buckets for this section. We try to renew the stamp only after a validation
+            // error, otherwise we keep going with the same.
+            long stamp = 0;
+            for (int bucket = 0; bucket < capacity; bucket++) {
+                if (stamp == 0) {
+                    stamp = tryOptimisticRead();
+                }
 
-            try {
+                V storedValue = values[bucket];
 
-                // Validate no rehashing
                 if (!validate(stamp)) {
-                    // Fallback to read lock
+                    // Fallback to acquiring read lock
                     stamp = readLock();
-                    acquiredReadLock = true;
-
-                    capacity = this.capacity;
-                    values = this.values;
-                }
-
-                // Go through all the buckets for this section
-                for (int bucket = 0; bucket < capacity; bucket++) {
-                    V storedValue = values[bucket];
-
-                    if (!acquiredReadLock && !validate(stamp)) {
-                        // Fallback to acquiring read lock
-                        stamp = readLock();
-                        acquiredReadLock = true;
-
-                        storedValue = values[bucket];
-                    }
-
-                    if (storedValue != DeletedValue && storedValue != EmptyValue) {
-                        processor.accept(storedValue);
-                    }
-                }
-            } finally {
-                if (acquiredReadLock) {
+                    storedValue = values[bucket];
                     unlockRead(stamp);
+                    stamp = 0;
+                }
+
+                if (storedValue != DeletedValue && storedValue != EmptyValue) {
+                    processor.accept(storedValue);
                 }
             }
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -386,8 +386,13 @@ public class ConcurrentOpenHashSet<V> {
                 if (!validate(stamp)) {
                     // Fallback to acquiring read lock
                     stamp = readLock();
-                    storedValue = values[bucket];
-                    unlockRead(stamp);
+
+                    try {
+                        storedValue = values[bucket];
+                    } finally {
+                        unlockRead(stamp);
+                    }
+
                     stamp = 0;
                 }
 


### PR DESCRIPTION
### Motivation

As discussed in #9764 the fact that we're potentially holding a read-lock while scanning through a section of the map has several implications: 

 1. If the process functions is taking a long time (eg: making a blocking request to ZK that might even timeout), the writes operations on that section of the map are stalled during that time.
 2. It's deadlock prone: 
    1. If a thread tries to use the map while scanning through it can deadlock itself
    2. If the processing operation waits for the completion of some operation from a different thread and that thread tries to use the same map, it can create a deadlock.

Instead of holding the lock throughout the scan of the section, we should instead release the read lock before calling the processing function, going back into the optimistic read mode.

This will not add any overhead (in terms of volatile reads) compared to the current implementation, but will avoid all the possible deadlock traps, since we're never going to be holding the lock while calling the user code.