### PR TITLE
[Doc] Support DLQ in key_shared subscription mode

### DIFF
--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -217,7 +217,7 @@ Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
 Dead letter topic depends on message re-delivery. Messages are redelivered either due to [acknowledgement timeout](#acknowledgement-timeout) or [negative acknowledgement](#negative-acknowledgement). If you are going to use negative acknowledgement on a message, make sure it is negatively acknowledged before the acknowledgement timeout. 
 
 > **Note**    
-> Currently, dead letter topic is enabled only in the shared subscription mode.
+> Currently, dead letter topic is enabled in the Shared and Key_Shared subscription modes.
 
 ### Retry letter topic
 


### PR DESCRIPTION

### Motivation

According to this [PR](https://github.com/apache/pulsar/pull/9678), the DLQ is supported in the key_shared sub. Therefore, update the docs accordingly.

### Modifications

Update the **Dead Letter topic** section in **Messaging** doc.

### Affected release:
2.8.0

