### PR TITLE
[Doc]--Add metrics for producer throttling

### DIFF
--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -394,7 +394,7 @@ All the connection metrics are labelled with the following labels:
 | pulsar_connection_create_fail_count | Gauge | The number of failed connections. |
 | pulsar_connection_closed_total_count | Gauge | The total number of closed connections. |
 | pulsar_broker_throttled_connections | Gauge | The number of throttled connections. |
-| pulsar_broker_throttled_connections_global_limit | Gauge | The number of connections throttled because of per-connection limit. |
+| pulsar_broker_throttled_connections_global_limit | Gauge | The number of throttled connections because of per-connection limit. |
 
 ## Pulsar Functions
 

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -95,21 +95,32 @@ All the metrics exposed by a broker are labelled with `cluster=${pulsar_cluster}
 
 The following metrics are available for broker:
 
-* [Namespace metrics](#namespace-metrics)
-    * [Replication metrics](#replication-metrics)
-* [Topic metrics](#topic-metrics)
-    * [Replication metrics](#replication-metrics-1)
-* [ManagedLedgerCache metrics](#managedledgercache-metrics)
-* [ManagedLedger metrics](#managedledger-metrics)
-* [LoadBalancing metrics](#loadbalancing-metrics)
-    * [BundleUnloading metrics](#bundleunloading-metrics)
-    * [BundleSplit metrics](#bundlesplit-metrics)
-* [Subscription metrics](#subscription-metrics)
-* [Consumer metrics](#consumer-metrics)
-* [ManagedLedger bookie client metrics](#managed-ledger-bookie-client-metrics)
-* [Token metrics](#token-metrics)
-* [Authentication metrics](#authentication-metrics) 
-* [Connection metrics](#connection-metrics)
+- [ZooKeeper](#zookeeper)
+  - [Server metrics](#server-metrics)
+  - [Request metrics](#request-metrics)
+- [BookKeeper](#bookkeeper)
+  - [Server metrics](#server-metrics-1)
+  - [Journal metrics](#journal-metrics)
+  - [Storage metrics](#storage-metrics)
+- [Broker](#broker)
+  - [Namespace metrics](#namespace-metrics)
+    - [Replication metrics](#replication-metrics)
+  - [Topic metrics](#topic-metrics)
+    - [Replication metrics](#replication-metrics-1)
+  - [ManagedLedgerCache metrics](#managedledgercache-metrics)
+  - [ManagedLedger metrics](#managedledger-metrics)
+  - [LoadBalancing metrics](#loadbalancing-metrics)
+    - [BundleUnloading metrics](#bundleunloading-metrics)
+    - [BundleSplit metrics](#bundlesplit-metrics)
+  - [Subscription metrics](#subscription-metrics)
+  - [Consumer metrics](#consumer-metrics)
+  - [Managed ledger bookie client metrics](#managed-ledger-bookie-client-metrics)
+  - [Token metrics](#token-metrics)
+  - [Authentication metrics](#authentication-metrics)
+  - [Connection metrics](#connection-metrics)
+- [Pulsar Functions](#pulsar-functions)
+- [Proxy](#proxy)
+- [Pulsar SQL Worker](#pulsar-sql-worker)
 
 ### Namespace metrics
 
@@ -382,6 +393,8 @@ All the connection metrics are labelled with the following labels:
 | pulsar_connection_create_success_count | Gauge | The number of successfully created connections. |
 | pulsar_connection_create_fail_count | Gauge | The number of failed connections. |
 | pulsar_connection_closed_total_count | Gauge | The total number of closed connections. |
+| pulsar_broker_throttled_connections | Gauge | The number of throttled connections. |
+| pulsar_broker_throttled_connections_global_limit | Gauge | The number of connections throttled because of per-connection limit. |
 
 ## Pulsar Functions
 


### PR DESCRIPTION
### Motivation
In [PR](https://github.com/apache/pulsar/pull/9649), the code is updated by adding metrics for producer throttling. Therefore, update the doc accordingly.

- Affected release: 2.8.0
- Updated docs: reference > pulsar metrics> broker > connection metrics