### PR TITLE
Harden RawReaderTest with Awaitility

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,6 +44,7 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -357,14 +359,14 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
         ManagedLedger ledger = topicRef.getManagedLedger();
-        for (int i = 0; i < 30; i++) {
-            if (ledger.openCursor(subscription).getProperties().get("foobar").equals(0xdeadbeefdecaL)) {
-                break;
-            }
-            Thread.sleep(100);
-        }
-        Assert.assertEquals(ledger.openCursor(subscription).getProperties().get("foobar"),
-                Long.valueOf(0xdeadbeefdecaL));
+
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                        Assert.assertEquals(
+                                ledger.openCursor(subscription).getProperties().get("foobar"),
+                                Long.valueOf(0xdeadbeefdecaL)));
+
     }
 
     @Test


### PR DESCRIPTION
### Motivation

testAcknowledgeWithProperties can fail via an exception and result in frequent test errors.

### Modification

Wrap with Awaitility to handle exceptions and retries.
