### PR TITLE
[Messaging] Add delay messages block integration test

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -36,15 +36,11 @@ import org.testng.annotations.Test;
  * Delay messaging test.
  */
 @Slf4j
-public class DelayMessagingTest extends PulsarTestSuite {
+public class DelayMessagingTest extends PulsarStandaloneTestSuite {
 
-    @Test(dataProvider = "ServiceUrls")
-    public void delayMsgBlockTest(String serviceUrl) throws Exception {
-        String nsName = generateNamespaceName();
-        pulsarCluster.createNamespace(nsName);
-
-        String topic = generateTopicName(nsName, "testDelayMsgBlock", true);
-        pulsarCluster.createPartitionedTopic(topic, 3);
+    @Test(dataProvider = "StandaloneServiceUrlAndTopics")
+    public void delayMsgBlockTest(String serviceUrl, boolean isPersistent) throws Exception {
+        String topic = generateTopicName("testDelayMsgBlock", isPersistent);
 
         String retryTopic = topic + "-RETRY";
         String deadLetterTopic = topic + "-DLT";
@@ -91,8 +87,6 @@ public class DelayMessagingTest extends PulsarTestSuite {
                 nullMsgFlag = true;
                 break;
             }
-//            Assert.assertNotNull(message, "Consumer can't receive message in double delayTimeSeconds time "
-//                    + delayTimeSeconds * 2 + "s");
             log.info("receive msg. reConsumeTimes: {}", message.getProperty("RECONSUMETIMES"));
             consumer.reconsumeLater(message, delayTimeSeconds, TimeUnit.SECONDS);
         }
@@ -100,16 +94,6 @@ public class DelayMessagingTest extends PulsarTestSuite {
         if (!nullMsgFlag) {
             Assert.fail("Currently consumer shouldn't receive all retry messages.");
         }
-
-//        @Cleanup
-//        Consumer<byte[]> dltConsumer = pulsarClient.newConsumer()
-//                .topic(deadLetterTopic)
-//                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-//                .subscriptionName("test")
-//                .subscribe();
-//
-//        message = dltConsumer.receive(10, TimeUnit.SECONDS);
-//        Assert.assertNotNull(message, "Dead letter topic consumer can't receive message.");
     }
 
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.messaging;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Delay messaging test.
+ */
+@Slf4j
+public class DelayMessagingTest extends PulsarTestSuite {
+
+    @Test(dataProvider = "ServiceUrls")
+    public void delayMsgBlockTest(String serviceUrl) throws Exception {
+        String nsName = generateNamespaceName();
+        pulsarCluster.createNamespace(nsName);
+
+        String topic = generateTopicName(nsName, "testDelayMsgBlock", true);
+        pulsarCluster.createPartitionedTopic(topic, 3);
+
+        String retryTopic = topic + "-RETRY";
+        String deadLetterTopic = topic + "-DLT";
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(serviceUrl).build();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .create();
+
+        final int redeliverCnt = 10;
+        final int delayTimeSeconds = 10;
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("test")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .enableRetry(true)
+                .deadLetterPolicy(DeadLetterPolicy.builder()
+                        .maxRedeliverCount(redeliverCnt)
+                        .retryLetterTopic(retryTopic)
+                        .deadLetterTopic(deadLetterTopic)
+                        .build())
+                .receiverQueueSize(100)
+                .ackTimeout(60, TimeUnit.SECONDS)
+                .subscribe();
+
+        producer.newMessage().value("hello".getBytes()).send();
+
+        // receive message at first time
+        Message<byte[]> message = consumer.receive(delayTimeSeconds * 2, TimeUnit.SECONDS);
+        Assert.assertNotNull(message, "Can't receive message at the first time.");
+        consumer.reconsumeLater(message, delayTimeSeconds, TimeUnit.SECONDS);
+
+        boolean nullMsgFlag = false;
+        // receive retry messages
+        for (int i = 0; i < redeliverCnt; i++) {
+            message = consumer.receive(delayTimeSeconds * 2, TimeUnit.SECONDS);
+            if (message == null) {
+                log.info("receive null retry message");
+                nullMsgFlag = true;
+                break;
+            }
+//            Assert.assertNotNull(message, "Consumer can't receive message in double delayTimeSeconds time "
+//                    + delayTimeSeconds * 2 + "s");
+            log.info("receive msg. reConsumeTimes: {}", message.getProperty("RECONSUMETIMES"));
+            consumer.reconsumeLater(message, delayTimeSeconds, TimeUnit.SECONDS);
+        }
+
+        if (!nullMsgFlag) {
+            Assert.fail("Currently consumer shouldn't receive all retry messages.");
+        }
+
+//        @Cleanup
+//        Consumer<byte[]> dltConsumer = pulsarClient.newConsumer()
+//                .topic(deadLetterTopic)
+//                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+//                .subscriptionName("test")
+//                .subscribe();
+//
+//        message = dltConsumer.receive(10, TimeUnit.SECONDS);
+//        Assert.assertNotNull(message, "Dead letter topic consumer can't receive message.");
+    }
+
+}

--- a/tests/integration/src/test/resources/pulsar-messaging.xml
+++ b/tests/integration/src/test/resources/pulsar-messaging.xml
@@ -24,6 +24,7 @@
         <classes>
             <class name="org.apache.pulsar.tests.integration.messaging.PersistentTopicMessagingTest" />
             <class name="org.apache.pulsar.tests.integration.messaging.NonPersistentTopicMessagingTest" />
+            <class name="org.apache.pulsar.tests.integration.messaging.DelayMessagingTest" />
             <class name="org.apache.pulsar.tests.integration.io.AvroKafkaSourceTest" />
         </classes>
     </test>


### PR DESCRIPTION
### Motivation

Currently, in the docker environment, if the consumer enables the retry feature and sets the retry topic in `DeadLetterPolicy`, the consumer will be blocked after receive retry messages many times.

I'll fix this problem in the next PR.

### Modifications

Add an integration test for reproducing this problem.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

