### PR TITLE
Add apache.httpcomponents.httpclient to dependencyManagement

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -420,8 +420,8 @@ The Apache Software License, Version 2.0
     - org.apache.distributedlog-distributedlog-protocol-4.13.0.jar
     - org.apache.bookkeeper.stats-codahale-metrics-provider-4.13.0.jar
   * Apache HTTP Client
-    - org.apache.httpcomponents-httpclient-4.5.5.jar
-    - org.apache.httpcomponents-httpcore-4.4.9.jar
+    - org.apache.httpcomponents-httpclient-4.5.13.jar
+    - org.apache.httpcomponents-httpcore-4.4.13.jar
  * AirCompressor
     - io.airlift-aircompressor-0.16.jar
  * AsyncHttpClient

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@ flexible messaging model and an intuitive client API.</description>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
     <docker-java.version>3.2.7</docker-java.version>
+    <apache-http-client.version>4.5.13</apache-http-client.version>
 
     <!-- test dependencies -->
     <cassandra.version>3.6.0</cassandra.version>
@@ -1027,6 +1028,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
         <version>${objenesis.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${apache-http-client.version}</version>
       </dependency>
 
     </dependencies>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -304,8 +304,8 @@ The Apache Software License, Version 2.0
     - trace-token-0.195.jar
     - units-1.6.jar
    * Apache HTTP Client
-    - httpclient-4.5.5.jar
-    - httpcore-4.4.9.jar
+    - httpclient-4.5.13.jar
+    - httpcore-4.4.13.jar
   * Error Prone Annotations
     - error_prone_annotations-2.3.4.jar
   * Esri Geometry API For Java


### PR DESCRIPTION
### Motivation

Different dependencies bring in different apache http client version.

The version we're currently picking is subject to security issues: https://nvd.nist.gov/vuln/detail/CVE-2020-13956

### Modifications

Pin the apache http client version in dependencyManagement