### PR TITLE
[Flaky test] Reduce flakiness in MultiTopicsReaderTest by configuring infinite retention

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
@@ -68,7 +69,11 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
                 new ClusterData(pulsar.getWebServiceAddress()));
         admin.tenants().createTenant("my-property",
                 new TenantInfo(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
-        admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));
+        Policies policies = new Policies();
+        policies.replication_clusters = Sets.newHashSet("test");
+        // infinite retention
+        policies.retention_policies = new RetentionPolicies(-1, -1);
+        admin.namespaces().createNamespace("my-property/my-ns", policies);
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
### Motivation

This is an attempt to fix #9636. By configuring infinite retention for the namespace, it ensures that retention handling doesn't cause messages to get discarded before they are consumes and therefore reducing flakiness of the test.

### Modifications

Configure infinite retention for the namespace used in the test.