### PR TITLE
[Build] Skip python 3.9 wheel build

### DIFF
--- a/pulsar-client-cpp/docker/build-client-lib.sh
+++ b/pulsar-client-cpp/docker/build-client-lib.sh
@@ -28,7 +28,6 @@ cd $ROOT_DIR
 
 PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
-   '3.9 cp39-cp39'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -33,7 +33,6 @@ PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
-   '3.9 cp39-cp39'
 )
 
 function contains() {


### PR DESCRIPTION
---

Master Issue: #9888

*Motivation*

We haven't published the image `apachepulsar/pulsar-build:manylinux-3.9`.
This will break our current master build python wheel file.
I was trying to build out the pulsar build image with python 3.9 but
that can not be done very quickly. So we can skip the python3.9 build and
after we build out the base image then we can add it back.
