### PR TITLE
[BUG]fix zkBookieRackAffinityMapping bug to support for bookkeeper dnsResolver 

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
@@ -128,8 +128,13 @@ public class ZkBookieRackAffinityMapping extends AbstractDNSToSwitchMapping
             if (conf instanceof ClientConfiguration) {
                 zkTimeout = ((ClientConfiguration) conf).getZkTimeout();
                 zkServers = ((ClientConfiguration) conf).getZkServers();
+                String zkLedgersRootPath = ((ClientConfiguration) conf).getZkLedgersRootPath();
                 try {
-                    ZooKeeper zkClient = ZooKeeperClient.newBuilder().connectString(zkServers)
+                    int zkLedgerRootIndex = zkLedgersRootPath.contains("/") ?
+                            zkLedgersRootPath.lastIndexOf("/") : 0;
+                    String zkChangeRoot = zkLedgersRootPath.substring(0, zkLedgerRootIndex);
+                    zkChangeRoot = zkChangeRoot.startsWith("/") ? zkChangeRoot : "/" + zkChangeRoot;
+                    ZooKeeper zkClient = ZooKeeperClient.newBuilder().connectString(zkServers + zkChangeRoot)
                             .sessionTimeoutMs(zkTimeout).build();
                     zkCache = new ZooKeeperCache("bookies-racks", zkClient,
                             (int) TimeUnit.MILLISECONDS.toSeconds(zkTimeout)) {


### PR DESCRIPTION
### Motivation
When using Region/Rack aware placement policy for pulsar managed ledger, we should also use those policy for bookkeeper and bookkeeper.conf should add the follow configuration. Otherwise, it the placement policy won't work for bookkeeper auto recovery.
```
ensemblePlacementPolicy=org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
reppDnsResolverClass=org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping
```
However, if we configured change root for Zookeeper in bookkeeper.conf, eg.
```
zkLedgersRootPath=/test-v1/ledgers
zkServers=localhost:2181
```
`/test-v1` is the change root for zookeeper.

The `zkBookieRackAffinityMapping` resolver will be invalid, and all resolved result will be `null`.

The reason is that `zkBookieRackAffinityMapping` initiate Zookeeper Client according to `zkServers` configured in `bookkeeper.conf`, and doesn't take change root into account. Thus it lead to get bookies placement policy from wrong place  , which is `/bookies` and not the correct `/test-v1/bookies`.

### Changes
1. Check whether configured Zookeeper change root in `bookkeeper.conf` before initiate Zookeeper Client. If it configured, use the change root path to initiate Zookeeper Client.