### PR TITLE
Reduce size of integration tests image by including only selected con…

### DIFF
--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -102,13 +102,13 @@ COPY --from=pulsar-function-go /go/bin /pulsar/examples/go-examples
 COPY --from=pulsar-all --chown=pulsar:0 /pulsar/offloaders /pulsar/offloaders
 
 # Include only the connectors needed by integration tests
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-cassandra-*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-debezium-*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-elastic-*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-hdfs*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-jdbc-postgres-*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-kafka-*.nar /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-rabbitmq-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-cassandra-*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-debezium-*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-elastic-*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-hdfs*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-jdbc-postgres-*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-kafka-*.nar /pulsar/connectors/
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-rabbitmq-*.nar /pulsar/connectors/
 
 # change ownership of files
 RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -19,7 +19,7 @@
 
 # build go lang examples first in a separate layer
 
-FROM apachepulsar/pulsar-all:latest as pulsar-function-go
+FROM apachepulsar/pulsar:latest as pulsar-function-go
 
 USER root
 
@@ -29,7 +29,7 @@ RUN apt-get install -y procps curl git
 ENV GOLANG_VERSION 1.13.3
 
 RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
-		| tar -v -C /usr/local -xz
+		| tar -C /usr/local -xz
 
 # RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
 # RUN export GOROOT=/usr/local/go && export GOPATH=$HOME/go && export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
@@ -47,7 +47,13 @@ RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go && go install ./...
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
 
-FROM apachepulsar/pulsar-all:latest
+# Reference pulsar-all to copy connectors from there
+FROM apachepulsar/pulsar-all:latest as pulsar-all
+
+########################################
+###### Main image build
+########################################
+FROM apachepulsar/pulsar:latest
 
 # Switch to run as the root user to simplify building container and then running
 # supervisord. Each of the pulsar components are spawned by supervisord and their
@@ -91,6 +97,18 @@ COPY target/java-test-functions.jar /pulsar/examples/
 
 # copy go test examples
 COPY --from=pulsar-function-go /go/bin /pulsar/examples/go-examples
+
+# Include all offloaders
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/offloaders /pulsar/offloaders
+
+# Include only the connectors needed by integration tests
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-cassandra-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-debezium-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-elastic-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-hdfs*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-jdbc-postgres-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-kafka-*.nar /pulsar/connectors
+COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-rabbitmq-*.nar /pulsar/connectors
 
 # change ownership of files
 RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar


### PR DESCRIPTION
### Motivation

Since we're not running integration tests on all the connectors, we can only include the subset which is actually needed. This way the image can be more easily cached.