### PR TITLE
[CI] Don’t run GitHub Actions on draft pull requests

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -35,12 +35,18 @@ env:
 jobs:
 
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: macos-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -20,6 +20,7 @@
 name: CI - Build - MacOS
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths-ignore: ['site2/**', 'deployment/**']
@@ -34,6 +35,7 @@ env:
 jobs:
 
   build:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: macos-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   cpp-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -20,6 +20,7 @@
 name: CI - CPP, Python Tests
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   cpp-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -20,6 +20,7 @@
 name: CI - Go Functions style check
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:
@@ -37,6 +38,7 @@ env:
 
 jobs:
   check-style:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     name: Go ${{ matrix.go-version }} Functions style check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -38,7 +38,6 @@ env:
 
 jobs:
   check-style:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     name: Go ${{ matrix.go-version }} Functions style check
     runs-on: ubuntu-latest
@@ -47,6 +46,13 @@ jobs:
         go-version: [1.11, 1.12, 1.13, 1.14]
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -20,6 +20,7 @@
 name: CI - Go Functions Tests
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:
@@ -38,6 +39,7 @@ env:
 jobs:
 
   go-functions-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Run Go Tests
     strategy:
       matrix:

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -39,7 +39,6 @@ env:
 jobs:
 
   go-functions-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Run Go Tests
     strategy:
       matrix:
@@ -49,6 +48,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   backwards-compatibility:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Backwards Compatibility
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   backwards-compatibility:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Cli
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   cli:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   cli:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Function & IO
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   function-state:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   function-state:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   messaging:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Messaging
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   messaging:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Process
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   process:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   process:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   schema:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Schema
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   schema:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Sql
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   sql:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   sql:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Standalone
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   standalone:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   standalone:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   thread:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Thread
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   thread:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   tiered-filesystem:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Tiered FileSystem
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   tiered-filesystem:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Tiered JCloud
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   tiered-jcloud:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   tiered-jcloud:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -33,11 +33,17 @@ env:
 jobs:
 
   transaction:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -20,6 +20,7 @@
 name: CI - Integration - Transaction
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   transaction:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   license-check:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: License check
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -20,6 +20,7 @@
 name: CI - Misc
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   license-check:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: License check
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -33,12 +33,18 @@ env:
 jobs:
 
   shade-check:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -20,6 +20,7 @@
 name: CI - Shade - Test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   shade-check:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 45
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -80,7 +86,7 @@ jobs:
         run: ./build/run_unit_group.sh BROKER_GROUP_1
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -89,7 +95,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Brokers - Broker Group 1
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Brokers - Broker Group 2
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -79,7 +85,7 @@ jobs:
         run: ./build/run_unit_group.sh BROKER_GROUP_2
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -88,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -80,7 +86,7 @@ jobs:
         run: ./build/run_unit_group.sh BROKER_CLIENT_API
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -89,7 +95,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Brokers - Client Api
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -80,7 +86,7 @@ jobs:
         run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -89,7 +95,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Brokers - Client Impl
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Brokers - Other
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -79,7 +85,7 @@ jobs:
         run: ./build/run_unit_group.sh BROKER_FLAKY
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -88,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -79,7 +85,7 @@ jobs:
         run: ./build/run_unit_group.sh PROXY
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -88,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit - Proxy
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -20,6 +20,7 @@
 name: CI - Unit
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
   push:
@@ -32,6 +33,7 @@ env:
 jobs:
 
   unit-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
 
   unit-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name:
     runs-on: ubuntu-latest
     container:
@@ -41,6 +40,13 @@ jobs:
     timeout-minutes: 120
 
     steps:
+
+      - name: fail PR drafts
+        if: ${{ github.event.pull_request.draft == true }}
+        run: |
+          echo "::warning::Skipping pull requests in draft status"
+          exit 99
+
       - name: checkout
         uses: actions/checkout@v2
 
@@ -67,7 +73,7 @@ jobs:
         run: ./build/run_unit_group.sh OTHER
 
       - name: package surefire artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         run: |
           rm -rf artifacts
           mkdir artifacts
@@ -76,7 +82,7 @@ jobs:
 
       - uses: actions/upload-artifact@master
         name: upload surefire-artifacts
-        if: failure()
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
         with:
           name: surefire-artifacts
           path: artifacts.zip


### PR DESCRIPTION
Fixes #9982

### Motivation

Don't run GitHub Actions for pull requests with "draft" status.

### Modifications

It is not fully possible to prevent GitHub Actions for PRs with draft status.

Initial solution was based on on https://github.community/t/dont-run-actions-on-draft-pull-requests/16817 . That filter pull_request events to types opened, synchronize, reopened, ready_for_review and adds condition that skips the job if PR has draft status.
However the downside of this solution is that the PR becomes mergable for a moment after the PR is changed from draft status to "ready for review".

Additional changes were made to prevent merging a PR right after it has been changed from draft to "ready for review" status. The solution is to mark builds for PR drafts as failed.