### PR TITLE
[C++] Fix segfault when get topic name from received message id

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -427,6 +427,7 @@ uint32_t ConsumerImpl::receiveIndividualMessagesFromBatch(const ClientConnection
         // This is a cheap copy since message contains only one shared pointer (impl_)
         Message msg = Commands::deSerializeSingleMessageInBatch(batchedMessage, i);
         msg.impl_->setRedeliveryCount(redeliveryCount);
+        msg.impl_->setTopicName(batchedMessage.getTopicName());
 
         if (startMessageId_.is_present()) {
             const MessageId& msgId = msg.getMessageId();

--- a/pulsar-client-cpp/tests/ConsumerTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerTest.cc
@@ -413,4 +413,51 @@ TEST(ConsumerTest, testBatchUnAckedMessageTracker) {
     client.close();
 }
 
+TEST(ConsumerTest, testGetTopicNameFromReceivedMessage) {
+    // topic1 and topic2 are non-partitioned topics, topic3 is a partitioned topic
+    const std::string topic1 = "testGetTopicNameFromReceivedMessage1-" + std::to_string(time(nullptr));
+    const std::string topic2 = "testGetTopicNameFromReceivedMessage2-" + std::to_string(time(nullptr));
+    const std::string topic3 = "testGetTopicNameFromReceivedMessage3-" + std::to_string(time(nullptr));
+    int res = makePutRequest(adminUrl + "admin/v2/persistent/public/default/" + topic3 + "/partitions", "3");
+    ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
+
+    Client client(lookupUrl);
+
+    auto sendMessage = [&client](const std::string& topic) {
+        Producer producer;
+        ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+        ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent("hello").build()));
+        LOG_INFO("Send 'hello' to " << topic);
+    };
+    auto validateTopicName = [](Consumer& consumer, const std::string& topic) {
+        Message msg;
+        ASSERT_EQ(ResultOk, consumer.receive(msg, 3000));
+
+        const auto fullTopic = "persistent://public/default/" + topic;
+        ASSERT_EQ(msg.getTopicName(), fullTopic);
+        ASSERT_EQ(msg.getMessageId().getTopicName(), fullTopic);
+    };
+
+    // 1. ConsumerImpl
+    Consumer consumer1;
+    ASSERT_EQ(ResultOk, client.subscribe(topic1, "sub-1", consumer1));
+
+    // 2. MultiTopicsConsumerImpl
+    Consumer consumer2;
+    ASSERT_EQ(ResultOk, client.subscribe({topic1, topic2}, "sub-2", consumer2));
+
+    sendMessage(topic1);
+    validateTopicName(consumer1, topic1);
+    validateTopicName(consumer2, topic1);
+
+    // 3. PartitionedConsumerImpl
+    Consumer consumer3;
+    ASSERT_EQ(ResultOk, client.subscribe(topic3, "sub-3", consumer3));
+    const auto partition = topic3 + "-partition-0";
+    sendMessage(partition);
+    validateTopicName(consumer3, partition);
+
+    client.close();
+}
+
 }  // namespace pulsar


### PR DESCRIPTION
### Motivation

Currently C++ client support get topic name from both received message and its message id. However, for a consumer that subscribes a non-partitioned topic, getting topic name from received message id will cause segmentation fault.

The C++ implementation of `Message::getTopicName` or `MessageId::getTopicName` requires the invocation of `Message::setTopicName`, which make the internal `std::string*` point to the topic string of the consumer. If `setTopicName` was not called, the `getTopicName` method would cause segmentation fault since a null pointer would be dereferenced.

However, when the consumer creates single messages from the batched message, `setTopicName` was not called.

### Modifications

- Use `setTopicName` for each single message when a consumer receives a batch.
- Add related tests for all types of `Consumer`, including `ConsumerImpl`, `MultiTopicsConsumerImpl` and `PartitionedConsumerImpl`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests `ConsumerTest.testGetTopicNameFromReceivedMessage`.