### PR TITLE
Exclude inner classes in surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1506,7 +1506,7 @@ flexible messaging model and an intuitive client API.</description>
                 <include>${include}</include>
             </includes>
             <excludes>
-                <exclude>${exclude}</exclude>
+                <exclude>**/*$*,${exclude}</exclude>
             </excludes>
             <groups>${groups}</groups>
             <excludedGroups>${excludedGroups}</excludedGroups>


### PR DESCRIPTION
### Motivation

- Surefire current tries to find test cases in inner classes and wastes time doing so.

### Modifications

- We provide a default exclusion "**/*$*" in all cases.