### PR TITLE
Pass envirnoment variables to the docker container when building whee…

### DIFF
--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -76,8 +76,8 @@ for line in "${PYTHON_VERSIONS[@]}"; do
 
     VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
     COMMAND="/pulsar/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh"
-    DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
+    DOCKER_CMD="docker run -i ${VOLUME_OPTION} -e USE_FULL_POM_NAME='${USE_FULL_POM_NAME}' -e NAME_POSTFIX='${NAME_POSTFIX}' ${IMAGE}"
 
-    $DOCKER_CMD bash -c "${COMMAND}" -e USE_FULL_POM_NAME='${USE_FULL_POM_NAME}' -e NAME_POSTFIX='${NAME_POSTFIX}'
+    $DOCKER_CMD bash -c "${COMMAND}"
 
 done

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -78,6 +78,6 @@ for line in "${PYTHON_VERSIONS[@]}"; do
     COMMAND="/pulsar/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh"
     DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 
-    $DOCKER_CMD bash -c "${COMMAND}"
+    $DOCKER_CMD bash -c "${COMMAND}" -e USE_FULL_POM_NAME='${USE_FULL_POM_NAME}' -e NAME_POSTFIX='${NAME_POSTFIX}'
 
 done

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -76,7 +76,7 @@ for line in "${PYTHON_VERSIONS[@]}"; do
 
     VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
     COMMAND="/pulsar/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh"
-    DOCKER_CMD="docker run -i ${VOLUME_OPTION} -e USE_FULL_POM_NAME='${USE_FULL_POM_NAME}' -e NAME_POSTFIX='${NAME_POSTFIX}' ${IMAGE}"
+    DOCKER_CMD="docker run -i ${VOLUME_OPTION} -e USE_FULL_POM_NAME -e NAME_POSTFIX ${IMAGE}"
 
     $DOCKER_CMD bash -c "${COMMAND}"
 


### PR DESCRIPTION
Motivation

Currently there is no way to pass env variables to the docker container when building the wheel files:
https://github.com/apache/pulsar/blob/e4b4627890b7deee6d3ea2b6f2e121f12586b2dd/pulsar-client-cpp/docker/build-wheels.sh#L81). 

But `setup.py` may still use these variables to custom build wheels:
https://github.com/apache/pulsar/blob/e4b4627890b7deee6d3ea2b6f2e121f12586b2dd/pulsar-client-cpp/python/setup.py#L32 and
https://github.com/apache/pulsar/blob/e4b4627890b7deee6d3ea2b6f2e121f12586b2dd/pulsar-client-cpp/python/setup.py#L49

This PR makes these variables can be passed by the environment