### PR TITLE
[fix #9851] Add forwardSourceMessageProperty to SourceConfig

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -315,6 +315,8 @@ public class CmdSources extends CmdBase {
         protected String sourceConfigString;
         @Parameter(names = "--custom-runtime-options", description = "A string that encodes options to customize the runtime, see docs for configured runtime for details")
         protected String customRuntimeOptions;
+        @Parameter(names = "--forward-source-message-property", description = "Forwarding input message's properties to output topic when processing")
+        protected Boolean forwardSourceMessageProperty = true;
 
         protected SourceConfig sourceConfig;
 
@@ -418,6 +420,10 @@ public class CmdSources extends CmdBase {
 
             if (customRuntimeOptions != null) {
                 sourceConfig.setCustomRuntimeOptions(customRuntimeOptions);
+            }
+
+            if (null != forwardSourceMessageProperty) {
+                sourceConfig.setForwardSourceMessageProperty(forwardSourceMessageProperty);
             }
             // check if source configs are valid
             validateSourceConfigs(sourceConfig);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
@@ -577,15 +577,19 @@ public class TestCmdSources {
 
         updateSource.archive = "new-archive";
 
+        updateSource.forwardSourceMessageProperty = true;
+
         updateSource.processArguments();
 
         updateSource.runCmd();
+
 
         verify(source).updateSource(eq(SourceConfig.builder()
                 .tenant(PUBLIC_TENANT)
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSource.name)
                 .archive(updateSource.archive)
+                .forwardSourceMessageProperty(true)
                 .build()), eq(updateSource.archive), eq(new UpdateOptions()));
 
 
@@ -593,9 +597,11 @@ public class TestCmdSources {
 
         updateSource.parallelism = 2;
 
-        updateSource.processArguments();
-
         updateSource.updateAuthData = true;
+
+        updateSource.forwardSourceMessageProperty = false;
+
+        updateSource.processArguments();
 
         UpdateOptions updateOptions = new UpdateOptions();
         updateOptions.setUpdateAuthData(true);
@@ -607,6 +613,7 @@ public class TestCmdSources {
                 .namespace(DEFAULT_NAMESPACE)
                 .name(updateSource.name)
                 .parallelism(2)
+                .forwardSourceMessageProperty(false)
                 .build()), eq(null), eq(updateOptions));
 
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSources.java
@@ -73,6 +73,7 @@ public class TestCmdSources {
     private static final Long RAM = 1024L * 1024L;
     private static final Long DISK = 1024L * 1024L * 1024L;
     private static final String SINK_CONFIG_STRING = "{\"created_at\":\"Mon Jul 02 00:33:15 +0000 2018\"}";
+    private static final boolean FORWARD_PROPERTIES = true;
 
     private PulsarAdmin pulsarAdmin;
     private Sources source;
@@ -114,6 +115,7 @@ public class TestCmdSources {
         sourceConfig.setArchive(JAR_FILE_PATH);
         sourceConfig.setResources(new Resources(CPU, RAM, DISK));
         sourceConfig.setConfigs(createSource.parseConfigs(SINK_CONFIG_STRING));
+        sourceConfig.setForwardSourceMessageProperty(FORWARD_PROPERTIES);
         return sourceConfig;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -71,4 +71,6 @@ public class SourceConfig {
     private BatchSourceConfig batchSourceConfig;
     // batchBuilder provides two types of batch construction methods, DEFAULT and KEY_BASED
     private String batchBuilder;
+
+    private Boolean forwardSourceMessageProperty;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -148,6 +148,10 @@ public class SourceConfigUtils {
             sinkSpecBuilder.setProducerSpec(ProducerConfigUtils.convert(sourceConfig.getProducerConfig()));
         }
 
+        if (sourceConfig.getForwardSourceMessageProperty() == Boolean.TRUE) {
+            sinkSpecBuilder.setForwardSourceMessageProperty(sourceConfig.getForwardSourceMessageProperty());
+        }
+
         functionDetailsBuilder.setSink(sinkSpecBuilder);
 
         // use default resources if resources not set
@@ -235,6 +239,8 @@ public class SourceConfigUtils {
         if (!isEmpty(functionDetails.getCustomRuntimeOptions())) {
             sourceConfig.setCustomRuntimeOptions(functionDetails.getCustomRuntimeOptions());
         }
+
+        sourceConfig.setForwardSourceMessageProperty(sinkSpec.getForwardSourceMessageProperty());
 
         return sourceConfig;
     }
@@ -391,6 +397,9 @@ public class SourceConfigUtils {
         if (newConfig.getBatchSourceConfig() != null) {
             validateBatchSourceConfigUpdate(existingConfig.getBatchSourceConfig(), newConfig.getBatchSourceConfig());
             mergedConfig.setBatchSourceConfig(newConfig.getBatchSourceConfig());
+        }
+        if (newConfig.getForwardSourceMessageProperty() != null) {
+            mergedConfig.setForwardSourceMessageProperty(newConfig.getForwardSourceMessageProperty());
         }
         return mergedConfig;
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -150,6 +150,8 @@ public class SourceConfigUtils {
 
         if (sourceConfig.getForwardSourceMessageProperty() == Boolean.TRUE) {
             sinkSpecBuilder.setForwardSourceMessageProperty(sourceConfig.getForwardSourceMessageProperty());
+        } else {
+            sinkSpecBuilder.setForwardSourceMessageProperty(false);
         }
 
         functionDetailsBuilder.setSink(sinkSpecBuilder);

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -358,6 +358,7 @@ public class SourceConfigUtilsTest extends PowerMockTestCase {
         sourceConfig.setParallelism(1);
         sourceConfig.setRuntimeFlags("-DKerberos");
         sourceConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
+        sourceConfig.setForwardSourceMessageProperty(true);
 
         Map<String, String> consumerConfigs = new HashMap<>();
         consumerConfigs.put("security.protocal", "SASL_PLAINTEXT");

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestPropertySource.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestPropertySource.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io;
+
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.Source;
+import org.apache.pulsar.io.core.SourceContext;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class TestPropertySource implements Source<String> {
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+    }
+
+    @Override
+    public Record<String> read() throws Exception {
+        Thread.sleep(50);
+        return new Record<String>() {
+            @Override
+            public Optional<String> getKey() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String getValue() {
+                return "property";
+            }
+            @Override
+            public Map<String, String> getProperties() {
+                HashMap<String, String> props = new HashMap<String, String>();
+                props.put("hello", "world");
+                props.put("foo", "bar");
+                return props;
+            }
+        };
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarSourcePropertyTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarSourcePropertyTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io;
+
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.functions.FunctionState;
+import org.apache.pulsar.common.policies.data.SinkStatus;
+import org.apache.pulsar.common.policies.data.SourceStatus;
+import org.apache.pulsar.tests.integration.docker.ContainerExecException;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.functions.utils.CommandGenerator;
+import org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.Runtime;
+import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
+import org.awaitility.Awaitility;
+import org.testng.annotations.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.JAVAJAR;
+import static org.apache.pulsar.tests.integration.suites.PulsarTestSuite.retryStrategically;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Source Property related test cases.
+ */
+@Slf4j
+public class PulsarSourcePropertyTest extends PulsarStandaloneTestSuite {
+    @Test(groups = {"source"})
+    public void testSourceProperty() throws Exception {
+        String outputTopicName = "test-source-property-input-" + randomName(8);
+        String sourceName = "test-source-property-" + randomName(8);
+        submitSourceConnector(sourceName, outputTopicName, "org.apache.pulsar.tests.integration.io.TestPropertySource",  JAVAJAR);
+
+        // get source info
+        getSourceInfoSuccess(sourceName);
+
+        // get source status
+        getSourceStatus(sourceName);
+
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(container.getHttpServiceUrl()).build()) {
+
+            Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+                SourceStatus status = admin.sources().getSourceStatus("public", "default", sourceName);
+                assertEquals(status.getInstances().size(), 1);
+                assertTrue(status.getInstances().get(0).getStatus().numWritten > 0);
+            });
+        }
+
+        @Cleanup PulsarClient client = PulsarClient.builder()
+                .serviceUrl(container.getPlainTextServiceUrl())
+                .build();
+        @Cleanup Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(outputTopicName)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscriptionName("test-sub")
+                .subscribe();
+
+        for (int i = 0; i < 10; i++) {
+            Message<String> msg = consumer.receive();
+            assertEquals(msg.getValue(), "property");
+            assertEquals(msg.getProperty("hello"), "world");
+            assertEquals(msg.getProperty("foo"), "bar");
+        }
+
+        // delete source
+        deleteSource(sourceName);
+
+        getSourceInfoNotFound(sourceName);
+    }
+
+    private void submitSourceConnector(String sourceName,
+                                       String outputTopicName,
+                                       String className,
+                                       String archive) throws Exception {
+        String[] commands = {
+                PulsarCluster.ADMIN_SCRIPT,
+                "sources", "create",
+                "--name", sourceName,
+                "--destinationTopicName", outputTopicName,
+                "--archive", archive,
+                "--classname", className
+        };
+        log.info("Run command : {}", StringUtils.join(commands, ' '));
+        ContainerExecResult result = container.execCmd(commands);
+        assertTrue(
+                result.getStdout().contains("\"Created successfully\""),
+                result.getStdout());
+    }
+
+    private void getSourceInfoSuccess(String sourceName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sources",
+                "get",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sourceName
+        );
+        assertTrue(result.getStdout().contains("\"name\": \"" + sourceName + "\""));
+    }
+
+    private void getSourceStatus(String sourceName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sources",
+                "status",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sourceName
+        );
+        assertTrue(result.getStdout().contains("\"running\" : true"));
+    }
+
+    private void deleteSource(String sourceName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sources",
+                "delete",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sourceName
+        );
+        assertTrue(result.getStdout().contains("Delete source successfully"));
+        result.assertNoStderr();
+    }
+
+    private void getSourceInfoNotFound(String sourceName) throws Exception {
+        try {
+            container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "sources",
+                    "get",
+                    "--tenant", "public",
+                    "--namespace", "default",
+                    "--name", sourceName);
+            fail("Command should have exited with non-zero");
+        } catch (ContainerExecException e) {
+            assertTrue(e.getResult().getStderr().contains("Reason: Source " + sourceName + " doesn't exist"));
+        }
+    }
+}

--- a/tests/integration/src/test/resources/pulsar-function.xml
+++ b/tests/integration/src/test/resources/pulsar-function.xml
@@ -24,6 +24,7 @@
         <classes>
             <class name="org.apache.pulsar.tests.integration.functions.PulsarStateTest" />
             <class name="org.apache.pulsar.tests.integration.io.GenericRecordSourceTest" />
+            <class name="org.apache.pulsar.tests.integration.io.PulsarSourcePropertyTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Fixes #9851

### Motivation

Pulsar IO Source connector cannot pass message properties to destination topic, as #9851 discussed, it is a bug that `forwardSourceMessageProperty` is not applied to Source connector properly. 

### Modifications

- add `forwardSourceMessageProperty` to `SourceConfig`
- add set `forwardSourceMessageProperty` from pulsar admin client
- add related logic in `SourceConfigUtils`
- add integration test

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
