### PR TITLE
[Build] Python-client build script use wrong path for root dir

### DIFF
--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -25,6 +25,7 @@ BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
 ROOT_DIR=$(dirname $0)/../..
 cd $ROOT_DIR
+ROOT_DIR=$(pwd)
 
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -23,11 +23,9 @@ set -e
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
-ROOT_DIR=$(dirname $0)/../..
-cd $ROOT_DIR
-
 # ROOT_DIR should be an absolute path so that Docker accepts it as a valid volumes path
-ROOT_DIR=$(pwd)
+ROOT_DIR=`cd $(dirname $0)/../..; pwd`
+cd $ROOT_DIR
 
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -25,6 +25,7 @@ BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
 # ROOT_DIR should be an absolute path so that Docker accepts it as a valid volumes path
 ROOT_DIR=`cd $(dirname $0)/../..; pwd`
+cd $ROOT_DIR
 
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -25,7 +25,6 @@ BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
 # ROOT_DIR should be an absolute path so that Docker accepts it as a valid volumes path
 ROOT_DIR=`cd $(dirname $0)/../..; pwd`
-cd $ROOT_DIR
 
 PYTHON_VERSIONS=(
    '2.7 cp27-cp27mu'

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -25,6 +25,8 @@ BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 
 ROOT_DIR=$(dirname $0)/../..
 cd $ROOT_DIR
+
+# ROOT_DIR should be an absolute path so that Docker accepts it as a valid volumes path
 ROOT_DIR=$(pwd)
 
 PYTHON_VERSIONS=(


### PR DESCRIPTION
Motivation

The current build process is broken by the wrong root dir. The same mistake that occurred in RPM build has been fixed by #9890 but it hasn't been fixed in python-client build.