### PR TITLE
Add jersey-client as dependency of pulsar-client-auth-sasl

### DIFF
--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -62,5 +62,10 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
### Motivation

When using `AuthenticationSasl`,  `ClassNotFoundException` will be thrown:

> Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: org.glassfish.jersey.client.JerseyClientBuilder

The `jersey-client` dependency must be imported. However the version of `jersey-client` must be consistent with what `pulsar-client-auth-sasl` depends, which is 2.31 currently. For example, if a newer version of `jersey-client` was imported like

```xml
    <dependency>
      <groupId>org.glassfish.jersey.core</groupId>
      <artifactId>jersey-client</artifactId>
      <version>3.0.1</version>
    </dependency>
```

Another exception would be thrown:

> Exception in thread "main" java.lang.NoClassDefFoundError: jakarta/ws/rs/client/ClientBuilder

So the best way to fix it is adding `jersey-client` as dependency of `pulsar-client-auth-sasl`.

### Modifications

Add `jersey-client` as dependency of `pulsar-client-auth-sasl`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.