### PR TITLE
[Logging] Exclude unnecessary logging libraries

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -323,9 +323,6 @@ The Apache Software License, Version 2.0
   * LevelDB
     - leveldb-0.10.jar
     - leveldb-api-0.10.jar
-  * Log4j implemented over SLF4J
-    - log4j-over-slf4j-1.7.29.jar
-    - log4j-over-slf4j-1.7.30.jar
   * Lucene Common Analyzers
     - lucene-analyzers-common-8.4.1.jar
     - lucene-core-8.4.1.jar
@@ -491,9 +488,7 @@ MIT License
  * PCollections
    - pcollections-2.1.2.jar
  * SLF4J
-   - slf4j-jdk14-1.7.29.jar
    - slf4j-api-1.7.25.jar
-   - slf4j-jdk14-1.7.30.jar
  * JCL 1.2 Implemented Over SLF4J
    - jcl-over-slf4j-1.7.25.jar
    - jcl-over-slf4j-1.7.29.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -102,6 +102,14 @@
                     <groupId>javax.activation</groupId>
                     <artifactId>activation</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -43,6 +43,16 @@
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
             <version>${dep.airlift.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -112,6 +122,16 @@
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation & Modifications

- Exclude `slf4j-jdk14`
  - This libraries routes all slf4j log event to Java Util Logging,
    which doesn't make any sense.
    - Causes some tests to fail such as `PulsarStateTest#testSinkState`
      - `assertTrue(result.getStderr().isEmpty())` fails since
         duplicate slf4j loggers cause output to stderr
      - This was flaky and didn't happen each time

- Exclude `log4j-over-slf4j`
  - Pulsar already contains `org.apache.logging.log4j:log4j-1.2-api`
    which routes Log4j 1.2.x API to Log4j2.