### PR TITLE
[Issue 10058]:apply-config-from-env.py to commented default values

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -44,12 +44,14 @@ for conf_filename in conf_files:
     for line in open(conf_filename):
         lines.append(line)
         line = line.strip()
-        if not line or line.startswith('#'):
+        if not line:
             continue
 
         try:
             k,v = line.split('=', 1)
-            keys[k] = len(lines) - 1
+            if k.startswith('#'):
+                k = k[1:]
+            keys[k.strip()] = len(lines) - 1
         except:
             print("[%s] skip Processing %s" % (conf_filename, line))
 


### PR DESCRIPTION
Add handling of commented name=value so that apply-config-from-env.py may un-comment the values if needed.

It is common practice to leave default values commented out in the configuration files. By not handling the commented case, the end customer may need to jump through hoops(such as adding un-commented values via script)  to make changes to these values in a production environment. This enhancement will ease the process by allowing the script to catalog the commented as well as un-commented values, and make replacements to both as needed, leading to a smoother customer experience when a support situation calls for adjusting the value to a commented variable. 

If a value is not supplied to  a commented variable, then the line remains commented out, and the default value should be assumed by the application. 

Any lines that do not contain a = or result in a parsing error should be ignored and the original line left in the configuration file.
