### PR TITLE
Fix possible name mismatch bugs when build wheel files within docker

### DIFF
--- a/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh
+++ b/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh
@@ -42,4 +42,4 @@ python setup.py bdist_wheel
 # Audit wheel will make sure no external dependencies are needed for
 # the shared library and that only symbols supported by most linux
 # distributions are used.
-auditwheel repair dist/pulsar_client-*-$PYTHON_SPEC-linux_x86_64.whl
+auditwheel repair dist/pulsar_client*-$PYTHON_SPEC-linux_x86_64.whl


### PR DESCRIPTION
Motivation

This PR fixes a name mismatch bug when developers specific `NAME_POSTFIX` for pulsar_client. In the previous release process, the generated wheel files were named pulsar_client-*-xxx.whl. Once `NAME_POSTFIX` is set, e.g. set to `my_suffix`, the build will be broken:

```
...
adding 'pulsar_client_my_suffix-2.8.0.dist-info/top_level.txt'
adding 'pulsar_client_my_suffix-2.8.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
+ auditwheel repair 'dist/pulsar_client-*-cp27-cp27mu-linux_x86_64.whl'
usage: auditwheel [-h] [-V] [-v] command ...
auditwheel: error: cannot access dist/pulsar_client-*-cp27-cp27mu-linux_x86_64.whl. No such file
...
```