### PR TITLE
Schema.OBJECT() + support for PrimitiveRecord in Schema.AUTO_CONSUME()

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -182,17 +182,75 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 .topic(topic)
                 .subscribe();
 
+        Consumer<Object> consumer2 = pulsarClient.newConsumer(Schema.OBJECT())
+                .subscriptionName("test-sub2")
+                .topic(topic)
+                .subscribe();
+
         producer.send(bytesRecord);
 
         Message<GenericRecord> message = consumer.receive();
         Message<Schemas.BytesRecord> message1 = consumer1.receive();
+        Message<Object> message2 = consumer2.receive();
 
         assertEquals(message.getValue().getField("address").getClass(),
                 message1.getValue().getAddress().getClass());
 
+        GenericRecord value2 = (GenericRecord) message2.getValue();
+        assertEquals(value2.getField("address").getClass(),
+                message1.getValue().getAddress().getClass());
+
+
         producer.close();
         consumer.close();
         consumer1.close();
+        consumer2.close();
+    }
+
+    @Test
+    public void testStringSchema() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicName = "test-string-schema";
+
+        final String topic = TopicName.get(
+                TopicDomain.persistent.value(),
+                tenant,
+                namespace,
+                topicName).toString();
+
+        admin.namespaces().createNamespace(
+                tenant + "/" + namespace,
+                Sets.newHashSet(CLUSTER_NAME));
+
+        admin.topics().createPartitionedTopic(topic, 2);
+
+        Producer<String> producer = pulsarClient
+                .newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .subscriptionName("test-sub")
+                .topic(topic)
+                .subscribe();
+
+        Consumer<Object> consumer2 = pulsarClient.newConsumer(Schema.OBJECT())
+                .subscriptionName("test-sub2")
+                .topic(topic)
+                .subscribe();
+
+        producer.send("foo");
+
+        Message<String> message = consumer.receive();
+        Message<Object> message2 = consumer2.receive();
+
+        assertEquals("foo", message.getValue());
+        assertEquals("foo", message2.getValue());
+
+        producer.close();
+        consumer.close();
+        consumer2.close();
     }
 
     @Test

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -371,6 +371,10 @@ public interface Schema<T> extends Cloneable{
         return DefaultImplementation.newAutoConsumeSchema();
     }
 
+    static Schema<Object> OBJECT() {
+        return DefaultImplementation.newObjectSchema();
+    }
+
     /**
      * Create a schema instance that accepts a serialized payload
      * and validates it against the topic schema.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/PrimitiveRecord.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/PrimitiveRecord.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api.schema;
+
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An interface represents a message with schema.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class PrimitiveRecord implements GenericRecord {
+
+    private final Object nativeRecord;
+    private final SchemaType schemaType;
+
+    public static PrimitiveRecord of(Object nativeRecord, SchemaType schemaType) {
+        return new PrimitiveRecord(nativeRecord, schemaType);
+    }
+
+    private PrimitiveRecord(Object nativeRecord, SchemaType schemaType) {
+        this.nativeRecord = nativeRecord;
+        this.schemaType = schemaType;
+    }
+
+    public byte[] getSchemaVersion() {
+        return null;
+    }
+
+    public List<Field> getFields() {
+        return Collections.emptyList();
+    }
+
+    public Object getField(String fieldName) {
+        return null;
+    }
+
+    public SchemaType getSchemaType() {
+        return schemaType;
+    }
+
+    public Object getNativeRecord() {
+        return nativeRecord;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toString(nativeRecord);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(nativeRecord);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (! (other instanceof PrimitiveRecord)) {
+            return false;
+        }
+        return Objects.equals(nativeRecord, ((PrimitiveRecord) other).nativeRecord);
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -284,6 +284,13 @@ public class DefaultImplementation {
                         .newInstance());
     }
 
+    public static Schema<Object> newObjectSchema() {
+        return catchExceptions(
+                () -> (Schema<Object>) newClassInstance(
+                        "org.apache.pulsar.client.impl.schema.ObjectSchema")
+                        .newInstance());
+    }
+
     public static Schema<byte[]> newAutoProduceSchema() {
         return catchExceptions(
                 () -> (Schema<byte[]>) newClassInstance(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -69,6 +69,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
+import org.apache.pulsar.client.impl.schema.AbstractAutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AutoProduceBytesSchema;
 import org.apache.pulsar.client.impl.schema.generic.MultiVersionSchemaInfoProvider;
@@ -241,7 +242,7 @@ public class PulsarClientImpl implements PulsarClient {
                 new PulsarClientException.InvalidConfigurationException("Producer configuration undefined"));
         }
 
-        if (schema instanceof AutoConsumeSchema) {
+        if (schema instanceof AbstractAutoConsumeSchema) {
             return FutureUtil.failedFuture(
                 new PulsarClientException.InvalidConfigurationException("AutoConsumeSchema is only used by consumers to detect schemas automatically"));
         }
@@ -863,7 +864,7 @@ public class PulsarClientImpl implements PulsarClient {
                 Schema finalSchema = schema;
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
-                        if (!(finalSchema instanceof AutoConsumeSchema)) {
+                        if (!(finalSchema instanceof AbstractAutoConsumeSchema)) {
                             // no schema info is found
                             return FutureUtil.failedFuture(
                                     new PulsarClientException.NotFoundException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractAutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractAutoConsumeSchema.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericProtobufNativeSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Auto detect schema.
+ */
+@Slf4j
+public abstract class AbstractAutoConsumeSchema <T> implements Schema<T> {
+
+    protected Schema<T> schema;
+
+    protected String topicName;
+
+    protected String componentName;
+
+    protected SchemaInfoProvider schemaInfoProvider;
+
+    public void setSchema(Schema<T> schema) {
+        this.schema = schema;
+    }
+
+    private void ensureSchemaInitialized() {
+        checkState(null != schema, "Schema is not initialized before used");
+    }
+
+    @Override
+    public void validate(byte[] message) {
+        ensureSchemaInitialized();
+
+        schema.validate(message);
+    }
+
+    @Override
+    public boolean supportSchemaVersioning() {
+        return true;
+    }
+
+    @Override
+    public byte[] encode(T message) {
+        ensureSchemaInitialized();
+
+        return schema.encode(message);
+    }
+
+    @Override
+    public T decode(byte[] bytes, byte[] schemaVersion) {
+        if (schema == null) {
+            SchemaInfo schemaInfo = null;
+            try {
+                schemaInfo = schemaInfoProvider.getLatestSchema().get();
+            } catch (InterruptedException | ExecutionException e ) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                log.error("Con't get last schema for topic {} use AutoConsumeSchema", topicName);
+                throw new SchemaSerializationException(e.getCause());
+            }
+            schema = generateSchema(schemaInfo);
+            schema.setSchemaInfoProvider(schemaInfoProvider);
+            log.info("Configure {} schema for topic {} : {}",
+                    componentName, topicName, schemaInfo.getSchemaDefinition());
+        }
+        ensureSchemaInitialized();
+        return schema.decode(bytes, schemaVersion);
+    }
+
+    @Override
+    public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
+        if (schema == null) {
+            this.schemaInfoProvider = schemaInfoProvider;
+        } else {
+            schema.setSchemaInfoProvider(schemaInfoProvider);
+        }
+    }
+
+    @Override
+    public SchemaInfo getSchemaInfo() {
+        if (schema == null) {
+            return null;
+        }
+        return schema.getSchemaInfo();
+    }
+
+    @Override
+    public boolean requireFetchingSchemaInfo() {
+        return this.schema == null || this.schema.requireFetchingSchemaInfo();
+    }
+
+    @Override
+    public void configureSchemaInfo(String topicName,
+                                    String componentName,
+                                    SchemaInfo schemaInfo) {
+        this.topicName = topicName;
+        this.componentName = componentName;
+        if (schemaInfo != null) {
+            Schema<T> genericSchema = generateSchema(schemaInfo);
+            setSchema(genericSchema);
+            log.info("Configure {} schema for topic {} : {}",
+                    componentName, topicName, schemaInfo.getSchemaDefinition());
+        }
+    }
+
+    @Override
+    public abstract Schema<T> clone();
+
+    private Schema<T> generateSchema(SchemaInfo schemaInfo) {
+        // when using `AutoConsumeSchema`, we use the schema associated with the messages as schema reader
+        // to decode the messages.
+        final boolean useProvidedSchemaAsReaderSchema = false;
+        switch (schemaInfo.getType()) {
+            case JSON:
+            case AVRO:
+                return (Schema<T>) GenericSchemaImpl.of(schemaInfo,useProvidedSchemaAsReaderSchema);
+            case PROTOBUF_NATIVE:
+                return GenericProtobufNativeSchema.of(schemaInfo, useProvidedSchemaAsReaderSchema);
+            default:
+                return (Schema<T>) getSchema(schemaInfo);
+        }
+    }
+
+    public static Schema<?> getSchema(SchemaInfo schemaInfo) {
+        switch (schemaInfo.getType()) {
+            case INT8:
+                return ByteSchema.of();
+            case INT16:
+                return ShortSchema.of();
+            case INT32:
+                return IntSchema.of();
+            case INT64:
+                return LongSchema.of();
+            case STRING:
+                return StringSchema.utf8();
+            case FLOAT:
+                return FloatSchema.of();
+            case DOUBLE:
+                return DoubleSchema.of();
+            case BOOLEAN:
+                return BooleanSchema.of();
+            case BYTES:
+                return BytesSchema.of();
+            case DATE:
+                return DateSchema.of();
+            case TIME:
+                return TimeSchema.of();
+            case TIMESTAMP:
+                return TimestampSchema.of();
+            case INSTANT:
+                return InstantSchema.of();
+            case LOCAL_DATE:
+                return LocalDateSchema.of();
+            case LOCAL_TIME:
+                return LocalTimeSchema.of();
+            case LOCAL_DATE_TIME:
+                return LocalDateTimeSchema.of();
+            case JSON:
+            case AVRO:
+                return GenericSchemaImpl.of(schemaInfo);
+            case PROTOBUF_NATIVE:
+                return GenericProtobufNativeSchema.of(schemaInfo);
+            case KEY_VALUE:
+                KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo =
+                    KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo);
+                Schema<?> keySchema = getSchema(kvSchemaInfo.getKey());
+                Schema<?> valueSchema = getSchema(kvSchemaInfo.getValue());
+                return KeyValueSchema.of(keySchema, valueSchema);
+            default:
+                throw new IllegalArgumentException("Retrieve schema instance from schema info for type '"
+                    + schemaInfo.getType() + "' is not supported yet");
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractAutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractAutoConsumeSchema.java
@@ -76,6 +76,10 @@ public abstract class AbstractAutoConsumeSchema <T> implements Schema<T> {
         return schema.encode(message);
     }
 
+    protected T adapt(Object value) {
+        return (T) value;
+    }
+
     @Override
     public T decode(byte[] bytes, byte[] schemaVersion) {
         if (schema == null) {
@@ -95,7 +99,7 @@ public abstract class AbstractAutoConsumeSchema <T> implements Schema<T> {
                     componentName, topicName, schemaInfo.getSchemaDefinition());
         }
         ensureSchemaInitialized();
-        return schema.decode(bytes, schemaVersion);
+        return adapt(schema.decode(bytes, schemaVersion));
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.schema;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.PrimitiveRecord;
 
 /**
  * Auto detect schema, returns only GenericRecord instances.
@@ -44,7 +45,17 @@ public class AutoConsumeSchema extends AbstractAutoConsumeSchema<GenericRecord> 
 
     @Override
     public boolean requireFetchingSchemaInfo() {
-        return true;
+        return schema == null || schema.requireFetchingSchemaInfo();
     }
 
+    @Override
+    protected GenericRecord adapt(Object value) {
+        if (value instanceof GenericRecord) {
+            return (GenericRecord) value;
+        }
+        if (this.schema == null) {
+            throw new IllegalStateException("Cannot decode a message without schema");
+        }
+        return PrimitiveRecord.of(value, this.schema.getSchemaInfo().getType());
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ObjectSchema.java
@@ -20,17 +20,16 @@ package org.apache.pulsar.client.impl.schema;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.schema.GenericRecord;
 
 /**
- * Auto detect schema, returns only GenericRecord instances.
+ * Auto detect schema.
  */
 @Slf4j
-public class AutoConsumeSchema extends AbstractAutoConsumeSchema<GenericRecord> {
+public class ObjectSchema extends AbstractAutoConsumeSchema<Object> {
 
     @Override
-    public Schema<GenericRecord> clone() {
-        Schema<GenericRecord> schema = Schema.AUTO_CONSUME();
+    public Schema<Object> clone() {
+        Schema<Object> schema = Schema.OBJECT();
         if (this.schema != null) {
             schema.configureSchemaInfo(topicName, componentName, this.schema.getSchemaInfo());
         } else {
@@ -40,11 +39,6 @@ public class AutoConsumeSchema extends AbstractAutoConsumeSchema<GenericRecord> 
             schema.setSchemaInfoProvider(schemaInfoProvider);
         }
         return schema;
-    }
-
-    @Override
-    public boolean requireFetchingSchemaInfo() {
-        return true;
     }
 
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -39,7 +39,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.schema.GenericRecord;
-import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.AbstractAutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.CryptoConfig;
@@ -216,7 +216,7 @@ public class PulsarSink<T> implements Sink<T> {
     class PulsarSinkAtMostOnceProcessor extends PulsarSinkProcessorBase {
         public PulsarSinkAtMostOnceProcessor(Schema schema, Crypto crypto) {
             super(schema, crypto);
-            if (!(schema instanceof AutoConsumeSchema)) {
+            if (!(schema instanceof AbstractAutoConsumeSchema)) {
                 // initialize default topic
                 try {
                     publishProducers.put(pulsarSinkConfig.getTopic(),

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoderFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoderFactory.java
@@ -37,8 +37,9 @@ import io.prestosql.spi.type.VarcharType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.pulsar.client.impl.schema.AbstractAutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AbstractSchema;
-import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -60,7 +61,7 @@ public class PulsarPrimitiveRowDecoderFactory implements PulsarRowDecoderFactory
     public PulsarRowDecoder createRowDecoder(TopicName topicName, SchemaInfo schemaInfo,
                                              Set<DecoderColumnHandle> columns) {
         if (columns.size() == 1) {
-            return new PulsarPrimitiveRowDecoder((AbstractSchema<?>) AutoConsumeSchema.getSchema(schemaInfo),
+            return new PulsarPrimitiveRowDecoder((AbstractSchema<?>) AbstractAutoConsumeSchema.getSchema(schemaInfo),
                     columns.iterator().next());
         } else {
             throw new RuntimeException("Primitive type must has only one ColumnHandle.");


### PR DESCRIPTION
This is a draft patch on top of #9895 that adds support for returning an implementation of GenericRecord named PrimitiveRecord that wraps primitive data types and allows Schema.AUTO_CONSUME() to deal with primitive data types.

Example: writing using "String" schema and consume as: String, Object and GenericRecord 

```
    Producer<String> producer = pulsarClient
                .newProducer(Schema.STRING)
                .topic(topic)
                .create();

        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
                .subscriptionName("test-sub")
                .topic(topic)
                .subscribe();

        Consumer<Object> consumer2 = pulsarClient.newConsumer(Schema.OBJECT())
                .subscriptionName("test-sub2")
                .topic(topic)
                .subscribe();

        // use GenericRecord even for primitive types
        // it will be a PrimitiveRecord
        Consumer<GenericRecord> consumer3 = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
                .subscriptionName("test-sub3")
                .topic(topic)
                .subscribe();

        producer.send("foo");

        Message<String> message = consumer.receive();
        Message<Object> message2 = consumer2.receive();
        Message<GenericRecord> message3 = consumer3.receive();

        assertEquals("foo", message.getValue());
        assertEquals("foo", message2.getValue());
        assertTrue(message3.getValue() instanceof PrimitiveRecord);
        assertEquals(SchemaType.STRING, message3.getValue().getSchemaType());
        assertEquals("foo", message3.getValue().getNativeRecord());
```