### PR TITLE
Allow DockerImage to be built from source tarball

### DIFF
--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -23,7 +23,7 @@ set -e
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(dirname $0)/../..
 cd $ROOT_DIR
 
 PYTHON_VERSIONS=(

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -21,7 +21,7 @@
 set -e -x
 
 cd /pulsar
-SRC_ROOT_DIR=$(git rev-parse --show-toplevel)
+SRC_ROOT_DIR=$(dirname $0)/../..
 cd $SRC_ROOT_DIR/pulsar-client-cpp/pkg/deb
 
 POM_VERSION=`$SRC_ROOT_DIR/src/get-project-version.py`

--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -21,7 +21,7 @@
 set -e -x
 
 cd /pulsar
-SRC_ROOT_DIR=$(dirname $0)/../..
+SRC_ROOT_DIR=$(pwd)
 cd $SRC_ROOT_DIR/pulsar-client-cpp/pkg/deb
 
 POM_VERSION=`$SRC_ROOT_DIR/src/get-project-version.py`

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(dirname $0)/../../..
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../..
+ROOT_DIR=$(dirname $0)/../../../..
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../../..
+ROOT_DIR=$(dirname $0)/../..
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../..
+ROOT_DIR=$(dirname $0)/../../..
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/rpm/build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/build-rpm.sh
@@ -21,7 +21,7 @@
 set -e
 
 cd /pulsar
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(dirname $0)/../..
 cd $ROOT_DIR/pulsar-client-cpp/pkg/rpm
 
 POM_VERSION=`$ROOT_DIR/src/get-project-version.py`

--- a/pulsar-client-cpp/pkg/rpm/build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/build-rpm.sh
@@ -21,7 +21,7 @@
 set -e
 
 cd /pulsar
-ROOT_DIR=$(pwd)
+ROOT_DIR=$(dirname $0)/../..
 cd $ROOT_DIR/pulsar-client-cpp/pkg/rpm
 
 POM_VERSION=`$ROOT_DIR/src/get-project-version.py`

--- a/pulsar-client-cpp/pkg/rpm/build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/build-rpm.sh
@@ -21,7 +21,7 @@
 set -e
 
 cd /pulsar
-ROOT_DIR=$(dirname $0)/../..
+ROOT_DIR=$(pwd)
 cd $ROOT_DIR/pulsar-client-cpp/pkg/rpm
 
 POM_VERSION=`$ROOT_DIR/src/get-project-version.py`

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../..
+ROOT_DIR=$(dirname $0)/../../../..
 
 docker pull apachepulsar/pulsar-build:centos-7
 

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(dirname $0)/../../..
 
 docker pull apachepulsar/pulsar-build:centos-7
 

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../..
+ROOT_DIR=$(dirname $0)/../../../..
 
 docker pull apachepulsar/pulsar-build:centos-7
 

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../../..
+ROOT_DIR=$(dirname $0)/../..
 
 docker pull apachepulsar/pulsar-build:centos-7
 


### PR DESCRIPTION
Fixes #9845
### Modifications

Do not use the git command in order to get the ROOT directory of the project.

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
I also tested it locally, it applies also to 2.7.1rc1 source tarball