### PR TITLE
[Build] RPM build script use wrong path for root dir

### DIFF
--- a/pulsar-client-cpp/pkg/rpm/build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/build-rpm.sh
@@ -21,7 +21,7 @@
 set -e
 
 cd /pulsar
-ROOT_DIR=$(dirname $0)/../..
+ROOT_DIR=$(pwd)
 cd $ROOT_DIR/pulsar-client-cpp/pkg/rpm
 
 POM_VERSION=`$ROOT_DIR/src/get-project-version.py`


### PR DESCRIPTION
---

*Motivation*

We use the wrong path for the root dir in the build rpm script
so this breaks the rpm build process.
