### PR TITLE
Implement Schema#OBJECT prototype with support for KeyValue objects

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -371,6 +371,10 @@ public interface Schema<T> extends Cloneable{
         return DefaultImplementation.newAutoConsumeSchema();
     }
 
+    static Schema<Object> OBJECT() {
+        return DefaultImplementation.newObjectSchema();
+    }
+
     /**
      * Create a schema instance that accepts a serialized payload
      * and validates it against the topic schema.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -284,6 +284,13 @@ public class DefaultImplementation {
                         .newInstance());
     }
 
+    public static Schema<Object> newObjectSchema() {
+        return catchExceptions(
+                () -> (Schema<Object>) newClassInstance(
+                        "org.apache.pulsar.client.impl.schema.ObjectSchema")
+                        .newInstance());
+    }
+
     public static Schema<byte[]> newAutoProduceSchema() {
         return catchExceptions(
                 () -> (Schema<byte[]>) newClassInstance(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.ObjectSchema;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.api.proto.KeyValue;
@@ -359,8 +360,16 @@ public class MessageImpl<T> implements Message<T> {
         }
     }
 
+    private KeyValueSchema getKeyValueSchema() {
+        if (schema instanceof ObjectSchema) {
+            return (KeyValueSchema) ((ObjectSchema)schema).getInternalSchema();
+        } else {
+            return (KeyValueSchema) schema;
+        }
+    }
+
     private T getKeyValueBySchemaVersion() {
-        KeyValueSchema kvSchema = (KeyValueSchema) schema;
+        KeyValueSchema kvSchema = getKeyValueSchema();
         byte[] schemaVersion = getSchemaVersion();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             return (T) kvSchema.decode(getKeyBytes(), getData(), schemaVersion);
@@ -370,7 +379,7 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     private T getKeyValue() {
-        KeyValueSchema kvSchema = (KeyValueSchema) schema;
+        KeyValueSchema kvSchema = getKeyValueSchema();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             return (T) kvSchema.decode(getKeyBytes(), getData(), null);
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -33,6 +33,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -71,6 +72,7 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AutoProduceBytesSchema;
+import org.apache.pulsar.client.impl.schema.ObjectSchema;
 import org.apache.pulsar.client.impl.schema.generic.MultiVersionSchemaInfoProvider;
 import org.apache.pulsar.client.impl.transaction.TransactionBuilderImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionCoordinatorClientImpl;
@@ -861,9 +863,11 @@ public class PulsarClientImpl implements PulsarClient {
             schema = schema.clone();
             if (schema.requireFetchingSchemaInfo()) {
                 Schema finalSchema = schema;
+
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
-                        if (!(finalSchema instanceof AutoConsumeSchema)) {
+                        if (!(finalSchema instanceof AutoConsumeSchema)
+                                && !(finalSchema instanceof ObjectSchema)) {
                             // no schema info is found
                             return FutureUtil.failedFuture(
                                     new PulsarClientException.NotFoundException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
@@ -163,4 +163,8 @@ public class ObjectSchema implements Schema<Object> {
         }
     }
 
+    public Schema getInternalSchema() {
+        return schema;
+    }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericProtobufNativeSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Auto detect schema.
+ */
+@Slf4j
+public class ObjectSchema implements Schema<Object> {
+
+    private Schema<Object> schema;
+
+    private String topicName;
+
+    private String componentName;
+
+    private SchemaInfoProvider schemaInfoProvider;
+
+    public void setSchema(Schema<Object> schema) {
+        this.schema = schema;
+    }
+
+    private void ensureSchemaInitialized() {
+        checkState(null != schema, "Schema is not initialized before used");
+    }
+
+    @Override
+    public void validate(byte[] message) {
+        ensureSchemaInitialized();
+
+        schema.validate(message);
+    }
+
+    @Override
+    public boolean supportSchemaVersioning() {
+        return true;
+    }
+
+    @Override
+    public byte[] encode(Object message) {
+        ensureSchemaInitialized();
+
+        return schema.encode(message);
+    }
+
+    @Override
+    public Object decode(byte[] bytes, byte[] schemaVersion) {
+        if (schema == null) {
+            SchemaInfo schemaInfo = null;
+            try {
+                schemaInfo = schemaInfoProvider.getLatestSchema().get();
+            } catch (InterruptedException | ExecutionException e ) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                log.error("Con't get last schema for topic {} use AutoConsumeSchema", topicName);
+                throw new SchemaSerializationException(e.getCause());
+            }
+            schema = generateSchema(schemaInfo);
+            schema.setSchemaInfoProvider(schemaInfoProvider);
+            log.info("Configure {} schema for topic {} : {}",
+                    componentName, topicName, schemaInfo.getSchemaDefinition());
+        }
+        ensureSchemaInitialized();
+        return schema.decode(bytes, schemaVersion);
+    }
+
+    @Override
+    public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
+        if (schema == null) {
+            this.schemaInfoProvider = schemaInfoProvider;
+        } else {
+            schema.setSchemaInfoProvider(schemaInfoProvider);
+        }
+    }
+
+    @Override
+    public SchemaInfo getSchemaInfo() {
+        if (schema == null) {
+            return null;
+        }
+        return schema.getSchemaInfo();
+    }
+
+    @Override
+    public boolean requireFetchingSchemaInfo() {
+        return true;
+    }
+
+    @Override
+    public void configureSchemaInfo(String topicName,
+                                    String componentName,
+                                    SchemaInfo schemaInfo) {
+        this.topicName = topicName;
+        this.componentName = componentName;
+        if (schemaInfo != null) {
+            Schema<Object> genericSchema = generateSchema(schemaInfo);
+            setSchema(genericSchema);
+            log.info("Configure {} schema for topic {} : {}",
+                    componentName, topicName, schemaInfo.getSchemaDefinition());
+        }
+    }
+
+    @Override
+    public Schema<Object> clone() {
+        Schema<Object> schema = Schema.OBJECT();
+        if (this.schema != null) {
+            schema.configureSchemaInfo(topicName, componentName, this.schema.getSchemaInfo());
+        } else {
+            schema.configureSchemaInfo(topicName, componentName, null);
+        }
+        if (schemaInfoProvider != null) {
+            schema.setSchemaInfoProvider(schemaInfoProvider);
+        }
+        return schema;
+    }
+
+    private Schema<Object> generateSchema(SchemaInfo schemaInfo) {
+        // when using `AutoConsumeSchema`, we use the schema associated with the messages as schema reader
+        // to decode the messages.
+        final boolean useProvidedSchemaAsReaderSchema = false;
+        switch (schemaInfo.getType()) {
+            case JSON:
+            case AVRO:
+                return (Schema) GenericSchemaImpl.of(schemaInfo, useProvidedSchemaAsReaderSchema);
+            case PROTOBUF_NATIVE:
+                return (Schema)GenericProtobufNativeSchema.of(schemaInfo, useProvidedSchemaAsReaderSchema);
+            default:
+                return (Schema) AutoConsumeSchema.getSchema(schemaInfo);
+        }
+    }
+
+}


### PR DESCRIPTION
Based on #9895, that is still a prototype.

This patch adds support for KeyValue in case of Schema#OBJECT.

Changes:
when we are looking up a Schema using the Http service the returned KeyValue schema does not work, because it is JSON encoded but we are expecting a KeyValue encoded value.

The patch converts the JSON version returned by the http service to the expected format.
