### PR TITLE
[Performance] Optimize NamespaceBundle.toString() which is on the hot path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
@@ -32,6 +32,8 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
     // Issue#596: remove this once we remove broker persistent/non-persistent mode configuration
     // it is used by load-manager while considering bundle ownership
     private boolean hasNonPersistentTopic = false;
+    private final String key;
+    private final String bundleRange;
 
     public NamespaceBundle(NamespaceName nsname, Range<Long> keyRange, NamespaceBundleFactory factory) {
         this.nsname = checkNotNull(nsname);
@@ -46,6 +48,8 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
                 "Invalid hash range. Upper Endpoint should be exclusive unless it is 0xffffffff");
         checkArgument(!this.keyRange.isEmpty(), "Cannot create bundle object for an empty key range");
         this.factory = checkNotNull(factory);
+        this.key = getKey(this.nsname, this.keyRange);
+        this.bundleRange = String.format("0x%08x_0x%08x", keyRange.lowerEndpoint(), keyRange.upperEndpoint());
     }
 
     @Override
@@ -55,7 +59,7 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
 
     @Override
     public String toString() {
-        return getKey(this.nsname, this.keyRange);
+        return key;
     }
 
     @Override
@@ -117,7 +121,7 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
     }
 
     public String getBundleRange() {
-        return String.format("0x%08x_0x%08x", keyRange.lowerEndpoint(), keyRange.upperEndpoint());
+        return bundleRange;
     }
 
     private static String getKey(NamespaceName nsname, Range<Long> keyRange) {


### PR DESCRIPTION
### Motivation

- This is on the hot path of ownership checks for topics

- also optimize getBundleRange() although the method doesn't seem to be on hot paths
  - it's more consistent with the change for toString() in NamespaceBundle class

### Modifications

Add final fields for pre-calculating the values returned by toString and getBundleRange methods