### PR TITLE
[Flaky test] Fix flaky RabbitMQSourceTest

### DIFF
--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -66,7 +66,7 @@ public class RabbitMQSinkTest {
 
         // open should success
         // rabbitmq service may need time to initialize
-        Awaitility.await().untilAsserted(() -> sink.open(configs, null));
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> sink.open(configs, null));
 
         // write should success
         Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.rabbitmq.source;
 
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSource;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -64,7 +65,8 @@ public class RabbitMQSourceTest {
         RabbitMQSource source = new RabbitMQSource();
 
         // open should success
-        source.open(configs, null);
+        // rabbitmq service may need time to initialize
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> source.open(configs, null));
     }
 
 }


### PR DESCRIPTION
### Motivation

RabbitMQSourceTest is flaky. It fails sporadically since RabbitMQ might not be started when the test proceeds to access RabbitMQ.

### Modifications

Make a similar change to RabbitMQSourceTest as was done for RabbitMQSinkTest in #9356.
It's also necessary to add `.ignoreExceptions()` to the `Awaitility` configuration so that exceptions are ignored.

