### PR TITLE
Remove inner class exclusion from run_unit_group selection

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -32,7 +32,7 @@ function broker_group_1() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/**/*.java" \
-                                      -Dexclude='**/*$*,org/apache/pulsar/broker/zookeeper/**/*.java,
+                                      -Dexclude='org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java,
                                                  **/AdminApiOffloadTest.java'
@@ -63,7 +63,7 @@ function broker_group_2() {
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/broker/zookeeper/**/*.java,
                                                  org/apache/pulsar/broker/loadbalance/**/*.java,
                                                  org/apache/pulsar/broker/service/**/*.java" \
-                                      -Dexclude='**/*$*,**/ReplicatorTest.java,
+                                      -Dexclude='**/ReplicatorTest.java,
                                                  **/MessagePublishBufferThrottleTest.java,
                                                  **/TopicOwnerTest.java,
                                                  **/*StreamingDispatcher*Test.java,
@@ -80,7 +80,7 @@ function broker_client_api() {
                                       -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-broker -Dinclude="org/apache/pulsar/client/api/**/*.java" \
-                                      -Dexclude='**/*$*,**/DispatcherBlockConsumerTest.java,
+                                      -Dexclude='**/DispatcherBlockConsumerTest.java,
                                                  **/SimpleProducerConsumerTest.java'
 }
 
@@ -89,7 +89,7 @@ function broker_client_impl() {
 }
 
 function broker_client_other() {
-  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude='**/*$*,org/apache/pulsar/broker/**/*.java,
+  $MVN_TEST_COMMAND -pl pulsar-broker -Dexclude='org/apache/pulsar/broker/**/*.java,
                                                  org/apache/pulsar/client/**/*.java'
 }
 
@@ -119,7 +119,7 @@ function proxy() {
                                      -DtestReuseFork=true
 
   $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -Dexclude='**/*$*,**/ProxyRolesEnforcementTest.java,
+                                     -Dexclude='**/ProxyRolesEnforcementTest.java,
                                                 **/ProxyAuthenticationTest.java,
                                                 **/ProxyTest.java,
                                                 **/MessagePublishBufferThrottleTest.java' \
@@ -128,7 +128,7 @@ function proxy() {
 
 function other() {
   build/retry.sh mvn -B -ntp install -PbrokerSkipTest \
-                                     -Dexclude='**/*$*,org/apache/pulsar/proxy/**/*.java,
+                                     -Dexclude='org/apache/pulsar/proxy/**/*.java,
                                                 **/ManagedLedgerTest.java,
                                                 **/TestPulsarKeyValueSchemaHandler.java,
                                                 **/PrimitiveSchemaTest.java,


### PR DESCRIPTION
### Motivation

The current unit test execution script has exclusion for surefire inner classes that is now duplicated by updates in root pom.xml

### Modifications

Remove inner class exclusion from unit test scripts.