### PR TITLE
[Build] Run PR builds for merge commit

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -41,9 +41,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v2

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -39,18 +39,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -60,12 +66,12 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -77,16 +83,16 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build package
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: build cpp artifacts
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           echo "Build C++ client library"
           export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so"
           pulsar-client-cpp/docker-build.sh
 
       - name: run c++ tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: pulsar-client-cpp/docker-tests.sh

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -47,38 +47,44 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: InstallTool
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.18.0
           ./bin/golangci-lint --version
 
       - name: Build
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           go build ./...
 
       - name: CheckStyle
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           ./bin/golangci-lint run -c ./golangci.yml ./pf

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -49,25 +49,31 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Run tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           go test -v $(go list ./... | grep -v examples)

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -51,14 +48,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -67,7 +73,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -76,21 +82,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh BACKWARDS_COMPAT

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -51,15 +48,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -67,7 +73,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -76,22 +82,22 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh CLI
 

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -51,15 +48,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -67,7 +73,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -76,21 +82,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh FUNCTION

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -51,15 +48,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -67,7 +73,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -76,21 +82,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh MESSAGING

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh PULSAR_CONNECTORS_PROCESS

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,18 +81,18 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SCHEMA

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SQL

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh STANDALONE

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration function
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh PULSAR_CONNECTORS_THREAD

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TIERED_FILESYSTEM

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,21 +81,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TIERED_JCLOUD

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -50,15 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -66,7 +72,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -75,18 +81,18 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TRANSACTION

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -39,18 +39,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -59,7 +65,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up JDK 1.8
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -69,15 +75,15 @@ jobs:
 
       # license check fails with 3.6.2 so we have to downgrade
       - name: Set up Maven
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: apache/pulsar-test-infra/setup-maven@master
         with:
           maven-version: 3.6.1
 
       - name: build and check license
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp -DskipTests apache-rat:check initialize license:check install
 
       - name: license check
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -37,9 +37,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Execute pulsarbot command
         id:   pulsarbot

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -51,15 +48,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
@@ -67,7 +73,7 @@ jobs:
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -76,21 +82,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run shade tests
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SHADE

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -41,18 +41,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -64,11 +70,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_1'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_1
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -41,15 +41,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -63,11 +69,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_2'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_2
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -41,18 +41,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -64,11 +70,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_API'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_API
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -41,18 +41,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -64,11 +70,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_IMPL'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -41,15 +41,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -63,11 +69,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_FLAKY'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_FLAKY
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -41,15 +41,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -63,11 +69,11 @@ jobs:
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules pulsar-proxy
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'PROXY'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh PROXY
 
       - name: package surefire artifacts

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -41,21 +41,27 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if this pull request only changes documentation
-        id:   docs
-        uses: apache/pulsar-test-infra/diff-only@master
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
         with:
-          args: site2 deployment .asf.yaml .ci ct.yaml
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - '**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
 
       - name: Replace maven's wagon-http version
         run: ./build/replace_maven-wagon-http-version.sh
 
       - name: run unit test 'OTHER'
-        if: steps.docs.outputs.changed_only == 'no'
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh OTHER
 
       - name: package surefire artifacts


### PR DESCRIPTION
### Motivation

[Mailing list discussion](https://lists.apache.org/thread.html/r8a72efa166bbb2dad660d958e138139c0cd25041eddfd52705f0de11%40%3Cdev.pulsar.apache.org%3E)

In GitHub Actions, the default way to handle PR builds is to checkout GitHub provided merge_commit_sha . 

GitHub's merge_commit_sha is explained in [this documentation](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request)
> Before merging a pull request, the merge_commit_sha attribute holds the SHA of the test merge commit.

Behind the scenes, GitHub automatically creates a "test merge commit" that merges the PR branch and the target branch (master). A pull request build won't be started at all if this test merge commit cannot be created without conflicts.

In Pulsar GitHub Actions workflows, the PR builds happen for the HEAD commit on the pull request branch, without a merge to the master branch. The downside of the approach used in the existing Pulsar CI is that the PR build won't pick up changes made in the master branch. It is required to explicitly rebase or merge the master branch to the pull request branch to get the changes. Another disadvantage is that there's a higher chance that the PR breaks the master branch after the PR is merged.
The isolated behavior might be seen as a benefit. The PR branch build will be only impacted by the changes made in the PR branch. 

This PR is about changing the Pulsar CI PR builds to use the GitHub Actions default for checking out the merge_commit_sha for PR builds.


### Modifications

- instead of running the build for PR branch HEAD commit,
  run the commit for GitHub provided merge_commit_sha

- switch pulsar-test-infra/diff-only to dorny/paths-filter
  since diff-only doesn't support the merge commits for PRs and
  paths-filter is a action with wide user base and it's actively
  developed