### PR TITLE
[Issue 9821] [pulsar-testclient] Fix perf tools to keep compatibility with previous version

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -83,8 +83,7 @@ public class PerformanceConsumer {
         @Parameter(names = { "-ns", "--num-subscriptions" }, description = "Number of subscriptions (per topic)")
         public int numSubscriptions = 1;
 
-        @Deprecated
-        @Parameter(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix", hidden = true)
+        @Parameter(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix")
         public String subscriberName = "sub";
 
         @Parameter(names = { "-ss", "--subscriptions" }, description = "A list of subscriptions to consume on (e.g. sub1,sub2)")
@@ -189,9 +188,19 @@ public class PerformanceConsumer {
         }
 
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
-            System.out.println("The size of topics list should be equal to --num-topics");
-            jc.usage();
-            System.exit(-1);
+            // keep compatibility with the previous version
+            if (arguments.topic.size() == 1) {
+                String prefixTopicName = TopicName.get(arguments.topic.get(0)).toString();
+                List<String> defaultTopics = Lists.newArrayList();
+                for (int i = 0; i < arguments.numTopics; i++) {
+                    defaultTopics.add(String.format("%s-%d", prefixTopicName, i));
+                }
+                arguments.topic = defaultTopics;
+            } else {
+                System.out.println("The size of topics list should be equal to --num-topics");
+                jc.usage();
+                System.exit(-1);
+            }
         }
 
         if (arguments.subscriptionType == SubscriptionType.Exclusive && arguments.numConsumers > 1) {
@@ -203,9 +212,18 @@ public class PerformanceConsumer {
         if (arguments.subscriptionType != SubscriptionType.Exclusive &&
                 arguments.subscriptions != null &&
                 arguments.subscriptions.size() != arguments.numConsumers) {
-            System.out.println("The size of subscriptions list should be equal to --num-consumers when subscriptionType isn't Exclusive");
-            jc.usage();
-            System.exit(-1);
+            // keep compatibility with the previous version
+            if (arguments.subscriptions.size() == 1) {
+                List<String> defaultSubscriptions = Lists.newArrayList();
+                for (int i = 0; i < arguments.numSubscriptions; i++) {
+                    defaultSubscriptions.add(String.format("%s-%d", arguments.subscriberName, i));
+                }
+                arguments.subscriptions = defaultSubscriptions;
+            } else {
+                System.out.println("The size of subscriptions list should be equal to --num-consumers when subscriptionType isn't Exclusive");
+                jc.usage();
+                System.exit(-1);
+            }
         }
 
         if (arguments.confFile != null) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -238,9 +238,19 @@ public class PerformanceProducer {
         }
 
         if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
-            System.out.println("The size of topics list should be equal to --num-topic");
-            jc.usage();
-            System.exit(-1);
+            // keep compatibility with the previous version
+            if (arguments.topics.size() == 1) {
+                String prefixTopicName = arguments.topics.get(0);
+                List<String> defaultTopics = Lists.newArrayList();
+                for (int i = 0; i < arguments.numTopics; i++) {
+                    defaultTopics.add(String.format("%s-%d", prefixTopicName, i));
+                }
+                arguments.topics = defaultTopics;
+            } else {
+                System.out.println("The size of topics list should be equal to --num-topic");
+                jc.usage();
+                System.exit(-1);
+            }
         }
 
         if (arguments.confFile != null) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -139,9 +139,19 @@ public class PerformanceReader {
         }
 
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
-            System.out.println("The size of topics list should be equal to --num-topics");
-            jc.usage();
-            System.exit(-1);
+            // keep compatibility with the previous version
+            if (arguments.topic.size() == 1) {
+                String prefixTopicName = arguments.topic.get(0);
+                List<String> defaultTopics = Lists.newArrayList();
+                for (int i = 0; i < arguments.numTopics; i++) {
+                    defaultTopics.add(String.format("%s-%d", prefixTopicName, i));
+                }
+                arguments.topic = defaultTopics;
+            } else {
+                System.out.println("The size of topics list should be equal to --num-topics");
+                jc.usage();
+                System.exit(-1);
+            }
         }
 
         if (arguments.confFile != null) {

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -441,6 +441,7 @@ Options
 |`-q`, `--receiver-queue-size`|Size of the receiver queue|1000|
 |`-u`, `--service-url`|Pulsar service URL||
 |`-i`, `--stats-interval-seconds`|Statistics interval seconds. If 0, statistics will be disabled|0|
+|`-s`, `--subscriber-name`|Subscriber name prefix|sub|
 |`-ss`, `--subscriptions`|A list of subscriptions to consume on (e.g. sub1,sub2)|sub|
 |`-st`, `--subscription-type`|Subscriber type. Possible values are Exclusive, Shared, Failover, Key_Shared.|Exclusive|
 |`-sp`, `--subscription-position`|Subscriber position. Possible values are Latest, Earliest.|Latest|


### PR DESCRIPTION
### Motivation

Fixes #9821

### Modifications

Add the logic to cover the default behaviour of previous versions. More details can be found in #9716.