### PR TITLE
[Tests] Cleanup test state after a failure, before retrying or proceeding to next methods

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -32,7 +32,7 @@ function broker_group_1() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/**/*.java" \
-                                      -Dexclude="org/apache/pulsar/broker/zookeeper/**/*.java,
+                                      -Dexclude="**/*$*,org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java,
                                                  **/AdminApiOffloadTest.java"
@@ -63,7 +63,7 @@ function broker_group_2() {
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java" \
-                                      -Dexclude="**/ReplicatorTest.java,
+                                      -Dexclude="**/*$*,**/ReplicatorTest.java,
                                                  **/MessagePublishBufferThrottleTest.java,
                                                  **/TopicOwnerTest.java,
                                                  **/*StreamingDispatcher*Test.java,
@@ -80,7 +80,7 @@ function broker_client_api() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/client/api/**/*.java" \
-                                      -Dexclude="**/DispatcherBlockConsumerTest.java,
+                                      -Dexclude="**/*$*,**/DispatcherBlockConsumerTest.java,
                                                  **/SimpleProducerConsumerTest.java"
 }
 
@@ -89,7 +89,7 @@ function broker_client_impl() {
 }
 
 function broker_client_other() {
-  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude="org/apache/pulsar/broker/**/*.java,
+  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude="**/*$*,org/apache/pulsar/broker/**/*.java,
                                                  org/apache/pulsar/client/**/*.java"
 }
 
@@ -119,7 +119,7 @@ function proxy() {
                                      -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -Dexclude="**/ProxyRolesEnforcementTest.java,
+                                     -Dexclude="**/*$*,**/ProxyRolesEnforcementTest.java,
                                                 **/ProxyAuthenticationTest.java,
                                                 **/ProxyTest.java,
                                                 **/MessagePublishBufferThrottleTest.java" \
@@ -128,7 +128,7 @@ function proxy() {
 
 function other() {
   build/retry.sh mvn -B -ntp install -PbrokerSkipTest \
-                                     -Dexclude="org/apache/pulsar/proxy/**/*.java,
+                                     -Dexclude="**/*$*,org/apache/pulsar/proxy/**/*.java,
                                                 **/ManagedLedgerTest.java,
                                                 **/TestPulsarKeyValueSchemaHandler.java,
                                                 **/PrimitiveSchemaTest.java,

--- a/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import java.lang.reflect.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * Adds support for resetting the internal state of the test
+ * by calling "cleanup" and "setup" methods before running a test method
+ * after a previous test method has failed.
+ *
+ * This is useful for making test retries to work on classes which use BeforeClass
+ * and AfterClass methods to setup a test environment that is shared across all test methods in the test
+ * class.
+ */
+public abstract class TestRetrySupport {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRetrySupport.class);
+    private int currentSetupNumber;
+    private int failedSetupNumber = -1;
+    private int cleanedUpSetupNumber;
+
+    @BeforeMethod(groups = "setup")
+    public final void stateCheck(Method method) throws Exception {
+        // run cleanup and setup if the current setup number is the one where a failure happened
+        // this is to cleanup state before retrying
+        if (currentSetupNumber == failedSetupNumber
+                && cleanedUpSetupNumber != failedSetupNumber) {
+            LOG.info("Previous test run has failed before {}.{}, failedSetupNumber={}. Running cleanup and setup.",
+                    method.getDeclaringClass().getSimpleName(), method.getName(), failedSetupNumber);
+            try {
+                cleanup();
+            } catch (Exception e) {
+                LOG.error("Cleanup failed, ignoring this.", e);
+            }
+            setup();
+            LOG.info("State cleanup finished.");
+            failedSetupNumber = -1;
+        }
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void failureCheck(ITestResult testResult, Method method) {
+        // track the setup number where the failure happened
+        if (!testResult.isSuccess()) {
+            LOG.info("Detected test failure in test {}.{}, currentSetupNumber={}",
+                    method.getDeclaringClass().getSimpleName(), method.getName(),
+                    currentSetupNumber);
+            failedSetupNumber = currentSetupNumber;
+        }
+    }
+
+    /**
+     * This method should be called in the setup method of the concrete class.
+     *
+     * This increases an internal counter and resets the failure state which are used to determine
+     * whether cleanup is needed before a test method is called.
+     *
+     */
+    protected final void incrementSetupNumber() {
+        currentSetupNumber++;
+        failedSetupNumber = -1;
+        LOG.debug("currentSetupNumber={}", currentSetupNumber);
+    }
+
+    protected final void markCurrentSetupNumberCleaned() {
+        cleanedUpSetupNumber = currentSetupNumber;
+        LOG.debug("cleanedUpSetupNumber={}", cleanedUpSetupNumber);
+    }
+
+    protected abstract void setup() throws Exception;
+
+    protected abstract void cleanup() throws Exception;
+}

--- a/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportBeforeMethodRetryTest.java
+++ b/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportBeforeMethodRetryTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import org.testng.Assert;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestRetrySupportBeforeMethodRetryTest extends TestRetrySupport {
+    public static class IllegalStateRetry implements IRetryAnalyzer {
+        @Override
+        public boolean retry(ITestResult result) {
+            return result.getThrowable().getClass() == IllegalStateException.class;
+        }
+    }
+
+    private int setupCallCount;
+    private int cleanupCallCount;
+    private int invocationCount;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        setupCallCount++;
+        incrementSetupNumber();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        cleanupCallCount++;
+        markCurrentSetupNumberCleaned();
+    }
+
+    @Test(retryAnalyzer = IllegalStateRetry.class)
+    void shouldNotDoAnythingWhenThereIsBeforeAndAfterMethod(ITestContext testContext) {
+        // get the number of times this method has been called
+        invocationCount++;
+        // setup method should have been called the same amount of times when TestRetrySupport
+        // is doing the handling. setup method has @BeforeClass annotation so that TestNG calls it
+        // only once
+        Assert.assertEquals(setupCallCount, invocationCount);
+        // cleanup method one less times
+        Assert.assertEquals(cleanupCallCount, invocationCount - 1);
+        // trigger a retry
+        if (invocationCount < 5) {
+            throw new IllegalStateException("Sample failure to trigger retry.");
+        }
+    }
+}

--- a/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportRetryTest.java
+++ b/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportRetryTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import java.lang.reflect.Method;
+import org.testng.Assert;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestRetrySupportRetryTest extends TestRetrySupport {
+    public static class IllegalStateRetry implements IRetryAnalyzer {
+        @Override
+        public boolean retry(ITestResult result) {
+            return result.getThrowable().getClass() == IllegalStateException.class;
+        }
+    }
+
+    private int setupCallCount;
+    private int cleanupCallCount;
+    private int invocationCount;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        setupCallCount++;
+        incrementSetupNumber();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        cleanupCallCount++;
+        markCurrentSetupNumberCleaned();
+    }
+
+    @Test(retryAnalyzer = IllegalStateRetry.class)
+    void shouldCallSetupBeforeRetrying(ITestContext testContext, Method method) {
+        // get the number of times this method has been called
+        invocationCount++;
+        // setup method should have been called the same amount of times when TestRetrySupport
+        // is doing the handling. setup method has @BeforeClass annotation so that TestNG calls it
+        // only once
+        Assert.assertEquals(setupCallCount, invocationCount);
+        // cleanup method one less times
+        Assert.assertEquals(cleanupCallCount, invocationCount - 1);
+        // trigger a retry
+        if (invocationCount < 5) {
+            throw new IllegalStateException("Sample failure to trigger retry.");
+        }
+    }
+}

--- a/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportSuccessTest.java
+++ b/buildtools/src/test/java/org/apache/pulsar/tests/TestRetrySupportSuccessTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that TestRetrySupport doesn't call setup & cleanup when tests are successful
+ */
+public class TestRetrySupportSuccessTest extends TestRetrySupport {
+    private int setupCallCount;
+    private int cleanupCallCount;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        setupCallCount++;
+        incrementSetupNumber();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        cleanupCallCount++;
+        markCurrentSetupNumberCleaned();
+    }
+
+    @Test
+    void shouldCallSetupOnce1() {
+        Assert.assertEquals(setupCallCount, 1);
+        Assert.assertEquals(cleanupCallCount, 0);
+    }
+
+    @Test
+    void shouldCallSetupOnce2() {
+        Assert.assertEquals(setupCallCount, 1);
+        Assert.assertEquals(cleanupCallCount, 0);
+    }
+
+    @Test
+    void shouldCallSetupOnce3() {
+        Assert.assertEquals(setupCallCount, 1);
+        Assert.assertEquals(cleanupCallCount, 0);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -57,6 +57,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
@@ -71,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * Base class for all tests that need a Pulsar instance without a ZK and BK cluster.
  */
 @PowerMockIgnore(value = {"org.slf4j.*", "com.sun.org.apache.xerces.*" })
-public abstract class MockedPulsarServiceBaseTest {
+public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected final String DUMMY_VALUE = "DUMMY_VALUE";
     protected final String GLOBAL_DUMMY_VALUE = "GLOBAL_DUMMY_VALUE";
@@ -102,7 +103,9 @@ public abstract class MockedPulsarServiceBaseTest {
         this.conf = getDefaultConf();
     }
 
+
     protected final void internalSetup() throws Exception {
+        incrementSetupNumber();
         init();
         lookupUrl = new URI(brokerUrl.toString());
         if (isTcpLookup) {
@@ -175,6 +178,7 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     protected final void internalCleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         // if init fails, some of these could be null, and if so would throw
         // an NPE in shutdown, obscuring the real error
         if (admin != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -50,14 +50,14 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass(timeOut = 300000)
-    void setup() throws Exception {
+    public void setup() throws Exception {
         super.setup();
     }
 
     @Override
     @AfterClass(alwaysRun = true, timeOut = 300000)
-    void shutdown() throws Exception {
-        super.shutdown();
+    public void cleanup() throws Exception {
+        super.cleanup();
     }
 
     @DataProvider(name = "lookupType")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -46,14 +46,14 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass(timeOut = 300000)
-    void setup() throws Exception {
+    public void setup() throws Exception {
         super.setup();
     }
 
     @Override
     @AfterClass(alwaysRun = true, timeOut = 300000)
-    void shutdown() throws Exception {
-        super.shutdown();
+    public void cleanup() throws Exception {
+        super.cleanup();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -61,14 +61,14 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass(timeOut = 300000)
-    void setup() throws Exception {
+    public void setup() throws Exception {
         super.setup();
     }
 
     @Override
     @AfterClass(alwaysRun = true, timeOut = 300000)
-    void shutdown() throws Exception {
-        super.shutdown();
+    public void cleanup() throws Exception {
+        super.cleanup();
         resetConfig1();
         resetConfig2();
         resetConfig3();
@@ -85,7 +85,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
     @Test
     public void testReplicatorRatePriority() throws Exception {
-        shutdown();
+        cleanup();
         config1.setSystemTopicEnabled(true);
         config1.setTopicLevelPoliciesEnabled(true);
         config1.setDispatchThrottlingRatePerReplicatorInMsg(100);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -104,14 +104,14 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass(timeOut = 300000)
-    void setup() throws Exception {
+    public void setup() throws Exception {
         super.setup();
     }
 
     @Override
     @AfterClass(alwaysRun = true, timeOut = 300000)
-    void shutdown() throws Exception {
-        super.shutdown();
+    public void cleanup() throws Exception {
+        super.cleanup();
     }
 
     @DataProvider(name = "partitionedTopic")
@@ -851,7 +851,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             }
             assertTrue(e.getCause() instanceof NamingException);
         }
-        
+
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -53,7 +54,7 @@ import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReplicatorTestBase {
+public class ReplicatorTestBase extends TestRetrySupport {
     URL url1;
     URL urlTls1;
     ServiceConfiguration config1 = new ServiceConfiguration();
@@ -98,7 +99,10 @@ public class ReplicatorTestBase {
         return false;
     }
 
-    void setup() throws Exception {
+    @Override
+    protected void setup() throws Exception {
+        incrementSetupNumber();
+
         log.info("--- Starting ReplicatorTestBase::setup ---");
         globalZkS = new ZookeeperServerTest(0);
         globalZkS.start();
@@ -258,7 +262,9 @@ public class ReplicatorTestBase {
         return (int) TimeUnit.SECONDS.convert(time, unit);
     }
 
-    void shutdown() throws Exception {
+    @Override
+    protected void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         log.info("--- Shutting down ---");
         executor.shutdown();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
@@ -34,7 +34,7 @@ public class ReplicatorTlsTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass(timeOut = 300000)
-    void setup() throws Exception {
+    public void setup() throws Exception {
         config1.setBrokerClientTlsEnabled(true);
         config2.setBrokerClientTlsEnabled(true);
         config3.setBrokerClientTlsEnabled(true);
@@ -43,8 +43,8 @@ public class ReplicatorTlsTest extends ReplicatorTestBase {
 
     @Override
     @AfterClass(alwaysRun = true, timeOut = 300000)
-    void shutdown() throws Exception {
-        super.shutdown();
+    public void cleanup() throws Exception {
+        super.cleanup();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Some of the Pulsar tests setup the test environment in BeforeClass method and run a cleanup in a AfterClass method. These test classes cannot be reliably retried since the test environment state might be invalid after a test failure. This PR includes changes that detect failures and whether cleanup has been called for the current state or not. If the test hasn't been cleaned up, the cleanup & setup will be called before the next test method is run.

### Modifications

- adds TestRetrySupport with the logic for tracking setup & cleanup state
- make MockedPulsarServiceBaseTest and ReplicatorTestBase extend TestRetrySupport
  so that all tests that extend these classes are covered with the solution that re-initializes the test state by calling cleanup & setup if a failure is detected. 
- the implementation has handling for test classes that handle test environment setup & cleanup in BeforeMethod and AfterMethod methods. The state tracking will detect this and won't call cleanup if the state has already been cleaned up in a AfterMethod cleanup method.
- [Maven Surefire excludes](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes) should always contain the default exclude `**/*$*` so that tests in inner classes aren't scanned. This prevents a problem with AdminApiTest$MockedPulsarService and V1_AdminApiTest$MockedPulsarService classes which are attempted to run as tests.