### PR TITLE
Pulsar client: allow to detect duplicate messages and to dump statistics

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -440,7 +440,7 @@ public class CmdConsume {
             AtomicLong count = messagesPerKey.computeIfAbsent(key, k -> new AtomicLong());
             long newValue = count.incrementAndGet();
             if (failOnDuplicateKey && newValue == 2) {
-                String message = "Key '"+key+"' has been received more than once";
+                String message = "Key '" + key + "' has been received more than once";
                 log.error(message);
                 throw new Exception(message);
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -36,7 +36,10 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
### Motivation and Modifications

This patch adds two features to pulsar-client:
- ability to dump a summary of the messages that have been received
- ability to fail in case of a reception of a duplicate message

With this two feature it is easy to use pulsar-client to automate consistency checks and check against data loss and message duplication errors.

You can use this feature in conjunction with `pulsar-perf produce -mk autoIncrement` and send load to your pulsar cluster, then you can validate that your are not losing messages and that you are not receiving the same message twice.

### Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? documented on the inline help
 