### PR TITLE
User seperate ports for rabbitmq source sink integration tests

### DIFF
--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
@@ -28,12 +28,10 @@ import java.nio.file.Path;
 
 public class RabbitMQBrokerManager {
 
-    private final String PORT = "5672";
     private final Broker broker = new Broker();
 
-
-    public void startBroker() throws Exception {
-        BrokerOptions brokerOptions = getBrokerOptions();
+    public void startBroker(String port) throws Exception {
+        BrokerOptions brokerOptions = getBrokerOptions(port);
         broker.startup(brokerOptions);
     }
 
@@ -41,7 +39,7 @@ public class RabbitMQBrokerManager {
         broker.shutdown();
     }
 
-    BrokerOptions getBrokerOptions() throws Exception {
+    BrokerOptions getBrokerOptions(String port) throws Exception {
         Path tmpFolder = Files.createTempDirectory("qpidWork");
         Path homeFolder = Files.createTempDirectory("qpidHome");
         File etc = new File(homeFolder.toFile(), "etc");
@@ -53,7 +51,7 @@ public class RabbitMQBrokerManager {
         BrokerOptions brokerOptions = new BrokerOptions();
 
         brokerOptions.setConfigProperty("qpid.work_dir", tmpFolder.toAbsolutePath().toString());
-        brokerOptions.setConfigProperty("qpid.amqp_port", PORT);
+        brokerOptions.setConfigProperty("qpid.amqp_port", port);
         brokerOptions.setConfigProperty("qpid.home_dir", homeFolder.toAbsolutePath().toString());
         String configPath = getFile("qpid.json").getAbsolutePath();
         brokerOptions.setInitialConfigurationLocation(configPath);

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
@@ -40,7 +40,7 @@ public class RabbitMQSinkConfigTest {
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(path);
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
-        assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(Integer.parseInt("5673"), config.getPort());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
@@ -58,7 +58,7 @@ public class RabbitMQSinkConfigTest {
     public final void loadFromMapTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
-        map.put("port", "5672");
+        map.put("port", "5673");
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
@@ -74,7 +74,7 @@ public class RabbitMQSinkConfigTest {
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
-        assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(Integer.parseInt("5673"), config.getPort());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
@@ -92,7 +92,7 @@ public class RabbitMQSinkConfigTest {
     public final void validValidateTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
-        map.put("port", "5672");
+        map.put("port", "5673");
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
@@ -114,7 +114,7 @@ public class RabbitMQSinkConfigTest {
     public final void missingExchangeValidateTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
-        map.put("port", "5672");
+        map.put("port", "5673");
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -37,11 +37,11 @@ public class RabbitMQSinkTest {
     @BeforeMethod
     public void setUp() throws Exception {
         rabbitMQBrokerManager = new RabbitMQBrokerManager();
-        rabbitMQBrokerManager.startBroker();
+        rabbitMQBrokerManager.startBroker("5673");
     }
 
     @AfterMethod(alwaysRun = true)
-    public void tearDown() throws Exception {
+    public void tearDown() {
         rabbitMQBrokerManager.stopBroker();
     }
 
@@ -49,7 +49,7 @@ public class RabbitMQSinkTest {
     public void TestOpenAndWriteSink() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put("host", "localhost");
-        configs.put("port", "5672");
+        configs.put("port", "5673");
         configs.put("virtualHost", "default");
         configs.put("username", "guest");
         configs.put("password", "guest");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 
 /**
@@ -52,8 +53,8 @@ public class RabbitMQSourceConfigTest {
         assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
         assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
         assertEquals(Integer.parseInt("0"), config.getPrefetchCount());
-        assertEquals(Boolean.parseBoolean("false"), config.isPrefetchGlobal());
-        assertEquals(Boolean.parseBoolean("false"), config.isPassive());
+        assertFalse(config.isPrefetchGlobal());
+        assertFalse(config.isPassive());
     }
 
     @Test
@@ -90,9 +91,9 @@ public class RabbitMQSourceConfigTest {
         assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
         assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
         assertEquals(Integer.parseInt("0"), config.getPrefetchCount());
-        assertEquals(Boolean.parseBoolean("false"), config.isPrefetchGlobal());
-        assertEquals(Boolean.parseBoolean("false"), config.isPrefetchGlobal());
-        assertEquals(Boolean.parseBoolean("true"), config.isPassive());
+        assertEquals(false, config.isPrefetchGlobal());
+        assertEquals(false, config.isPrefetchGlobal());
+        assertEquals(true, config.isPassive());
     }
 
     @Test

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -35,16 +35,16 @@ public class RabbitMQSourceTest {
     @BeforeMethod
     public void setUp() throws Exception {
         rabbitMQBrokerManager = new RabbitMQBrokerManager();
-        rabbitMQBrokerManager.startBroker();
+        rabbitMQBrokerManager.startBroker("5672");
     }
 
     @AfterMethod(alwaysRun = true)
-    public void tearDown() throws Exception {
+    public void tearDown() {
         rabbitMQBrokerManager.stopBroker();
     }
 
     @Test
-    public void TestOpenAndWriteSink() throws Exception {
+    public void TestOpenAndWriteSink() {
         Map<String, Object> configs = new HashMap<>();
         configs.put("host", "localhost");
         configs.put("port", "5672");

--- a/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
+++ b/pulsar-io/rabbitmq/src/test/resources/sinkConfig.yaml
@@ -19,7 +19,7 @@
 
 {
 "host": "localhost",
-"port": "5672",
+"port": "5673",
 "virtualHost": "/",
 "username": "guest",
 "password": "guest",


### PR DESCRIPTION
### Motivation

- Rabbitmq integration tests still fail some percentage for the time as it fails to start another broker on the same port.

### Modifications

- use different ports for rabbitmq source and sink