### PR TITLE
9923-zookeeper-sslQuorum

### DIFF
--- a/conf/zookeeper.conf
+++ b/conf/zookeeper.conf
@@ -54,3 +54,16 @@ autopurge.purgeInterval=1
 # updates to be synced to the media.
 # WARNING: it's not recommended to run a production ZK cluster with forceSync disabled.
 forceSync=yes
+
+# Enable Quorum TLS on each node.
+# To Transition from nontls to tls without downtime: the system needs to be restarted several times.
+# First, Restart zookeepers with portUnification: true.
+# Next,  Restart zookeepers with sqlQuorum: true
+# Finally, Restart zookeepers with portUnification: false
+# Default: false
+sslQuorum=false
+
+# Specifies that the client port should accept SSL connections
+# (using the same configuration as the secure client port).
+# Default: false
+portUnification=false


### PR DESCRIPTION
Add sslQuorum and portUnification configurations to zookeeper.conf for transitioning to leader elections over tls based ports as made available by zookeeper 3.5+