### PR TITLE
[Pulsar SQL] Make the Pulsar SQL support query the uppercase topic

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -283,7 +282,7 @@ public class PulsarMetadata implements ConnectorMetadata {
 
         SchemaInfo schemaInfo;
         try {
-            schemaInfo = this.pulsarAdmin.schemas().getSchemaInfo(topicName.toString());
+            schemaInfo = this.pulsarAdmin.schemas().getSchemaInfo(topicName.getSchemaName());
         } catch (PulsarAdminException e) {
             if (e.getStatusCode() == 404) {
                 // use default schema because there is no schema
@@ -364,8 +363,11 @@ public class PulsarMetadata implements ConnectorMetadata {
         TopicName topicName;
         try {
             topicName = tableNameTopicNameCache.get(schemaTableName);
-        } catch (ExecutionException e) {
+        } catch (Exception e) {
             log.error(e, "Failed to get table handler for tableName " + schemaTableName);
+            if (e.getCause() != null && e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
             throw new TableNotFoundException(schemaTableName);
         }
         return topicName;

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
@@ -102,8 +102,7 @@ public class PulsarSplitManager implements ConnectorSplitManager {
         TupleDomain<ColumnHandle> tupleDomain = layoutHandle.getTupleDomain();
 
         String namespace = restoreNamespaceDelimiterIfNeeded(tableHandle.getSchemaName(), pulsarConnectorConfig);
-        TopicName topicName = TopicName.get("persistent", NamespaceName.get(namespace),
-                tableHandle.getTableName());
+        TopicName topicName = TopicName.get("persistent", NamespaceName.get(namespace), tableHandle.getTopicName());
 
         SchemaInfo schemaInfo;
 
@@ -251,7 +250,7 @@ public class PulsarSplitManager implements ConnectorSplitManager {
                 numSplits,
                 tableHandle,
                 schemaInfo,
-                tableHandle.getTableName(),
+                topicName.getLocalName(),
                 tupleDomain,
                 offloadPolicies);
     }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplitManager.java
@@ -108,17 +108,17 @@ public class PulsarSplitManager implements ConnectorSplitManager {
 
         try {
             schemaInfo = this.pulsarAdmin.schemas().getSchemaInfo(
-                    String.format("%s/%s", namespace, tableHandle.getTableName()));
+                    String.format("%s/%s", namespace, tableHandle.getTopicName()));
         } catch (PulsarAdminException e) {
             if (e.getStatusCode() == 401) {
                 throw new PrestoException(QUERY_REJECTED,
                         String.format("Failed to get pulsar topic schema for topic %s/%s: Unauthorized",
-                                namespace, tableHandle.getTableName()));
+                                namespace, tableHandle.getTopicName()));
             } else if (e.getStatusCode() == 404) {
                 schemaInfo = PulsarSqlSchemaInfoProvider.defaultSchema();
             } else {
                 throw new RuntimeException("Failed to get pulsar topic schema for topic "
-                        + String.format("%s/%s", namespace, tableHandle.getTableName())
+                        + String.format("%s/%s", namespace, tableHandle.getTopicName())
                         + ": " + ExceptionUtils.getRootCause(e).getLocalizedMessage(), e);
             }
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -118,10 +118,15 @@ public class TestBasicPresto extends TestPulsarSQLBase {
         TopicName topicName2 = TopicName.get("public/default/diff_case_topic_" + randomSuffix);
         prepareData(topicName1, false, false, JSONSchema.of(Stock.class));
         prepareData(topicName2, false, false, JSONSchema.of(Stock.class));
-        ContainerExecResult result =
-                execQuery("select * from pulsar.\"public/default\".\"diff_case_topic_" + randomSuffix + "\"");
-        log.info(result.getStderr());
-        Assert.assertTrue(result.getStderr().contains("failed: There are multiple topics"));
+        try {
+            String query = "select * from pulsar.\"public/default\".\"diff_case_topic_" + randomSuffix + "\"";
+            ContainerExecResult result = execQuery(query);
+            Assert.fail("The query [" + query + "] should be failed.");
+        } catch (Exception e) {
+            log.info("Expected exception. exception class: {}, exception message: {}",
+                    e.getCause().getClass(), e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("There are multiple topics"));
+        }
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -106,7 +106,7 @@ public class TestBasicPresto extends TestPulsarSQLBase {
     }
 
     @Test
-    public void testForUpperCaseTopic() throws Exception {
+    public void testForUppercaseTopic() throws Exception {
         TopicName topicName = TopicName.get("public/default/case_UPPER_topic_" + randomName(5));
         pulsarSQLBasicTest(topicName, false, false, JSONSchema.of(Stock.class));
     }
@@ -119,9 +119,9 @@ public class TestBasicPresto extends TestPulsarSQLBase {
         prepareData(topicName1, false, false, JSONSchema.of(Stock.class));
         prepareData(topicName2, false, false, JSONSchema.of(Stock.class));
         ContainerExecResult result =
-                execQuery("select * from pulsar.\"public/default\".\"diff_case_topic_\"" + randomSuffix);
-        log.info(result.getStdout());
-        Assert.assertTrue(result.getStdout().contains("failed: There are multiple topics"));
+                execQuery("select * from pulsar.\"public/default\".\"diff_case_topic_" + randomSuffix + "\"");
+        log.info(result.getStderr());
+        Assert.assertTrue(result.getStderr().contains("failed: There are multiple topics"));
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -123,8 +123,7 @@ public class TestBasicPresto extends TestPulsarSQLBase {
             ContainerExecResult result = execQuery(query);
             Assert.fail("The query [" + query + "] should be failed.");
         } catch (Exception e) {
-            log.info("Expected exception. exception class: {}, exception message: {}",
-                    e.getCause().getClass(), e.getMessage());
+            log.warn("Expected exception. exception message: {}", e.getMessage(), e);
             Assert.assertTrue(e.getMessage().contains("There are multiple topics"));
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -35,6 +35,8 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -101,6 +103,25 @@ public class TestBasicPresto extends TestPulsarSQLBase {
         }
         String topic = String.format("public/default/schema_%s_test_%s", schemaFlag, randomName(5)).toLowerCase();
         pulsarSQLBasicTest(TopicName.get(topic), false, false, schema);
+    }
+
+    @Test
+    public void testForUpperCaseTopic() throws Exception {
+        TopicName topicName = TopicName.get("public/default/case_UPPER_topic_" + randomName(5));
+        pulsarSQLBasicTest(topicName, false, false, JSONSchema.of(Stock.class));
+    }
+
+    @Test
+    public void testForDifferentCaseTopic() throws Exception {
+        String randomSuffix = randomName(5);
+        TopicName topicName1 = TopicName.get("public/default/diff_CASE_topic_" + randomSuffix);
+        TopicName topicName2 = TopicName.get("public/default/diff_case_topic_" + randomSuffix);
+        prepareData(topicName1, false, false, JSONSchema.of(Stock.class));
+        prepareData(topicName2, false, false, JSONSchema.of(Stock.class));
+        ContainerExecResult result =
+                execQuery("select * from pulsar.\"public/default\".\"diff_case_topic_\"" + randomSuffix);
+        log.info(result.getStdout());
+        Assert.assertTrue(result.getStdout().contains("failed: There are multiple topics"));
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -133,7 +133,8 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
                     ContainerExecResult r = execQuery(
                             String.format("show tables in pulsar.\"%s\";", topicName.getNamespace()));
                     assertThat(r.getExitCode()).isEqualTo(0);
-                    assertThat(r.getStdout()).contains(topicName.getLocalName());
+                    // the show tables query return lowercase table names, so ignore case
+                    assertThat(r.getStdout()).containsIgnoringCase(topicName.getLocalName());
                 }
         );
     }


### PR DESCRIPTION
### Motivation

When querying the uppercase topic (e.g. `public/default/case_UPPER_topic`) by the Pulsar SQL, it will throw the error "topic not found" because of the class `SchemaTableName`, in the Pulsar SQL, we couldn't get the exact table name (e.g. `Test`, `tEst`) but only lowercase table name (e.g. `test`), this is the presto behavior.

Refer to the presto class `SchemaTableName`.
```
@JsonCreator
public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName) {
    this.schemaName = SchemaUtil.checkNotEmpty(schemaName, "schemaName").toLowerCase(Locale.ENGLISH);
    this.tableName = SchemaUtil.checkNotEmpty(tableName, "tableName").toLowerCase(Locale.ENGLISH);
}
```

If there are topics `public/default/case_UPPER_topic`, `public/default/case_upper_topic`, the query `show tables in pulsar."public/default"` will return one result `public/default/case_upper_topic`, this behavior is determined by the presto spi.

There is a precondition for querying the uppercase topic, the topic name must be unique. For example, if there are topics `public/default/case_UPPER_topic`, `public/default/case_upper_topic`, the query `select * from pulsar."public/default"."case_upper_topic" will throw error no matched topic, because of that we could get the exact topic by the lowercase table name `case_upper_topic`.

If there is a unique topic `public/default/case_UPPER_topic`, the query `select * from pulsar."public/default"."case_UPPER_topic` or `select * from pulsar."public/default"."case_upper_topic` will query that unique topic.

topics | allow query | table name
--|--|--
test, Test | false | -
test | true | test, Test

### Modifications

Get the matched topic by the lowercase table name in the method `getTableHandle`.

### Verifying this change

Add new integration tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

