### PR TITLE
Remove Deb package from pulsar docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -35,7 +35,6 @@ COPY scripts/watch-znode.py /pulsar/bin
 COPY scripts/install-pulsar-client-37.sh /pulsar/bin
 
 COPY target/python-client/ /pulsar/pulsar-client
-COPY target/cpp-client/ /pulsar/cpp-client
 
 RUN mkdir /pulsar/data
 
@@ -74,10 +73,6 @@ RUN mkdir /pulsar && chown pulsar:0 /pulsar && chmod g=u /pulsar
 COPY --from=pulsar --chown=pulsar:0 /pulsar /pulsar
 
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/jre/lib/security/java.security
-RUN apt-get update \
-     && apt install -y /pulsar/cpp-client/*.deb \
-     && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -46,7 +46,7 @@
       <id>docker</id>
       <build>
         <plugins>
-          <!-- build cpp client, copy the wheel file and then build docker image -->
+          <!-- build Python client, copy the wheel file and then build docker image -->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
@@ -68,18 +68,6 @@
                   </arguments>
                 </configuration>
               </execution>
-              <execution>
-                <id>build-pulsar-cpp-client-deb</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <skip>${skipBuildCppClient}</skip>
-                  <workingDirectory>${project.basedir}/target</workingDirectory>
-                  <executable>${project.basedir}/../../pulsar-client-cpp/pkg/deb/docker-build-deb.sh</executable>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -98,21 +86,6 @@
                     <echo>copy python wheel file</echo>
                     <mkdir dir="${basedir}/target/python-client"/>
                     <copydir src="${basedir}/../../pulsar-client-cpp/python/wheelhouse" dest="${basedir}/target/python-client"/>
-                  </target>
-                </configuration>
-              </execution>
-              <execution>
-                <id>copy-pulsar-cpp-client</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <skip>${skipCopyCppClient}</skip>
-                  <target>
-                    <echo>copy cpp client deb file</echo>
-                    <mkdir dir="${basedir}/target/cpp-client"/>
-                    <copydir src="${basedir}/../../pulsar-client-cpp/pkg/deb/BUILD/DEB" dest="${basedir}/target/cpp-client"/>
                   </target>
                 </configuration>
               </execution>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -113,8 +113,6 @@ COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-rabbitmq-*.
 # change ownership of files
 RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar
 
-# remove static libpulsar*.a libraries to reduce image size
-RUN rm /usr/lib/libpulsar*.a
 # remove gcc
 RUN apt-get -y remove --autoremove --purge build-essential
 


### PR DESCRIPTION
### Motivation

We're currently building the Deb pkg for the pulsar c++ client lib and including it in the Docker image. 

This was initially done in order to support Go Pulsar functions out of the box, since the Go client lib was based on CGo and it required the C++ client library. 

Since we're using the native Go client library, the Deb package it's no longer required and should be removed.