### PR TITLE
Pulsar IO: Allow to develop Sinks that support Schema but without setting it at build time (Sink<GenericObject>)

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -368,11 +368,11 @@ brokerClientTlsCiphers=
 brokerClientTlsProtocols=
 
 # Enable or disable system topic
-systemTopicEnabled=true
+systemTopicEnabled=false
 
 # Enable or disable topic level policies, topic level policies depends on the system topic
 # Please enable the system topic first.
-topicLevelPoliciesEnabled=true
+topicLevelPoliciesEnabled=false
 
 # If a topic remains fenced for this number of seconds, it will be closed forcefully.
 # If it is set to 0 or a negative number, the fenced topic will not be closed.
@@ -927,10 +927,8 @@ allowAutoSubscriptionCreation=true
 # The number of partitioned topics that is allowed to be automatically created if allowAutoTopicCreationType is partitioned.
 defaultNumPartitions=1
 
-transactionCoordinatorEnabled=true
-
 ### --- Transaction config variables --- ###
-#transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider
 
 ### --- Packages management service configuration variables (begin) --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -368,11 +368,11 @@ brokerClientTlsCiphers=
 brokerClientTlsProtocols=
 
 # Enable or disable system topic
-systemTopicEnabled=false
+systemTopicEnabled=true
 
 # Enable or disable topic level policies, topic level policies depends on the system topic
 # Please enable the system topic first.
-topicLevelPoliciesEnabled=false
+topicLevelPoliciesEnabled=true
 
 # If a topic remains fenced for this number of seconds, it will be closed forcefully.
 # If it is set to 0 or a negative number, the fenced topic will not be closed.
@@ -927,8 +927,10 @@ allowAutoSubscriptionCreation=true
 # The number of partitioned topics that is allowed to be automatically created if allowAutoTopicCreationType is partitioned.
 defaultNumPartitions=1
 
+transactionCoordinatorEnabled=true
+
 ### --- Transaction config variables --- ###
-transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider
+#transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider
 
 ### --- Packages management service configuration variables (begin) --- ###
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
-import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
@@ -124,8 +123,8 @@ public class TopicSchema {
             || ByteBuf.class.equals(clazz)
             || ByteBuffer.class.equals(clazz)) {
             return SchemaType.NONE;
-        } else if (GenericRecord.class.isAssignableFrom(clazz)) {
-            // the function is taking generic record, so we do auto schema detection
+        } else if (GenericObject.class.isAssignableFrom(clazz)) {
+            // the function is taking generic record/object, so we do auto schema detection
             return SchemaType.AUTO_CONSUME;
         } else if (String.class.equals(clazz)) {
             // If type is String, then we use schema type string, otherwise we fallback on default schema

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -97,7 +98,7 @@ public class TopicSchema {
      * If the topic is already created, we should be able to fetch the schema type (avro, json, ...)
      */
     private SchemaType getSchemaTypeOrDefault(String topic, Class<?> clazz) {
-        if (GenericRecord.class.isAssignableFrom(clazz)) {
+        if (GenericObject.class.isAssignableFrom(clazz)) {
             return SchemaType.AUTO_CONSUME;
         } else if (byte[].class.equals(clazz)
                 || ByteBuf.class.equals(clazz)

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.KVRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.Sink;
+import org.apache.pulsar.io.core.SinkContext;
+import org.apache.pulsar.io.core.Source;
+import org.apache.pulsar.io.core.SourceContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class TestGenericObjectSink implements Sink<GenericObject> {
+
+    @Override
+    public void open(Map<String, Object> config, SinkContext sourceContext) throws Exception {
+    }
+
+    public void write(Record<GenericObject> record) {
+        log.info("received record {} {}", record, record.getClass());
+        log.info("schema {}", record.getSchema());
+        log.info("native schema {}", record.getSchema().getNativeSchema().orElse(null));
+
+        log.info("value {}", record.getValue());
+        log.info("value schema type {}", record.getValue().getSchemaType());
+        log.info("value native object {}", record.getValue().getNativeObject());
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
@@ -78,7 +78,7 @@ public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
         // sinks execution happens in parallel
         List<SinkSpec> specs = Arrays.asList(
                 new SinkSpec("test-kv-sink-input-string-" + randomName(8), "test-kv-sink-string-" + randomName(8), Schema.STRING, "foo"),
-                new SinkSpec("test-kv-sink-input-int-" + randomName(8), "test-kv-sink-int-" + randomName(8), Schema.STRING, 123),
+                new SinkSpec("test-kv-sink-input-int-" + randomName(8), "test-kv-sink-int-" + randomName(8), Schema.INT32, 123),
                 new SinkSpec("test-kv-sink-input-avro-" + randomName(8), "test-kv-sink-avro-" + randomName(8), Schema.AVRO(Pojo.class), Pojo.builder().field1("a").field2(2).build()),
                 new SinkSpec("test-kv-sink-input-json-" + randomName(8), "test-kv-sink-json-" + randomName(8), Schema.JSON(Pojo.class), Pojo.builder().field1("a").field2(2).build())
         );

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
@@ -60,7 +60,8 @@ public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
             this.outputTopicName = outputTopicName;
             this.sinkName = sinkName;
             this.schema = schema;
-            this.testValue = testValue};
+            this.testValue = testValue;
+        }
     }
 
     @Data

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.io;
+
+import lombok.Builder;
+import lombok.Cleanup;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.policies.data.SinkStatus;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.tests.integration.docker.ContainerExecException;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
+import org.awaitility.Awaitility;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.pulsar.tests.integration.functions.utils.CommandGenerator.JAVAJAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Test behaviour of simple sinks
+ */
+@Slf4j
+public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
+
+    private static final class SinkSpec<T> {
+        final String outputTopicName;
+        final String sinkName;
+        final Schema<T> schema;
+        final T testValue;
+
+        public SinkSpec(String outputTopicName, String sinkName, Schema<T> schema, T testValue) {
+            this.outputTopicName = outputTopicName;
+            this.sinkName = sinkName;
+            this.schema = schema;
+            this.testValue = testValue};
+    }
+
+    @Data
+    @Builder
+    public static final class Pojo {
+        private String field1;
+        private int field2;
+    }
+
+    @Test(groups = {"sink"})
+    public void testGenericObjectSink() throws Exception {
+        // we are not using a parametrized test in order to save resources
+        // we create N sinks, send the records and verify each sink
+        // sinks execution happens in parallel
+        List<SinkSpec> specs = Arrays.asList(
+                new SinkSpec("test-kv-sink-input-string-" + randomName(8), "test-kv-sink-string-" + randomName(8), Schema.STRING, "foo"),
+                new SinkSpec("test-kv-sink-input-int-" + randomName(8), "test-kv-sink-int-" + randomName(8), Schema.STRING, 123),
+                new SinkSpec("test-kv-sink-input-avro-" + randomName(8), "test-kv-sink-avro-" + randomName(8), Schema.AVRO(Pojo.class), Pojo.builder().field1("a").field2(2).build()),
+                new SinkSpec("test-kv-sink-input-json-" + randomName(8), "test-kv-sink-json-" + randomName(8), Schema.JSON(Pojo.class), Pojo.builder().field1("a").field2(2).build())
+        );
+        // submit all sinks
+        for (SinkSpec spec : specs) {
+            submitSinkConnector(spec.sinkName, spec.outputTopicName, "org.apache.pulsar.tests.integration.io.TestGenericObjectSink", JAVAJAR);
+        }
+        // check all sinks
+        for (SinkSpec spec : specs) {
+            // get sink info
+            getSinkInfoSuccess(spec.sinkName);
+            getSinkStatus(spec.sinkName);
+        }
+
+        @Cleanup PulsarClient client = PulsarClient.builder()
+                .serviceUrl(container.getPlainTextServiceUrl())
+                .build();
+
+        final int numRecords = 10;
+
+        for (SinkSpec spec : specs) {
+            @Cleanup Producer<Object> producer = client.newProducer(spec.schema)
+                    .topic(spec.outputTopicName)
+                    .create();
+            for (int i = 0; i < numRecords; i++) {
+                producer.send(spec.testValue);
+            }
+        }
+
+        // wait that all sinks processed all records without errors
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(container.getHttpServiceUrl()).build()) {
+
+            for (SinkSpec spec : specs) {
+                Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+                    SinkStatus status = admin.sinks().getSinkStatus("public", "default", spec.sinkName);
+                    assertEquals(status.getInstances().size(), 1);
+                    assertTrue(status.getInstances().get(0).getStatus().numReadFromPulsar >= numRecords);
+                    assertTrue(status.getInstances().get(0).getStatus().numSinkExceptions == 0);
+                    assertTrue(status.getInstances().get(0).getStatus().numSystemExceptions == 0);
+                });
+            }
+        }
+
+
+        for (SinkSpec spec : specs) {
+            deleteSink(spec.sinkName);
+            getSinkInfoNotFound(spec.sinkName);
+        }
+    }
+
+    private void submitSinkConnector(String sinkName,
+                                     String inputTopicName,
+                                     String className,
+                                     String archive) throws Exception {
+        String[] commands = {
+                PulsarCluster.ADMIN_SCRIPT,
+                "sinks", "create",
+                "--name", sinkName,
+                "-i", inputTopicName,
+                "--archive", archive,
+                "--classname", className
+        };
+        log.info("Run command : {}", StringUtils.join(commands, ' '));
+        ContainerExecResult result = container.execCmd(commands);
+        assertTrue(
+                result.getStdout().contains("\"Created successfully\""),
+                result.getStdout());
+    }
+
+    private void getSinkInfoSuccess(String sinkName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sinks",
+                "get",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sinkName
+        );
+        assertTrue(result.getStdout().contains("\"name\": \"" + sinkName + "\""));
+    }
+
+    private void getSinkStatus(String sinkName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sinks",
+                "status",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sinkName
+        );
+        assertTrue(result.getStdout().contains("\"running\" : true"));
+    }
+
+    private void deleteSink(String sinkName) throws Exception {
+        ContainerExecResult result = container.execCmd(
+                PulsarCluster.ADMIN_SCRIPT,
+                "sinks",
+                "delete",
+                "--tenant", "public",
+                "--namespace", "default",
+                "--name", sinkName
+        );
+        assertTrue(result.getStdout().contains("successfully"));
+        result.assertNoStderr();
+    }
+
+    private void getSinkInfoNotFound(String sinkName) throws Exception {
+        try {
+            container.execCmd(
+                    PulsarCluster.ADMIN_SCRIPT,
+                    "sinks",
+                    "get",
+                    "--tenant", "public",
+                    "--namespace", "default",
+                    "--name", sinkName);
+            fail("Command should have exited with non-zero");
+        } catch (ContainerExecException e) {
+            assertTrue(e.getResult().getStderr().contains(sinkName + " doesn't exist"));
+        }
+    }
+}
+

--- a/tests/integration/src/test/resources/pulsar-function.xml
+++ b/tests/integration/src/test/resources/pulsar-function.xml
@@ -25,6 +25,7 @@
             <class name="org.apache.pulsar.tests.integration.functions.PulsarStateTest" />
             <class name="org.apache.pulsar.tests.integration.io.GenericRecordSourceTest" />
             <class name="org.apache.pulsar.tests.integration.io.PulsarSourcePropertyTest"/>
+            <class name="org.apache.pulsar.tests.integration.io.PulsarGenericObjectSinkTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Motivation

Support users that want to implement a Sink that is aware of the Schema but it is not tied to a specific schema type at compile time.
With this patch you can implement a Sink that is aware of the Schema but it is not tied to a particular schema type at compile time.

```
public class ObjectSink implements Sink<GenericObject> {

    @Override
    public void write(Record<GenericObject> record) throws Exception {
        try {
            Schema<?> schema = record.getSchema();
            SchemaType type = record.getValue().getType();
            Object value = record.getValue().getNativeObject();
            log.info("Record {} type {} schema {} value {}", record, type, schema, value);
            record.ack();
        } catch (Throwable t) {
            .....
        }
    }
```


### Modifications

We are adding support in TopicSchema.java  to deal with GenericObject, the same way we did with GenericRecord. GenericRecord is a subtype of GenericObject, and AutoConsumeSchema now returns GenericObject instances that wrap primitive data types

### Verifying this change

I will add test cases and integration tests as soon as the community accepts this feature.

### Does this pull request potentially affect one of the following parts:

With this feature Sink developers will be able to write advanced Sinks

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs

I will be happy to provide documentation as soon as this feature lands to Pulsar