### PR TITLE
[Build] Upgrade Apache parent pom version and upgrade maven plugins

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -33,6 +33,11 @@
   <version>2.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Pulsar Build Tools</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -72,13 +77,6 @@
           <mapping>
             <java>JAVADOC_STYLE</java>
           </mapping>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -50,8 +50,8 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>distro-assembly</id>

--- a/distribution/io/src/assemble/io.xml
+++ b/distribution/io/src/assemble/io.xml
@@ -18,10 +18,9 @@
     under the License.
 
 -->
-<assembly
-  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>bin</id>
   <formats>
     <format>dir</format>

--- a/distribution/offloaders/pom.xml
+++ b/distribution/offloaders/pom.xml
@@ -70,8 +70,8 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>distro-assembly</id>

--- a/distribution/offloaders/src/assemble/offloaders.xml
+++ b/distribution/offloaders/src/assemble/offloaders.xml
@@ -18,10 +18,9 @@
     under the License.
 
 -->
-<assembly
-  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>bin</id>
   <formats>
     <format>tar.gz</format>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -282,8 +282,8 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>distro-assembly</id>

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -18,10 +18,9 @@
     under the License.
 
 -->
-<assembly
-  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
@@ -64,6 +63,18 @@
     <fileSet>
       <directory>${basedir}/../../pulsar-sql/presto-distribution/target/pulsar-presto-distribution</directory>
       <outputDirectory>lib/presto</outputDirectory>
+      <excludes>
+        <exclude>bin</exclude>
+        <exclude>bin/**</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/../../pulsar-sql/presto-distribution/target/pulsar-presto-distribution</directory>
+      <outputDirectory>lib/presto</outputDirectory>
+      <includes>
+        <include>bin/**</include>
+      </includes>
+      <fileMode>755</fileMode>
     </fileSet>
   </fileSets>
   <files>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -30,6 +30,11 @@
   <name>Apache Pulsar :: Docker Images :: Pulsar Latest Version</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <skipBuildPythonClient>false</skipBuildPythonClient>
+    <skipCopyPythonClients>false</skipCopyPythonClients>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>
@@ -77,6 +77,9 @@ flexible messaging model and an intuitive client API.</description>
   </issueManagement>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <!--config keys to congiure test selection -->
     <include>*</include>
     <exclude/>
@@ -93,6 +96,7 @@ flexible messaging model and an intuitive client API.</description>
     <testRetryCount>1</testRetryCount>
     <docker.organization>apachepulsar</docker.organization>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
+    <skipBuildDistribution>false</skipBuildDistribution>
 
     <!-- apache commons -->
     <commons-compress.version>1.19</commons-compress.version>
@@ -206,30 +210,28 @@ flexible messaging model and an intuitive client API.</description>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <aspectj-maven-plugin.version>1.11.1</aspectj-maven-plugin.version>
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
     <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <!-- surefire.version is defined in apache parent pom -->
+    <!-- it is used for surefire, failsafe and surefire-report plugins -->
+    <!-- do not upgrade surefire.version to 3.0.0-M5 since it runs slowly and breaks tests. -->
+    <surefire.version>3.0.0-M3</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-    <maven-clean-plugin.version>2.4.1</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin>3.2.4</maven-shade-plugin>
-    <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
-    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-    <maven-archiver.version>2.5</maven-archiver.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <git-commit-id-plugin.version>4.0.2</git-commit-id-plugin.version>
-    <wagon-ssh-external.version>2.10</wagon-ssh-external.version>
+    <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
-    <spotbugs-maven-plugin.version>4.1.3</spotbugs-maven-plugin.version>
-    <spotbugs.version>4.2.0</spotbugs.version>
-    <errorprone.version>2.4.0</errorprone.version>
+    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
+    <spotbugs.version>4.2.2</spotbugs.version>
+    <errorprone.version>2.5.1</errorprone.version>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <lightproto-maven-plugin.version>0.2</lightproto-maven-plugin.version>
@@ -1129,8 +1131,6 @@ flexible messaging model and an intuitive client API.</description>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <encoding>UTF-8</encoding>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
@@ -1510,7 +1510,6 @@ flexible messaging model and an intuitive client API.</description>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <includes>
                 <include>${include}</include>
@@ -1528,23 +1527,15 @@ flexible messaging model and an intuitive client API.</description>
           <version>${maven-dependency-plugin.version}</version>
         </plugin>
         <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>${maven-clean-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
           <configuration>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>none</doclint>
           </configuration>
         </plugin>
         <plugin>
@@ -1555,11 +1546,6 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-archiver</artifactId>
-          <version>${maven-archiver.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.nifi</groupId>

--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -80,7 +80,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
         <configuration>
           <!-- get all project dependencies -->
           <descriptorRefs>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>23</version>
     </parent>
 
     <groupId>org.apache.pulsar</groupId>
@@ -34,7 +34,9 @@
     <version>2.8.0-SNAPSHOT</version>
 
     <properties>
-        <jersey.version>2.31</jersey.version>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <jersey.version>2.31</jersey.version>
         <presto.version>332</presto.version>
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
@@ -262,9 +264,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>
@@ -324,19 +323,12 @@
                 </mapping>
               </configuration>
             </plugin>
-            <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
-              </configuration>
-            </plugin>
         </plugins>
         <extensions>
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ssh-external</artifactId>
-                <version>2.10</version>
+                <version>3.4.3</version>
             </extension>
         </extensions>
     </build>

--- a/pulsar-sql/presto-distribution/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-distribution/src/assembly/assembly.xml
@@ -18,9 +18,9 @@
     under the License.
 
 -->
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>bin</id>
     <formats>
         <format>tar.gz</format>
@@ -55,6 +55,13 @@
             <outputDirectory></outputDirectory>
             <includes>
                 <include>io.airlift:launcher:tar.gz:bin:${airlift.version}</include>
+            </includes>
+            <unpack>true</unpack>
+            <fileMode>755</fileMode>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory></outputDirectory>
+            <includes>
                 <include>io.airlift:launcher:tar.gz:properties:${airlift.version}</include>
             </includes>
             <unpack>true</unpack>

--- a/pulsar-sql/presto-pulsar-plugin/pom.xml
+++ b/pulsar-sql/presto-pulsar-plugin/pom.xml
@@ -52,9 +52,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>

--- a/pulsar-sql/presto-pulsar-plugin/src/assembly/assembly.xml
+++ b/pulsar-sql/presto-pulsar-plugin/src/assembly/assembly.xml
@@ -18,9 +18,9 @@
     under the License.
 
 -->
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>bin</id>
     <formats>
         <format>tar.gz</format>

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -153,9 +153,9 @@
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>${aspectj-maven-plugin.version}</version>
         <configuration>
-          <complianceLevel>1.8</complianceLevel>
-          <source>1.8</source>
-          <target>1.8</target>
+          <complianceLevel>${maven.compiler.target}</complianceLevel>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
           <showWeaveInfo>true</showWeaveInfo>
         </configuration>
         <executions>

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -39,12 +39,12 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
     </dependency>
-    
+
     <dependency>
        <groupId>io.dropwizard.metrics</groupId>
        <artifactId>metrics-core</artifactId>
@@ -98,9 +98,9 @@
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>${aspectj-maven-plugin.version}</version>
         <configuration>
-          <complianceLevel>1.8</complianceLevel>
-          <source>1.8</source>
-          <target>1.8</target>
+          <complianceLevel>${maven.compiler.target}</complianceLevel>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
           <showWeaveInfo>true</showWeaveInfo>
           <weaveDependencies>
             <weaveDependency>


### PR DESCRIPTION
### Motivation

- The current version of [Apache Parent POM](https://github.com/apache/maven-apache-parent) in use is version 18. It is from May 2016

### Modifications

- use [most recent Apache Parent POM version 23 from January 2020](https://search.maven.org/artifact/org.apache/apache)
- use `surefire.version` property to set surefire version, since that's the way the parent pom supports
- use `maven.compiler.source` / `maven.compiler.target` properties since that's what the parent pom supports
- use `maven.compiler.source` / `maven.compiler.target` properties also for setting `aspectj-maven-plugin` configuration
- remove plugin overrides for plugins that are at sufficient level in parent pom
  - maven-clean-plugin
  - maven-compiler-plugin
  - maven-javadoc-plugin
- fix issue with Pulsar SQL / Presto distribution launcher not having execution permissions set
  - upgrade assembly descriptor files to use newer xml schema consistently
  - set fileMode 755 for launcher files
- upgrade most maven plugins to recent versions
  - exec-maven-plugin 1.6.0 -> 3.0.0
  - maven-enforcer-plugin 3.0.0-M2 -> 3.0.0-M3
  - maven-checkstyle-plugin 3.1.1 -> 3.1.2
  - wagon-ssh-external 2.10 -> 3.4.3
  - jacoco-maven-plugin 0.8.3 -> 0.8.6
  - spotbugs-maven-plugin 4.1.3 -> 4.2.2
- build related libraries
  - spotbugs 4.2.0 -> 4.2.2
  - errorprone 2.4.0 -> 2.5.1
