### PR TITLE
Fix NPE caused by null value of SchemaInfo's properties

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -238,7 +238,7 @@ public final class SchemaUtils {
             sortedProperties.putAll(properties);
             JsonObject object = new JsonObject();
             sortedProperties.forEach((key, value) -> {
-                object.add(key, new JsonPrimitive(value));
+                object.add(key, (value != null) ? new JsonPrimitive(value) : null);
             });
             return object;
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -322,10 +322,10 @@ public class SchemaInfoTest {
         public void testNullPropertyValue() {
             final Map<String, String> map = new HashMap<>();
             map.put("key", null);
-            final SchemaInfo schemaInfo = Schema.INT32.getSchemaInfo();
-            schemaInfo.setProperties(map);
-
-            assertEquals(map, Schema.INT32.getSchemaInfo().getProperties());
+            final IntSchema schema = new IntSchema();
+            schema.getSchemaInfo().setProperties(map);
+            // null key will be skipped by Gson when serializing JSON to String
+            assertEquals(schema.getSchemaInfo().toString(), INT32_SCHEMA_INFO);
         }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
@@ -317,5 +318,14 @@ public class SchemaInfoTest {
             assertEquals(schemaInfo.getProperties(), Maps.newHashMap(map));
         }
 
+        @Test
+        public void testNullPropertyValue() {
+            final Map<String, String> map = new HashMap<>();
+            map.put("key", null);
+            final SchemaInfo schemaInfo = Schema.INT32.getSchemaInfo();
+            schemaInfo.setProperties(map);
+
+            assertEquals(map, Schema.INT32.getSchemaInfo().getProperties());
+        }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -694,9 +694,11 @@ public class Commands {
                 .setType(getSchemaType(schemaInfo.getType()));
 
         schemaInfo.getProperties().entrySet().stream().forEach(entry -> {
-            schema.addProperty()
-                .setKey(entry.getKey())
-                .setValue(entry.getValue());
+            if (entry.getKey() != null && entry.getValue() != null) {
+                schema.addProperty()
+                        .setKey(entry.getKey())
+                        .setValue(entry.getValue());
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #9964 

### Motivation

If there exists a null value of `SchemaInfo`'s properties, NPE will be thrown in `SchemaInfo#toString` or `Commands#newSubscribe`.

### Modifications

- Add null checks before `JsonPrimitive`'s constructor, `KeyValue#setKey` and `KeyValue#setValue`.
- Add related tests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows: `SchemaTest#testNullKeyValueProperty` and `SchemaInfoTest#testNullPropertyValue`.