### PR TITLE
[Transaction] Transaction buffer metrics.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -129,7 +129,7 @@ public class TransactionMetadataStoreService {
 
     public void addTransactionMetadataStore(TransactionCoordinatorID tcId) {
         pulsarService.getBrokerService()
-                .getManagedLedgerConfig(TopicName.get(MLTransactionLogImpl.TRANSACTION_LOG_PREFIX + tcId))
+                .getManagedLedgerConfig(TopicName.get(MLTransactionLogImpl.TRANSACTION_LOG_PREFIX + tcId.getId()))
                 .whenComplete((v, e) -> {
                     if (e != null) {
                         LOG.error("Add transaction metadata store with id {} error", tcId.getId(), e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -101,6 +101,7 @@ import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.broker.stats.ReplicationMetrics;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferDisable;
+import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferStats;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
 import org.apache.pulsar.client.api.MessageId;
@@ -1741,6 +1742,13 @@ public class PersistentTopic extends AbstractTopic
         stats.deduplicationStatus = messageDeduplication.getStatus().toString();
         stats.topicEpoch = topicEpoch.orElse(null);
         stats.offloadedStorageSize = ledger.getOffloadedSize();
+        TransactionBufferStats transactionBufferStats = transactionBuffer.getTransactionBufferStats();
+        stats.activeTransactions = transactionBufferStats.activeTransactions;
+        stats.commitTransactionCount = transactionBufferStats.commitTransactionCount;
+        stats.abortTransactionCount = transactionBufferStats.abortTransactionCount;
+        stats.registeredTransactionCount = transactionBufferStats.registeredTransactionCount;
+        stats.publishTxnMessageCount = transactionBufferStats.publishTxnMessageCount;
+        stats.existedAbortTransactions = transactionBufferStats.existedAbortTransactions;
         return stats;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -117,6 +117,12 @@ public class NamespaceStatsAggregator {
         stats.bytesInCounter = tStatus.bytesInCounter;
         stats.msgOutCounter = tStatus.msgOutCounter;
         stats.bytesOutCounter = tStatus.bytesOutCounter;
+        stats.activeTransactions = tStatus.activeTransactions;
+        stats.commitTransactionCount = tStatus.commitTransactionCount;
+        stats.abortTransactionCount = tStatus.abortTransactionCount;
+        stats.registeredTransactionCount = tStatus.registeredTransactionCount;
+        stats.publishTxnMessageCount = tStatus.publishTxnMessageCount;
+        stats.existedAbortTransactions = tStatus.existedAbortTransactions;
 
         stats.producersCount = 0;
         topic.getProducers().values().forEach(producer -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -59,6 +59,15 @@ class TopicStats {
     // Used for tracking duplicate TYPE definitions
     static Map<String, String> metricWithTypeDefinition = new HashMap<>();
 
+    // Transaction buffer stats
+    long activeTransactions;
+    long commitTransactionCount;
+    long abortTransactionCount;
+    long registeredTransactionCount;
+    long publishTxnMessageCount;
+    long existedAbortTransactions;
+
+
 
     public void reset() {
         subscriptionsCount = 0;
@@ -87,6 +96,13 @@ class TopicStats {
         storageWriteLatencyBuckets.reset();
         storageLedgerWriteLatencyBuckets.reset();
         entrySizeBuckets.reset();
+
+        activeTransactions = 0;
+        commitTransactionCount = 0;
+        abortTransactionCount = 0;
+        registeredTransactionCount = 0;
+        publishTxnMessageCount = 0;
+        existedAbortTransactions = 0;
     }
 
     static void resetTypes() {
@@ -249,6 +265,19 @@ class TopicStats {
 
         metric(stream, cluster, namespace, topic, "pulsar_in_bytes_total", stats.bytesInCounter);
         metric(stream, cluster, namespace, topic, "pulsar_in_messages_total", stats.msgInCounter);
+
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_active_transactions",
+                stats.activeTransactions);
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_commit_transaction_count",
+                stats.commitTransactionCount);
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_abort_transaction_count",
+                stats.abortTransactionCount);
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_registered_transaction_count",
+                stats.registeredTransactionCount);
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_existed_abort_transactions",
+                stats.existedAbortTransactions);
+        metric(stream, cluster, namespace, topic, "pulsar_transaction_buffer_publish_message_count",
+                stats.publishTxnMessageCount);
     }
 
     static void metricType(SimpleTextOutputStream stream, String name) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferStats;
 import org.apache.pulsar.client.api.transaction.TxnID;
 
 /**
@@ -147,4 +148,10 @@ public interface TransactionBuffer {
      * @return the stable position.
      */
     PositionImpl getMaxReadPosition();
+
+    /**
+     * Get the transaction buffer stats.
+     * @return the transaction buffer stats.
+     */
+    TransactionBufferStats getTransactionBufferStats();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -364,4 +364,9 @@ class InMemTransactionBuffer implements TransactionBuffer {
         return PositionImpl.latest;
     }
 
+    @Override
+    public TransactionBufferStats getTransactionBufferStats() {
+        return new TransactionBufferStats();
+    }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -85,4 +85,9 @@ public class TransactionBufferDisable implements TransactionBuffer {
     public PositionImpl getMaxReadPosition() {
         return PositionImpl.latest;
     }
+
+    @Override
+    public TransactionBufferStats getTransactionBufferStats() {
+        return new TransactionBufferStats();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferStats.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+public class TransactionBufferStats {
+
+    /** The active transactions. */
+    public long activeTransactions;
+
+    /** The commit transaction count of this transaction buffer. */
+    public long commitTransactionCount;
+
+    /** The abort transaction count of this transaction buffer. */
+    public long abortTransactionCount;
+
+    /** The registered transaction count of this transaction buffer. */
+    public long registeredTransactionCount;
+
+    /** The public transaction message count of this transaction buffer. */
+    public long publishTxnMessageCount;
+
+    /** The existed abort transactions of this transaction buffer. */
+    public long existedAbortTransactions;
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
@@ -91,6 +91,24 @@ public class TopicStats {
     /** The serialized size of non-contiguous deleted messages ranges. */
     public int nonContiguousDeletedMessagesRangesSerializedSize;
 
+    /** The active transactions. */
+    public long activeTransactions;
+
+    /** The commit transaction count of this transaction buffer. */
+    public long commitTransactionCount;
+
+    /** The abort transaction count of this transaction buffer. */
+    public long abortTransactionCount;
+
+    /** The registered transaction count of this transaction buffer. */
+    public long registeredTransactionCount;
+
+    /** The public transaction message count of this transaction buffer. */
+    public long publishTxnMessageCount;
+
+    /** The existed abort transactions of this transaction buffer. */
+    public long existedAbortTransactions;
+
     public TopicStats() {
         this.publishers = Lists.newArrayList();
         this.subscriptions = Maps.newHashMap();
@@ -119,6 +137,12 @@ public class TopicStats {
         this.nonContiguousDeletedMessagesRanges = 0;
         this.nonContiguousDeletedMessagesRangesSerializedSize = 0;
         this.offloadedStorageSize = 0;
+        this.activeTransactions = 0;
+        this.commitTransactionCount = 0;
+        this.abortTransactionCount = 0;
+        this.registeredTransactionCount = 0;
+        this.publishTxnMessageCount = 0;
+        this.existedAbortTransactions = 0;
     }
 
     // if the stats are added for the 1st time, we will need to make a copy of these stats and add it to the current

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -34,6 +34,8 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.TransactionLog;
 import org.apache.pulsar.transaction.coordinator.TransactionLogReplayCallback;
@@ -49,7 +51,7 @@ public class MLTransactionLogImpl implements TransactionLog {
 
     private final ManagedLedger managedLedger;
 
-    public final static String TRANSACTION_LOG_PREFIX = NamespaceName.SYSTEM_NAMESPACE + "/transaction-log-";
+    public final static String TRANSACTION_LOG_PREFIX = "transaction_log_";
 
     private final ManagedCursor cursor;
 
@@ -64,14 +66,15 @@ public class MLTransactionLogImpl implements TransactionLog {
 
     private final long tcId;
 
-    private final String topicName;
+    private final TopicName topicName;
 
     public MLTransactionLogImpl(TransactionCoordinatorID tcID,
                                 ManagedLedgerFactory managedLedgerFactory,
                                 ManagedLedgerConfig managedLedgerConfig) throws Exception {
-        this.topicName = TRANSACTION_LOG_PREFIX + tcID;
+        this.topicName = TopicName.get(TopicDomain.persistent.value(),
+                NamespaceName.SYSTEM_NAMESPACE, "transaction_log_" + tcID.getId());
         this.tcId = tcID.getId();
-        this.managedLedger = managedLedgerFactory.open(topicName, managedLedgerConfig);
+        this.managedLedger = managedLedgerFactory.open(topicName.getPersistenceNamingEncoding(), managedLedgerConfig);
         this.cursor =  managedLedger.openCursor(TRANSACTION_SUBSCRIPTION_NAME,
                 CommandSubscribe.InitialPosition.Earliest);
         this.currentLoadPosition = (PositionImpl) this.cursor.getMarkDeletedPosition();


### PR DESCRIPTION
## Motivation
Transaction buffer metrics add.

## implement
```
    /** The active transactions. */
    public long activeTransactions;

    /** The commit transaction count of this transaction buffer. */
    public long commitTransactionCount;

    /** The abort transaction count of this transaction buffer. */
    public long abortTransactionCount;

    /** The registered transaction count of this transaction buffer. */
    public long registeredTransactionCount;

    /** The public transaction message count of this transaction buffer. */
    public long publishTxnMessageCount;

    /** The existed abort transactions of this transaction buffer. */
    public long existedAbortTransactions;
```
This is transaction buffer metrics.
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

