### PR TITLE
[Issue 10010][Client] fixed memory leak

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -696,11 +696,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
             List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
 
-            if (listenChannel != null) {
+            if (listenChannel != null && listenChannel.isOpen()) {
                 asyncCloseFutures.add(closeChannel(listenChannel));
             }
 
-            if (listenChannelTls != null) {
+            if (listenChannelTls != null && listenChannelTls.isOpen()) {
                 asyncCloseFutures.add(closeChannel(listenChannelTls));
             }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -539,7 +539,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         producer.flush();
 
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             log.info("Received: [{}]", new String(msg.getData()));
@@ -986,7 +986,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         EntryCacheImpl entryCache = spy((EntryCacheImpl) cacheField.get(ledger));
         cacheField.set(ledger, entryCache);
 
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
         // 2. Produce messages
         for (int i = 0; i < 30; i++) {
             String message = "my-message-" + i;
@@ -1082,7 +1082,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final long maxMessageCacheRetentionTimeMillis = conf.getManagedLedgerCacheEvictionTimeThresholdMillis();
         final long maxActiveCursorBacklogEntries = conf.getManagedLedgerCursorBackloggedThreshold();
 
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
         final int totalMsgs = (int) maxActiveCursorBacklogEntries + receiverSize + 1;
         // 2. Produce messages
         for (int i = 0; i < totalMsgs; i++) {
@@ -1216,7 +1216,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // Trigger the send timeout
         stopBroker();
-        List<CompletableFuture<MessageId>> futures = new ArrayList<CompletableFuture<MessageId>>();
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
         for(int i = 0 ; i < 3 ; i++) {
              CompletableFuture<MessageId> future = producer.newMessage().sequenceId(i).value(message.getBytes()).sendAsync();
              futures.add(future);
@@ -1291,7 +1291,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             producer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
         Set<Message<byte[]>> consumerMsgSet1 = Sets.newHashSet();
         Set<Message<byte[]>> consumerMsgSet2 = Sets.newHashSet();
         for (int i = 0; i < 5; i++) {
@@ -1396,7 +1396,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
+            Message<byte[]> msg;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -1442,10 +1442,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      * due to reaching ack-threshold (500) 3. Consumer acks messages after stop getting messages 4. Consumer again tries
      * to consume messages 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
      *
-     * @throws Exception
      */
     @Test(dataProvider = "ackReceiptEnabled")
-    public void testConsumerBlockingWithUnAckedMessagesMultipleIteration(boolean ackReceiptEnabled) throws Exception {
+    public void testConsumerBlockingWithUnAckedMessagesMultipleIteration(boolean ackReceiptEnabled) {
         log.info("-- Starting {} test --", methodName);
 
         int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
@@ -1476,7 +1475,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (2) Receive Messages
             for (int j = 0; j < totalReceiveIteration; j++) {
 
-                Message<byte[]> msg = null;
+                Message<byte[]> msg;
                 List<Message<byte[]>> messages = Lists.newArrayList();
                 for (int i = 0; i < totalProducedMsgs; i++) {
                     msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -1552,7 +1551,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message<byte[]> msg = null;
+            Message<byte[]> msg;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -1702,7 +1701,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
+            Message<byte[]> msg;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -1866,7 +1865,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message<byte[]> msg = null;
+            Message<byte[]> msg;
             List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -2007,9 +2006,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // client should not receive all produced messages and should be blocked due to unack-messages
             assertEquals(messages1.size(), unAckedMessagesBufferSize);
-            Set<MessageIdImpl> redeliveryMessages = messages1.stream().map(m -> {
-                return (MessageIdImpl) m.getMessageId();
-            }).collect(Collectors.toSet());
+            Set<MessageIdImpl> redeliveryMessages = messages1.stream().map(m ->
+                    (MessageIdImpl) m.getMessageId()).collect(Collectors.toSet());
 
             // (3) redeliver all consumed messages
             consumer.redeliverUnacknowledgedMessages(Sets.newHashSet(redeliveryMessages));
@@ -2081,7 +2079,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                     .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
+            Message<byte[]> msg;
             List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -2094,9 +2092,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // client should not receive all produced messages and should be blocked due to unack-messages
-            Set<MessageIdImpl> redeliveryMessages = messages1.stream().map(m -> {
-                return (MessageIdImpl) m.getMessageId();
-            }).collect(Collectors.toSet());
+            Set<MessageIdImpl> redeliveryMessages = messages1.stream().map(m ->
+                    (MessageIdImpl) m.getMessageId()).collect(Collectors.toSet());
 
             // (3) redeliver all consumed messages
             consumer.redeliverUnacknowledgedMessages(Sets.newHashSet(redeliveryMessages));
@@ -2207,7 +2204,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 10000)
+    @Test(timeOut = 30000)
     public void testSharedSamePriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
         final int queueSize = 5;
@@ -2359,7 +2356,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
         // (1.a) consume first consumeMsgInParts msgs and trigger redeliver
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
         List<Message<byte[]>> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
             msg = consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -2515,7 +2512,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             cryptoProducer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message<byte[]> msg;
 
         msg = normalConsumer.receive(RECEIVE_TIMEOUT_MEDIUM_MILLIS, TimeUnit.MILLISECONDS);
         // should not able to read message using normal message.
@@ -2600,7 +2597,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             producer2.send(message.getBytes());
         }
 
-        MessageImpl<byte[]> msg = null;
+        MessageImpl<byte[]> msg;
 
         msg = (MessageImpl<byte[]>) normalConsumer.receive(RECEIVE_TIMEOUT_MEDIUM_MILLIS, TimeUnit.MILLISECONDS);
         // should not able to read message using normal message.
@@ -2902,7 +2899,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         final int totalMsg = 10;
 
-        MessageImpl<byte[]> msg = null;
+        MessageImpl<byte[]> msg;
         Set<String> messageSet = Sets.newHashSet();
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/myenc-ns/myenc-topic1").subscriptionName("my-subscriber-name")
@@ -3080,7 +3077,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         ByteBuf payloadBuf = Unpooled.wrappedBuffer(msg.getData());
         // try to decrypt use default MessageCryptoBc
-        MessageCrypto crypto = new MessageCryptoBc("test", false);
+        @SuppressWarnings("rawtypes") MessageCrypto crypto = new MessageCryptoBc("test", false);
 
         MessageMetadata messageMetadata = new MessageMetadata()
                 .setEncryptionParam(encrParam)
@@ -3219,7 +3216,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
         assertEquals(counter, 10);
 
-        producer.close();;
+        producer.close();
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
     }
@@ -3299,6 +3296,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     // Issue 1452: https://github.com/apache/pulsar/issues/1452
     // reachedEndOfTopic should be called only once if a topic has been terminated before subscription
+    @SuppressWarnings("rawtypes")
     @Test
     public void testReachedEndOfTopic() throws Exception
     {
@@ -3311,7 +3309,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         admin.topics().terminateTopicAsync(topicName).get();
 
         CountDownLatch latch = new CountDownLatch(2);
-        Consumer consumer = pulsarClient.newConsumer()
+        @SuppressWarnings("unchecked") Consumer consumer = pulsarClient.newConsumer()
             .topic(topicName)
             .subscriptionName("my-subscriber-name")
             .messageListener(new MessageListener()

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -281,7 +281,8 @@ public interface PulsarClient extends Closeable {
      * Perform immediate shutdown of PulsarClient.
      *
      * <p>Release all the resources and close all the producer, consumer and reader instances without waiting
-     * for ongoing operations to complete.
+     * for ongoing operations to complete. Resources passed from the outside like EventLoopGroup or ConnectionPool
+     * will not be closed.
      *
      * @throws PulsarClientException
      *             if the forceful shutdown fails

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -281,8 +281,7 @@ public interface PulsarClient extends Closeable {
      * Perform immediate shutdown of PulsarClient.
      *
      * <p>Release all the resources and close all the producer, consumer and reader instances without waiting
-     * for ongoing operations to complete. Resources passed from the outside like EventLoopGroup or ConnectionPool
-     * will not be closed.
+     * for ongoing operations to complete.
      *
      * @throws PulsarClientException
      *             if the forceful shutdown fails

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -1,20 +1,20 @@
-/*
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.pulsar.client.impl;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1000,7 +1000,7 @@ public class PulsarClientImpl implements PulsarClient {
             }
             schema = schema.clone();
             if (schema.requireFetchingSchemaInfo()) {
-                @SuppressWarnings("rawtypes") Schema finalSchema = schema;
+                Schema<?> finalSchema = schema;
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
                         if (!(finalSchema instanceof AutoConsumeSchema)) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1000,7 +1000,7 @@ public class PulsarClientImpl implements PulsarClient {
             }
             schema = schema.clone();
             if (schema.requireFetchingSchemaInfo()) {
-                Schema<?> finalSchema = schema;
+                @SuppressWarnings("rawtypes") Schema finalSchema = schema;
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
                         if (!(finalSchema instanceof AutoConsumeSchema)) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -793,11 +793,16 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public synchronized void updateServiceUrl(String serviceUrl) throws PulsarClientException {
-        log.info("Updating service URL to {}", serviceUrl);
+        try {
+            log.info("Updating service URL to {}", serviceUrl);
 
-        conf.setServiceUrl(serviceUrl);
-        lookup.updateServiceUrl(serviceUrl);
-        cnxPool.closeAllConnections();
+            conf.setServiceUrl(serviceUrl);
+            lookup.updateServiceUrl(serviceUrl);
+            cnxPool.closeAllConnections();
+        } catch (Throwable t) {
+            log.warn("Failed to update service URL.");
+            close();
+        }
     }
 
     protected CompletableFuture<ClientCnx> getConnection(final String topic) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -793,16 +793,11 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public synchronized void updateServiceUrl(String serviceUrl) throws PulsarClientException {
-        try {
-            log.info("Updating service URL to {}", serviceUrl);
+        log.info("Updating service URL to {}", serviceUrl);
 
-            conf.setServiceUrl(serviceUrl);
-            lookup.updateServiceUrl(serviceUrl);
-            cnxPool.closeAllConnections();
-        } catch (Throwable t) {
-            log.warn("Failed to update service URL.");
-            close();
-        }
+        conf.setServiceUrl(serviceUrl);
+        lookup.updateServiceUrl(serviceUrl);
+        cnxPool.closeAllConnections();
     }
 
     protected CompletableFuture<ClientCnx> getConnection(final String topic) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -142,43 +142,49 @@ public class PulsarClientImpl implements PulsarClient {
 
     public PulsarClientImpl(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, ConnectionPool cnxPool, Timer timer)
             throws PulsarClientException {
-        if (conf == null || isBlank(conf.getServiceUrl()) || eventLoopGroup == null) {
-            throw new PulsarClientException.InvalidConfigurationException("Invalid client configuration");
-        }
-        this.eventLoopGroup = eventLoopGroup;
-        setAuth(conf);
-        this.conf = conf;
-        this.clientClock = conf.getClock();
-        conf.getAuthentication().start();
-        this.cnxPool = cnxPool;
-        externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(), "pulsar-external-listener");
-        internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(), "pulsar-client-internal");
-        if (conf.getServiceUrl().startsWith("http")) {
-            lookup = new HttpLookupService(conf, eventLoopGroup);
-        } else {
-            lookup = new BinaryProtoLookupService(this, conf.getServiceUrl(), conf.getListenerName(), conf.isUseTls(), externalExecutorProvider.getExecutor());
-        }
-        if (timer == null) {
-            this.timer = new HashedWheelTimer(getThreadFactory("pulsar-timer"), 1, TimeUnit.MILLISECONDS);
-            needStopTimer = true;
-        } else {
-            this.timer = timer;
-        }
-        producers = Collections.newSetFromMap(new ConcurrentHashMap<>());
-        consumers = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-        if (conf.isEnableTransaction()) {
-            tcClient = new TransactionCoordinatorClientImpl(this);
-            try {
-                tcClient.start();
-            } catch (Throwable e) {
-                log.error("Start transactionCoordinatorClient error.", e);
-                throw new PulsarClientException(e);
+        try {
+            if (conf == null || isBlank(conf.getServiceUrl()) || eventLoopGroup == null) {
+                throw new PulsarClientException.InvalidConfigurationException("Invalid client configuration");
             }
-        }
+            this.eventLoopGroup = eventLoopGroup;
+            setAuth(conf);
+            this.conf = conf;
+            this.clientClock = conf.getClock();
+            conf.getAuthentication().start();
+            this.cnxPool = cnxPool;
+            externalExecutorProvider = new ExecutorProvider(conf.getNumListenerThreads(), "pulsar-external-listener");
+            internalExecutorService = new ExecutorProvider(conf.getNumIoThreads(), "pulsar-client-internal");
+            if (conf.getServiceUrl().startsWith("http")) {
+                lookup = new HttpLookupService(conf, eventLoopGroup);
+            } else {
+                lookup = new BinaryProtoLookupService(this, conf.getServiceUrl(), conf.getListenerName(), conf.isUseTls(), externalExecutorProvider.getExecutor());
+            }
+            if (timer == null) {
+                this.timer = new HashedWheelTimer(getThreadFactory("pulsar-timer"), 1, TimeUnit.MILLISECONDS);
+                needStopTimer = true;
+            } else {
+                this.timer = timer;
+            }
+            producers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+            consumers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-        memoryLimitController = new MemoryLimitController(conf.getMemoryLimitBytes());
-        state.set(State.Open);
+                if (conf.isEnableTransaction()) {
+                    tcClient = new TransactionCoordinatorClientImpl(this);
+                    try {
+                        tcClient.start();
+                    } catch (Throwable e) {
+                        log.error("Start transactionCoordinatorClient error.", e);
+                        throw new PulsarClientException(e);
+                    }
+                }
+
+                memoryLimitController = new MemoryLimitController(conf.getMemoryLimitBytes());
+                state.set(State.Open);
+        } catch (Throwable t) {
+            shutdown();
+            shutdownEventLoopGroup(eventLoopGroup);
+            throw t;
+        }
     }
 
     private void setAuth(ClientConfigurationData conf) throws PulsarClientException {
@@ -245,8 +251,9 @@ public class PulsarClientImpl implements PulsarClient {
         return createProducerAsync(conf, schema, null);
     }
 
+    @SuppressWarnings("rawtypes")
     public <T> CompletableFuture<Producer<T>> createProducerAsync(ProducerConfigurationData conf, Schema<T> schema,
-          ProducerInterceptors interceptors) {
+                                                                  ProducerInterceptors interceptors) {
         if (conf == null) {
             return FutureUtil.failedFuture(
                 new PulsarClientException.InvalidConfigurationException("Producer configuration undefined"));
@@ -353,7 +360,8 @@ public class PulsarClientImpl implements PulsarClient {
      * @param interceptors producer interceptors
      * @param producerCreatedFuture future for signaling completion of async producer creation
      * @param <T> message type class
-     * @return
+     *
+     * @return a producer instance
      */
     protected <T> ProducerImpl<T> newProducerImpl(String topic, int partitionIndex,
                                                   ProducerConfigurationData conf,
@@ -485,12 +493,12 @@ public class PulsarClientImpl implements PulsarClient {
 
                 List<String> topicsList = topicsPatternFilter(topics, conf.getTopicsPattern());
                 conf.getTopicNames().addAll(topicsList);
-                ConsumerBase<T> consumer = new PatternMultiTopicsConsumerImpl<T>(conf.getTopicsPattern(),
-                    PulsarClientImpl.this,
-                    conf,
-                    externalExecutorProvider,
-                    consumerSubscribedFuture,
-                    schema, subscriptionMode, interceptors);
+                ConsumerBase<T> consumer = new PatternMultiTopicsConsumerImpl<>(conf.getTopicsPattern(),
+                        PulsarClientImpl.this,
+                        conf,
+                        externalExecutorProvider,
+                        consumerSubscribedFuture,
+                        schema, subscriptionMode, interceptors);
 
                 consumers.add(consumer);
             })
@@ -593,9 +601,7 @@ public class PulsarClientImpl implements PulsarClient {
 
             consumers.add(consumer);
 
-            consumerSubscribedFuture.thenRun(() -> {
-                readerFuture.complete(reader);
-            }).exceptionally(ex -> {
+            consumerSubscribedFuture.thenRun(() -> readerFuture.complete(reader)).exceptionally(ex -> {
                 log.warn("[{}] Failed to get create topic reader", topic, ex);
                 readerFuture.completeExceptionally(ex);
                 return null;
@@ -680,17 +686,102 @@ public class PulsarClientImpl implements PulsarClient {
     @Override
     public void shutdown() throws PulsarClientException {
         try {
-            lookup.close();
-            cnxPool.close();
-            if (needStopTimer) {
-                timer.stop();
+            // We will throw the last thrown exception only, though logging all of them.
+            Throwable throwable = null;
+            if (lookup != null) {
+                try {
+                    lookup.close();
+                } catch (Throwable t) {
+                    log.warn("Failed to shutdown lookup", t);
+                    throwable = t;
+                }
             }
-            externalExecutorProvider.shutdownNow();
-            internalExecutorService.shutdownNow();
-            conf.getAuthentication().close();
+            try {
+                // Shutting down eventLoopGroup separately because in some cases, cnxPool might be using different
+                // eventLoopGroup.
+                shutdownEventLoopGroup(eventLoopGroup);
+            } catch (Throwable t) {
+                log.warn("Failed to shutdown eventLoopGroup", t);
+                throwable = t;
+            }
+            if (cnxPool != null) {
+                try {
+                    cnxPool.close();
+                } catch (Throwable t) {
+                    log.warn("Failed to shutdown cnxPool", t);
+                    throwable = t;
+                }
+            }
+            if (timer != null && needStopTimer) {
+                try {
+                    timer.stop();
+                } catch (Throwable t) {
+                    log.warn("Failed to shutdown timer", t);
+                    throwable = t;
+                }
+            }
+            try {
+                shutdownExecutors();
+            } catch (Throwable t) {
+                throwable = t;
+            }
+            if (conf != null && conf.getAuthentication() != null) {
+                try {
+                    conf.getAuthentication().close();
+                } catch (Throwable t) {
+                    log.warn("Failed to close authentication", t);
+                    throwable = t;
+                }
+            }
+            if (tcClient != null) {
+                try {
+                    tcClient.close();
+                } catch (Throwable t) {
+                    log.warn("Failed to close tcClient");
+                    throwable = t;
+                }
+            }
+            if (throwable != null) {
+                throw throwable;
+            }
         } catch (Throwable t) {
             log.warn("Failed to shutdown Pulsar client", t);
             throw PulsarClientException.unwrap(t);
+        }
+    }
+
+    private void shutdownEventLoopGroup(EventLoopGroup eventLoopGroup) throws PulsarClientException {
+        if (eventLoopGroup != null && !eventLoopGroup.isShutdown()) {
+            try {
+                eventLoopGroup.shutdownGracefully().get();
+            } catch (Throwable t) {
+                throw PulsarClientException.unwrap(t);
+            }
+        }
+    }
+
+    private void shutdownExecutors() throws PulsarClientException {
+        PulsarClientException pulsarClientException = null;
+
+        if (externalExecutorProvider != null && !externalExecutorProvider.isShutdown()) {
+            try {
+                externalExecutorProvider.shutdownNow();
+            } catch (Throwable t) {
+                log.warn("Failed to shutdown externalExecutorProvider", t);
+                pulsarClientException = PulsarClientException.unwrap(t);
+            }
+        }
+        if (internalExecutorService != null && !internalExecutorService.isShutdown()) {
+            try {
+                internalExecutorService.shutdownNow();
+            } catch (Throwable t) {
+                log.warn("Failed to shutdown internalExecutorService", t);
+                pulsarClientException = PulsarClientException.unwrap(t);
+            }
+        }
+
+        if (pulsarClientException != null) {
+            throw pulsarClientException;
         }
     }
 
@@ -895,7 +986,7 @@ public class PulsarClientImpl implements PulsarClient {
             }
             schema = schema.clone();
             if (schema.requireFetchingSchemaInfo()) {
-                Schema finalSchema = schema;
+                @SuppressWarnings("rawtypes") Schema finalSchema = schema;
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
                         if (!(finalSchema instanceof AutoConsumeSchema)) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -203,11 +203,12 @@ public class PulsarClientImplTest {
         ClientConfigurationData conf = clientImpl.conf;
         conf.setServiceUrl("");
         initializeEventLoopGroup(conf);
-        assertFalse(eventLoopGroup.isShutdown());
+        ConnectionPool connectionPool = new ConnectionPool(conf, eventLoopGroup);
         try {
-            assertThrows(() -> new PulsarClientImpl(conf, eventLoopGroup));
+            assertThrows(() -> new PulsarClientImpl(conf, eventLoopGroup, connectionPool));
         } finally {
-            assertTrue(eventLoopGroup.isShutdown());
+            // Externally passed eventLoopGroup should not be shutdown.
+            assertFalse(eventLoopGroup.isShutdown());
         }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -200,23 +200,6 @@ public class PulsarClientImplTest {
 
     @Test
     public void testResourceCleanup() throws PulsarClientException {
-        // 1. A case when resources are initialised but constructor errors out
-        // before getting completed.
-        assertFalse(eventLoopGroup.isShutdown());
-        assertFalse(clientImpl.externalExecutorProvider().isShutdown());
-        assertFalse(clientImpl.getInternalExecutorService().isShutdown());
-
-        try {
-            clientImpl.updateServiceUrl("localhost");
-        } finally {
-            // All the resources should have been released.
-            assertTrue(eventLoopGroup.isShutdown());
-            assertTrue(clientImpl.externalExecutorProvider().isShutdown());
-            assertTrue(clientImpl.getInternalExecutorService().isShutdown());
-        }
-
-        // 2. A case when initialisation fails immediately.
-
         ClientConfigurationData conf = clientImpl.conf;
         conf.setServiceUrl("");
         initializeEventLoopGroup(conf);


### PR DESCRIPTION
trying to close all the resources even if previous one fails during close/shutdown
code clean up as per the idea suggestions

Fixes #10010

### Motivation

Fixed memory leak caused by reception thrown from the PulsarClientImpl constructor in some cases. Resources were not getting closed which used to end up throwing OOM if user code tries to create a client unless succeeded.

### Modifications

Handled exception in the constructor with try-catch and updated shutdown method to close all resources correctly. Previously, it was not attempting to close further resource if the previous one failed. Now it will try to close all of them individully.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no): no
  - The public API: (yes / no): no
  - The schema: (yes / no / don't know): no
  - The default values of configurations: (yes / no): no
  - The wire protocol: (yes / no): no
  - The rest endpoints: (yes / no): no
  - The admin cli options: (yes / no): no
  - Anything that affects deployment: (yes / no / don't know): no

### Documentation

  - Does this pull request introduce a new feature? (yes / no): no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): not applicable
  - If a feature is not applicable for documentation, explain why?: nothing to concerned with the end-user
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation: not required
