### PR TITLE
[Tests] Pass stdout and stderr in error message when it's asserted to be empty

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -88,8 +88,7 @@ public class CLITest extends PulsarTestSuite {
                 "--subscription",
                 "" + subscriptionPrefix + i
             );
-            assertTrue(result.getStdout().isEmpty());
-            assertTrue(result.getStderr().isEmpty());
+            result.assertNoOutput();
             i++;
         }
     }
@@ -161,8 +160,7 @@ public class CLITest extends PulsarTestSuite {
             "-f",
             "/pulsar/conf/schema_example.conf"
         );
-        assertTrue(result.getStdout().isEmpty());
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoOutput();
 
         // get schema
         result = container.execCmd(
@@ -178,8 +176,7 @@ public class CLITest extends PulsarTestSuite {
             "schemas",
             "delete",
             topicName);
-        assertTrue(result.getStdout().isEmpty());
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoOutput();
 
         // get schema again
         try {
@@ -208,14 +205,7 @@ public class CLITest extends PulsarTestSuite {
         };
 
         result = pulsarCluster.runAdminCommandOnAnyBroker(setCommand);
-        assertTrue(
-            result.getStdout().isEmpty(),
-            result.getStdout()
-        );
-        assertTrue(
-            result.getStderr().isEmpty(),
-            result.getStdout()
-        );
+        result.assertNoOutput();
 
         String[] getCommand = {
             "namespaces", "get-retention", "public/" + namespace

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/FunctionsCLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/FunctionsCLITest.java
@@ -85,8 +85,7 @@ public class FunctionsCLITest extends PulsarFunctionsTestBase {
         };
         output = container.execCmd(diffCommand);
         assertEquals(0, output.getExitCode());
-        assertTrue(output.getStdout().isEmpty());
-        assertTrue(output.getStderr().isEmpty());
+        output.assertNoOutput();
     }
 
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
@@ -131,7 +131,7 @@ public class PackagesCliTest {
 
         result = runPackagesCommand("list-versions", "function://public/default/test");
         assertEquals(result.getExitCode(), 0);
-        assertTrue(result.getStdout().isEmpty());
+        result.assertNoStdout();
     }
 
     private ContainerExecResult runPackagesCommand(String... commands) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/docker/ContainerExecResult.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/docker/ContainerExecResult.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.docker;
 
+import static org.testng.Assert.assertTrue;
 import lombok.Data;
 
 /**
@@ -30,4 +31,18 @@ public class ContainerExecResult {
     private final String stdout;
     private final String stderr;
 
+    public void assertNoOutput() {
+        assertNoStdout();
+        assertNoStderr();
+    }
+
+    public void assertNoStdout() {
+        assertTrue(stdout.isEmpty(),
+                "stdout should be empty, but was '" + stdout + "'");
+    }
+
+    public void assertNoStderr() {
+        assertTrue(stderr.isEmpty(),
+                "stderr should be empty, but was '" + stderr + "'");
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -570,10 +570,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             result.getStdout().contains("Deleted successfully"),
             result.getStdout()
         );
-        assertTrue(
-            result.getStderr().isEmpty(),
-            result.getStderr()
-        );
+        result.assertNoStderr();
     }
 
     protected void getSinkInfoNotFound(String tenant, String namespace, String sinkName) throws Exception {
@@ -843,10 +840,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             result.getStdout().contains("Delete source successfully"),
             result.getStdout()
         );
-        assertTrue(
-            result.getStderr().isEmpty(),
-            result.getStderr()
-        );
+        result.assertNoStderr();
     }
 
     protected void getSourceInfoNotFound(String tenant, String namespace, String sourceName) throws Exception {
@@ -2152,7 +2146,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             "--name", functionName
         );
         assertTrue(result.getStdout().contains("Deleted successfully"));
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoStderr();
     }
 
     @Test(groups = "function")

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -430,7 +430,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
             "--name", functionName
         );
         assertTrue(result.getStdout().contains("Deleted successfully"));
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoStderr();
     }
 
     private void deleteSource(String sourceName) throws Exception {
@@ -443,7 +443,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 "--name", sourceName
         );
         assertTrue(result.getStdout().contains("Delete source successfully"));
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoStderr();
     }
 
     private void deleteSink(String sinkName) throws Exception {
@@ -456,7 +456,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
                 "--name", sinkName
         );
         assertTrue(result.getStdout().contains("Deleted successfully"));
-        assertTrue(result.getStderr().isEmpty());
+        result.assertNoStderr();
     }
 
     private void getSourceInfoNotFound(String sourceName) throws Exception {


### PR DESCRIPTION
### Motivation

When a test fails, it's hard to debug the problem if the output causing the failure isn't returned in the error message.

### Modifications

Pass stdout and stderr in error message when it's asserted to be empty