### PR TITLE
[Performance] Omit call to log.debug in hot code path ManagedLedgerImpl.doCacheEviction

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -149,8 +149,10 @@ public class EntryCacheImpl implements EntryCache {
         final PositionImpl firstPosition = PositionImpl.get(-1, 0);
 
         if (firstPosition.compareTo(lastPosition) > 0) {
-            log.debug("Attempted to invalidate entries in an invalid range : {} ~ {}",
-                firstPosition, lastPosition);
+            if (log.isDebugEnabled()) {
+                log.debug("Attempted to invalidate entries in an invalid range : {} ~ {}",
+                        firstPosition, lastPosition);
+            }
             return;
         }
 


### PR DESCRIPTION
### Motivation

`log.debug` calls should be omitted on hot code paths. There was a `log.debug` call on the frequently called
`ManagedLedgerImpl.doCacheEviction` code path

### Modifications

wrap `log.debug` call with `if (log.isDebugEnabled()) { ... }`