### PR TITLE
[Documentation][Geo Replication] Document clusters create step in geo replication

### DIFF
--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -47,11 +47,17 @@ As stated in [Geo-replication and Pulsar properties](#geo-replication-and-pulsar
 
 The following example connects three clusters: **us-east**, **us-west**, and **us-cent**.
 
-### Connect Clusters
+### Connect replication clusters
 
-To replicate among clusters, you must first configure each cluster to connect to the other. You can use the [`pulsar-admin`](reference-pulsar-admin.md#clusters) tool to create the connection.
+To replicate data among clusters, you need to configure each cluster to connect to the other. You can use the [`pulsar-admin`](http://pulsar.apache.org/tools/pulsar-admin/) tool to create a connection.
 
-Run the following command in **us-west** to configure the connection to **us-east**:
+**Example**
+
+Suppose that you have 3 replication clusters: `us-west`, `us-cent`, and `us-east`.
+
+1. Configure the connection from `us-west` to `us-east`.
+
+   Run the following command on `us-west`.
 
 ```shell
 $ bin/pulsar-admin clusters create \
@@ -60,7 +66,13 @@ $ bin/pulsar-admin clusters create \
   us-east
 ```
 
-Then, run the following command in **us-west** to configure the connection to **us-cent**:
+   > #### Tip
+   >
+   > If you want to use a secure connection for a cluster, you can use the flags `--broker-url-secure` and `--url-secure`. For more information, see [pulsar-admin clusters create](http://pulsar.apache.org/tools/pulsar-admin/).
+
+2. Configure the connection from `us-west` to `us-cent`.
+
+   Run the following command on `us-west`.
 
 ```shell
 $ bin/pulsar-admin clusters create \
@@ -69,7 +81,7 @@ $ bin/pulsar-admin clusters create \
   us-cent
 ```
 
-Analogous commands will need to be run in **us-east** and **us-cent** to create the remaining necessary cluster connections for replication. For clusters using a secure connection, see the [`pulsar-admin`](reference-pulsar-admin.md#clusters) create command. 
+3. Run similar commands on `us-east` and `us-cent` to create connections among clusters.
 
 ### Grant permissions to properties
 

--- a/site2/docs/administration-geo.md
+++ b/site2/docs/administration-geo.md
@@ -45,6 +45,32 @@ All messages produced in any of the three clusters are delivered to all subscrip
 
 As stated in [Geo-replication and Pulsar properties](#geo-replication-and-pulsar-properties) section, geo-replication in Pulsar is managed at the [tenant](reference-terminology.md#tenant) level.
 
+The following example connects three clusters: **us-east**, **us-west**, and **us-cent**.
+
+### Connect Clusters
+
+To replicate among clusters, you must first configure each cluster to connect to the other. You can use the [`pulsar-admin`](reference-pulsar-admin.md#clusters) tool to create the connection.
+
+Run the following command in **us-west** to configure the connection to **us-east**:
+
+```shell
+$ bin/pulsar-admin clusters create \
+  --broker-url pulsar://<DNS-OF-US-EAST>:<PORT>	\
+  --url http://<DNS-OF-US-EAST>:<PORT> \
+  us-east
+```
+
+Then, run the following command in **us-west** to configure the connection to **us-cent**:
+
+```shell
+$ bin/pulsar-admin clusters create \
+  --broker-url pulsar://<DNS-OF-US-CENT>:<PORT>	\
+  --url http://<DNS-OF-US-CENT>:<PORT> \
+  us-cent
+```
+
+Analogous commands will need to be run in **us-east** and **us-cent** to create the remaining necessary cluster connections for replication. For clusters using a secure connection, see the [`pulsar-admin`](reference-pulsar-admin.md#clusters) create command. 
+
 ### Grant permissions to properties
 
 To replicate to a cluster, the tenant needs permission to use that cluster. You can grant permission to the tenant when you create the tenant or grant later.


### PR DESCRIPTION
### Motivation

The geo replication documentation should reference the way to configure connections among clusters, as they are essential to configuring geo replication.

### Modifications

Added documentation to the primary site2 documentation.

### Question

I think it'd be valuable to update the documentation for earlier versions of pulsar, but I haven't looked into it yet. If these changes are accepted, I'm happy to discuss which versions to update.

### Acknowledgements

I want to acknowledge that the content for this documentation update is motivated by @pckeyan's blog: https://medium.com/@pckeyan/apache-pulsar-geo-replication-ad4f0ca3224b. The change is not a straight copy from the blog, though.