### PR TITLE
[ISSUE 9757][pulsar-admin] add cmd to get service url of the leader broker

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -440,6 +440,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Assert.assertNotNull(list2);
         Assert.assertEquals(list2.size(), 1);
 
+        String leaderBroker = admin.brokers().getLeaderBroker();
+        Assert.assertNotNull(leaderBroker);
+
         Map<String, NamespaceOwnershipStatus> nsMap = admin.brokers().getOwnedNamespaces("test", list.get(0));
         // since sla-monitor ns is not created nsMap.size() == 1 (for HeartBeat Namespace)
         Assert.assertEquals(nsMap.size(), 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -70,6 +70,7 @@ import org.apache.pulsar.broker.admin.v2.SchemasResource;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
+import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
@@ -620,6 +621,11 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         Set<String> activeBrokers = brokers.getActiveBrokers("use");
         assertEquals(activeBrokers.size(), 1);
         assertEquals(activeBrokers, Sets.newHashSet(pulsar.getAdvertisedAddress() + ":" + pulsar.getListenPortHTTP().get()));
+
+        String leaderBroker = brokers.getLeaderBroker();
+        assertEquals(leaderBroker, pulsar.getLeaderElectionService().getCurrentLeader()
+                .map(LeaderBroker::getServiceUrl)
+                .orElse("None"));
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -73,6 +73,40 @@ public interface Brokers {
     CompletableFuture<List<String>> getActiveBrokersAsync(String cluster);
 
     /**
+     * Get the service url of the leader broker.
+     * <p/>
+     * Get the service url of the leader broker.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>"prod1-broker1.messaging.use.example.com:8080"</code>
+     * </pre>
+     *
+     * @return the service url of the leader broker
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    String getLeaderBroker() throws PulsarAdminException;
+
+    /**
+     * Get the service url of the leader broker asynchronously.
+     * <p/>
+     * Get the service url of the leader broker.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>"prod1-broker1.messaging.use.example.com:8080"</code>
+     * </pre>
+     *
+     * @return the service url of the leader broker
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    CompletableFuture<String> getLeaderBrokerAsync() throws PulsarAdminException;
+
+    /**
      * Get the map of owned namespaces and their status from a single broker in the cluster.
      * <p/>
      * The map is returned in a JSON object format below

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -75,6 +75,9 @@ public class PulsarAdminToolTest {
         brokers.run(split("list use"));
         verify(mockBrokers).getActiveBrokers("use");
 
+        brokers.run(split("leader-broker"));
+        verify(mockBrokers).getLeaderBroker();
+
         brokers.run(split("namespaces use --url http://my-service.url:8080"));
         verify(mockBrokers).getOwnedNamespaces("use", "http://my-service.url:8080");
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -40,6 +40,15 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Get the service url of the leader broker")
+    private class LeaderBroker extends CliCommand {
+
+        @Override
+        void run() throws Exception {
+            print(getAdmin().brokers().getLeaderBroker());
+        }
+    }
+
     @Parameters(commandDescription = "List namespaces owned by the broker")
     private class Namespaces extends CliCommand {
         @Parameter(description = "cluster-name\n", required = true)
@@ -77,7 +86,7 @@ public class CmdBrokers extends CmdBase {
             getAdmin().brokers().deleteDynamicConfiguration(configName);
         }
     }
-    
+
     @Parameters(commandDescription = "Get all overridden dynamic-configuration values")
     private class GetAllConfigurationsCmd extends CliCommand {
 
@@ -86,7 +95,7 @@ public class CmdBrokers extends CmdBase {
             print(getAdmin().brokers().getAllDynamicConfigurations());
         }
     }
-    
+
     @Parameters(commandDescription = "Get list of updatable configuration name")
     private class GetUpdatableConfigCmd extends CliCommand {
 
@@ -140,6 +149,7 @@ public class CmdBrokers extends CmdBase {
     public CmdBrokers(Supplier<PulsarAdmin> admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
+        jcommander.addCommand("leader-broker", new LeaderBroker());
         jcommander.addCommand("namespaces", new Namespaces());
         jcommander.addCommand("update-dynamic-config", new UpdateConfigurationCmd());
         jcommander.addCommand("delete-dynamic-config", new DeleteConfigurationCmd());


### PR DESCRIPTION
### Motivation
see #9757 add cmd to get service url of the leader broker.

### Modifications
add cmd parameter "leader-broker" in CmdBrokers, and provide "/admin/v2/brokers/leaderBroker" web endpoint to get service url of the leader broker.

### Verifying this change
- [ ] Make sure that the change passes the CI checks.

### Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? ( JavaDocs )
