### PR TITLE
[WebSocket Client] Make the browser client support the token authentication

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -65,7 +65,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
 
     public AbstractWebSocketHandler(WebSocketService service, HttpServletRequest request, ServletUpgradeResponse response) {
         this.service = service;
-        this.request = request;
+        this.request = new WebSocketHttpServletRequestWrapper(request);
         this.topic = extractTopicName(request);
 
         this.queryParams = new TreeMap<>();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.websocket;
 
 import javax.servlet.http.HttpServletRequest;
@@ -19,9 +37,8 @@ public class WebSocketHttpServletRequestWrapper extends HttpServletRequestWrappe
 
     @Override
     public String getHeader(String name) {
-        // The Javascript WebSocket client couldn't add the auth param to the request header,
-        // so add the auth param in the queryParameter, use the query param `token` value instead of
-        // the Authorization header if the Authorization header not exist.
+        // The browser javascript WebSocket client couldn't add the auth param to the request header, use the
+        // query param `token` to transport the auth token for the browser javascript WebSocket client.
         if (name.equals(HTTP_HEADER_NAME)
                 && !((UpgradeHttpServletRequest) this.getRequest()).getHeaders().containsKey(HTTP_HEADER_NAME)) {
             return getRequest().getParameter(TOKEN);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
@@ -1,0 +1,31 @@
+package org.apache.pulsar.websocket;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.eclipse.jetty.websocket.servlet.UpgradeHttpServletRequest;
+
+
+/**
+ * WebSocket HttpServletRequest wrapper.
+ */
+public class WebSocketHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+    final static String HTTP_HEADER_NAME = "Authorization";
+    final static String TOKEN = "token";
+
+    public WebSocketHttpServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        // The Javascript WebSocket client couldn't add the auth param to the request header,
+        // so add the auth param in the queryParameter, use the query param `token` value instead of
+        // the Authorization header if the Authorization header not exist.
+        if (name.equals(HTTP_HEADER_NAME)
+                && !((UpgradeHttpServletRequest) this.getRequest()).getHeaders().containsKey(HTTP_HEADER_NAME)) {
+            return getRequest().getParameter(TOKEN);
+        }
+        return super.getHeader(name);
+    }
+}

--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -67,6 +67,16 @@ Pulsar's WebSocket API offers three endpoints for [producing](#producer-endpoint
 
 All exchanges via the WebSocket API use JSON.
 
+### Authentication
+
+#### Broswer javascript WebSocket client
+
+Use the query param `token` transport the authentication token.
+
+```http
+ws://broker-service-url:8080/path?token=token
+```
+
 ### Producer endpoint
 
 The producer endpoint requires you to specify a tenant, namespace, and topic in the URL:
@@ -89,6 +99,7 @@ Key | Type | Required? | Explanation
 `producerName` | string | no | Specify the name for the producer. Pulsar will enforce only one producer with same name can be publishing on a topic
 `initialSequenceId` | long | no | Set the baseline for the sequence ids for messages published by the producer.
 `hashingScheme` | string | no | [Hashing function](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ProducerConfiguration.HashingScheme.html) to use when publishing on a partitioned topic: `JavaStringHash`, `Murmur3_32Hash`
+`token` | string | no | Authentication token, this is used for the browser javascript client
 
 
 #### Publishing a message
@@ -156,6 +167,7 @@ Key | Type | Required? | Explanation
 `maxRedeliverCount` | int | no | Define a [maxRedeliverCount](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ConsumerBuilder.html#deadLetterPolicy-org.apache.pulsar.client.api.DeadLetterPolicy-) for the consumer (default: 0). Activates [Dead Letter Topic](https://github.com/apache/pulsar/wiki/PIP-22%3A-Pulsar-Dead-Letter-Topic) feature.
 `deadLetterTopic` | string | no | Define a [deadLetterTopic](http://pulsar.apache.org/api/client/org/apache/pulsar/client/api/ConsumerBuilder.html#deadLetterPolicy-org.apache.pulsar.client.api.DeadLetterPolicy-) for the consumer (default: {topic}-{subscription}-DLQ). Activates [Dead Letter Topic](https://github.com/apache/pulsar/wiki/PIP-22%3A-Pulsar-Dead-Letter-Topic) feature.
 `pullMode` | boolean | no | Enable pull mode (default: false). See "Flow Control" below.
+`token` | string | no | Authentication token, this is used for the browser javascript client
 
 NB: these parameter (except `pullMode`) apply to the internal consumer of the WebSocket service.
 So messages will be subject to the redelivery settings as soon as the get into the receive queue,
@@ -264,6 +276,7 @@ Key | Type | Required? | Explanation
 `readerName` | string | no | Reader name
 `receiverQueueSize` | int | no | Size of the consumer receive queue (default: 1000)
 `messageId` | int or enum | no | Message ID to start from, `earliest` or `latest` (default: `latest`)
+`token` | string | no | Authentication token, this is used for the browser javascript client
 
 ##### Receiving messages
 


### PR DESCRIPTION
Fixes issue #9854 

### Motivation

Currently, the WebSocket client uses the HTTP request header to transport the authentication params, but the browser javascript WebSocket client couldn't add new headers.

### Modifications

Use the query param `token` to transport the authentication token for the browser javascript WebSocket client.

### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

 Update the WebSocket client document.