### PR TITLE
change log level for topic polices cache not init exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -403,7 +403,7 @@ public abstract class AdminResource extends PulsarWebResource {
         } catch (RestException re) {
             throw re;
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e){
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             throw new RestException(e);
         } catch (Exception e) {
             log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -565,7 +565,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             asyncResponse.resume(new RestException(e));
             return;
         }
@@ -829,8 +829,8 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
-            throw new RestException(Status.PRECONDITION_FAILED, "Policies cache have not init");
+            log.error("Topic {} policies have not been initialized yet.", topicName);
+            throw new RestException(Status.PRECONDITION_FAILED, "Policies have not been initialized yet");
         }
         if (topicPolicies == null) {
             topicPolicies = new TopicPolicies();
@@ -883,9 +883,9 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
-                    "Policies cache have not init"));
+                    "Policies have not been initialized yet"));
         }
         if (topicPolicies == null) {
             topicPolicies = new TopicPolicies();
@@ -947,8 +947,8 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
-            throw new RestException(Status.PRECONDITION_FAILED, "Policies cache have not init");
+            log.error("Topic {} policies have not been initialized yet.", topicName);
+            throw new RestException(Status.PRECONDITION_FAILED, "Policies have not been initialized yet");
         }
         if (topicPolicies == null) {
             topicPolicies = new TopicPolicies();
@@ -980,9 +980,9 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
-                    "Policies cache have not init"));
+                    "Policies have not been initialized yet"));
         }
         if (topicPolicies == null) {
             topicPolicies = new TopicPolicies();
@@ -2561,7 +2561,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             asyncResponse.resume(new RestException(e));
             return;
         }
@@ -2622,8 +2622,8 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
-            throw new RestException(Status.PRECONDITION_FAILED, "Policies cache have not init");
+            log.error("Topic {} policies have not been initialized yet.", topicName);
+            throw new RestException(Status.PRECONDITION_FAILED, "Policies have not been initialized yet");
         }
         if (topicPolicies == null) {
             topicPolicies = new TopicPolicies();
@@ -2642,7 +2642,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.error("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies have not been initialized yet.", topicName);
             asyncResponse.resume(new RestException(e));
             return;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2561,7 +2561,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.warn("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies cache have not init.", topicName);
             asyncResponse.resume(new RestException(e));
             return;
         }
@@ -2642,7 +2642,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             topicPolicies = pulsar().getTopicPoliciesService().getTopicPolicies(topicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.warn("Topic {} policies cache have not init.", topicName);
+            log.error("Topic {} policies cache have not init.", topicName);
             asyncResponse.resume(new RestException(e));
             return;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -806,10 +806,10 @@ public abstract class AbstractTopic implements Topic {
         try {
             return brokerService.pulsar().getTopicPoliciesService().getTopicPolicies(cloneTopicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.warn("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
+            log.debug("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
             return null;
         } catch (NullPointerException e) {
-            log.warn("Topic level policies are not enabled. "
+            log.debug("Topic level policies are not enabled. "
                     + "Please refer to systemTopicEnabled and topicLevelPoliciesEnabled on broker.conf");
             return null;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -806,7 +806,7 @@ public abstract class AbstractTopic implements Topic {
         try {
             return brokerService.pulsar().getTopicPoliciesService().getTopicPolicies(cloneTopicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.debug("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
+            log.debug("Topic {} policies have not been initialized yet.", topicName.getPartitionedTopicName());
             return null;
         } catch (NullPointerException e) {
             log.debug("Topic level policies are not enabled. "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1228,7 +1228,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                         topicLevelOffloadPolicies = topicPolicies.getOffloadPolicies();
                     }
                 } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-                    log.warn("Topic {} policies cache have not init.", topicName);
+                    log.debug("Topic {} policies cache have not init.", topicName);
                 }
             }
 
@@ -2534,10 +2534,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             checkTopicLevelPolicyEnable();
             return pulsar.getTopicPoliciesService().getTopicPolicies(cloneTopicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.warn("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
+            log.debug("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
             return null;
         } catch (RestException | NullPointerException e) {
-            log.warn("Topic level policies are not enabled. "
+            log.debug("Topic level policies are not enabled. "
                     + "Please refer to systemTopicEnabled and topicLevelPoliciesEnabled on broker.conf");
             return null;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1228,7 +1228,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                         topicLevelOffloadPolicies = topicPolicies.getOffloadPolicies();
                     }
                 } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-                    log.debug("Topic {} policies cache have not init.", topicName);
+                    log.debug("Topic {} policies have not been initialized yet.", topicName);
                 }
             }
 
@@ -2534,7 +2534,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             checkTopicLevelPolicyEnable();
             return pulsar.getTopicPoliciesService().getTopicPolicies(cloneTopicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.debug("Topic {} policies cache have not init.", topicName.getPartitionedTopicName());
+            log.debug("Topic {} policies have not been initialized yet.", topicName.getPartitionedTopicName());
             return null;
         } catch (RestException | NullPointerException e) {
             log.debug("Topic level policies are not enabled. "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -199,7 +199,7 @@ public class DispatchRateLimiter {
                         break;
                 }
             } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-                log.debug("Topic {} policies cache have not init.", topicName);
+                log.debug("Topic {} policies have not been initialized yet.", topicName);
             } catch (Exception e) {
                 log.debug("[{}] Failed to get topic dispatch rate. ", topicName, e);
             }


### PR DESCRIPTION
### Motivation
The `police cache not init` exception log level is warn, which lead too much warning logs in broker.log when the topic doesn't set topic policy

### Changes
1. Change the log level from warn to debug for the exception which can be correct by namespace policy
2. Change the log level from warn to error for the exception which will throw outer.