### PR TITLE
[Testing] Fix Maven Surefire default exclude

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -32,10 +32,10 @@ function broker_group_1() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/**/*.java" \
-                                      -Dexclude="**/*$*,org/apache/pulsar/broker/zookeeper/**/*.java,
+                                      -Dexclude='**/*$*,org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java,
-                                                 **/AdminApiOffloadTest.java"
+                                                 **/AdminApiOffloadTest.java'
 
 }
 
@@ -63,11 +63,11 @@ function broker_group_2() {
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java" \
-                                      -Dexclude="**/*$*,**/ReplicatorTest.java,
+                                      -Dexclude='**/*$*,**/ReplicatorTest.java,
                                                  **/MessagePublishBufferThrottleTest.java,
                                                  **/TopicOwnerTest.java,
                                                  **/*StreamingDispatcher*Test.java,
-                                                 **/AntiAffinityNamespaceGroupTest.java"
+                                                 **/AntiAffinityNamespaceGroupTest.java'
 }
 
 function broker_client_api() {
@@ -80,8 +80,8 @@ function broker_client_api() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/client/api/**/*.java" \
-                                      -Dexclude="**/*$*,**/DispatcherBlockConsumerTest.java,
-                                                 **/SimpleProducerConsumerTest.java"
+                                      -Dexclude='**/*$*,**/DispatcherBlockConsumerTest.java,
+                                                 **/SimpleProducerConsumerTest.java'
 }
 
 function broker_client_impl() {
@@ -89,8 +89,8 @@ function broker_client_impl() {
 }
 
 function broker_client_other() {
-  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude="**/*$*,org/apache/pulsar/broker/**/*.java,
-                                                 org/apache/pulsar/client/**/*.java"
+  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude='**/*$*,org/apache/pulsar/broker/**/*.java,
+                                                 org/apache/pulsar/client/**/*.java'
 }
 
 function proxy() {
@@ -119,20 +119,20 @@ function proxy() {
                                      -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -Dexclude="**/*$*,**/ProxyRolesEnforcementTest.java,
+                                     -Dexclude='**/*$*,**/ProxyRolesEnforcementTest.java,
                                                 **/ProxyAuthenticationTest.java,
                                                 **/ProxyTest.java,
-                                                **/MessagePublishBufferThrottleTest.java" \
+                                                **/MessagePublishBufferThrottleTest.java' \
                                      -DtestReuseFork=true
 }
 
 function other() {
   build/retry.sh mvn -B -ntp install -PbrokerSkipTest \
-                                     -Dexclude="**/*$*,org/apache/pulsar/proxy/**/*.java,
+                                     -Dexclude='**/*$*,org/apache/pulsar/proxy/**/*.java,
                                                 **/ManagedLedgerTest.java,
                                                 **/TestPulsarKeyValueSchemaHandler.java,
                                                 **/PrimitiveSchemaTest.java,
-                                                BlobStoreManagedLedgerOffloaderTest.java"
+                                                BlobStoreManagedLedgerOffloaderTest.java'
 
   $MVN_TEST_COMMAND -pl managed-ledger -Dinclude="**/ManagedLedgerTest.java" \
                                        -DtestForkCount=1 \

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
-
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.Cleanup;
-
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -42,10 +42,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Starts 3 brokers that are in 3 different clusters
@@ -69,9 +65,6 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     @AfterClass(alwaysRun = true, timeOut = 300000)
     public void cleanup() throws Exception {
         super.cleanup();
-        resetConfig1();
-        resetConfig2();
-        resetConfig3();
     }
 
     enum DispatchRateType {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -286,6 +286,10 @@ public class ReplicatorTestBase extends TestRetrySupport {
         bkEnsemble2.stop();
         bkEnsemble3.stop();
         globalZkS.stop();
+
+        resetConfig1();
+        resetConfig2();
+        resetConfig3();
     }
 
     static class MessageProducer implements AutoCloseable {


### PR DESCRIPTION
### Motivation

- Problem introduced in PR #9823
- In the shell script `**/*$*` gets replaced with `**/*` when using double quotes. This makes the test run skip most tests for the groups that use excludes.

### Modifications 

- Fix: use single quotes for the exclude parameter in `run_unit_group.sh` script