### PR TITLE
[Performance] Optimize CompletableFuture timeout handling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -179,6 +180,13 @@ import org.slf4j.LoggerFactory;
 @Setter(AccessLevel.PROTECTED)
 public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies> {
     private static final Logger log = LoggerFactory.getLogger(BrokerService.class);
+    private static final Duration FUTURE_DEADLINE_TIMEOUT_DURATION = Duration.ofSeconds(60);
+    private static final TimeoutException FUTURE_DEADLINE_TIMEOUT_EXCEPTION =
+            FutureUtil.createTimeoutException("Future didn't finish within deadline", BrokerService.class,
+                    "futureWithDeadline(...)");
+    private static final TimeoutException FAILED_TO_LOAD_TOPIC_TIMEOUT_EXCEPTION =
+            FutureUtil.createTimeoutException("Failed to load topic within timeout", BrokerService.class,
+                    "futureWithDeadline(...)");
 
     private final PulsarService pulsar;
     private final ManagedLedgerFactory managedLedgerFactory;
@@ -847,7 +855,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             }
         } catch (IllegalArgumentException e) {
             log.warn("[{}] Illegalargument exception when loading topic", topic, e);
-            return failedFuture(e);
+            return FutureUtil.failedFuture(e);
         } catch (RuntimeException e) {
             Throwable cause = e.getCause();
             if (cause instanceof ServiceUnitNotReadyException) {
@@ -856,7 +864,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 log.warn("[{}] Unexpected exception when loading topic: {}", topic, e.getMessage(), e);
             }
 
-            return failedFuture(cause);
+            return FutureUtil.failedFuture(cause);
         }
     }
 
@@ -964,25 +972,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return topicFuture;
     }
 
-    private static <T> CompletableFuture<T> failedFuture(Throwable t) {
-        CompletableFuture<T> future = new CompletableFuture<>();
-        future.completeExceptionally(t);
-        return future;
-    }
-
-    private <T> CompletableFuture<T> futureWithDeadline(Long delay, TimeUnit unit, Exception exp) {
-        CompletableFuture<T> future = new CompletableFuture<T>();
-        executor().schedule(() -> {
-            if (!future.isDone()) {
-                future.completeExceptionally(exp);
-            }
-        }, delay, unit);
-        return future;
-    }
-
     private <T> CompletableFuture<T> futureWithDeadline() {
-        return futureWithDeadline(60000L, TimeUnit.MILLISECONDS,
-                new TimeoutException("Future didn't finish within deadline"));
+        return FutureUtil.createFutureWithTimeout(FUTURE_DEADLINE_TIMEOUT_DURATION, executor(),
+                () -> FUTURE_DEADLINE_TIMEOUT_EXCEPTION);
     }
 
     public PulsarClient getReplicationClient(String cluster) {
@@ -1093,9 +1085,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      */
     protected CompletableFuture<Optional<Topic>> loadOrCreatePersistentTopic(final String topic,
             boolean createIfMissing) throws RuntimeException {
-        final CompletableFuture<Optional<Topic>> topicFuture = futureWithDeadline(
-                pulsar.getConfiguration().getTopicLoadTimeoutSeconds(),
-                TimeUnit.SECONDS, new TimeoutException("Failed to load topic within timeout"));
+        final CompletableFuture<Optional<Topic>> topicFuture = FutureUtil.createFutureWithTimeout(
+                Duration.ofSeconds(pulsar.getConfiguration().getTopicLoadTimeoutSeconds()), executor(),
+                () -> FAILED_TO_LOAD_TOPIC_TIMEOUT_EXCEPTION);
         if (!pulsar.getConfiguration().isEnablePersistentTopics()) {
             if (log.isDebugEnabled()) {
                 log.debug("Broker is unable to load persistent topic {}", topic);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -18,9 +18,15 @@
  */
 package org.apache.pulsar.common.util;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 /**
  * This class is aimed at simplifying work with {@code CompletableFuture}.
@@ -48,6 +54,73 @@ public class FutureUtil {
             return unwrapCompletionException(t.getCause());
         } else {
             return t;
+        }
+    }
+
+    /**
+     * Creates a new {@link CompletableFuture} instance with timeout handling.
+     *
+     * @param timeout the duration of the timeout
+     * @param executor the executor to use for scheduling the timeout
+     * @param exceptionSupplier the supplier for creating the exception
+     * @param <T> type parameter for the future
+     * @return the new {@link CompletableFuture} instance
+     */
+    public static <T> CompletableFuture<T> createFutureWithTimeout(Duration timeout,
+                                                                   ScheduledExecutorService executor,
+                                                                   Supplier<Throwable> exceptionSupplier) {
+        return addTimeoutHandling(new CompletableFuture<>(), timeout, executor, exceptionSupplier);
+    }
+
+    /**
+     * Adds timeout handling to an existing {@link CompletableFuture}.
+     *
+     * @param future the target future
+     * @param timeout the duration of the timeout
+     * @param executor the executor to use for scheduling the timeout
+     * @param exceptionSupplier the supplier for creating the exception
+     * @param <T> type parameter for the future
+     * @return returns the original target future
+     */
+    public static <T> CompletableFuture<T> addTimeoutHandling(CompletableFuture<T> future, Duration timeout,
+                                               ScheduledExecutorService executor,
+                                               Supplier<Throwable> exceptionSupplier) {
+        ScheduledFuture<?> scheduledFuture = executor.schedule(() -> {
+            if (!future.isDone()) {
+                future.completeExceptionally(exceptionSupplier.get());
+            }
+        }, timeout.toMillis(), TimeUnit.MILLISECONDS);
+        future.whenComplete((res, exception) -> scheduledFuture.cancel(false));
+        return future;
+    }
+
+    /**
+     * Creates a low-overhead timeout exception which is performance optimized to minimize allocations
+     * and cpu consumption. It sets the stacktrace of the exception to the given source class and
+     * source method name. The instances of this class can be cached or stored as constants and reused
+     * multiple times.
+     *
+     * @param message exception message
+     * @param sourceClass source class for manually filled in stacktrace
+     * @param sourceMethod source method name for manually filled in stacktrace
+     * @return new TimeoutException instance
+     */
+    public static TimeoutException createTimeoutException(String message, Class<?> sourceClass, String sourceMethod) {
+        return new LowOverheadTimeoutException(message, sourceClass, sourceMethod);
+    }
+
+    private static class LowOverheadTimeoutException extends TimeoutException {
+        private static final long serialVersionUID = 1L;
+
+        LowOverheadTimeoutException(String message, Class<?> sourceClass, String sourceMethod) {
+            super(message);
+            setStackTrace(new StackTraceElement[]{new StackTraceElement(sourceClass.getName(), sourceMethod,
+                    null, -1)});
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
         }
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.common.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+import org.testng.annotations.Test;
+
+public class FutureUtilTest {
+
+    @Test
+    public void testCreateTimeoutException() {
+        TimeoutException timeoutException = FutureUtil.createTimeoutException("hello world", getClass(), "test(...)");
+        assertNotNull(timeoutException);
+        assertEquals(timeoutException.getMessage(), "hello world");
+        StringWriter stringWriter = new StringWriter();
+        timeoutException.printStackTrace(new PrintWriter(stringWriter, true));
+        assertEquals(stringWriter.toString(),
+                "org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: "
+                + "hello world\n"
+                + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)\n");
+    }
+
+    @Test
+    public void testTimeoutHandling() {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        Exception e = new Exception();
+        try {
+            FutureUtil.addTimeoutHandling(future, Duration.ofMillis(1), executor, () -> e);
+            future.get();
+            fail("Should have failed.");
+        } catch (InterruptedException interruptedException) {
+            fail("Shouldn't occur");
+        } catch (ExecutionException executionException) {
+            assertEquals(executionException.getCause(), e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testTimeoutHandlingNoTimeout() throws ExecutionException, InterruptedException {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        try {
+            FutureUtil.addTimeoutHandling(future, Duration.ofMillis(100), executor, () -> new Exception());
+            future.complete(null);
+            future.get();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCreatingFutureWithTimeoutHandling() {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        Exception e = new Exception();
+        try {
+            CompletableFuture<Void> future = FutureUtil.createFutureWithTimeout(Duration.ofMillis(1), executor,
+                    () -> e);
+            future.get();
+            fail("Should have failed.");
+        } catch (InterruptedException interruptedException) {
+            fail("Shouldn't occur");
+        } catch (ExecutionException executionException) {
+            assertEquals(executionException.getCause(), e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

In profiling, there can be seen an inefficiency in handling timeouts for CompletableFutures. For example, when creating topics, this can be seen in the flamegraph:

![image](https://user-images.githubusercontent.com/66864/112792205-accdc900-906b-11eb-9fa3-2236f90c9420.png)

The root cause of this particular performance issue is that the exceptions are created eagerly.

### Modifications

* Add methods to FutureUtils for adding timeout handling to existing futures and creating futures with timeout handling
* Add a performance optimized subclass for TimeoutException that can be created by a factory method in FutureUtils
  * The exception doesn't create a stack trace because of performance reasons. Instead, the caller class and method name are provided when creating the exception.
  * The instances of this class are immutable and can be reused to minimize allocations.
* Refactor existing code to use FutureUtils for adding timeout handling to futures.