### PR TITLE
[Doc] Use pluggable function runtime setting in the doc

### DIFF
--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -21,7 +21,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -31,7 +32,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -57,7 +59,8 @@ The Kubernetes runtime supports secrets, so you can create a Kubernetes secret a
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.5.0/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.5.0/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.5.1/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.5.1/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.5.2/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.5.2/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.6.0/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.6.0/functions-runtime.md
@@ -19,7 +19,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -29,7 +30,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -47,7 +49,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.6.1/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.6.1/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.6.2/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.6.2/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.6.3/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.6.3/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -50,7 +52,8 @@ processContainerFactory:
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.7.0/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.7.0/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -58,7 +60,8 @@ The Kubernetes runtime supports secrets, so you can create a Kubernetes secret a
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty

--- a/site2/website/versioned_docs/version-2.7.1/functions-runtime.md
+++ b/site2/website/versioned_docs/version-2.7.1/functions-runtime.md
@@ -22,7 +22,8 @@ The differences of the thread and process modes are:
 It is easy to configure *Thread* runtime. In most cases, you do not need to configure anything. You can customize the thread group name with the following settings:
 
 ```yaml
-threadContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory
+functionRuntimeFactoryConfigs:
   threadGroupName: "Your Function Container Group"
 ```
 
@@ -32,7 +33,8 @@ threadContainerFactory:
 When you enable *Process* runtime, you do not need to configure anything.
 
 ```yaml
-processContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.process.ProcessRuntimeFactory
+functionRuntimeFactoryConfigs:
   # the directory for storing the function logs
   logDirectory:
   # change the jar location only when you put the java instance jar in a different location
@@ -58,7 +60,8 @@ The Kubernetes runtime supports secrets, so you can create a Kubernetes secret a
 It is easy to configure Kubernetes runtime. You can just uncomment the settings of `kubernetesContainerFactory` in the `functions_worker.yaml` file. The following is an example.
 
 ```yaml
-kubernetesContainerFactory:
+functionRuntimeFactoryClassName: org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory
+functionRuntimeFactoryConfigs:
   # uri to kubernetes cluster, leave it to empty and it will use the kubernetes settings in function worker
   k8Uri:
   # the kubernetes namespace to run the function instances. it is `default`, if this setting is left to be empty


### PR DESCRIPTION

### Motivation
In #5463, we have added the pluggable function runtime setting since 2.5.0. It is better if we can use this feature in the doc.

### Modifications

Update the doc to use pluggable function runtime.
