### PR TITLE
Reduced size of integration tests image

### DIFF
--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -110,18 +110,4 @@ COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-jdbc-postgr
 COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-kafka-*.nar /pulsar/connectors/
 COPY --from=pulsar-all --chown=pulsar:0 /pulsar/connectors/pulsar-io-rabbitmq-*.nar /pulsar/connectors/
 
-# change ownership of files
-RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar
-
-# remove static libpulsar*.a libraries to reduce image size
-RUN rm /usr/lib/libpulsar*.a
-# remove gcc
-RUN apt-get -y remove --autoremove --purge build-essential
-
-# cleanup
-RUN apt-get -y autoremove \
-    && apt-get clean \
-    && apt-get autoclean \
-    && rm -rf /var/lib/apt/lists/*
-
 CMD bash


### PR DESCRIPTION
### Motivation

The chown & chmod operations added in #9627 are causing docker to actually duplicate all the files in the overlay filesystem, increasing the image size by ~2GB. 

After this change the test image size is ~2.5 GB.