### PR TITLE
[Tests] Reduce functions integration test flakiness

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1640,13 +1640,8 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         // update parallelism
         updateFunctionParallelism(functionName, 2);
 
-        Awaitility.await()
-                .pollInterval(Duration.ofMillis(500L))
-                .ignoreExceptions()
-                .untilAsserted(() ->
-                //get function status
-                getFunctionStatus(functionName, 0, true, 2)
-        );
+        //get function status
+        getFunctionStatus(functionName, 0, true, 2);
 
         // delete function
         deleteFunction(functionName);
@@ -1993,6 +1988,16 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
     private void getFunctionStatus(String functionName, int numMessages, boolean checkRestarts, int parallelism)
         throws Exception {
+        Awaitility.await()
+                .pollInterval(Duration.ofSeconds(1))
+                .atMost(Duration.ofSeconds(15))
+                .ignoreExceptions()
+                .untilAsserted(() ->
+                        doGetFunctionStatus(functionName, numMessages, checkRestarts, parallelism));
+    }
+
+    private void doGetFunctionStatus(String functionName, int numMessages, boolean checkRestarts, int parallelism)
+            throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
             PulsarCluster.ADMIN_SCRIPT,
             "functions",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -895,7 +895,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         commandGenerator.setAdminUrl("pulsar://pulsar-broker-0:6650");
         commandGenerator.setSourceTopic(inputTopicName);
         commandGenerator.setSinkTopic(outputTopicName);
-        commandGenerator.setFunctionName("localRunTest");
+        commandGenerator.setFunctionName("localRunTest-" + randomName(8));
         commandGenerator.setRuntime(runtime);
         switch (runtime) {
             case JAVA:
@@ -2228,7 +2228,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         log.info("testAvroSchemaFunction start ...");
         final String inputTopic = "test-avroschema-input-" + randomName(8);
         final String outputTopic = "test-avroschema-output-" + randomName(8);
-        final String functionName = "test-avroschema-fn-202003241756";
+        final String functionName = "test-avroschema-fn-" + randomName(8);
         final int numMessages = 10;
 
         if (pulsarCluster == null) {


### PR DESCRIPTION
### Motivation

PulsarFunctionsProcessTest tests are currently the most flaky tests. This PR contains a few changes as an attempt to reduce flakiness.

### Modifications

* Use unique function names for all tests
* Use Awaitility in all getFunctionStatus calls
  * extend maximum polling time to 15 seconds
