### PR TITLE
[Flaky test] Fix flaky test PulsarFunctionsTest.testExclamationFunction

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.gson.Gson;
-
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
@@ -35,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.Failsafe;
@@ -93,6 +91,7 @@ import org.apache.pulsar.tests.integration.io.SourceTester;
 import org.apache.pulsar.tests.integration.topologies.FunctionRuntimeType;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.shaded.com.google.common.collect.Sets;
 import org.testng.annotations.Test;
@@ -1647,8 +1646,13 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         // update parallelism
         updateFunctionParallelism(functionName, 2);
 
-        //get function status
-        getFunctionStatus(functionName, 0, true, 2);
+        Awaitility.await()
+                .pollInterval(Duration.ofMillis(500L))
+                .ignoreExceptions()
+                .untilAsserted(() ->
+                //get function status
+                getFunctionStatus(functionName, 0, true, 2)
+        );
 
         // delete function
         deleteFunction(functionName);


### PR DESCRIPTION
Fixes #9863

### Motivation

Fixes flaky test PulsarFunctionsTest.testExclamationFunction , see #9863

### Modifications

After updating function parallelism to 2, use Awaitility to poll for the updated status.