### PR TITLE
Issue-9977: [Functions] Enabled server side routing for state store

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreProviderImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreProviderImpl.java
@@ -77,6 +77,7 @@ public class BKStateStoreProviderImpl implements StateStoreProvider {
 
         StorageClientSettings settings = StorageClientSettings.newBuilder()
             .serviceUri(stateStorageServiceUrl)
+            .enableServerSideRouting(true)
             .clientName("function-" + tableNs)
             // configure a maximum 2 minutes jitter backoff for accessing table service
             .backoffPolicy(Jitter.of(


### PR DESCRIPTION

Fixes #9977 

### Motivation

Stateful functions would not run on a Pulsar standalone cluster running inside a Docker container

### Modifications

Changed the client type used by the BKStateStoreProvider from a Thick client to the thgin

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: No
  - The schema: No
  - The default values of configurations: No
  - The wire protocol: No
  - The rest endpoints: No
  - The admin cli options: No
  - Anything that affects deployment: No

### Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable 
  - If a feature is not applicable for documentation, explain why? It is just a fix to some low-level implementation that the user is unaware of
