### PR TITLE
Support start from separate MessageId for each topic/ partition

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -688,5 +688,12 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             assertTrue(e.getMessage().contains("Function must be set"));
         }
         assertNull(consumer.seekAsync((topic)-> null).get());
+        try {
+            assertNull(consumer.seekAsync((topic)-> new Object()).get());
+            fail("should fail");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof PulsarClientException);
+            assertTrue(e.getCause().getMessage().contains("Only support seek by messageId or timestamp"));
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,18 +34,22 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 import org.testng.annotations.AfterClass;
@@ -492,5 +497,150 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             }
         }
         assertTrue(hasConsumerNotDisconnected);
+    }
+
+    @Test
+    public void testSeekByFunction() throws Exception {
+        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        int partitionNum = 4;
+        int msgNum = 160;
+        admin.topics().createPartitionedTopic(topicName, partitionNum);
+        creatProducerAndSendMsg(topicName, msgNum);
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient
+                .newConsumer(Schema.STRING).startMessageIdInclusive()
+                .topic(topicName).subscriptionName("my-sub").subscribe();
+
+        TopicName partitionedTopic = TopicName.get(topicName);
+        Reader<String> reader = pulsarClient.newReader(Schema.STRING)
+                .startMessageId(MessageId.earliest)
+                .topic(partitionedTopic.getPartition(0).toString()).create();
+        List<MessageId> list = new ArrayList<>();
+        while (reader.hasMessageAvailable()) {
+            list.add(reader.readNext().getMessageId());
+        }
+        // get middle msg from partition-0
+        MessageId middleMsgIdInPartition0 = list.get(list.size() / 2);
+        List<MessageId> msgNotIn = list.subList(0, list.size() / 2 - 1);
+        // get last msg from partition-1
+        MessageId lastMsgInPartition1 = admin.topics().getLastMessageId(partitionedTopic.getPartition(1).toString());
+        reader.close();
+        reader = pulsarClient.newReader(Schema.STRING)
+                .startMessageId(MessageId.earliest)
+                .topic(partitionedTopic.getPartition(2).toString()).create();
+        // get first msg from partition-2
+        MessageId firstMsgInPartition2 = reader.readNext().getMessageId();
+
+        consumer.seek((topic) -> {
+            int index = TopicName.get(topic).getPartitionIndex();
+            if (index == 0) {
+                return middleMsgIdInPartition0;
+            } else if (index == 1) {
+                return lastMsgInPartition1;
+            } else if (index == 2) {
+                return firstMsgInPartition2;
+            }
+            return null;
+        });
+        Set<MessageId> received = new HashSet<>();
+        while (true) {
+            Message<String> message = consumer.receive(2, TimeUnit.SECONDS);
+            if (message == null) {
+                break;
+            }
+            TopicMessageIdImpl topicMessageId = (TopicMessageIdImpl) message.getMessageId();
+            received.add(topicMessageId.getInnerMessageId());
+        }
+        int msgNumFromPartition1 = list.size() / 2;
+        int msgNumFromPartition2 = 1;
+        int msgNumFromPartition3 = msgNum / partitionNum;
+        assertEquals(received.size(), msgNumFromPartition1 + msgNumFromPartition2 + msgNumFromPartition3);
+        assertTrue(received.contains(middleMsgIdInPartition0));
+        assertTrue(received.contains(lastMsgInPartition1));
+        assertTrue(received.contains(firstMsgInPartition2));
+        for (MessageId messageId : msgNotIn) {
+            assertFalse(received.contains(messageId));
+        }
+        reader.close();
+        consumer.close();
+    }
+
+    private List<MessageId> creatProducerAndSendMsg(String topic, int msgNum) throws Exception {
+        List<MessageId> messageIds = new ArrayList<>();
+        Producer<String> producer = pulsarClient
+                .newProducer(Schema.STRING)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .topic(topic).create();
+        for (int i = 0; i < msgNum; i++) {
+            messageIds.add(producer.send("msg" + i));
+        }
+        producer.close();
+        return messageIds;
+    }
+
+    @Test
+    public void testSeekByFunctionAndMultiTopic() throws Exception {
+        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        final String topicName2 = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        int partitionNum = 3;
+        int msgNum = 15;
+        admin.topics().createPartitionedTopic(topicName, partitionNum);
+        admin.topics().createPartitionedTopic(topicName2, partitionNum);
+        creatProducerAndSendMsg(topicName, msgNum);
+        creatProducerAndSendMsg(topicName2, msgNum);
+        TopicName topic = TopicName.get(topicName);
+        TopicName topic2 = TopicName.get(topicName2);
+        MessageId msgIdInTopic1Partition0 = admin.topics().getLastMessageId(topic.getPartition(0).toString());
+        MessageId msgIdInTopic1Partition2 = admin.topics().getLastMessageId(topic.getPartition(2).toString());
+        MessageId msgIdInTopic2Partition0 = admin.topics().getLastMessageId(topic2.getPartition(0).toString());
+        MessageId msgIdInTopic2Partition2 = admin.topics().getLastMessageId(topic2.getPartition(2).toString());
+
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient
+                .newConsumer(Schema.STRING).startMessageIdInclusive()
+                .topics(Arrays.asList(topicName, topicName2)).subscriptionName("my-sub").subscribe();
+        consumer.seek((partitionedTopic) -> {
+            if (partitionedTopic.equals(topic.getPartition(0).toString())) {
+                return msgIdInTopic1Partition0;
+            }
+            if (partitionedTopic.equals(topic.getPartition(2).toString())) {
+                return msgIdInTopic1Partition2;
+            }
+            if (partitionedTopic.equals(topic2.getPartition(0).toString())) {
+                return msgIdInTopic2Partition0;
+            }
+            if (partitionedTopic.equals(topic2.getPartition(2).toString())) {
+                return msgIdInTopic2Partition2;
+            }
+            return MessageId.earliest;
+        });
+        int count = 0;
+        while (true) {
+            Message message = consumer.receive(2, TimeUnit.SECONDS);
+            if (message == null) {
+                break;
+            }
+            count++;
+        }
+        int msgInTopic1Partition0 = 1;
+        int msgInTopic1Partition1 = msgNum / partitionNum;
+        int msgInTopic1Partition2 = 1;
+        assertEquals(count, (msgInTopic1Partition0 + msgInTopic1Partition1 + msgInTopic1Partition2) * 2);
+    }
+
+    @Test
+    public void testExceptionBySeekFunction() throws Exception {
+        final String topicName = "persistent://prop/use/ns-abc/test" + UUID.randomUUID();
+        creatProducerAndSendMsg(topicName,10);
+        org.apache.pulsar.client.api.Consumer consumer = pulsarClient
+                .newConsumer()
+                .topic(topicName).subscriptionName("my-sub").subscribe();
+        try {
+            consumer.seek((Function<String, MessageId>) null);
+            fail("should fail");
+        } catch (Exception e) {
+            assertTrue(e instanceof PulsarClientException);
+            assertTrue(e.getMessage().contains("Function must be set"));
+        }
+        assertNull(consumer.seekAsync((topic)-> null).get());
     }
 }

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.v1;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
@@ -142,12 +143,20 @@ public class ConsumerV1Impl implements Consumer {
         consumer.seek(arg0);
     }
 
+    public void seek(Function<String, MessageId> function) throws PulsarClientException {
+        consumer.seek(function);
+    }
+
     public CompletableFuture<Void> seekAsync(long arg0) {
         return consumer.seekAsync(arg0);
     }
 
     public CompletableFuture<Void> seekAsync(MessageId arg0) {
         return consumer.seekAsync(arg0);
+    }
+
+    public CompletableFuture<Void> seekAsync(Function<String, MessageId> function) {
+        return consumer.seekAsync(function);
     }
 
     public void unsubscribe() throws PulsarClientException {

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/v1/ConsumerV1Impl.java
@@ -143,7 +143,7 @@ public class ConsumerV1Impl implements Consumer {
         consumer.seek(arg0);
     }
 
-    public void seek(Function<String, MessageId> function) throws PulsarClientException {
+    public void seek(Function<String, Object> function) throws PulsarClientException {
         consumer.seek(function);
     }
 
@@ -155,7 +155,7 @@ public class ConsumerV1Impl implements Consumer {
         return consumer.seekAsync(arg0);
     }
 
-    public CompletableFuture<Void> seekAsync(Function<String, MessageId> function) {
+    public CompletableFuture<Void> seekAsync(Function<String, Object> function) {
         return consumer.seekAsync(function);
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -613,7 +613,7 @@ public interface Consumer<T> extends Closeable {
     void seek(Function<String, MessageId> function) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id.
+     * Reset the subscription associated with this consumer to a specific message id asynchronously.
      * <p>
      * The Function input is topic+partition.
      * <p>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -597,6 +598,32 @@ public interface Consumer<T> extends Closeable {
      *            the message publish time where to reposition the subscription
      */
     void seek(long timestamp) throws PulsarClientException;
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id.
+     * <p>
+     * The Function input is topic+partition.
+     * <p>
+     * The return value is the seek position of the current partition.
+     * <p>
+     * If returns null, the current partition will not do any processing.
+     * @param function
+     * @throws PulsarClientException
+     */
+    void seek(Function<String, MessageId> function) throws PulsarClientException;
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id.
+     * <p>
+     * The Function input is topic+partition.
+     * <p>
+     * The return value is the seek position of the current partition.
+     * <p>
+     * If returns null, the current partition will not do any processing.
+     * @param function
+     * @return
+     */
+    CompletableFuture<Void> seekAsync(Function<String, MessageId> function);
 
     /**
      * Reset the subscription associated with this consumer to a specific message id.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -604,26 +604,26 @@ public interface Consumer<T> extends Closeable {
      * <p>
      * The Function input is topic+partition.
      * <p>
-     * The return value is the seek position of the current partition.
+     * The return value is the seek position/timestamp of the current partition.
      * <p>
      * If returns null, the current partition will not do any processing.
      * @param function
      * @throws PulsarClientException
      */
-    void seek(Function<String, MessageId> function) throws PulsarClientException;
+    void seek(Function<String, Object> function) throws PulsarClientException;
 
     /**
      * Reset the subscription associated with this consumer to a specific message id asynchronously.
      * <p>
      * The Function input is topic+partition.
      * <p>
-     * The return value is the seek position of the current partition.
+     * The return value is the seek position/timestamp of the current partition.
      * <p>
      * If returns null, the current partition will not do any processing.
      * @param function
      * @return
      */
-    CompletableFuture<Void> seekAsync(Function<String, MessageId> function);
+    CompletableFuture<Void> seekAsync(Function<String, Object> function);
 
     /**
      * Reset the subscription associated with this consumer to a specific message id.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1771,7 +1771,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 .equals(Long.class.getTypeName())) {
             return seekAsync((long) seekPosition);
         }
-        return CompletableFuture.completedFuture(null);
+        return FutureUtil.failedFuture(
+                new PulsarClientException("Only support seek by messageId or timestamp"));
     }
 
     private Optional<CompletableFuture<Void>> seekAsyncCheckState(String seekBy) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -671,6 +671,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     public CompletableFuture<Void> seekAsync(Function<String, MessageId> function) {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(function)));
+        unAckedMessageTracker.clear();
+        incomingMessages.clear();
+        resetIncomingMessageSize();
         return FutureUtil.waitForAll(futures);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -64,6 +64,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -658,13 +659,28 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
 
     @Override
+    public void seek(Function<String, MessageId> function) throws PulsarClientException {
+        try {
+            seekAsync(function).get();
+        } catch (Exception e) {
+            throw PulsarClientException.unwrap(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> seekAsync(Function<String, MessageId> function) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
+        consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(function)));
+        return FutureUtil.waitForAll(futures);
+    }
+
+    @Override
     public CompletableFuture<Void> seekAsync(MessageId messageId) {
-        CompletableFuture<Void> seekFuture = new CompletableFuture<>();
         MessageIdImpl targetMessageId = MessageIdImpl.convertToMessageIdImpl(messageId);
         if (targetMessageId == null || isIllegalMultiTopicsMessageId(messageId)) {
-            seekFuture.completeExceptionally(
-                    new PulsarClientException("Illegal messageId, messageId can only be earliest/latest"));
-            return seekFuture;
+            return FutureUtil.failedFuture(
+                    new PulsarClientException("Illegal messageId, messageId can only be earliest/latest")
+            );
         }
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumerImpl -> futures.add(consumerImpl.seekAsync(targetMessageId)));
@@ -673,14 +689,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         incomingMessages.clear();
         resetIncomingMessageSize();
 
-        FutureUtil.waitForAll(futures).whenComplete((result, exception) -> {
-            if (exception != null) {
-                seekFuture.completeExceptionally(exception);
-            } else {
-                seekFuture.complete(result);
-            }
-        });
-        return seekFuture;
+        return FutureUtil.waitForAll(futures);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -659,7 +659,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
 
     @Override
-    public void seek(Function<String, MessageId> function) throws PulsarClientException {
+    public void seek(Function<String, Object> function) throws PulsarClientException {
         try {
             seekAsync(function).get();
         } catch (Exception e) {
@@ -668,7 +668,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     }
 
     @Override
-    public CompletableFuture<Void> seekAsync(Function<String, MessageId> function) {
+    public CompletableFuture<Void> seekAsync(Function<String, Object> function) {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(function)));
         unAckedMessageTracker.clear();


### PR DESCRIPTION
### Motivation
Prepare for #9301

Currently in MultiTopicsConsumerImpl the API allow to ‘setStartMessageId’ only from single message ID and this apply to all consumers in the MultiTopicsConsumerImpl.

It is possible to add start message per partition / topic.

### Modifications
add seek by Function

### Verifying this change

