### PR TITLE
[Docs] Message Queue example in Go

### DIFF
--- a/site2/docs/cookbooks-message-queue.md
+++ b/site2/docs/cookbooks-message-queue.md
@@ -92,3 +92,26 @@ Consumer consumer;
 Result result = client.subscribe(topic, subscription, consumerConfig, consumer);
 ```
 
+## Go clients
+
+Here is an example of a Go consumer configuration that uses a shared subscription:
+
+```go
+import "github.com/apache/pulsar-client-go/pulsar"
+
+client, err := pulsar.NewClient(pulsar.ClientOptions{
+    URL: "pulsar://localhost:6650",
+})
+if err != nil {
+    log.Fatal(err)
+}
+consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+    Topic:             "persistent://public/default/mq-topic-1",
+    SubscriptionName:  "sub-1",
+    Type:              pulsar.Shared,
+    ReceiverQueueSize: 10, // If you'd like to restrict the receiver queue size
+})
+if err != nil {
+    log.Fatal(err)
+}
+```

--- a/site2/website/versioned_docs/version-2.7.0/cookbooks-message-queue.md
+++ b/site2/website/versioned_docs/version-2.7.0/cookbooks-message-queue.md
@@ -93,3 +93,26 @@ Consumer consumer;
 Result result = client.subscribe(topic, subscription, consumerConfig, consumer);
 ```
 
+## Go clients
+
+Here is an example of a Go consumer configuration that uses a shared subscription:
+
+```go
+import "github.com/apache/pulsar-client-go/pulsar"
+
+client, err := pulsar.NewClient(pulsar.ClientOptions{
+    URL: "pulsar://localhost:6650",
+})
+if err != nil {
+    log.Fatal(err)
+}
+consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+    Topic:             "persistent://public/default/mq-topic-1",
+    SubscriptionName:  "sub-1",
+    Type:              pulsar.Shared,
+    ReceiverQueueSize: 10, // If you'd like to restrict the receiver queue size
+})
+if err != nil {
+    log.Fatal(err)
+}
+```


### PR DESCRIPTION
### Motivation

The Go pulsar client works perfectly for message queue scenarios, the docs should contain an example in Go so new adopters don't think Go is a second-class citizen driver in Pulsar.

### Modifications

* Added new example to demo shared consumers for both `next` and `2.7.0` docs

### Verifying this change

`site2/website && yarn start` renders correctly for both master and 2.7.0 versioned sites in the page `Using Pulsar as a message queue`, urls:

- http://localhost:3000/docs/en/next/cookbooks-message-queue
- http://localhost:3000/docs/en/cookbooks-message-queue

