### PR TITLE
[docs] add key_shared subscription type

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -309,7 +309,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/docs/reference-terminology.md
+++ b/site2/docs/reference-terminology.md
@@ -41,8 +41,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.4.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.4.0/developing-binary-protocol.md
@@ -307,7 +307,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.5.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.5.1/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.5.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.5.2/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.6.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.6.0/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.6.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.6.1/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.6.2/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.6.2/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.6.3/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.6.3/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.7.0/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.7.0/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 

--- a/site2/website/versioned_docs/version-2.7.1/developing-binary-protocol.md
+++ b/site2/website/versioned_docs/version-2.7.1/developing-binary-protocol.md
@@ -310,7 +310,7 @@ message CommandSubscribe {
 Parameters:
  * `topic` → Complete topic name to where you want to create the consumer on
  * `subscription` → Subscription name
- * `subType` → Subscription type: Exclusive, Shared, Failover
+ * `subType` → Subscription type: Exclusive, Shared, Failover, Key_Shared
  * `consumer_id` → Client generated consumer identifier. Needs to be unique
     within the same connection
  * `request_id` → Identifier for this request. Used to match the response with

--- a/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-terminology.md
@@ -42,8 +42,8 @@ An administrative unit for allocating capacity and enforcing an authentication/a
 
 #### Subscription
 
-A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has three subscription
-modes (exclusive, shared, and failover).
+A lease on a [topic](#topic) established by a group of [consumers](#consumer). Pulsar has four subscription
+modes (exclusive, shared, failover and key_shared).
 
 #### Pub-Sub
 


### PR DESCRIPTION
Signed-off-by: YANGLiiN <ielin@qq.com>

### Motivation

with pip-34 since 2.4.0 add Key_shared subscription type, but the doc still miss the subtype.


### Modifications

add Key_shared subscription type for the doc


