### PR TITLE
[Issue-9946][Pulsar Functions]Fix: Deleting a Pulsar Function with a name that includes a colon character crashes the pulsar broker

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionInstanceId.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionInstanceId.java
@@ -38,13 +38,13 @@ public class FunctionInstanceId {
         this.tenant = t1[0];
         this.namespace = t1[1];
 
-        String[] t2 = t1[2].split(":");
+        int instanceIdDelimiterIndex = t1[2].lastIndexOf(':');
 
-        if (t2.length != 2) {
-            throw new IllegalArgumentException("Invalid format for fully qualified instance name: " + fullyQualifiedInstanceName);
+        if (instanceIdDelimiterIndex < 0) {
+            throw new IllegalArgumentException("Invalid format for fully qualified instance name: " + fullyQualifiedInstanceName);            
         }
-
-        this.name = t2[0];
-        this.instanceId = Integer.parseInt(t2[1]);
+        
+        this.name = t1[2].substring(0, instanceIdDelimiterIndex);
+        this.instanceId = Integer.parseInt(t1[2].substring(instanceIdDelimiterIndex + 1));
     }
 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionInstanceIdTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionInstanceIdTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Unit test of {@link FunctionInstanceId}.
+ */
+public class FunctionInstanceIdTest {
+
+    @Test
+    public void testThrowsExceptionWhenTenantNamespaceFunctionNameNotProperlyDelimited() {
+	try {
+	    FunctionInstanceId id = new FunctionInstanceId("tenant/namespace:function");
+	    
+	    fail("Expected exception!");
+	} catch (IllegalArgumentException e) {
+	    //pass
+	}
+    }
+    
+    @Test
+    public void testThrowsExceptionWhenFunctionInstanceIdNotPropertyDelimited() {
+	try {
+	    FunctionInstanceId id = new FunctionInstanceId("tenant/namespace/function-1");
+	    
+	    fail("Expected exception!");
+	} catch (IllegalArgumentException e) {
+	    //pass
+	}	
+    }
+    
+    @Test
+    public void testAllowsColonsInFunctionName() {
+        FunctionInstanceId id = new FunctionInstanceId("tenant/namespace/my:function:name:-1");
+        
+        assertEquals("tenant", id.getTenant());
+        assertEquals("namespace", id.getNamespace());
+        assertEquals("my:function:name", id.getName());
+        assertEquals(-1, id.getInstanceId());
+    }
+}


### PR DESCRIPTION
Fixes #9946

### Motivation

I'm able to successfully deploy in Pulsar a Pulsar function that includes a ':' as part of its function name. When I later try to delete the function deployment, the Pulsar broker ends up crashing with an IllegalArgumentException in its log stating "Invalid format for fully qualified instance name: :". If the KubernetesRuntime is configured, this prevents deletion of the function's statefulset.

Since pulsar accepts a function name that includes ':' during creation, it should support it during deletion as well.

### Modifications

- Changed org.apache.pulsar.functions.utils.FunctionInstanceId constructor to split on the last colon in the function name, so that it both retrieves the instanceId and tolerates the presence of colons in the function name
- Added unit test org.apache.pulsar.functions.utils.FunctionInstanceIdTest to validate parsing

### Verifying this change

This change added tests and can be verified as follows:

**pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionInstanceIdTest**
  - *Added test to verify parsing of / delimiters*
  - *Added test to verify parsing of instanceId*
  - *Added test to verify successful parsing of function names that include colons*

### Documentation

  - Does this pull request introduce a new feature? no
