### PR TITLE
Removed null check in MessageImpl.getMessageId() to match documented behavior.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -81,7 +81,8 @@ public interface Message<T> {
      *
      * <p>Only messages received from the consumer will have a message id assigned.
      *
-     * @return the message id null if this message was not received by this client instance
+     * @return the message id
+     * @throws NullPointerException if the message is null (message was not received by this client instance)
      */
     MessageId getMessageId();
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -81,8 +81,7 @@ public interface Message<T> {
      *
      * <p>Only messages received from the consumer will have a message id assigned.
      *
-     * @return the message id
-     * @throws NullPointerException if the message is null (message was not received by this client instance)
+     * @return the message id null if this message was not received by this client instance
      */
     MessageId getMessageId();
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -440,8 +440,8 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             } catch (PulsarClientException e) {
                 return FutureUtil.failedFuture(e);
             }
-            reconsumeLaterAsync(message,delayTime, unit);
         }
+        messages.forEach(message -> reconsumeLaterAsync(message,delayTime, unit));
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -535,6 +535,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                        long delayTime,
                                                        TimeUnit unit) {
         MessageId messageId = message.getMessageId();
+        if (messageId == null) {
+            return FutureUtil.failedFuture(new PulsarClientException
+                    .InvalidMessageException("Cannot handle message with null messageId"));
+        }
+
         if(messageId instanceof TopicMessageIdImpl) {
             messageId = ((TopicMessageIdImpl)messageId).getInnerMessageId();
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -432,7 +432,6 @@ public class MessageImpl<T> implements Message<T> {
 
     @Override
     public MessageId getMessageId() {
-        checkNotNull(messageId, "Cannot get the message id of a message that was not received");
         return messageId;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -473,6 +473,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                                        long delayTime,
                                                        TimeUnit unit) {
         MessageId messageId = message.getMessageId();
+        if (messageId == null) {
+            return FutureUtil.failedFuture(new PulsarClientException
+                    .InvalidMessageException("Cannot handle message with null messageId"));
+        }
         checkArgument(messageId instanceof TopicMessageIdImpl);
         TopicMessageIdImpl topicMessageId = (TopicMessageIdImpl) messageId;
         if (getState() != State.Ready) {


### PR DESCRIPTION
Fixes #10022

### Motivation

Removed null check in MessageImpl.getMessageId() to match documented behavior.
Details at https://github.com/apache/pulsar/issues/10022

### Modifications

Removed "checkNotNull"

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

