### PR TITLE
[Issue 9867][scripts] Fixes issue

### DIFF
--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -37,6 +37,19 @@ INT_KEYS = [
     'instanceLivenessCheckFreqMs'
 ]
 
+SET_KEYS = [
+    'brokerInterceptors',
+    'messagingProtocols',
+    'tlsProtocols',
+    'tlsCiphers',
+    'authenticationProviders',
+    'superUserRoles',
+    'proxyRoles',
+    'schemaRegistryCompatibilityCheckers',
+    'brokerClientTlsCiphers',
+    'brokerClientTlsProtocols'
+]
+
 PF_ENV_PREFIX = 'PF_'
 
 if len(sys.argv) < 2:
@@ -66,6 +79,8 @@ for conf_filename in conf_files:
             if i == (len(key_parts) - 1):
                 if key_part in INT_KEYS:
                     conf_to_modify[key_part] = int(v)
+                elif key_part in SET_KEYS:
+                    conf_to_modify[key_part] = v.split(',')
                 else:
                     conf_to_modify[key_part] = v
                 modified = True


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #9867 

### Motivation

As described in the issue the script to modify configuration yaml file (used by functions worker) did not work with array type variables. 

This fix allows specifying same values for array properties like `authenticationProviders` in environment variables (with `PF_` prefix) as the ones used by `apply-config-from-env.py` for conf files, i.e. a comma separated list of values.

E.g. You can define environment variable `PF_authenticationProviders` taking value `org.apache.pulsar.broker.authentication.AuthenticationProviderTls,org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz` to specify two values or `org.apache.pulsar.broker.authentication.AuthenticationProviderTls` to specify only one. In both cases value will be correctly set in final yaml file as an array:

```yaml
authenticationProviders:
- org.apache.pulsar.broker.authentication.AuthenticationProviderTls
- org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz
```

### Modifications

We have just added a check on the variable names that have type `Set<String>` in `WorkerConfig` the same way it is done for  `int` variables. We then split the value using ",", which already produces an array type.

### Verifying this change

I have verified locally that it works. Indicated command in the  #9867  issue can also be run with the expected result.

No tests were added (are there any for these scripts?)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / `no`)
  - The public API: (yes / `no`)
  - The schema: (yes / `no` / don't know)
  - The default values of configurations: (yes / `no`)
  - The wire protocol: (yes / `no`)
  - The rest endpoints: (yes / `no`)
  - The admin cli options: (yes / `no`)
  - Anything that affects deployment: (`yes` / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / `no`)
  - If yes, how is the feature documented? (`not applicable` / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why? There was **no previous documentation on this script**
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
