### PR TITLE
pulsar-perf: add ability to create partitioned topics

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -123,18 +123,18 @@ public class PerformanceClient {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.help) {
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.topics.size() != 1) {
             System.err.println("Only one topic name is allowed");
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.confFile != null) {
@@ -145,7 +145,7 @@ public class PerformanceClient {
             } catch (IOException e) {
                 log.error("Error in loading config file");
                 jc.usage();
-                System.exit(1);
+                PerfClientUtils.exit(1);
             }
 
             if (isBlank(arguments.proxyURL)) {
@@ -248,7 +248,7 @@ public class PerformanceClient {
                             if (totalSent >= messages) {
                                 log.trace("------------------- DONE -----------------------");
                                 Thread.sleep(10000);
-                                System.exit(0);
+                                PerfClientUtils.exit(0);
                             }
                         }
 
@@ -256,7 +256,7 @@ public class PerformanceClient {
 
                         if (producersMap.get(topic).getSocket().getSession() == null) {
                             Thread.sleep(10000);
-                            System.exit(0);
+                            PerfClientUtils.exit(0);
                         }
                         producersMap.get(topic).getSocket().sendMsg(String.valueOf(totalSent++), sizeOfMessage);
                         messagesSent.increment();
@@ -266,7 +266,7 @@ public class PerformanceClient {
 
             } catch (Throwable t) {
                 log.error(t.getMessage());
-                System.exit(0);
+                PerfClientUtils.exit(0);
             }
         });
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
@@ -479,7 +479,7 @@ public class BrokerMonitor {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
         final ZooKeeper zkClient = new ZooKeeper(arguments.connectString, ZOOKEEPER_TIMEOUT_MILLIS, null);
         final BrokerMonitor monitor = new BrokerMonitor(zkClient);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -342,7 +342,7 @@ public class LoadSimulationClient {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
         PerfClientUtils.printJVMInformation(log);
         (new LoadSimulationClient(mainArguments)).run();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
@@ -678,7 +678,7 @@ public class LoadSimulationController {
                     break;
                 case "quit":
                 case "exit":
-                    System.exit(0);
+                    PerfClientUtils.exit(0);
                     break;
                 default:
                     log.info("ERROR: Unknown command \"{}\"", command);
@@ -720,7 +720,7 @@ public class LoadSimulationController {
         } catch (Exception ex) {
             System.out.println(ex.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
         (new LoadSimulationController(arguments)).run();
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -132,12 +132,12 @@ public class ManagedLedgerWriter {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.help) {
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         arguments.testTime = TimeUnit.SECONDS.toMillis(arguments.testTime);
@@ -247,7 +247,7 @@ public class ManagedLedgerWriter {
                         @Override
                         public void addFailed(ManagedLedgerException exception, Object ctx) {
                             log.warn("Write error on message", exception);
-                            System.exit(-1);
+                            PerfClientUtils.exit(-1);
                         }
                     };
 
@@ -261,7 +261,7 @@ public class ManagedLedgerWriter {
                                     printAggregatedStats();
                                     isDone.set(true);
                                     Thread.sleep(5000);
-                                    System.exit(0);
+                                    PerfClientUtils.exit(0);
                                 }
                             }
 
@@ -271,7 +271,7 @@ public class ManagedLedgerWriter {
                                     printAggregatedStats();
                                     isDone.set(true);
                                     Thread.sleep(5000);
-                                    System.exit(0);
+                                    PerfClientUtils.exit(0);
                                 }
                             }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -23,12 +23,25 @@ import lombok.experimental.UtilityClass;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import java.lang.management.ManagementFactory;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 /**
  * Utility for test clients
  */
 @UtilityClass
 public class PerfClientUtils {
+
+    private static volatile  Consumer<Integer> exitProcedure = System::exit;
+
+    public static void setExitProcedure(Consumer<Integer> exitProcedure) {
+        PerfClientUtils.exitProcedure = Objects.requireNonNull(exitProcedure);
+    }
+
+    public static void exit(int code) {
+        exitProcedure.accept(code);
+    }
 
     /**
      * Print useful JVM information, you need this information in order to be able
@@ -40,4 +53,6 @@ public class PerfClientUtils {
         log.info("Netty max memory (PlatformDependent.maxDirectMemory()) {}", FileUtils.byteCountToDisplaySize(PlatformDependent.maxDirectMemory()));
         log.info("JVM max heap memory (Runtime.getRuntime().maxMemory()) {}", FileUtils.byteCountToDisplaySize(Runtime.getRuntime().maxMemory()));
     }
+
+
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -179,12 +179,12 @@ public class PerformanceConsumer {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.help) {
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
@@ -199,14 +199,14 @@ public class PerformanceConsumer {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topics");
                 jc.usage();
-                System.exit(-1);
+                PerfClientUtils.exit(-1);
             }
         }
 
         if (arguments.subscriptionType == SubscriptionType.Exclusive && arguments.numConsumers > 1) {
             System.out.println("Only one consumer is allowed when subscriptionType is Exclusive");
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.subscriptionType != SubscriptionType.Exclusive &&
@@ -222,7 +222,7 @@ public class PerformanceConsumer {
             } else {
                 System.out.println("The size of subscriptions list should be equal to --num-consumers when subscriptionType isn't Exclusive");
                 jc.usage();
-                System.exit(-1);
+                PerfClientUtils.exit(-1);
             }
         }
 
@@ -275,7 +275,7 @@ public class PerformanceConsumer {
                 if (System.nanoTime() > testEndTime) {
                     log.info("------------------- DONE -----------------------");
                     printAggregatedStats();
-                    System.exit(0);
+                    PerfClientUtils.exit(0);
                 }
             }
             messagesReceived.increment();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -240,12 +240,12 @@ public class PerformanceProducer {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.help) {
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.topics != null && arguments.topics.size() != arguments.numTopics) {
@@ -260,7 +260,7 @@ public class PerformanceProducer {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topic");
                 jc.usage();
-                System.exit(-1);
+                PerfClientUtils.exit(-1);
             }
         }
 
@@ -369,7 +369,7 @@ public class PerformanceProducer {
                         if (partitionedTopicMetadata.partitions != arguments.partitions) {
                             log.error("Topic {} already exists but it has a wrong number of partitions: {}, expecting {}",
                                     topic, partitionedTopicMetadata.partitions, arguments.partitions);
-                            System.exit(-1);
+                            PerfClientUtils.exit(-1);
                         }
                     }
                 }
@@ -558,7 +558,7 @@ public class PerformanceProducer {
                             printAggregatedStats();
                             doneLatch.countDown();
                             Thread.sleep(5000);
-                            System.exit(0);
+                            PerfClientUtils.exit(0);
                         }
                     }
 
@@ -568,7 +568,7 @@ public class PerformanceProducer {
                             printAggregatedStats();
                             doneLatch.countDown();
                             Thread.sleep(5000);
-                            System.exit(0);
+                            PerfClientUtils.exit(0);
                         }
                     }
                     rateLimiter.acquire();
@@ -616,7 +616,7 @@ public class PerformanceProducer {
                         log.warn("Write error on message", ex);
                         messagesFailed.increment();
                         if (arguments.exitOnFailure) {
-                            System.exit(-1);
+                            PerfClientUtils.exit(-1);
                         }
                         return null;
                     });

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -69,6 +69,8 @@ import org.apache.pulsar.client.api.TypedMessageBuilder;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
+
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.testclient.utils.PaddingDecimalFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -361,6 +363,12 @@ public class PerformanceProducer {
                         client.topics().createPartitionedTopic(topic, arguments.createTopicPartitions);
                     } catch (PulsarAdminException.ConflictException alreadyExists) {
                         log.debug("Topic "+topic+" already exists: " + alreadyExists);
+                        PartitionedTopicMetadata partitionedTopicMetadata = client.topics().getPartitionedTopicMetadata(topic);
+                        if (partitionedTopicMetadata.partitions != arguments.createTopicPartitions) {
+                            log.error("Topic {} already exists but it has a wrong number of partitions: {}, expecting {}",
+                                    topic, partitionedTopicMetadata.partitions, arguments.createTopicPartitions);
+                            System.exit(-1);
+                        }
                     }
                 }
             }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -130,12 +130,12 @@ public class PerformanceReader {
         } catch (ParameterException e) {
             System.out.println(e.getMessage());
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.help) {
             jc.usage();
-            System.exit(-1);
+            PerfClientUtils.exit(-1);
         }
 
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
@@ -150,7 +150,7 @@ public class PerformanceReader {
             } else {
                 System.out.println("The size of topics list should be equal to --num-topics");
                 jc.usage();
-                System.exit(-1);
+                PerfClientUtils.exit(-1);
             }
         }
 
@@ -206,7 +206,7 @@ public class PerformanceReader {
             if (arguments.testTime > 0) {
                 if (System.nanoTime() > testEndTime) {
                     log.info("------------------- DONE -----------------------");
-                    System.exit(0);
+                    PerfClientUtils.exit(0);
                 }
             }
             messagesReceived.increment();

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -143,4 +143,21 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         newConsumer1.close();
         newConsumer2.close();
     }
+
+    @Test(timeOut = 20000)
+    public void testCreatePartitions() throws Exception {
+        String argString = "%s -r 10 -u %s -au %s -m 5 -np 10";
+        String topic = testTopic + UUID.randomUUID().toString();
+        String args = String.format(argString, topic, pulsar.getBrokerServiceUrl(), pulsar.getWebServiceAddress());
+        Thread thread = new Thread(() -> {
+            try {
+                PerformanceProducer.main(args.split(" "));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        thread.start();
+        thread.join();
+        Assert.assertEquals(10, pulsar.getAdminClient().topics().getPartitionedTopicMetadata(topic).partitions);
+    }
 }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -32,17 +33,28 @@ import org.testng.annotations.Test;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.testng.Assert.fail;
+
+@Slf4j
 public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
     private final String testTenant = "prop-xyz";
     private final String testNamespace = "ns1";
     private final String myNamespace = testTenant + "/" + testNamespace;
     private final String testTopic = "persistent://" + myNamespace + "/test-";
+    private final AtomicInteger lastExitCode = new AtomicInteger(0);
 
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
+        PerfClientUtils.setExitProcedure(code -> {
+            log.error("JVM exit code is {}", code);
+            if (code != 0) {
+                throw new RuntimeException("JVM should exit with code " + code);
+            }
+        });
         // Setup namespaces
         admin.clusters().createCluster("test", new ClusterData(pulsar.getWebServiceAddress()));
         TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
@@ -54,6 +66,10 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        int exitCode = lastExitCode.get();
+        if (exitCode != 0) {
+            fail("Unexpected JVM exit code "+exitCode);
+        }
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
### Motivation
When you are using pulsar-perf you have to pre-create the topic if you want it to be partitioned.
This is very awkward and error prone.

### Modifications

This patch adds the ability to set a number of partitions.
Before starting the main procedure we are going to create the topics as partitioned topics.
I needed to add support to pass explicitly the http service url, because by default the serverURL is the binary protocol URL and it is not suitable for PulsarAdmin. The default value is http://localhost:8080.

I added support for not calling System.exit and execute a custom callback, otherwise it is not possible to execute reliably the tests without crashing the JVM.

### Verifying this change

This change added tests and can be verified bu testing manually the new option.

### Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? internal help for pulsar-perf (just run "pulsar-perf produce" in order to see the help)
