### PR TITLE
[CI] Improve Maven repository caching in Pulsar CI / GitHub Actions

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -46,10 +46,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/pulsar
-            !~/.m2/.gradle-enterprise
-          key: ${{ runner.os }}-maven-dependencies-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -59,10 +59,12 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -80,6 +82,7 @@ jobs:
           df -h
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build package

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -63,6 +55,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/setup-java@v1
@@ -70,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -63,6 +55,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -70,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -63,6 +55,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -70,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -63,6 +55,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -70,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -62,6 +54,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -69,6 +73,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -59,10 +59,13 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 1.8
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -71,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       # license check fails with 3.6.2 so we have to downgrade

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow keeps the GitHub Action Caches up-to-date in the repository.
+#
+# A pull request build cannot update the cache of the upstream repository. Pull
+# requests have a cache in the context of the fork of the upstream repository.
+# A pull request build will lookup cache entries from the cache of the upstream
+# repository in the case that a cache entry is missing in the pull request source
+# repository's cache.
+# To reduce cache misses for pull request builds, it is necessary that the
+# caches in the upstream repository are up-to-date.
+# If the cache entry already exists, the cache won't be updated. This will keep the
+# update job very efficient and the downloading and updating will only run if one of the pom.xml
+# files has been modified or the cache entry expires.
+#
+
+name: CI - Maven Dependency Cache Update
+on:
+  # trigger on every commit to given branches
+  push:
+    branches:
+      - master
+  # trigger on a schedule so that the cache will be rebuilt if it happens to expire
+  schedule:
+    - cron: '30 */12 * * *'
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  update-maven-dependencies-cache:
+    name: Update Maven dependency cache for ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: all modules
+            runs-on: ubuntu-latest
+            cache_name: 'm2-dependencies-all'
+            mvn_arguments: ''
+
+          - name: all modules - macos
+            runs-on: macos-latest
+            cache_name: 'm2-dependencies-all'
+
+          - name: core-modules
+            runs-on: ubuntu-latest
+            cache_name: 'm2-dependencies-core-modules'
+            mvn_arguments: '-Pcore-modules'
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Changed files check
+        if: ${{ github.event_name != 'schedule' }}
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
+        with:
+          filters: |
+            poms:
+              - 'pom.xml'
+              - '**/pom.xml'
+
+      - name: Cache local Maven repository
+        if: ${{ github.event_name == 'schedule' || steps.changes.outputs.poms == 'true' }}
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-${{ matrix.cache_name }}-${{ hashFiles('**/pom.xml') }}
+          # there is no restore-keys here so that the cache size doesn't keep
+          # on growing from old entries which wouldn't never expire if the old
+          # cache would be used as the starting point for a new cache entry
+
+      - name: Set up JDK 1.8
+        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Replace maven's wagon-http version
+        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
+
+      - name: Download dependencies
+        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          # workaround issue https://github.com/sundrio/sundrio/issues/168
+          perl -0777 -i.original -pe 's/<dependency>\s+<groupId>io.sundr<\/groupId>.*?<\/dependency>//sg' pulsar-functions/runtime/pom.xml pulsar-functions/secrets/pom.xml || true
+          # download dependencies, ignore errors
+          mvn -B -fn -ntp ${{ matrix.mvn_arguments }} dependency:go-offline

--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -34,6 +34,25 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-swagger-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Replace maven's wagon-http version
+        run: sudo ./build/replace_maven-wagon-http-version.sh
+
       - name: build
         run: mvn -B clean package -DskipTests -Pswagger
 

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
@@ -63,6 +55,18 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
@@ -70,6 +74,7 @@ jobs:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 45
 
     steps:
@@ -61,13 +59,22 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -58,15 +56,25 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -61,13 +59,22 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -61,13 +59,22 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -58,15 +56,25 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -58,15 +56,25 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules pulsar-proxy
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -34,8 +34,6 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    container:
-      image: apachepulsar/pulsar-build:latest
     timeout-minutes: 120
 
     steps:
@@ -57,8 +55,26 @@ jobs:
               - '*.md'
               - '**/*.md'
 
+      - name: Cache local Maven repository
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        with:
+          java-version: 1.8
+
       - name: Replace maven's wagon-http version
-        run: ./build/replace_maven-wagon-http-version.sh
+        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: run unit test 'OTHER'
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}


### PR DESCRIPTION
### Motivation

Maven repository caching has several issues in Pulsar CI:

- caching doesn't work for dependencies of a build that builds all modules if a cache entry has been published
  from a build that was built for core-modules
  - the GitHub Actions cache restores the complete ~/m2/repository directory for a cache key at once 
    and doesn't do lookups for individual files.

- cache step is run for document only changes. This might lead to an empty cache entry when the document build updates the cache entry.

- Pulsar build artifacts in ~/.m2/repository/org/apache/pulsar get cached. This consumes unnecessary bandwidth and could lead to surprises unless every build rebuilds all Pulsar libraries. It's better to exclude the files from the Maven dependency cache entries since they aren't needed there.

A pull request build cannot update the cache of the upstream repository. Pull requests have a cache in the context of the fork of the upstream repository.  A pull request build will lookup cache entries from the cache of the upstream repository in the case that a cache entry is missing in the pull request source repository's cache. To reduce cache misses for pull request builds, it is necessary that the  caches in the upstream repository are up-to-date. This pull request adds a scheduled workflow to keep the maven dependency caches up-to-date.

**When the cache is up-to-date, it will reduce the build times significantly.**
This is the duration of downloading dependencies [in an experiment running on GitHub Actions](https://github.com/lhotari/pulsar/actions/runs/682166744):
- 8 minutes 23 seconds for downloading dependencies for all modules 
- 13 minutes 6 seconds  for downloading dependencies for all modules on MacOS
- 2 minutes 57 seconds for downloading dependencies for core-modules profile
Restoring the dependencies from the cache is fast. 24 seconds for all modules, 31 seconds for all modules on MacOS and 7 seconds for core-modules (durations are [from an experiment where caches are restored](https://github.com/lhotari/pulsar/actions/runs/680519485)).

### Modifications

- exclude ~/.m2/repository/org/apache/pulsar from caching since
  - exclude syntax needs special care. The exclusion pattern must  be defined at the same sub-directory level as the inclusion pattern. this is explained as a workaround in actions/cache issue 364

- use separate caches for builds that build only the core-modules and other builds that build all modules

- skip cache steps when there are document-only changes

- remove the unnecessary build container used for running some unit tests.

- add ci-maven-cache-update.yaml workflow that gets triggered for every push to master branch and also runs every 12 hours to keep dependencies up-to-date.
  - for pushes to master branch, the job will only run if there's a change to a pom.xml file
  - scheduled job will update the cache unless the cache entry for maven dependencies already exists.