### PR TITLE
[issue][improve] add SCRAM-SHA256 support for SASL

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/AuthenticationProviderSaslScramImpl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/AuthenticationProviderSaslScramImpl.java
@@ -157,8 +157,8 @@ public class AuthenticationProviderSaslScramImpl implements AuthenticationProvid
         HmacRoleToken hmacRoleToken = HmacRoleToken.parse(rawValue);
 
         if (hmacRoleToken.isExpired()) {
-            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) token expired");
-            throw new AuthenticationException("token expired");
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) token expired or expire time invalid");
+            throw new AuthenticationException("token expired or expire time invalid");
         }
 
         if (!getScramUsers().containsKey(hmacRoleToken.getUserRole())) {

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/AuthenticationProviderSaslScramImpl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/AuthenticationProviderSaslScramImpl.java
@@ -1,0 +1,318 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.sasl.scram.HmacRoleToken;
+import org.apache.pulsar.common.sasl.scram.HmacRoleTokenSigner;
+import org.apache.pulsar.common.sasl.scram.ScramCredential;
+import org.apache.pulsar.common.sasl.scram.ScramFormatter;
+import org.apache.pulsar.common.util.Decryption;
+import org.apache.pulsar.common.util.DecryptionUtils;
+import org.apache.zookeeper.ZooKeeper;
+
+import javax.naming.AuthenticationException;
+import javax.net.ssl.SSLSession;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.pulsar.common.sasl.SaslConstants.HMAC_AUTH_ROLE_TOKEN;
+
+@Slf4j
+public class AuthenticationProviderSaslScramImpl implements AuthenticationProvider {
+
+    private static final String SCRAM_PATH_NAME = "scram-user";
+
+    private CuratorFramework client = null;
+
+    private Map<String, ScramCredential> scramUsers = new ConcurrentHashMap<String, ScramCredential>();
+
+    private Timer userReloadTimer = new Timer("scram-user-reload");
+
+    private Decryption decryptionInterface = null;
+
+    public AuthenticationProviderSaslScramImpl() {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initialize(ServiceConfiguration serviceConfiguration) throws IOException {
+
+        log.info("SASL-SCRAM-SERVER INIT sasl Salted Challenge Response Authentication Mechanism(SCRAM) auth");
+        initCuratorClient(serviceConfiguration.getZookeeperServers(),
+                (int) serviceConfiguration.getZooKeeperSessionTimeoutMillis(),
+                (int) serviceConfiguration.getZooKeeperSessionTimeoutMillis());
+
+
+        decryptionInterface = DecryptionUtils.getDecryptionClass(serviceConfiguration.getDecryptionInterface());
+
+        long reloadTime = Long.parseLong(System.getProperty("pulsar.broker.scram.user.releadTime", "60000"));
+
+//        reload();
+        userReloadTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    reload();
+                } catch (Exception e) {
+                    log.error("", e);
+                }
+            }
+        }, 0, reloadTime);
+
+
+        String adminUser = System.getProperty("pulsarSaslAdminUser");
+        String adminPassword = System.getProperty("pulsarSaslAdminPassword");
+        String adminSCRAMConfig = System.getProperty("pulsarSaslAdminScramConf");
+
+        if (StringUtils.isNotBlank(adminUser) && StringUtils.isNotBlank(adminPassword) && StringUtils.isNotBlank(adminSCRAMConfig)) {
+
+            String scramsha256 = decryptionInterface.decrypt(adminSCRAMConfig);
+            String password = decryptionInterface.decrypt(adminPassword);
+            ScramCredential sc = ScramFormatter.credentialFromString(scramsha256);
+            sc.setPwd(password);
+            scramUsers.put(adminUser, sc);
+            log.info("SASL-SCRAM-SERVER init load adminUser from system properties {}", adminUser);
+        }
+    }
+
+
+    /**
+     *
+     */
+    @Override
+    public AuthenticationState newAuthState(AuthData authData, SocketAddress remoteAddress, SSLSession sslSession)
+            throws AuthenticationException {
+        log.info("SASL-SCRAM-SERVER New Auth State (TCP)");
+        return new SaslAuthenticationStateScramImpl(authData, remoteAddress, sslSession, this);
+    }
+
+    /**
+     * {@inheritDoc} HTTP auth handle
+     */
+    @Override
+    public String authenticate(AuthenticationDataSource authDataSource) throws AuthenticationException {
+        log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) begin");
+        if (!authDataSource.hasDataFromHttp()) {
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) dataSource doesn't has Data For Http");
+            throw new AuthenticationException("Authentication failed: not a HTTP request");
+        }
+
+        String clientAddress = authDataSource.getPeerAddress().toString();
+
+        String token = authDataSource.getHttpHeader(HMAC_AUTH_ROLE_TOKEN);
+
+        if (token.isEmpty()) {
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) {} token is empty ,clientAddress :{}", HMAC_AUTH_ROLE_TOKEN, clientAddress);
+            throw new AuthenticationException(
+                    "Authentication datasource does not have a client token message: " + clientAddress);
+        }
+
+        int index = token.lastIndexOf(HmacRoleTokenSigner.SIGNATURE);
+        if (index == -1) {
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) Invalid format signed text");
+            throw new AuthenticationException("Invalid format signed text");
+        }
+
+        String originalSignature = token.substring(index + HmacRoleTokenSigner.SIGNATURE.length());
+        String rawValue = token.substring(0, index);
+
+        HmacRoleToken hmacRoleToken = HmacRoleToken.parse(rawValue);
+
+        if (hmacRoleToken.isExpired()) {
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) token expired");
+            throw new AuthenticationException("token expired");
+        }
+
+        if (!getScramUsers().containsKey(hmacRoleToken.getUserRole())) {
+            throw new AuthenticationException("Invalid user");
+        }
+
+        HmacRoleTokenSigner signer = new HmacRoleTokenSigner(getScramUsers().get(hmacRoleToken.getUserRole()).getPwd());
+
+        String currentSignature = signer.computeSignature(rawValue);
+        if (!originalSignature.equals(currentSignature)) {
+            log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) Invalid signature");
+            throw new AuthenticationException("Invalid signature");
+        }
+        log.info("SASL-SCRAM-SERVER Admin client Auth (HTTP) Success with user {}", hmacRoleToken.getUserRole());
+        return hmacRoleToken.getUserRole();
+    }
+
+
+    @Override
+    public boolean authenticateHttpRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+        if (log.isInfoEnabled()) {
+            log.info("SASL-SCRAM-SERVER AuthenticationProvider: SCRAM; authenticateHttpRequest of scram, URI: {}",
+                    request == null ? "null" : request.getRequestURI());
+        }
+
+        throw new AuthenticationException("current scram not supported");
+    }
+
+
+    /**
+     * update user info ,get user info from zookeeper /scram-user
+     */
+    public void reload() {
+        try {
+
+            log.info("SASL-SCRAM-SERVER RELOAD try to reload scram user ");
+            List<String> userList = client.getChildren().forPath("/" + SCRAM_PATH_NAME);
+            for (String username : userList) {
+                byte[] data = client.getData().forPath("/" + SCRAM_PATH_NAME + "/" + username);
+                ScramCredential uinfo = getUserScramCredential(username, data);
+
+                if (uinfo == null) {
+                    continue;
+                }
+
+                if (uinfo.getPwd() == null) {
+                    continue;
+                }
+
+                if (!getScramUsers().containsKey(username)) {
+                    log.info("SASL-SCRAM-SERVER RELOAD load user {}", username);
+                    getScramUsers().put(username, uinfo);
+                    continue;
+                }
+
+                if (!uinfo.getPwd().equals(getScramUsers().get(username).getPwd())) {
+                    log.warn("SASL-SCRAM-SERVER RELOAD user : {} password  change !" + username);
+                    getScramUsers().put(username, uinfo);
+                }
+            }
+        } catch (Exception e) {
+            log.error("", e);
+        }
+    }
+
+    /**
+     * init curator zookeeper client
+     *
+     * @param zkaddr          metadata zookeeper address
+     * @param connectTimeout  connect timeout (ms)
+     * @param sessionTimerout session timeout (ms)
+     * @throws UnsupportedEncodingException
+     */
+    public void initCuratorClient(String zkaddr, int connectTimeout, int sessionTimerout)
+            throws UnsupportedEncodingException {
+        client = CuratorFrameworkFactory.builder()
+                .connectString(zkaddr)
+                .sessionTimeoutMs(sessionTimerout)
+                .connectionTimeoutMs(connectTimeout)
+                .retryPolicy(new RetryNTimes(Integer.MAX_VALUE, 1000))
+                .zookeeperFactory((connectString, sessionTimeout, watcher, canBeReadOnly) -> {
+                    ZooKeeper zookeeper = new ZooKeeper(connectString, sessionTimeout, watcher);
+                    return zookeeper;
+                })
+                .build();
+
+        client.start();
+    }
+
+    /**
+     * @param userName
+     * @param data
+     * @return
+     */
+    public ScramCredential getUserScramCredential(String userName, byte[] data) {
+
+        try {
+
+            if (data == null) {
+                return null;
+            }
+
+            String userData = new String(data, "UTF-8");
+
+            ObjectMapper objectMapper = new ObjectMapper();
+
+            ZookeeperSaslScramUser user = objectMapper.readValue(userData, ZookeeperSaslScramUser.class);
+
+            String scramsha256 = decryptionInterface.decrypt(user.getScramSha256());
+            String password = decryptionInterface.decrypt(user.getPassword());
+            ScramCredential sc = ScramFormatter.credentialFromString(scramsha256);
+            sc.setPwd(password);
+
+            return sc;
+
+        } catch (Throwable e) {
+            log.error("SASL-SCRAM-SERVER getUserScramCredential error :", e);
+        }
+        return null;
+
+    }
+
+    public Map<String, ScramCredential> getScramUsers() {
+        return scramUsers;
+    }
+
+    public void setScramUsers(Map<String, ScramCredential> scramUsers) {
+        this.scramUsers = scramUsers;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAuthMethodName() {
+        return "scram";
+    }
+
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    public void setClient(CuratorFramework client) {
+        this.client = client;
+    }
+
+}

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/SaslAuthenticationDataSourceScramImpl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/SaslAuthenticationDataSourceScramImpl.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.common.api.AuthData;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
+
+
+@Slf4j
+public class SaslAuthenticationDataSourceScramImpl implements AuthenticationDataSource {
+
+    protected final String authData;
+
+    protected final SocketAddress remoteAddress;
+
+    protected final SSLSession sslSession;
+
+    public SaslAuthenticationDataSourceScramImpl(String authData, SocketAddress remoteAddress, SSLSession sslSession) {
+        this.authData = authData;
+        this.remoteAddress = remoteAddress;
+        this.sslSession = sslSession;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasDataFromCommand() {
+        return ((authData != null) && !authData.isEmpty());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCommandData() {
+        return authData;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasDataFromPeer() {
+        return (remoteAddress != null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SocketAddress getPeerAddress() {
+        return remoteAddress;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasDataFromTls() {
+        return (sslSession != null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Certificate[] getTlsCertificates() {
+        try {
+            return sslSession.getPeerCertificates();
+        } catch (SSLPeerUnverifiedException e) {
+            return new Certificate[0];
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthData authenticate(AuthData authData) {
+        return authData;
+    }
+}

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/SaslAuthenticationStateScramImpl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/SaslAuthenticationStateScramImpl.java
@@ -1,0 +1,271 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.sasl.scram.ScramFormatter;
+import org.apache.pulsar.common.sasl.scram.ScramStage;
+
+import javax.naming.AuthenticationException;
+import javax.net.ssl.SSLSession;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+@Slf4j
+public class SaslAuthenticationStateScramImpl implements AuthenticationState {
+
+    private static final Pattern CLIENT_FIRST_MESSAGE =
+            Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$");
+
+    private static final Pattern CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
+
+    private final String mServerPartNonce = UUID.randomUUID().toString();
+
+    private final AuthenticationDataSource authenticationDataSource;
+
+    private final long stateId;
+
+    private String credential;
+
+    private String clientFirstMessageBare;
+
+    private String mixNonce;
+
+    private String serverFirstMessage;
+
+    private ScramStage stage = ScramStage.INIT;
+
+    private AuthenticationProviderSaslScramImpl provider;
+
+    private transient ScramFormatter sf = new ScramFormatter();
+
+    public SaslAuthenticationStateScramImpl(AuthData authData, SocketAddress remoteAddress, SSLSession sslSession,
+                                            AuthenticationProviderSaslScramImpl provider) throws AuthenticationException {
+
+        log.info("SASL-SCRAM-SERVER TCP-STATE constructed");
+
+        this.provider = provider;
+        this.authenticationDataSource =
+                new SaslAuthenticationDataSourceScramImpl(new String(authData.getBytes(), UTF_8), remoteAddress, sslSession);
+        stateId = new SecureRandom().nextLong();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthData authenticate(AuthData authData) throws AuthenticationException {
+
+        String clientAddress;
+
+        if (!authenticationDataSource.hasDataFromPeer()) {
+            throw new AuthenticationException("pulsar server scrame auth hasDataFromPeer return false ");
+        }
+
+        SocketAddress socketAddress = authenticationDataSource.getPeerAddress();
+        clientAddress = socketAddress.toString();
+
+        if (ScramStage.INIT.equals(stage)) {
+
+            if (authData == null) {
+                throw new AuthenticationException(
+                        "pulsar server scrame auth does not have a client message, from client: " + clientAddress);
+            }
+
+            String clientFirstMessage = new String(authData.getBytes(), UTF_8);
+
+            if (clientFirstMessage.isEmpty()) {
+                throw new AuthenticationException(
+                        "pulsar server scrame auth client_first_message is empty, from client: " + clientAddress);
+            }
+
+            Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
+            if (!m.matches()) {
+                throw new AuthenticationException(
+                        "pulsar server scrame auth client_first_message is invalid, format error " + clientAddress);
+            }
+
+            // sample n,,n=user,r=xxxxx
+            clientFirstMessageBare = m.group(5);
+            credential = m.group(6);
+            String clientNonce = m.group(7);
+
+            String salt = Base64.getEncoder().encodeToString(getSaltByUser(credential));
+            int iteration = getIterationByUser(credential);
+            mixNonce = clientNonce + mServerPartNonce;
+            serverFirstMessage = String.format(Locale.ROOT, "r=%s,s=%s,i=%d", mixNonce, salt, iteration);
+
+            stage = ScramStage.FIRST;
+
+            log.info(
+                    "SASL-SCRAM-SERVER TCP-STATE AUTH INIT pulsar server scram auth handler client_first_message success and return server_first_message {}",
+                    credential);
+
+            return AuthData.of(serverFirstMessage.getBytes(StandardCharsets.UTF_8));
+
+        } else if (ScramStage.FIRST.equals(stage)) {
+
+            try {
+                if (authData == null) {
+                    throw new AuthenticationException(
+                            "pulsar server scrame auth does not have a client_final_Message, from client: " + credential);
+                }
+
+                String clientFinalMessage = new String(authData.getBytes(), UTF_8);
+
+                Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
+                if (!m.matches()) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "pulsar server scrame auth  client_final_Message invalid, from client: " + credential);
+                }
+
+                String clientFinalMessageWithoutProof = m.group(1);
+                String clientNonce = m.group(3);
+                String proof = m.group(4);
+
+                if (!mixNonce.equals(clientNonce)) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "pulsar server scrame auth  client_final_Message  mixNonce not equal, from client: "
+                                    + credential);
+                }
+
+                String authMessage =
+                        clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+
+                byte[] expectedStoredKey = getStoredKeyByUser(credential);
+                byte[] clientSignature = sf.hmac(expectedStoredKey, authMessage.getBytes(StandardCharsets.UTF_8));
+
+                byte[] decodedProof = Base64.getDecoder().decode(proof);
+
+                byte[] computedStoredKey = sf.storedKey(clientSignature, decodedProof);
+
+                if (!Arrays.equals(computedStoredKey, expectedStoredKey)) {
+                    throw new AuthenticationException(
+                            "pulsar server scrame auth  client_final_Message  is invalid, storekey authentication failed"
+                                    + credential);
+                }
+
+                byte[] serverKey = getServerKeyByUser(credential);
+                byte[] serverSignature = sf.hmac(serverKey, authMessage.getBytes(StandardCharsets.UTF_8));
+
+                String serverFinalMessage = "v=" + Base64.getEncoder().encodeToString(serverSignature);
+                stage = ScramStage.FINAL;
+
+                log.info(
+                        "SASL-SCRAM-SERVER TCP-STATE AUTH FIRST pulsar server scrame auth  client_final_Message handle success and return server_final_message : {}",
+                        credential);
+
+                return AuthData.of(serverFinalMessage.getBytes(StandardCharsets.UTF_8));
+
+            } catch (AuthenticationException aue) {
+                throw aue;
+            } catch (Exception e) {
+                throw new AuthenticationException("ScramStage.FIRST failed");
+            }
+
+        } else if (ScramStage.FINAL.equals(stage)) {
+            log.info("SASL-SCRAM-SERVER TCP-STATE AUTH FINISH success");
+            stage = ScramStage.FINISH;
+            return null;
+        } else {
+            log.error("SASL-SCRAM-SERVER pulsar server scrame auth error with invalid stage");
+            throw new AuthenticationException(
+                    "Authentication datasource stage is invalid: " + stage + ", from client: " + credential);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isComplete() {
+        boolean isFinish = ScramStage.FINISH.equals(stage);
+        return isFinish;
+    }
+
+    private byte[] getSaltByUser(String credential) {
+        if (!provider.getScramUsers().containsKey(credential)) {
+            throw new IllegalArgumentException();
+        }
+        return provider.getScramUsers().get(credential).salt();
+    }
+
+    private int getIterationByUser(String credential) {
+        if (!provider.getScramUsers().containsKey(credential)) {
+            throw new IllegalArgumentException();
+        }
+        return provider.getScramUsers().get(credential).iterations();
+    }
+
+    private byte[] getStoredKeyByUser(String credential) {
+
+        if (!provider.getScramUsers().containsKey(credential)) {
+            throw new IllegalArgumentException();
+        }
+        return provider.getScramUsers().get(credential).storedKey();
+
+    }
+
+    private byte[] getServerKeyByUser(String credential) {
+        if (!provider.getScramUsers().containsKey(credential)) {
+            throw new IllegalArgumentException();
+        }
+        return provider.getScramUsers().get(credential).serverKey();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationDataSource getAuthDataSource() {
+        return authenticationDataSource;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAuthRole() {
+        return credential;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getStateId() {
+        return stateId;
+    }
+
+}

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/ZookeeperSaslScramUser.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/scram/ZookeeperSaslScramUser.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ZookeeperSaslScramUser {
+
+    private String password = null;
+
+    private String scramSha256 = null;
+
+    public ZookeeperSaslScramUser() {
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getScramSha256() {
+        return scramSha256;
+    }
+
+    @JsonProperty("SCRAM_SHA_256")
+    public void setScramSha256(String scramSha256) {
+        this.scramSha256 = scramSha256;
+    }
+
+}

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/scram/SaslSCRAMAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/scram/SaslSCRAMAuthenticateTest.java
@@ -1,0 +1,499 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.shaded.com.google.common.collect.Maps;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderList;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.impl.auth.scram.AuthenticationSaslScramImpl;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.sasl.scram.HmacRoleTokenSigner;
+import org.apache.pulsar.common.sasl.scram.ScramCredential;
+import org.apache.pulsar.common.sasl.scram.ScramFormatter;
+import org.junit.BeforeClass;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.naming.AuthenticationException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.*;
+
+//@PowerMockIgnore({"javax.net.ssl.*", "javax.management.*", "javax.security.*", "javax.crypto.*",
+//        "com.sun.management.OperatingSystemMXBean","org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory"})
+@PrepareForTest({AuthenticationProviderSaslScramImpl.class, AuthenticationProvider.class, Class.class})
+@Slf4j
+public class SaslSCRAMAuthenticateTest extends ProducerConsumerBase {
+
+    private static Properties properties;
+
+    private static String localHostname = "localhost";
+
+    private static Authentication authSasl;
+
+    private static String username = "pulsarAdmin";
+    private static String password = "0123456789012345678901234567890123456789";
+    private static String decryptClass = "";
+
+//    @ObjectFactory
+//    public IObjectFactory objectFactory() {
+//        return new PowerMockObjectFactory();
+//    }
+
+    @BeforeClass
+    public static void initTestCase() throws Exception {
+
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+
+        //prepare user info
+        String adminUser = System.getProperty("pulsarSaslAdminUser");
+        String adminPassword = System.getProperty("pulsarSaslAdminPassword");
+        String adminSCRAMConfig = System.getProperty("pulsarSaslAdminScramConf");
+
+        System.setProperty("pulsarSaslAdminUser", username);
+        System.setProperty("pulsarSaslAdminPassword", password);
+
+        ScramCredential credential = new ScramFormatter().generateCredential(password, 10000);
+
+        System.setProperty("pulsarSaslAdminScramConf", ScramFormatter.credentialToString(credential));
+
+
+//        AuthenticationProviderSaslScramImpl spy = PowerMockito.spy(new AuthenticationProviderSaslScramImpl());
+//        Mockito.when(spy.getScramUsers()).thenReturn(scramUsers);
+//        c.mockStatic(Class.class);
+//        PowerMockito.when((AuthenticationProviderSaslScramImpl) Class.forName(AuthenticationProviderSaslScramImpl.class.getName()).newInstance()).thenReturn(spy);
+//        PowerMockito.whenNew(AuthenticationProviderSaslScramImpl.class).withAnyArguments().thenReturn(spy);
+
+
+        Map<String, String> authParams = Maps.newHashMap();
+        authParams.put("saslRole", username);
+        authParams.put("roleSecret", password);
+        authParams.put("decryptClass", decryptClass);
+        authSasl = AuthenticationFactory.create(AuthenticationSaslScramImpl.class.getName(), authParams);
+
+
+        log.info("-- {} --, start at host: {}", methodName, localHostname);
+        // use http lookup to verify HttpClient works well.
+        isTcpLookup = false;
+
+        conf.setAdvertisedAddress(localHostname);
+        conf.setAuthenticationEnabled(true);
+        conf.setSaslJaasClientAllowedIds(".*");
+        conf.setSaslJaasServerSectionName("PulsarBroker");
+        Set<String> providers = new HashSet<>();
+        providers.add(AuthenticationProviderSaslScramImpl.class.getName());
+        conf.setAuthenticationProviders(providers);
+        conf.setClusterName("test");
+        conf.setSuperUserRoles(ImmutableSet.of(username));
+
+        super.init();
+
+        lookupUrl = new URI(pulsar.getWebServiceAddress());
+
+        replacePulsarClient(PulsarClient.builder()
+                .serviceUrl(lookupUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .authentication(authSasl));
+
+        // set admin auth, to verify admin web resources
+
+        log.info("set client jaas section name: PulsarClient");
+        admin = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl.toString())
+                .authentication(authSasl)
+                .build();
+        log.info("-- {} --, end.", methodName);
+
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+
+    // Test could verify with kerberos configured.
+    @Test
+    public void testProducerAndConsumerPassed() throws Exception {
+        log.info("-- {} -- start", methodName);
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/my-ns/my-topic")
+                .subscriptionName("my-subscriber-name")
+                .subscribe();
+
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/my-ns/my-topic")
+                .enableBatching(false);
+
+        Producer<byte[]> producer = producerBuilder.create();
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            log.info("Produced message: [{}]", message);
+        }
+
+        Message<byte[]> msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < 10; i++) {
+            msg = consumer.receive(5, TimeUnit.SECONDS);
+            String receivedMessage = new String(msg.getData());
+            log.info("Received message: [{}]", receivedMessage);
+            String expectedMessage = "my-message-" + i;
+            testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+        }
+        // Acknowledge the consumption of all messages at once
+        consumer.acknowledgeCumulative(msg);
+        consumer.close();
+
+        log.info("-- {} -- end", methodName);
+    }
+
+    // Test sasl server/client auth.
+    @Test
+    public void testSaslServerAndClientAuth() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        // auth between server and client.
+        // first time auth
+        AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        AuthenticationState authState = saslServer.newAuthState(initData1, clientAddress, null);
+        System.out.println("client data " + new String(initData1.getBytes(), UTF_8));
+
+        AuthData serverData1 = authState.authenticate(initData1);
+
+        System.out.println("server data " + new String(serverData1.getBytes(), UTF_8));
+        boolean complete = authState.isComplete();
+        assertFalse(complete);
+
+        // second time auth, completed
+        AuthData initData2 = dataProvider.authenticate(serverData1);
+
+        System.out.println("client data " + new String(initData2.getBytes(), UTF_8));
+
+        AuthData serverData2 = authState.authenticate(initData2);
+
+
+        System.out.println("server data " + new String(serverData2.getBytes(), UTF_8));
+
+
+        // second time auth, completed
+        AuthData initData3 = dataProvider.authenticate(serverData2);
+
+        System.out.println("client data " + new String(initData3.getBytes(), UTF_8));
+
+        AuthData serverData3 = authState.authenticate(initData3);
+
+
+        complete = authState.isComplete();
+
+        assertTrue(complete);
+        assertNull(serverData3);
+
+        // if completed, server could not auth again.
+        try {
+            authState.authenticate(initData2);
+            fail("Expected fail because auth completed for authState");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+
+    @Test
+    public void testSaslServerAndClientAuthInvalidNonce() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider clientDataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        // auth between server and client.
+        // first time auth
+        AuthData initData1 = clientDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+        //n,,n=pulsarAdmin,r=7af38d4d-95a5-4829-9082-77922b76bb04
+        //change client to server data
+        initData1 = AuthData.of("n,,n=pulsarAdmin,r=7af38d4d-95a5-4829-9082-77922b76bb04".getBytes(UTF_8));
+
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        AuthenticationState serverAuthState = saslServer.newAuthState(initData1, clientAddress, null);
+
+        System.out.println("client data " + new String(initData1.getBytes(), UTF_8));
+        //server auth invalid data and return invalid nonce data r=7af38d4d-95a5-4829-9082-77922b76bb0416f594b8-ad1e-4dd1-a223-70fba60a34a4,s=dHp0b2R1c2lxaHE3YXprcm8zaDV3dWl0eA==,i=10000
+        AuthData serverData1 = serverAuthState.authenticate(initData1);
+
+        System.out.println("server data " + new String(serverData1.getBytes(), UTF_8));
+
+        AuthData initData2 = null;
+        try {
+            initData2 = clientDataProvider.authenticate(serverData1);
+            fail("invalid");
+        } catch (AuthenticationException e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage().contains("invalid nonce"));
+            boolean complete = serverAuthState.isComplete();
+            assertFalse(complete);
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+
+    @Test
+    public void testSaslHmacAdminAuth() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        AuthenticationDataSource spy = Mockito.spy(new AuthenticationDataSource() {
+        });
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        Mockito.when(spy.hasDataFromHttp()).thenReturn(true);
+        Mockito.when(spy.getPeerAddress()).thenReturn(clientAddress);
+
+
+//        "u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105"
+        String signval = "u=" + username + "&i=scram&e=" + (System.currentTimeMillis() + 300000);
+        String sg = new HmacRoleTokenSigner(password).sign(signval);
+        Mockito.when(spy.getHttpHeader("HmacAuthRoleToken")).thenReturn(sg);
+
+
+        try {
+            String role = saslServer.authenticate(spy);
+            assertTrue(role.equals(username));
+            System.out.println(role);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("invalid");
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+
+    @Test
+    public void testSaslHmacAdminAuthExpired() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        AuthenticationDataSource spy = Mockito.spy(new AuthenticationDataSource() {
+        });
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        Mockito.when(spy.hasDataFromHttp()).thenReturn(true);
+        Mockito.when(spy.getPeerAddress()).thenReturn(clientAddress);
+
+
+//        "u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105"
+        String signval = "u=" + username + "&i=scram&e=" + (System.currentTimeMillis() - 300000);
+        String sg = new HmacRoleTokenSigner(password).sign(signval);
+        Mockito.when(spy.getHttpHeader("HmacAuthRoleToken")).thenReturn(sg);
+
+        try {
+            String role = saslServer.authenticate(spy);
+            fail("invalid");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("token expired"));
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+
+    @Test
+    public void testSaslHmacAdminAuthInvalidUser() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        AuthenticationDataSource spy = Mockito.spy(new AuthenticationDataSource() {
+        });
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        Mockito.when(spy.hasDataFromHttp()).thenReturn(true);
+        Mockito.when(spy.getPeerAddress()).thenReturn(clientAddress);
+
+        String username = "abc";
+
+//        "u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105"
+        String signval = "u=" + username + "&i=scram&e=" + (System.currentTimeMillis() + 300000);
+        String sg = new HmacRoleTokenSigner(password).sign(signval);
+        Mockito.when(spy.getHttpHeader("HmacAuthRoleToken")).thenReturn(sg);
+
+        try {
+            String role = saslServer.authenticate(spy);
+            fail("invalid");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage().contains("Invalid user"));
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+    @Test
+    public void testSaslHmacAdminAuthInvalidSignValue() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        AuthenticationDataSource spy = Mockito.spy(new AuthenticationDataSource() {
+        });
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        Mockito.when(spy.hasDataFromHttp()).thenReturn(true);
+        Mockito.when(spy.getPeerAddress()).thenReturn(clientAddress);
+
+
+//        "u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105"
+        String signval = "u=" + username + "&i=scram&e=" + (System.currentTimeMillis() + 300000);
+//        String sg = new HmacRoleTokenSigner(password).sign(signval);
+        String sg = signval + "&s=xxx";
+        Mockito.when(spy.getHttpHeader("HmacAuthRoleToken")).thenReturn(sg);
+
+        try {
+            String role = saslServer.authenticate(spy);
+            fail("invalid");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage().contains("Invalid signature"));
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+
+    @Test
+    public void testSaslHmacAdminAuthInvalidSignFormat() throws Exception {
+        log.info("-- {} -- start", methodName);
+        String hostName = "localhost";
+
+        // prepare client and server side resource
+        AuthenticationDataProvider dataProvider = authSasl.getAuthData(hostName);
+
+        AuthenticationProviderList providerList = (AuthenticationProviderList)
+                (pulsar.getBrokerService().getAuthenticationService()
+                        .getAuthenticationProvider("scram"));
+        AuthenticationProviderSaslScramImpl saslServer =
+                (AuthenticationProviderSaslScramImpl) providerList.getProviders().get(0);
+
+
+        AuthenticationDataSource spy = Mockito.spy(new AuthenticationDataSource() {
+        });
+        SocketAddress clientAddress = new InetSocketAddress("127.0.0.1", 1234);
+        Mockito.when(spy.hasDataFromHttp()).thenReturn(true);
+        Mockito.when(spy.getPeerAddress()).thenReturn(clientAddress);
+
+
+//        "u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105"
+//        String signval = "u=" + username + "&i=scram&e=" + (System.currentTimeMillis() + 300000);
+//        String sg = new HmacRoleTokenSigner(password).sign(signval);
+//        String sg = signval + "&s=xxx";
+        Mockito.when(spy.getHttpHeader("HmacAuthRoleToken")).thenReturn("i am a invalid sign");
+
+        try {
+            String role = saslServer.authenticate(spy);
+            fail("invalid");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage().contains("Invalid format signed text"));
+        }
+
+        log.info("-- {} -- end", methodName);
+    }
+}

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/scram/SaslScramDataTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/scram/SaslScramDataTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication.scram;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.pulsar.common.sasl.scram.ScramFormatter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.naming.directory.AttributeModificationException;
+import java.security.InvalidKeyException;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class SaslScramDataTest {
+
+    @BeforeMethod
+    public void setUp() {
+    }
+
+    @AfterMethod
+    public void tearDown() {
+    }
+
+    @Test
+    public void testScramData() {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ZookeeperSaslScramUser user = null;
+        String scramData = null;
+        try {
+
+            String password = "abc";
+
+            scramData = ScramFormatter.credentialToString(new ScramFormatter().generateCredential(password, 10000));
+
+            String userData = "{\"SCRAM_SHA_256\":\"" + scramData + "\",\"password\":\"" + password + "\"}";
+
+            System.out.println(userData);
+
+            user = objectMapper.readValue(userData, ZookeeperSaslScramUser.class);
+
+            assertTrue(scramData.equals(user.getScramSha256()));
+            assertTrue(password.equals(user.getPassword()));
+
+        } catch (JsonProcessingException e) {
+            fail("parse data failed");
+        } catch (InvalidKeyException e) {
+            fail("parse data failed");
+        } catch (AttributeModificationException e) {
+            fail("parse data failed");
+        }
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -306,6 +306,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private long topicLoadTimeoutSeconds = 60;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            required = false,
+            doc = "defined your own decryption interface"
+    )
+    private String decryptionInterface;
+
+    @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Enable backlog quota check. Enforces actions on topic when the quota is reached"
     )

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/scram/AuthenticationSaslScramImpl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/scram/AuthenticationSaslScramImpl.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.scram;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.AuthenticationUtil;
+import org.apache.pulsar.common.util.DecryptionUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * Authentication provider for SASL SCRAM authentication.
+ */
+@Slf4j
+public class AuthenticationSaslScramImpl implements Authentication, EncodedAuthenticationParameterSupport {
+    private static final long serialVersionUID = 1L;
+
+    private static final String APPID_KEY = "saslRole";
+
+    private static final String APP_SECRET_KEY = "roleSecret";
+
+    private static final String SELF_DECRYPT_CLASS = "decryptClass";
+
+    private Map<String, String> configuration;
+
+    public AuthenticationSaslScramImpl() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(String encodedAuthParamString) {
+        if (isBlank(encodedAuthParamString)) {
+            log.warn("SASL-SCRAM-CLIENT authParams is empty");
+        }
+
+        try {
+            setAuthParams(AuthenticationUtil.configureFromJsonString(encodedAuthParamString));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse SASL authParams", e);
+        }
+    }
+
+    // use passed in parameter to config ange get jaasCredentialsContainer.
+    private void setAuthParams(Map<String, String> authParams) {
+        this.configuration = authParams;
+        if (!configuration.containsKey(APPID_KEY) || !configuration.containsKey(APP_SECRET_KEY)) {
+            throw new IllegalArgumentException("Failed to parse SASL authParams credential or secret");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(Map<String, String> authParams) {
+        setAuthParams(authParams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() throws PulsarClientException {
+        log.info("SASL-SCRAM-CLIENT start ");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        log.info("SASL-SCRAM-CLIENT close ");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAuthMethodName() {
+        return "scram";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationDataProvider getAuthData(String brokerHostName) throws PulsarClientException {
+        return this.getAuthData();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationDataProvider getAuthData() throws PulsarClientException {
+
+        String userName = configuration.get(APPID_KEY);
+        String secret = configuration.get(APP_SECRET_KEY);
+        String selfDecryptClass = configuration.getOrDefault(SELF_DECRYPT_CLASS, "");
+
+        log.info("SASL-SCRAM-CLIENT NEW getAuthData with user: {} and selfDecryptClass :{}", userName, selfDecryptClass);
+
+        String secretAfterDecrypt = DecryptionUtils.getDecryptionClass(selfDecryptClass).decrypt(secret);
+        return new SaslAuthenticationDataProviderScramImpl(userName,
+                secretAfterDecrypt);
+    }
+}

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/scram/SaslAuthenticationDataProviderScramImpl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/scram/SaslAuthenticationDataProviderScramImpl.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.scram;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.sasl.SaslConstants;
+import org.apache.pulsar.common.sasl.scram.HmacRoleToken;
+import org.apache.pulsar.common.sasl.scram.HmacRoleTokenSigner;
+import org.apache.pulsar.common.sasl.scram.ScramFormatter;
+import org.apache.pulsar.common.sasl.scram.ScramStage;
+
+import javax.naming.AuthenticationException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class SaslAuthenticationDataProviderScramImpl implements AuthenticationDataProvider {
+    private static final long serialVersionUID = 1L;
+
+    private static final Pattern SERVER_FIRST_MESSAGE = Pattern.compile("r=([^,]*),s=([^,]*),i=(.*)$");
+
+    private static final Pattern SERVER_FINAL_MESSAGE = Pattern.compile("v=([^,]*)$");
+
+    //
+    private static final long DEFAULT_SASL_SIGN_TOKEN_EXPIRE_TIME2 = 18000000;
+
+    // 5min
+    private static final long DEFAULT_SASL_SIGN_TOKEN_EXPIRE_TIME = 300000;
+
+    private static final String HEADER = "n,,";
+
+    private final String saslRole;
+
+    private final String roleSecret;
+
+    //TCP
+    private String clientNonce = null;
+
+    private byte[] saltPassword;
+
+    private String authMessage;
+
+    private ScramStage stage = ScramStage.INIT;
+
+    private transient ScramFormatter sf = null;
+
+    private HmacRoleTokenSigner signer = null;
+
+    public SaslAuthenticationDataProviderScramImpl(String saslRole, String roleSecret) {
+
+        this.saslRole = saslRole;
+        this.roleSecret = roleSecret;
+        this.sf = new ScramFormatter();
+        this.signer = new HmacRoleTokenSigner(roleSecret);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthData authenticate(AuthData authData) throws AuthenticationException {
+
+        if (Arrays.equals(authData.getBytes(), AuthData.INIT_AUTH_DATA.getBytes())) {
+            clientNonce = UUID.randomUUID().toString();
+            String clientFirstMessageBare = String.format(Locale.ROOT, "n=%s,r=%s", saslRole, clientNonce);
+
+            String clientFirstMessage = HEADER + clientFirstMessageBare;
+            stage = ScramStage.FIRST;
+            log.info("SASL-SCRAM-CLIENT INIT (TCP) pulsar client scram auth send client_first_message {}", saslRole);
+            return AuthData.of(clientFirstMessage.getBytes(StandardCharsets.UTF_8));
+        } else if (ScramStage.FIRST.equals(stage)) {
+
+            try {
+                String serverFirstMessage = new String(authData.getBytes(), StandardCharsets.UTF_8);
+                Matcher m = SERVER_FIRST_MESSAGE.matcher(serverFirstMessage);
+                if (!m.matches()) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "pulsar client scram auth server_first_message is invalid Matcher failed " + saslRole);
+                }
+
+                String nonce = m.group(1);
+
+                if (!nonce.startsWith(clientNonce)) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "pulsar client scram auth server_first_message is invalid nonce " + saslRole);
+                }
+
+                String salt = m.group(2);
+                String iterationCountString = m.group(3);
+                int iterations = Integer.parseInt(iterationCountString);
+                if (iterations <= 0) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "pulsar client scram auth server_first_message is invalid iterations " + saslRole);
+                }
+
+                saltPassword = sf.saltedPassword(roleSecret, Base64.getDecoder().decode(salt), iterations);
+
+                String clientFirstMessageBare = String.format(Locale.ROOT, "n=%s,r=%s", saslRole, clientNonce);
+
+                String clientFinalMessageWithoutProof = "c="
+                        + Base64.getEncoder().encodeToString(HEADER.getBytes(StandardCharsets.UTF_8)) + ",r=" + nonce;
+
+                authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+
+                byte[] clientProof = sf.clientProof(saltPassword, authMessage);
+
+                stage = ScramStage.FINAL;
+
+                String clientFinalMessage = String.format(Locale.ROOT, "%s,p=%s", clientFinalMessageWithoutProof,
+                        Base64.getEncoder().encodeToString(clientProof));
+
+                log.info(
+                        "SASL-SCRAM-CLIENT FIRST(TCP)  pulsar client scram auth handle server_first_message success and send client_final_message {}",
+                        saslRole);
+                return AuthData.of(clientFinalMessage.getBytes(StandardCharsets.UTF_8));
+
+            } catch (AuthenticationException aue) {
+                throw aue;
+            } catch (Exception e) {
+                throw new AuthenticationException("ScramStage.FINAL failed");
+            }
+
+        } else if (ScramStage.FINAL.equals(stage)) {
+            try {
+                String serverFinalMessage = new String(authData.getBytes(), StandardCharsets.UTF_8);
+
+                Matcher m = SERVER_FINAL_MESSAGE.matcher(serverFinalMessage);
+                if (!m.matches()) {
+                    stage = ScramStage.FINISH;
+                    throw new AuthenticationException(
+                            "SASL-SCRAM-CLIENT FINAL(TCP)  pulsar client scram auth serverFinalMessage is invalid Matcher failed " + saslRole);
+                }
+
+                byte[] serverSignature = Base64.getDecoder().decode(m.group(1));
+
+                byte[] serverKey = sf.serverKey(saltPassword);
+
+                byte[] serverSignatureExpected = sf.hmac(serverKey, authMessage.getBytes(StandardCharsets.UTF_8));
+
+                if (!Arrays.equals(serverSignatureExpected, serverSignature)) {
+                    throw new AuthenticationException(
+                            "pulsar client scram auth server_final_message is invalid, server signature error "
+                                    + saslRole);
+                }
+
+                stage = ScramStage.FINISH;
+                log.info(
+                        "SASL-SCRAM-CLIENT FINISH(TCP) pulsar client scram auth handle server_final_message success and send client_complete_message {}",
+                        saslRole);
+
+                return AuthData.of("Authentication Complete".getBytes(StandardCharsets.UTF_8));
+            } catch (AuthenticationException aue) {
+                throw aue;
+            } catch (Exception e) {
+                throw new AuthenticationException("ScramStage.FINAL failed " + e.getMessage());
+            }
+        } else {
+            throw new AuthenticationException("authData or stage is invalid: " + stage);
+        }
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Entry<String, String>> getHttpHeaders() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //TODO: token cahce
+        try {
+            log.info("SASL-SCRAM-CLIENT (HTTP) create sign token {}", saslRole);
+            //expired after 10 min
+            HmacRoleToken token = new HmacRoleToken(saslRole, "scram", System.currentTimeMillis() + 600000);
+            String clientToken = signer.sign(token.toString());
+
+            headers.put(SaslConstants.HMAC_AUTH_ROLE_TOKEN, clientToken);
+        } catch (Exception e) {
+            log.error("SASL-SCRAM-CLIENT (HTTP) create sign token failed ", e);
+        }
+        return headers.entrySet();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasDataFromCommand() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCommandData() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasDataForHttp() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHttpAuthType() {
+        return null;
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/SaslConstants.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/SaslConstants.java
@@ -65,6 +65,7 @@ public class SaslConstants {
     public static final String SASL_AUTH_ROLE_TOKEN = "SaslAuthRoleToken";
     public static final String SASL_AUTH_ROLE_TOKEN_EXPIRED = "SaslAuthRoleTokenExpired";
 
+    public static final String HMAC_AUTH_ROLE_TOKEN = "HmacAuthRoleToken";
     /**
      * HTTP header used by the SASL client/server during an authentication sequence.
      */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleToken.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleToken.java
@@ -32,6 +32,9 @@ public class HmacRoleToken implements Principal {
      */
     public static final HmacRoleToken ANONYMOUS = new HmacRoleToken();
 
+    // 1 hour
+    private static final long MAX_EXPIRE_TIME_MS = 3600000;
+
     private static final String ATTR_SEPARATOR = "&";
     private static final String USER_ROLE = "u";
     private static final String EXPIRES = "e";
@@ -152,12 +155,21 @@ public class HmacRoleToken implements Principal {
     }
 
     /**
-     * Returns if the token has expired.
+     * Returns if the token has expired or invalid expire time.
      *
-     * @return if the token has expired.
+     * @return if the token has expired or invalid expire time.
      */
     public boolean isExpired() {
-        return getExpires() != -1 && System.currentTimeMillis() > getExpires();
+
+        if (getExpires() == -1) {
+            return true;
+        }
+
+        if (getExpires() - System.currentTimeMillis() > MAX_EXPIRE_TIME_MS) {
+            return true;
+        }
+
+        return System.currentTimeMillis() > getExpires();
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleToken.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleToken.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.sasl.scram;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.naming.AuthenticationException;
+import java.security.Principal;
+import java.util.*;
+
+@Slf4j
+public class HmacRoleToken implements Principal {
+
+    /**
+     * Constant that identifies an anonymous request.
+     */
+    public static final HmacRoleToken ANONYMOUS = new HmacRoleToken();
+
+    private static final String ATTR_SEPARATOR = "&";
+    private static final String USER_ROLE = "u";
+    private static final String EXPIRES = "e";
+    private static final String SESSION = "i";
+
+    private final static Set<String> ATTRIBUTES =
+        new HashSet<String>(Arrays.asList(USER_ROLE,  EXPIRES,  SESSION));
+
+    private String userRole;
+    private String session;
+    private long expires;
+    private String token;
+
+    private HmacRoleToken() {
+        userRole = null;
+        session = null;
+        expires = -1;
+        token = "ANONYMOUS";
+        generateToken();
+    }
+
+    private static final String ILLEGAL_ARG_MSG = " is NULL, empty or contains a '" + ATTR_SEPARATOR + "'";
+
+    /**
+     * Creates an authentication token.
+     *
+     * @param userRole user name.
+     * @param session the sessionId.
+     * (<code>System.currentTimeMillis() + validityPeriod</code>).
+     */
+    public HmacRoleToken(String userRole, String session) {
+        checkForIllegalArgument(session, "session");
+        this.userRole = userRole;
+        this.session = session;
+        this.expires = -1;
+        generateToken();
+    }
+
+    public HmacRoleToken(String userRole, String session, long expires) {
+        checkForIllegalArgument(userRole, "userRole");
+        checkForIllegalArgument(session, "session");
+        this.userRole = userRole;
+        this.session = session;
+        this.expires = expires;
+        generateToken();
+    }
+
+    /**
+     * Check if the provided value is invalid. Throw an error if it is invalid, NOP otherwise.
+     *
+     * @param value the value to check.
+     * @param name the parameter name to use in an error message if the value is invalid.
+     */
+    private static void checkForIllegalArgument(String value, String name) {
+        if (value == null || value.length() == 0 || value.contains(ATTR_SEPARATOR)) {
+            throw new IllegalArgumentException(name + ILLEGAL_ARG_MSG);
+        }
+    }
+
+    /**
+     * Sets the expiration of the token.
+     *
+     * @param expires expiration time of the token in milliseconds since the epoch.
+     */
+    public void setExpires(long expires) {
+        if (this != HmacRoleToken.ANONYMOUS) {
+            this.expires = expires;
+            generateToken();
+        }
+    }
+
+    /**
+     * Generates the token.
+     */
+    private void generateToken() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(USER_ROLE).append("=").append(getUserRole()).append(ATTR_SEPARATOR);
+        sb.append(SESSION).append("=").append(getSession()).append(ATTR_SEPARATOR);
+        sb.append(EXPIRES).append("=").append(getExpires());
+        token = sb.toString();
+    }
+
+    /**
+     * Returns the user name.
+     *
+     * @return the user name.
+     */
+    public String getUserRole() {
+        return userRole;
+    }
+
+    /**
+     * Returns the principal name (this method name comes from the JDK {@link Principal} interface).
+     *
+     * @return the principal name.
+     */
+    @Override
+    public String getName() {
+        return userRole;
+    }
+
+    /**
+     * Returns the authentication mechanism of the token.
+     *
+     * @return the authentication mechanism of the token.
+     */
+    public String getSession() {
+        return session;
+    }
+
+    /**
+     * Returns the expiration time of the token.
+     *
+     * @return the expiration time of the token, in milliseconds since Epoc.
+     */
+    public long getExpires() {
+        return expires;
+    }
+
+    /**
+     * Returns if the token has expired.
+     *
+     * @return if the token has expired.
+     */
+    public boolean isExpired() {
+        return getExpires() != -1 && System.currentTimeMillis() > getExpires();
+    }
+
+    /**
+     * Returns the string representation of the token.
+     * <p/>
+     * This string representation is parseable by the {@link #parse} method.
+     *
+     * @return the string representation of the token.
+     */
+    @Override
+    public String toString() {
+        return token;
+    }
+
+    /**
+     * Parses a string into an authentication token.
+     *
+     * @param tokenStr string representation of a token.
+     *
+     * @return the parsed authentication token.
+     *
+     * @throws AuthenticationException thrown if the string representation could not be parsed into
+     * an authentication token.
+     */
+    public static HmacRoleToken parse(String tokenStr) throws AuthenticationException {
+        Map<String, String> map = split(tokenStr);
+        if (!map.keySet().equals(ATTRIBUTES)) {
+            throw new AuthenticationException("Invalid token string, missing attributes");
+        }
+        long expires = Long.parseLong(map.get(EXPIRES));
+        HmacRoleToken token = new HmacRoleToken(map.get(USER_ROLE), map.get(SESSION));
+        token.setExpires(expires);
+        return token;
+    }
+
+    /**
+     * Splits the string representation of a token into attributes pairs.
+     *
+     * @param tokenStr string representation of a token.
+     *
+     * @return a map with the attribute pairs of the token.
+     *
+     * @throws AuthenticationException thrown if the string representation of the token could not be broken into
+     * attribute pairs.
+     */
+    private static Map<String, String> split(String tokenStr) throws AuthenticationException {
+        Map<String, String> map = new HashMap<String, String>();
+        StringTokenizer st = new StringTokenizer(tokenStr, ATTR_SEPARATOR);
+        while (st.hasMoreTokens()) {
+            String part = st.nextToken();
+            int separator = part.indexOf('=');
+            if (separator == -1) {
+                throw new AuthenticationException("Invalid authentication token");
+            }
+            String key = part.substring(0, separator);
+            String value = part.substring(separator + 1);
+            map.put(key, value);
+        }
+        return map;
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleTokenSigner.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/HmacRoleTokenSigner.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.sasl.scram;
+
+import io.netty.util.internal.StringUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.naming.AuthenticationException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+@Slf4j
+public class HmacRoleTokenSigner {
+    public static final String SIGNATURE = "&s=";
+
+    private byte[] key;
+
+    private static final int HMAC_KEY_LENGTH = 32;
+
+    /**
+     * Creates a SaslRoleTokenSigner instance using the specified secret.
+     *
+     * @param secret secret to use for creating the digest.
+     */
+    public HmacRoleTokenSigner(String secret) {
+        //a valid HmacKey Length should be more than 64
+        if (secret == null || secret.length() < HMAC_KEY_LENGTH) {
+            throw new IllegalArgumentException("secret cannot be NULL or less than " + HMAC_KEY_LENGTH);
+        }
+        this.key = StringUtil.decodeHexDump(secret);
+    }
+
+    /**
+     * Returns a signed string.
+     * <p/>
+     * The signature '&s=SIGNATURE' is appended at the end of the string.
+     *
+     * @param str string to sign.
+     * @return the signed string.
+     */
+    public String sign(String str) {
+        if (str == null || str.length() == 0) {
+            throw new IllegalArgumentException("NULL or empty string to sign");
+        }
+        String signature = computeSignature(str);
+        return str + SIGNATURE + signature;
+    }
+
+    /**
+     * Returns the signature of a string.
+     *
+     * @param str string to sign.
+     * @return the signature(HMAC-SHA256) for the string.
+     */
+    public String computeSignature(String str) {
+        try {
+
+            SecretKeySpec secretKey = new SecretKeySpec(key, "HmacSHA256");
+            Mac mac = Mac.getInstance(secretKey.getAlgorithm());
+            mac.init(secretKey);
+            byte[] digest = mac.doFinal(str.getBytes(StandardCharsets.UTF_8));
+
+            return StringUtil.toHexString(digest).toUpperCase(Locale.ROOT);
+
+        } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+            throw new RuntimeException("It should not happen, " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramCredential.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramCredential.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.common.sasl.scram;
+
+public class ScramCredential {
+
+    private final byte[] salt;
+
+    private final byte[] serverKey;
+
+    private final byte[] storedKey;
+
+    private final int iterations;
+
+    private String pwd = null;
+
+    /**
+     * Constructs a new credential.
+     */
+    public ScramCredential(byte[] salt, byte[] storedKey, byte[] serverKey, int iterations) {
+        this.salt = salt;
+        this.serverKey = serverKey;
+        this.storedKey = storedKey;
+        this.iterations = iterations;
+    }
+
+    /**
+     * Returns the salt used to process this credential using the SCRAM algorithm.
+     */
+    public byte[] salt() {
+        return salt;
+    }
+
+    /**
+     * Server key computed from the client password using the SCRAM algorithm.
+     */
+    public byte[] serverKey() {
+        return serverKey;
+    }
+
+    /**
+     * Stored key computed from the client password using the SCRAM algorithm.
+     */
+    public byte[] storedKey() {
+        return storedKey;
+    }
+
+    /**
+     * Number of iterations used to process this credential using the SCRAM
+     * algorithm.
+     */
+    public int iterations() {
+        return iterations;
+    }
+
+    public String getPwd() {
+        return pwd;
+    }
+
+    public void setPwd(String pwd) {
+        this.pwd = pwd;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramFormatter.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramFormatter.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.sasl.scram;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.naming.directory.AttributeModificationException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Properties;
+
+/**
+ * ScramFormatter
+ */
+public class ScramFormatter {
+
+    private static final String SALT = "salt";
+
+    private static final String STORED_KEY = "stored_key";
+
+    private static final String SERVER_KEY = "server_key";
+
+    private static final String ITERATIONS = "iterations";
+
+
+    private final MessageDigest messageDigest;
+
+    private final Mac mac;
+
+    private final SecureRandom random;
+
+
+    public ScramFormatter() {
+        try {
+            this.random = new SecureRandom();
+            this.messageDigest = MessageDigest.getInstance("SHA-256");
+            this.mac = Mac.getInstance("HmacSHA256");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public byte[] hmac(byte[] key, byte[] bytes) throws InvalidKeyException {
+        mac.init(new SecretKeySpec(key, mac.getAlgorithm()));
+        return mac.doFinal(bytes);
+    }
+
+    public byte[] hash(byte[] str) {
+        return messageDigest.digest(str);
+    }
+
+    public byte[] xor(byte[] first, byte[] second) {
+        if (first.length != second.length)
+            throw new IllegalArgumentException("Argument arrays must be of the same length");
+        byte[] result = new byte[first.length];
+        for (int i = 0; i < result.length; i++)
+            result[i] = (byte) (first[i] ^ second[i]);
+        return result;
+    }
+
+    public byte[] hi(byte[] str, byte[] salt, int iterations) throws InvalidKeyException {
+        mac.init(new SecretKeySpec(str, mac.getAlgorithm()));
+        mac.update(salt);
+        byte[] u1 = mac.doFinal(new byte[]{0, 0, 0, 1});
+        byte[] prev = u1;
+        byte[] result = u1;
+        for (int i = 2; i <= iterations; i++) {
+            byte[] ui = hmac(str, prev);
+            result = xor(result, ui);
+            prev = ui;
+        }
+        return result;
+    }
+
+    public byte[] clientProof(byte[] saltedPassword, String authMessage) throws InvalidKeyException {
+        byte[] clientKey = clientKey(saltedPassword);
+        byte[] storedKey = hash(clientKey);
+        byte[] clientSignature = hmac(storedKey, authMessage.getBytes(StandardCharsets.UTF_8));
+        return xor(clientKey, clientSignature);
+    }
+
+    public byte[] normalize(String str) {
+        return toBytes(str);
+    }
+
+    public byte[] saltedPassword(String password, byte[] salt, int iterations) throws InvalidKeyException {
+        return hi(normalize(password), salt, iterations);
+    }
+
+    public byte[] clientKey(byte[] saltedPassword) throws InvalidKeyException {
+        return hmac(saltedPassword, toBytes("Client Key"));
+    }
+
+    public byte[] storedKey(byte[] clientKey) {
+        return hash(clientKey);
+    }
+
+    public byte[] storedKey(byte[] clientSignature, byte[] clientProof) {
+        return hash(xor(clientSignature, clientProof));
+    }
+
+    public byte[] serverKey(byte[] saltedPassword) throws InvalidKeyException {
+        return hmac(saltedPassword, toBytes("Server Key"));
+    }
+
+    public byte[] toBytes(String str) {
+        return str.getBytes(StandardCharsets.UTF_8);
+    }
+
+
+    public static String credentialToString(ScramCredential credential) {
+        return String.format(Locale.ROOT, "%s=%s,%s=%s,%s=%s,%s=%d", SALT,
+                Base64.getEncoder().encodeToString(credential.salt()), STORED_KEY,
+                Base64.getEncoder().encodeToString(credential.storedKey()), SERVER_KEY,
+                Base64.getEncoder().encodeToString(credential.serverKey()), ITERATIONS, credential.iterations());
+    }
+
+    public static ScramCredential credentialFromString(String str) {
+        Properties props = toProps(str);
+        if (props.size() != 4 || !props.containsKey(SALT) || !props.containsKey(STORED_KEY)
+                || !props.containsKey(SERVER_KEY) || !props.containsKey(ITERATIONS)) {
+            throw new IllegalArgumentException("Credentials not valid: " + str);
+        }
+        byte[] salt = Base64.getDecoder().decode(props.getProperty(SALT));
+        byte[] storedKey = Base64.getDecoder().decode(props.getProperty(STORED_KEY));
+        byte[] serverKey = Base64.getDecoder().decode(props.getProperty(SERVER_KEY));
+        int iterations = Integer.parseInt(props.getProperty(ITERATIONS));
+        return new ScramCredential(salt, storedKey, serverKey, iterations);
+    }
+
+    private static Properties toProps(String str) {
+        Properties props = new Properties();
+        String[] tokens = str.split(",");
+        for (String token : tokens) {
+            int index = token.indexOf('=');
+            if (index <= 0)
+                throw new IllegalArgumentException("Credentials not valid: " + str);
+            props.put(token.substring(0, index), token.substring(index + 1));
+        }
+        return props;
+    }
+
+
+    //Tool
+    public ScramCredential generateCredential(String password, int iterations)
+            throws AttributeModificationException, InvalidKeyException {
+        byte[] salt = secureRandomBytes();
+        byte[] saltedPassword = saltedPassword(password, salt, iterations);
+        byte[] clientKey = clientKey(saltedPassword);
+        byte[] storedKey = storedKey(clientKey);
+        byte[] serverKey = serverKey(saltedPassword);
+        return new ScramCredential(salt, storedKey, serverKey, iterations);
+    }
+
+    public String secureRandomString() {
+        return new BigInteger(130, random).toString(Character.MAX_RADIX);
+    }
+
+    public byte[] secureRandomBytes() {
+        return toBytes(secureRandomString());
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramStage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/sasl/scram/ScramStage.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.sasl.scram;
+
+/**
+ *
+ */
+public enum ScramStage {
+    INIT,
+    FIRST,
+    FINAL,
+    FINISH,
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Decryption.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Decryption.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.common.util;
+
+/**
+ * common decryption interface
+ */
+public interface Decryption {
+
+    /**
+     * decrypt
+     * @param secret
+     * @return secret after decrypt
+     */
+    public String decrypt(String secret);
+
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/DecryptionUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/DecryptionUtils.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.util.Decryption;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * common decryption tool
+ */
+public class DecryptionUtils {
+
+    /**
+     * return src secret with decrypt
+     * @return Decryption class
+     */
+    public static Decryption getNoneDecryptionClass() {
+
+        return new Decryption() {
+            @Override
+            public String decrypt(String secret) {
+                return secret;
+            }
+        };
+    }
+
+    /**
+     * invoke service own decrypt class
+     * @param className
+     * @return
+     */
+    public static Decryption getDecryptionClass(String className) {
+
+        if (StringUtils.isBlank(className)) {
+            return getNoneDecryptionClass();
+        }
+
+        try {
+            Class<?> srcClass = Class.forName(className);
+
+            Constructor<?> constructor = srcClass.getConstructor();
+
+            Object o = constructor.newInstance();
+            if (o instanceof Decryption) {
+                return (Decryption) o;
+            }
+        } catch (InvocationTargetException e) {
+            throw new IllegalArgumentException(e.getTargetException());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("please check you classpath. ");
+        }
+        throw new IllegalArgumentException("please check your Decryption class name . ");
+    }
+}


### PR DESCRIPTION
Fixes part of #8670 #9367 i feedback

### Motivation

1、SASL-SCRAM-SHA256 auth is more lightweight than SASL-Kerberos ,not need depends on a third part modules like KDC ,and can be use without TLS in Intranet．

2、we can save scram user info (salt、serverkey、storekeyiterations) to meta center (zookeeper now )

3、in admin scenario ，we can use hmacsha256 sign value as a token , than we can use curl、postman httpclient to send a admin request ,it is more easier and safer than get a sha token after SASL-kerberos auth  ,but it is also suggest use https to protected your hmacValue

   http header : HmacAuthRoleToken like SaslAuthRoleToken 
   value format ：u=pulsarAdmin&i=scram&e=1616416871193&s=C4681422F1C98DB5C02F7E5812D54E61AB5219841CC1BA3ECEF89E31FA60105

### Modifications

1、extend a new sasl SCRAM-Sha256 ,will effect after user open it 
2、add a interface Decryption ,it is better store your password 、scram info with encrypted ，and we will invoke your Decryption impl ,when use load data to mem



### Verifying this change


This change is already covered by existing tests, such as SaslSCRAMAuthenticateTest,SaslScramDataTest 
like the sasl-kerboer testcase SaslAuthenticateTest and SaslServerTokenSignerTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: ( no)
  - The schema: (no)
  - The default values of configurations: ( no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented now ,and if this feature can be merge ,will update the doc ,now it can be check the useage by testcase)

