### PR TITLE
Log stacktraces of threads that failed to terminate on shutdown within timeout in ExecutorProvider

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3295,6 +3295,53 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @Test
+    public void test() throws Exception
+    {
+        String topicName = "persistent://my-property/my-ns/testReachedEndOfTopic";
+        Producer producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .enableBatching(false).create();
+
+
+
+        CountDownLatch latch = new CountDownLatch(2);
+        Consumer consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName("my-subscriber-name")
+                .messageListener(new MessageListener()
+                {
+                    @Override
+                    public void reachedEndOfTopic(Consumer consumer)
+                    {
+                        log.info("called reachedEndOfTopic  {}", methodName);
+                    }
+
+                    @Override
+                    public void received(Consumer consumer, Message message)
+                    {
+                        while(true) {
+                            try {
+                                log.info("sleep");
+                                Thread.sleep(10000000);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                })
+                .subscribe();
+
+        Thread.sleep(1000);
+        producer.send("foo".getBytes());
+        Thread.sleep(1000);
+
+        consumer.close();
+        producer.close();
+        pulsarClient.close();
+
+    }
+
     // Issue 1452: https://github.com/apache/pulsar/issues/1452
     // reachedEndOfTopic should be called only once if a topic has been terminated before subscription
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3295,53 +3295,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test
-    public void test() throws Exception
-    {
-        String topicName = "persistent://my-property/my-ns/testReachedEndOfTopic";
-        Producer producer = pulsarClient.newProducer()
-                .topic(topicName)
-                .enableBatching(false).create();
-
-
-
-        CountDownLatch latch = new CountDownLatch(2);
-        Consumer consumer = pulsarClient.newConsumer()
-                .topic(topicName)
-                .subscriptionName("my-subscriber-name")
-                .messageListener(new MessageListener()
-                {
-                    @Override
-                    public void reachedEndOfTopic(Consumer consumer)
-                    {
-                        log.info("called reachedEndOfTopic  {}", methodName);
-                    }
-
-                    @Override
-                    public void received(Consumer consumer, Message message)
-                    {
-                        while(true) {
-                            try {
-                                log.info("sleep");
-                                Thread.sleep(10000000);
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
-                            }
-                        }
-                    }
-                })
-                .subscribe();
-
-        Thread.sleep(1000);
-        producer.send("foo".getBytes());
-        Thread.sleep(1000);
-
-        consumer.close();
-        producer.close();
-        pulsarClient.close();
-
-    }
-
     // Issue 1452: https://github.com/apache/pulsar/issues/1452
     // reachedEndOfTopic should be called only once if a topic has been terminated before subscription
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -145,8 +145,8 @@ public class PulsarClientImpl implements PulsarClient {
         this.clientClock = conf.getClock();
         conf.getAuthentication().start();
         this.cnxPool = cnxPool;
-        externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(), getThreadFactory("pulsar-external-listener"));
-        internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(), getThreadFactory("pulsar-client-internal"));
+        externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(),"pulsar-external-listener");
+        internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(),"pulsar-client-internal");
         if (conf.getServiceUrl().startsWith("http")) {
             lookup = new HttpLookupService(conf, eventLoopGroup);
         } else {
@@ -791,7 +791,7 @@ public class PulsarClientImpl implements PulsarClient {
         return EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), threadFactory);
     }
 
-    private static ThreadFactory getThreadFactory(String poolName) {
+    public static ThreadFactory getThreadFactory(String poolName) {
         return new DefaultThreadFactory(poolName, Thread.currentThread().isDaemon());
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -145,8 +145,8 @@ public class PulsarClientImpl implements PulsarClient {
         this.clientClock = conf.getClock();
         conf.getAuthentication().start();
         this.cnxPool = cnxPool;
-        externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(),"pulsar-external-listener");
-        internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(),"pulsar-client-internal");
+        externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(), "pulsar-external-listener");
+        internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(), "pulsar-client-internal");
         if (conf.getServiceUrl().startsWith("http")) {
             lookup = new HttpLookupService(conf, eventLoopGroup);
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
@@ -96,7 +96,7 @@ public class ExecutorProvider {
                         .collect(Collectors.toList());
 
         StringBuilder dump = new StringBuilder();
-        
+
         for (Map.Entry<Thread, StackTraceElement[]> e : activeThreads) {
             Thread thread = e.getKey();
             dump.append('\n');

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 public class ConsumerImplTest {
 
 
-    private final ExecutorProvider executorProvider = new ExecutorProvider(1, new DefaultThreadFactory("ConsumerImplTest"));
+    private final ExecutorProvider executorProvider = new ExecutorProvider(1,"ConsumerImplTest");
     private ConsumerImpl<byte[]> consumer;
     private ConsumerConfigurationData consumerConf;
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -65,7 +65,7 @@ public class MultiTopicsConsumerImplTest {
 
         ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
         EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), threadFactory);
-        ExecutorProvider executorProvider = new ExecutorProvider(1, threadFactory);
+        ExecutorProvider executorProvider = new ExecutorProvider(1, "client-test-stats");
 
         PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
 


### PR DESCRIPTION

### Motivation

Log stacktraces of threads that failed to terminate on shutdown within timeout in ExecutorProvider so that we have more insights on where threads are getting stuck especially for message listener threads that run user code.

