### PR TITLE
Try to ease the wait time for some of test case for StreamingEntryReader to reduce flakiness.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
@@ -74,7 +74,7 @@ public class StreamingEntryReader implements AsyncCallbacks.ReadEntryCallback, W
             1, TimeUnit.SECONDS, 0, TimeUnit.MILLISECONDS);
 
     /**
-     * Read entries in streaming way, that said instead reading with micro batch and send entries to consumer after all
+     * Read entries in streaming way, that said instead of reading with micro batch and send entries to consumer after all
      * entries in the batch are read from ledger, this method will fire numEntriesToRead requests to managedLedger
      * and send entry to consumer whenever it is read && all entries before it have been sent to consumer.
      * @param numEntriesToRead number of entry to read from ledger.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReader.java
@@ -74,8 +74,8 @@ public class StreamingEntryReader implements AsyncCallbacks.ReadEntryCallback, W
             1, TimeUnit.SECONDS, 0, TimeUnit.MILLISECONDS);
 
     /**
-     * Read entries in streaming way, that said instead of reading with micro batch and send entries to consumer after all
-     * entries in the batch are read from ledger, this method will fire numEntriesToRead requests to managedLedger
+     * Read entries in streaming way, that said instead of reading with micro batch and send entries to consumer after
+     * all entries in the batch are read from ledger, this method will fire numEntriesToRead requests to managedLedger
      * and send entry to consumer whenever it is read && all entries before it have been sent to consumer.
      * @param numEntriesToRead number of entry to read from ledger.
      * @param maxReadSizeByte maximum byte will be read from ledger.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
@@ -179,7 +179,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
 
         // Only 2 entries should be read with this request.
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
         assertEquals(entries.size(), 2);
         // Assert cursor's read position has been properly updated to the third entry, since we should only read
         // 2 retries with previous request
@@ -187,13 +187,13 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         reset(ledger);
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         assertEquals(entries.size(), 8);
         for (int i = 0; i < entries.size(); i++) {
@@ -226,11 +226,11 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         ).when(mockDispatcher).readEntryComplete(any(Entry.class), any(PendingReadEntryRequest.class));
 
         streamingEntryReader.asyncReadEntries(5,  100, null);
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 5);
+        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 5);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         streamingEntryReader.asyncReadEntries(5, 100, null);
         // We only write 7 entries initially so only 7 entries can be read.
-        await().atMost(300, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 7);
+        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 7);
         // Add new entry and await for it to be send to reader.
         entryProcessed.set(false);
         ledger.addEntry("message-7".getBytes(Encoding));


### PR DESCRIPTION
Fixes #9885

### Motivation
StreamingEntryReaderTests is flaky. The testCanReadEntryFromMLedgerSizeExceededLimit test method fails sporadically.

### Modifications
Increased timeout to ease the bound.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
