### PR TITLE
[docs] Remove pulsar-admin from reference section

### DIFF
--- a/site2/docs/admin-api-overview.md
+++ b/site2/docs/admin-api-overview.md
@@ -16,7 +16,7 @@ You can interact with the admin interface via:
      $ bin/pulsar-admin
     ```
 
-    For details of `pulsar-admin` tool, see the [Pulsar command-line tools](reference-pulsar-admin.md) doc.
+    For complete commands of `pulsar-admin` tool, see [Pulsar admin snapshot](http://pulsar.apache.org/tools/pulsar-admin/).
 
 
 > **The REST API is the admin interface**. Both the `pulsar-admin` CLI tool and the Java client use the REST API. If you implement your own admin interface client, you should use the REST API. 

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1908,9 +1908,6 @@ Subcommands
 * `get-inactive-topic-policies`
 * `set-inactive-topic-policies`
 * `remove-inactive-topic-policies`
-* `set-max-subscriptions`
-* `get-max-subscriptions`
-* `remove-max-subscriptions`
 
 ### `compact`
 Run compaction on the specified topic (persistent topics only)
@@ -2440,30 +2437,6 @@ Remove a deduplication policy from a topic.
 Usage
 ```bash
 $ pulsar-admin topics remove-deduplication tenant/namespace/topic
-```
-
-### `set-max-subscriptions`
-Set the maximum number of subscriptions for a topic.
-
-Usage
-```bash
-$ pulsar-admin topics set-max-subscriptions tenant/namespace/topic options
-```
-
-### `get-max-subscriptions`
-Get the maximum number of subscriptions for a topic.
-
-Usage
-```bash
-$ pulsar-admin topics get-max-subscriptions tenant/namespace/topic
-```
-
-### `remove-max-subscriptions`
-Remove the maximum number of subscriptions for a topic.
-
-Usage
-```bash
-$ pulsar-admin topics remove-max-subscriptions tenant/namespace/topic
 ```
 
 ## `tenants`

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -1908,6 +1908,9 @@ Subcommands
 * `get-inactive-topic-policies`
 * `set-inactive-topic-policies`
 * `remove-inactive-topic-policies`
+* `set-max-subscriptions`
+* `get-max-subscriptions`
+* `remove-max-subscriptions`
 
 ### `compact`
 Run compaction on the specified topic (persistent topics only)
@@ -2437,6 +2440,30 @@ Remove a deduplication policy from a topic.
 Usage
 ```bash
 $ pulsar-admin topics remove-deduplication tenant/namespace/topic
+```
+
+### `set-max-subscriptions`
+Set the maximum number of subscriptions for a topic.
+
+Usage
+```bash
+$ pulsar-admin topics set-max-subscriptions tenant/namespace/topic options
+```
+
+### `get-max-subscriptions`
+Get the maximum number of subscriptions for a topic.
+
+Usage
+```bash
+$ pulsar-admin topics get-max-subscriptions tenant/namespace/topic
+```
+
+### `remove-max-subscriptions`
+Remove the maximum number of subscriptions for a topic.
+
+Usage
+```bash
+$ pulsar-admin topics remove-max-subscriptions tenant/namespace/topic
 ```
 
 ## `tenants`

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -150,7 +150,6 @@
     "Reference": [
       "reference-terminology",
       "reference-cli-tools",
-      "pulsar-admin",
       "reference-configuration",
       "reference-metrics"
     ]


### PR DESCRIPTION
### Motivation

Currently, we have [CLI website](http://pulsar.apache.org/tools/pulsar-admin/2.8.0-SNAPSHOT/), which generate `pulsar-admin` commands and usage automatically.

### Modifications
1. Remove the `pulsar-admin` section from Reference.
2. Navigate the original link to `pulsar-admin` reference page to the CLI website.

Related info:
1. The change will take effect in 2.8.0 release. For the earlier releases, keep it in the sidebar.
2. We still keep the `reference-pulsar-admin.md` file in the directory. If [this link](https://pulsar.apache.org/docs/en/next/pulsar-admin/) is used externally, it still works.
3. In future, if we add reference to the complete `pulsar-admin` usage, we can navigate to the CLI website. And we'll not maintain the `reference-pulsar-admin.md` file anymore.