### PR TITLE
Reorg pulsar-proxy unit test execution

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -94,36 +94,7 @@ function broker_client_other() {
 }
 
 function proxy() {
-  $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -DtestReuseFork=true \
-                                     -Dinclude="**/ProxyRolesEnforcementTest.java" \
-                                     -DtestForkCount=1 \
-                                     -DtestReuseFork=true
-
-  $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -DtestReuseFork=true \
-                                     -Dinclude="**/ProxyAuthenticationTest.java" \
-                                     -DtestForkCount=1 \
-                                     -DtestReuseFork=true
-
-  $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -DtestReuseFork=true \
-                                     -Dinclude="**/ProxyTest.java" \
-                                     -DtestForkCount=1 \
-                                     -DtestReuseFork=true
-
-  $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -DtestReuseFork=true \
-                                     -Dinclude="**/MessagePublishBufferThrottleTest.java" \
-                                     -DtestForkCount=1 \
-                                     -DtestReuseFork=true
-
-  $MVN_TEST_COMMAND -pl pulsar-proxy -DtestForkCount=1 \
-                                     -Dexclude='**/ProxyRolesEnforcementTest.java,
-                                                **/ProxyAuthenticationTest.java,
-                                                **/ProxyTest.java,
-                                                **/MessagePublishBufferThrottleTest.java' \
-                                     -DtestReuseFork=true
+  $MVN_TEST_COMMAND -pl pulsar-proxy
 }
 
 function other() {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
@@ -57,7 +57,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 	private static final Logger log = LoggerFactory.getLogger(ProxyAuthenticationTest.class);
 
 	public static class BasicAuthenticationData implements AuthenticationDataProvider {
-		private String authParam;
+		private final String authParam;
 
 		public BasicAuthenticationData(String authParam) {
 			this.authParam = authParam;
@@ -163,16 +163,16 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 		conf.setBrokerClientAuthenticationParameters(
 				"entityType:broker,expiryTime:" + (System.currentTimeMillis() + 3600 * 1000));
 
-		Set<String> superUserRoles = new HashSet<String>();
+		Set<String> superUserRoles = new HashSet<>();
 		superUserRoles.add("admin");
 		conf.setSuperUserRoles(superUserRoles);
 
-		Set<String> providers = new HashSet<String>();
+		Set<String> providers = new HashSet<>();
 		providers.add(BasicAuthenticationProvider.class.getName());
 		conf.setAuthenticationProviders(providers);
 
 		conf.setClusterName("test");
-		Set<String> proxyRoles = new HashSet<String>();
+		Set<String> proxyRoles = new HashSet<>();
 		proxyRoles.add("proxy");
 		conf.setProxyRoles(proxyRoles);
         conf.setAuthenticateOriginalAuthData(true);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
@@ -55,7 +55,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(ProxyRolesEnforcementTest.class);
 
     public static class BasicAuthenticationData implements AuthenticationDataProvider {
-        private String authParam;
+        private final String authParam;
 
         public BasicAuthenticationData(String authParam) {
             this.authParam = authParam;
@@ -150,16 +150,16 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
         conf.setBrokerClientAuthenticationPlugin(BasicAuthentication.class.getName());
         conf.setBrokerClientAuthenticationParameters("authParam:broker");
 
-        Set<String> superUserRoles = new HashSet<String>();
+        Set<String> superUserRoles = new HashSet<>();
         superUserRoles.add("admin");
         conf.setSuperUserRoles(superUserRoles);
 
-        Set<String> providers = new HashSet<String>();
+        Set<String> providers = new HashSet<>();
         providers.add(BasicAuthenticationProvider.class.getName());
         conf.setAuthenticationProviders(providers);
 
         conf.setClusterName("test");
-        Set<String> proxyRoles = new HashSet<String>();
+        Set<String> proxyRoles = new HashSet<>();
         proxyRoles.add("proxy");
         conf.setProxyRoles(proxyRoles);
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,7 +58,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
 
     private ProxyService proxyService;
     private WebServer proxyWebServer;
-    private ProxyConfiguration proxyConfig = new ProxyConfiguration();
+    private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
     @Override
     @BeforeClass
@@ -93,7 +94,6 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
-
         proxyService.close();
     }
 
@@ -194,7 +194,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
      * @throws Exception
      */
     @Test
-    public void testChangeLogLevel() throws Exception {
+    public void testChangeLogLevel() {
         Assert.assertEquals(proxyService.getProxyLogLevel(), 2);
         int newLogLevel = 1;
         Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -73,7 +73,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
     private final String TLS_SUPERUSER_CLIENT_TRUST_CERT_FILE_PATH = "./src/test/resources/authentication/tls/cacert.pem";
 
     private ProxyService proxyService;
-    private ProxyConfiguration proxyConfig = new ProxyConfiguration();
+    private final ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
     @DataProvider(name = "hostnameVerification")
     public Object[][] hostnameVerificationCodecProvider() {
@@ -210,7 +210,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         proxyService.close();
     }
 
-    void startProxy() throws Exception {
+    private void startProxy() throws Exception {
         proxyService.start();
     }
 
@@ -458,7 +458,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    protected final void createAdminClient() throws Exception {
+    private void createAdminClient() throws Exception {
         Map<String, String> authParams = Maps.newHashMap();
         authParams.put("tlsCertFile", TLS_SUPERUSER_CLIENT_CERT_FILE_PATH);
         authParams.put("tlsKeyFile", TLS_SUPERUSER_CLIENT_KEY_FILE_PATH);


### PR DESCRIPTION
### Motivation
We currently use class regex matches to break proxy unit tests into small groups.

### Modifications
* Move to whole module test execution.
* The test fixes in prior mr, mean we don't this patter anymore.
