### PR TITLE
Fix schema not added when subscribe an empty topic without schema

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -973,7 +973,13 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     @Override
     public CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema) {
         return hasSchema().thenCompose((hasSchema) -> {
-            if (hasSchema || isActive() || ENTRIES_ADDED_COUNTER_UPDATER.get(this) != 0) {
+            int numActiveConsumers = subscriptions.values().stream()
+                    .mapToInt(subscription -> subscription.getConsumers().size())
+                    .sum();
+            if (hasSchema
+                    || (!producers.isEmpty())
+                    || (numActiveConsumers != 0)
+                    || ENTRIES_ADDED_COUNTER_UPDATER.get(this) != 0) {
                 return checkSchemaCompatibleForConsumer(schema);
             } else {
                 return addSchema(schema).thenCompose(schemaVersion -> CompletableFuture.completedFuture(null));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2510,8 +2510,9 @@ public class PersistentTopic extends AbstractTopic
     public CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema) {
         return hasSchema()
             .thenCompose((hasSchema) -> {
-                if (hasSchema || isActive(InactiveTopicDeleteMode.delete_when_no_subscriptions)
-                        || ledger.getTotalSize() != 0) {
+                final boolean activeOrNotEmpty =
+                        isActive(InactiveTopicDeleteMode.delete_when_no_subscriptions) || (ledger.getTotalSize() != 0);
+                if (hasSchema && activeOrNotEmpty) {
                     return checkSchemaCompatibleForConsumer(schema);
                 } else {
                     return addSchema(schema).thenCompose(schemaVersion ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2513,7 +2513,10 @@ public class PersistentTopic extends AbstractTopic
                 int numActiveConsumers = subscriptions.values().stream()
                         .map(subscription -> subscription.getConsumers().size())
                         .reduce(0, Integer::sum);
-                if (hasSchema || (numActiveConsumers != 0) || (ledger.getTotalSize() != 0)) {
+                if (hasSchema
+                        || (!producers.isEmpty())
+                        || (numActiveConsumers != 0)
+                        || (ledger.getTotalSize() != 0)) {
                     return checkSchemaCompatibleForConsumer(schema);
                 } else {
                     return addSchema(schema).thenCompose(schemaVersion ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2511,8 +2511,8 @@ public class PersistentTopic extends AbstractTopic
         return hasSchema()
             .thenCompose((hasSchema) -> {
                 int numActiveConsumers = subscriptions.values().stream()
-                        .map(subscription -> subscription.getConsumers().size())
-                        .reduce(0, Integer::sum);
+                        .mapToInt(subscription -> subscription.getConsumers().size())
+                        .sum();
                 if (hasSchema
                         || (!producers.isEmpty())
                         || (numActiveConsumers != 0)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -631,34 +631,28 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         final String topic1 = "persistent://my-property/my-ns/testAutoCreatedSchema-1";
         final String topic2 = "persistent://my-property/my-ns/testAutoCreatedSchema-2";
 
-        try (Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic1).create()) {
-            // topic1's schema becomes BYTES now.
-        }
+        pulsarClient.newProducer(Schema.BYTES).topic(topic1).create().close();
         try {
+            // BYTES schema is treated as no schema
             admin.schemas().getSchemaInfo(topic1);
             fail("The schema of topic1 should not exist");
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 404);
         }
-        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic1).create()) {
-            // Should pass, STRING schema is compatible with BYTES schema
-        }
+        pulsarClient.newProducer(Schema.STRING).topic(topic1).create().close();
+        // topic1's schema becomes STRING now
         Assert.assertEquals(admin.schemas().getSchemaInfo(topic1).getType(), SchemaType.STRING);
 
-        try (Consumer<byte[]> consumer
-                     = pulsarClient.newConsumer(Schema.BYTES).topic(topic2).subscriptionName("sub").subscribe()) {
-            // topic2's schema becomes BYTES now.
-        }
+        pulsarClient.newConsumer(Schema.BYTES).topic(topic2).subscriptionName("sub").subscribe().close();
         try {
+            // BYTES schema is treated as no schema
             admin.schemas().getSchemaInfo(topic2);
             fail("The schema of topic2 should not exist");
         } catch (PulsarAdminException e) {
             Assert.assertEquals(e.getStatusCode(), 404);
         }
-        try (Consumer<String> consumer
-                     = pulsarClient.newConsumer(Schema.STRING).topic(topic2).subscriptionName("sub").subscribe()) {
-            // topic2's schema becomes BYTES now.
-        }
+        pulsarClient.newConsumer(Schema.STRING).topic(topic2).subscriptionName("sub").subscribe().close();
+        // topic2's schema becomes STRING now.
         Assert.assertEquals(admin.schemas().getSchemaInfo(topic2).getType(), SchemaType.STRING);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -56,7 +56,6 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -75,6 +74,11 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     @DataProvider(name = "schemaValidationModes")
     public static Object[][] schemaValidationModes() {
         return new Object[][] { { true }, { false } };
+    }
+
+    @DataProvider(name = "topicDomain")
+    public static Object[] topicDomain() {
+        return new Object[] { "persistent://", "non-persistent://" };
     }
 
     private final boolean schemaValidationEnforced;
@@ -640,10 +644,10 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         Assert.assertTrue(binaryLookupService.getSchema(TopicName.get(topic), ByteBuffer.allocate(8).putLong(1).array()).get().isPresent());
     }
 
-    @Test
-    public void testAutoCreatedSchema() throws Exception {
-        final String topic1 = "persistent://my-property/my-ns/testAutoCreatedSchema-1";
-        final String topic2 = "persistent://my-property/my-ns/testAutoCreatedSchema-2";
+    @Test(dataProvider = "topicDomain")
+    public void testAutoCreatedSchema(String domain) throws Exception {
+        final String topic1 = domain + "my-property/my-ns/testAutoCreatedSchema-1";
+        final String topic2 = domain + "my-property/my-ns/testAutoCreatedSchema-2";
 
         pulsarClient.newProducer(Schema.BYTES).topic(topic1).create().close();
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -56,6 +56,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -422,6 +423,19 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
             V1Data toSend = new V1Data(1);
             p.send(toSend);
             Assert.assertEquals(toSend, c.receive().getValue());
+        }
+    }
+
+    @Test
+    public void newConsumerWithSchemaOnExistingTopicWithoutSchema() throws Exception {
+        String topic = "my-property/my-ns/schema-test";
+
+        try (Producer<byte[]> p = pulsarClient.newProducer().topic(topic).create();
+             Consumer<V1Data> c = pulsarClient.newConsumer(Schema.AVRO(V1Data.class))
+                     .topic(topic).subscriptionName("sub1").subscribe()) {
+            Assert.fail("Shouldn't be able to consume with a schema from a topic which has no schema set");
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof IncompatibleSchemaException);
         }
     }
 


### PR DESCRIPTION
Fixes #7728 

### Motivation

When a consumer with a schema subscribes an empty topic without schema, the current check uses `isActive`, which only checks if the topic can be deleted. However, it should check if there's any connected producer or consumer of this topic. For current implementation, even if a topic has no active producers of consumers, the topic's subscription list may be not empty and `isActive` will return true. Then the schema of consumer won't be attached to the topic and it will throw an `IncompatibleSchemaException`.

### Modifications

- Check if the topic has active producers or consumers instead of whether it can be deleted.
- Add related tests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests `testAutoCreatedSchema`.