### PR TITLE
[C++] Support configure debug level logs simply

### DIFF
--- a/pulsar-client-cpp/include/pulsar/SimpleLoggerFactory.h
+++ b/pulsar-client-cpp/include/pulsar/SimpleLoggerFactory.h
@@ -23,11 +23,36 @@
 
 namespace pulsar {
 
+/**
+ * The default LoggerFactory of Client if `USE_LOG4CXX` macro was not defined during compilation.
+ *
+ *
+ * The log format is "yyyy-mm-dd hh:MM:ss.xxx <level> <thread-id> <file>:<line> | <msg>", like
+ *
+ * ```
+ * 2021-03-24 17:35:46.571 INFO  [0x10a951e00] ConnectionPool:85 | Created connection for ...
+ * ```
+ *
+ * It uses `std::cout` to prints logs to standard output. You can use this factory class to change your log
+ * level simply.
+ *
+ * ```c++
+ * #include <pulsar/SimpleLoggerFactory.h>
+ *
+ * ClientConfiguration conf;
+ * conf.setLogger(new SimpleLoggerFactory(Logger::LEVEL_DEBUG));
+ * Client client("pulsar://localhost:6650", conf);
+ * ```
+ */
 class SimpleLoggerFactory : public LoggerFactory {
    public:
-    Logger* getLogger(const std::string& fileName);
+    explicit SimpleLoggerFactory() = default;
+    explicit SimpleLoggerFactory(Logger::Level level) : level_(level) {}
 
-    static std::unique_ptr<LoggerFactory> create();
+    Logger* getLogger(const std::string& fileName) override;
+
+   private:
+    Logger::Level level_{Logger::LEVEL_INFO};
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -26,7 +26,7 @@
 #include "PartitionedConsumerImpl.h"
 #include "MultiTopicsConsumerImpl.h"
 #include "PatternMultiTopicsConsumerImpl.h"
-#include "SimpleLoggerImpl.h"
+#include <pulsar/SimpleLoggerFactory.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <sstream>
 #include <lib/HTTPLookupService.h>
@@ -101,11 +101,11 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
             loggerFactory = Log4CxxLoggerFactory::create(clientConfiguration_.getLogConfFilePath());
         } else {
             // Use default simple console logger
-            loggerFactory = SimpleLoggerFactory::create();
+            loggerFactory.reset(new SimpleLoggerFactory);
         }
 #else
         // Use default simple console logger
-        loggerFactory = SimpleLoggerFactory::create();
+        loggerFactory.reset(new SimpleLoggerFactory);
 #endif
     }
     LogUtils::setLoggerFactory(std::move(loggerFactory));

--- a/pulsar-client-cpp/lib/LogUtils.cc
+++ b/pulsar-client-cpp/lib/LogUtils.cc
@@ -20,8 +20,8 @@
 
 #include <atomic>
 #include <iostream>
+#include <pulsar/SimpleLoggerFactory.h>
 
-#include "SimpleLoggerImpl.h"
 #include "Log4CxxLogger.h"
 
 namespace pulsar {

--- a/pulsar-client-cpp/lib/SimpleLoggerFactory.cc
+++ b/pulsar-client-cpp/lib/SimpleLoggerFactory.cc
@@ -47,10 +47,8 @@ inline std::ostream &operator<<(std::ostream &s, Logger::Level level) {
 }
 
 class SimpleLogger : public Logger {
-    std::string logger_;
-
    public:
-    SimpleLogger(const std::string &logger, Level level) : logger_(logger), level_(level) {}
+    SimpleLogger(const std::string &filename, Level level) : filename_(filename), level_(level) {}
 
     bool isEnabled(Level level) { return level >= level_; }
 
@@ -58,7 +56,7 @@ class SimpleLogger : public Logger {
         std::stringstream ss;
 
         printTimestamp(ss);
-        ss << " " << level << " [" << std::this_thread::get_id() << "] " << logger_ << ":" << line << " | "
+        ss << " " << level << " [" << std::this_thread::get_id() << "] " << filename_ << ":" << line << " | "
            << message << "\n";
 
         std::cout << ss.str();
@@ -66,7 +64,8 @@ class SimpleLogger : public Logger {
     }
 
    private:
-    Level level_;
+    const std::string filename_;
+    const Level level_;
 
     static std::ostream &printTimestamp(std::ostream &s) {
         boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();

--- a/pulsar-client-cpp/lib/SimpleLoggerFactory.cc
+++ b/pulsar-client-cpp/lib/SimpleLoggerFactory.cc
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "SimpleLoggerImpl.h"
+#include <pulsar/SimpleLoggerFactory.h>
 
 #include <iostream>
 #include <sstream>
@@ -47,18 +47,18 @@ inline std::ostream &operator<<(std::ostream &s, Logger::Level level) {
 }
 
 class SimpleLogger : public Logger {
-    std::string _logger;
+    std::string logger_;
 
    public:
-    SimpleLogger(const std::string &logger) : _logger(logger) {}
+    SimpleLogger(const std::string &logger, Level level) : logger_(logger), level_(level) {}
 
-    bool isEnabled(Level level) { return level >= Logger::LEVEL_INFO; }
+    bool isEnabled(Level level) { return level >= level_; }
 
     void log(Level level, int line, const std::string &message) {
         std::stringstream ss;
 
         printTimestamp(ss);
-        ss << " " << level << " [" << std::this_thread::get_id() << "] " << _logger << ":" << line << " | "
+        ss << " " << level << " [" << std::this_thread::get_id() << "] " << logger_ << ":" << line << " | "
            << message << "\n";
 
         std::cout << ss.str();
@@ -66,6 +66,8 @@ class SimpleLogger : public Logger {
     }
 
    private:
+    Level level_;
+
     static std::ostream &printTimestamp(std::ostream &s) {
         boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
 
@@ -80,9 +82,6 @@ class SimpleLogger : public Logger {
     }
 };
 
-Logger *SimpleLoggerFactory::getLogger(const std::string &file) { return new SimpleLogger(file); }
+Logger *SimpleLoggerFactory::getLogger(const std::string &file) { return new SimpleLogger(file, level_); }
 
-std::unique_ptr<LoggerFactory> SimpleLoggerFactory::create() {
-    return std::unique_ptr<LoggerFactory>(new SimpleLoggerFactory());
-}
 }  // namespace pulsar

--- a/pulsar-client-cpp/tests/CustomLoggerTest.cc
+++ b/pulsar-client-cpp/tests/CustomLoggerTest.cc
@@ -17,7 +17,7 @@
  * under the License.
  */
 #include <pulsar/Client.h>
-#include <pulsar/Logger.h>
+#include <pulsar/SimpleLoggerFactory.h>
 #include <LogUtils.h>
 #include <gtest/gtest.h>
 #include <thread>
@@ -66,4 +66,34 @@ TEST(CustomLoggerTest, testCustomLogger) {
     client.close();
     // custom logger didn't get any new lines
     ASSERT_EQ(logLines.size(), 2);
+}
+
+TEST(CustomLoggerTest, testSimpleLoggerFactory) {
+    std::unique_ptr<SimpleLoggerFactory> factory(new SimpleLoggerFactory);
+    std::unique_ptr<Logger> logger(factory->getLogger(__FILE__));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_DEBUG));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_INFO));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_WARN));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_ERROR));
+
+    factory.reset(new SimpleLoggerFactory(Logger::LEVEL_DEBUG));
+    logger.reset(factory->getLogger(__FILE__));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_DEBUG));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_INFO));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_WARN));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_ERROR));
+
+    factory.reset(new SimpleLoggerFactory(Logger::LEVEL_WARN));
+    logger.reset(factory->getLogger(__FILE__));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_DEBUG));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_INFO));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_WARN));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_ERROR));
+
+    factory.reset(new SimpleLoggerFactory(Logger::LEVEL_ERROR));
+    logger.reset(factory->getLogger(__FILE__));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_DEBUG));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_INFO));
+    ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_WARN));
+    ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_ERROR));
 }

--- a/pulsar-client-cpp/tests/CustomLoggerTest.cc
+++ b/pulsar-client-cpp/tests/CustomLoggerTest.cc
@@ -17,9 +17,9 @@
  * under the License.
  */
 #include <pulsar/Client.h>
+#include <pulsar/Logger.h>
 #include <LogUtils.h>
 #include <gtest/gtest.h>
-#include <lib/SimpleLoggerImpl.h>
 #include <thread>
 
 using namespace pulsar;


### PR DESCRIPTION
### Motivation

For C++ client, if we want to see debug logs, there're two ways:
1. Build C++ library with CMake macro `-DUSE_LOG4CXX=ON`, and configure `log4cxx.conf`.
2. Custom the logger factory for `Client`.

The first way needs log4cxx dependency that is not easy to install. It's also why the `USE_LOG4CXX` option is disabled by default. The second way needs a lot of extra code. Sometimes, we just want to set logger's default log level to debug.

### Modifications

This PR exposes the internal `SimpleLoggerFactory` and support configure debug level simply, for example

```c++
    ClientConfiguration conf;
    conf.setLogger(new SimpleLoggerFactory(Logger::LEVEL_DEBUG));
    Client client("pulsar://localhost:6650", conf);
```

Add tests for the `Logger` created by `SimpleLoggerFactory::getLogger`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests `CustomLoggerTest.testSimpleLoggerFactory`.