### PR TITLE
[pulsar-websocket] Allow websocket to consume and pass message to client without decryption

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -27,7 +27,6 @@ import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -35,8 +34,6 @@ import java.util.concurrent.atomic.LongAdder;
 
 import javax.servlet.http.HttpServletRequest;
 
-import io.netty.util.concurrent.CompleteFuture;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
@@ -389,8 +386,14 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             builder.deadLetterPolicy(dlpBuilder.build());
         }
 
-        // default disable message decryption and let websocket pass decrypted message to client
-        builder.cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME);
+        if (queryParams.containsKey("cryptoFailureAction")) {
+            String action = queryParams.get("cryptoFailureAction");
+            try {
+                builder.cryptoFailureAction(ConsumerCryptoFailureAction.valueOf(action));
+            } catch (Exception e) {
+                log.warn("Failed to configure cryptoFailureAction {} , {}", action, e.getMessage());
+            }
+        }
 
         return builder;
     }
@@ -423,5 +426,4 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     }
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerHandler.class);
-
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -40,6 +40,7 @@ import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -387,6 +388,9 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             }
             builder.deadLetterPolicy(dlpBuilder.build());
         }
+
+        // default disable message decryption and let websocket pass decrypted message to client
+        builder.cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME);
 
         return builder;
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
@@ -89,12 +89,17 @@ public class ReaderHandler extends AbstractWebSocketHandler {
             ReaderBuilder<byte[]> builder = service.getPulsarClient().newReader()
                     .topic(topic.toString())
                     .startMessageId(getMessageId())
-                    .cryptoFailureAction(
-                            // default disable message decryption and let websocket pass decrypted message to client
-                            ConsumerCryptoFailureAction.CONSUME)
                     .receiverQueueSize(receiverQueueSize);
             if (queryParams.containsKey("readerName")) {
                 builder.readerName(queryParams.get("readerName"));
+            }
+            if (queryParams.containsKey("cryptoFailureAction")) {
+                String action = queryParams.get("cryptoFailureAction");
+                try {
+                    builder.cryptoFailureAction(ConsumerCryptoFailureAction.valueOf(action));
+                } catch (Exception e) {
+                    log.warn("Failed to configure cryptoFailureAction {} , {}", action, e.getMessage());
+                }
             }
 
             this.reader = builder.create();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
 import org.apache.pulsar.client.api.Reader;
@@ -88,6 +89,9 @@ public class ReaderHandler extends AbstractWebSocketHandler {
             ReaderBuilder<byte[]> builder = service.getPulsarClient().newReader()
                     .topic(topic.toString())
                     .startMessageId(getMessageId())
+                    .cryptoFailureAction(
+                            // default disable message decryption and let websocket pass decrypted message to client
+                            ConsumerCryptoFailureAction.CONSUME)
                     .receiverQueueSize(receiverQueueSize);
             if (queryParams.containsKey("readerName")) {
                 builder.readerName(queryParams.get("readerName"));


### PR DESCRIPTION
### Motivation
Right now, websocket proxy fails to receive and send message to client-consumer if message is encrypted. Websocket proxy should default pass encrypted message to client without decrypting and let client app handles it.  So, add default decryption action as : `CONSUME`. I will create a separate PR to support decryption at websocket proxy in specific scenario where user wants websocket to handle message decryption.