### PR TITLE
[Messaging] Fix delay message block

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -88,7 +88,9 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
      */
     @Override
     public boolean hasMessageAvailable() {
-        return !priorityQueue.isEmpty() && priorityQueue.peekN1() <= clock.millis();
+        // Avoid the TimerTask run before reach the timeout.
+        long cutOffTime = clock.millis() + tickTimeMillis;
+        return !priorityQueue.isEmpty() && priorityQueue.peekN1() <= cutOffTime;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -90,7 +90,12 @@ public class InMemoryDelayedDeliveryTracker implements DelayedDeliveryTracker, T
     public boolean hasMessageAvailable() {
         // Avoid the TimerTask run before reach the timeout.
         long cutOffTime = clock.millis() + tickTimeMillis;
-        return !priorityQueue.isEmpty() && priorityQueue.peekN1() <= cutOffTime;
+        boolean hasMessageAvailable = !priorityQueue.isEmpty() && priorityQueue.peekN1() <= cutOffTime;
+        if (!hasMessageAvailable) {
+            // prevent the first delay message later than cutoffTime
+            updateTimer();
+        }
+        return hasMessageAvailable;
     }
 
     /**

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
@@ -58,7 +58,7 @@ public class DelayMessagingTest extends PulsarTestSuite {
                 .create();
 
         final int redeliverCnt = 10;
-        final int delayTimeSeconds = 10;
+        final int delayTimeSeconds = 5;
         @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(topic)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/DelayMessagingTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.messaging;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Delay messaging test.
+ */
+@Slf4j
+public class DelayMessagingTest extends PulsarTestSuite {
+
+    @Test(dataProvider = "ServiceUrls")
+    public void delayMsgBlockTest(String serviceUrl) throws Exception {
+        String nsName = generateNamespaceName();
+        pulsarCluster.createNamespace(nsName);
+
+        String topic = generateTopicName(nsName, "testDelayMsgBlock", true);
+        pulsarCluster.createPartitionedTopic(topic, 3);
+
+        String retryTopic = topic + "-RETRY";
+        String deadLetterTopic = topic + "-DLT";
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(serviceUrl).build();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .create();
+
+        final int redeliverCnt = 10;
+        final int delayTimeSeconds = 10;
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("test")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .enableRetry(true)
+                .deadLetterPolicy(DeadLetterPolicy.builder()
+                        .maxRedeliverCount(redeliverCnt)
+                        .retryLetterTopic(retryTopic)
+                        .deadLetterTopic(deadLetterTopic)
+                        .build())
+                .receiverQueueSize(100)
+                .ackTimeout(60, TimeUnit.SECONDS)
+                .subscribe();
+
+        producer.newMessage().value("hello".getBytes()).send();
+
+        // receive message at first time
+        Message<byte[]> message = consumer.receive(delayTimeSeconds * 2, TimeUnit.SECONDS);
+        Assert.assertNotNull(message, "Can't receive message at the first time.");
+        consumer.reconsumeLater(message, delayTimeSeconds, TimeUnit.SECONDS);
+
+        boolean nullMsgFlag = false;
+        // receive retry messages
+        for (int i = 0; i < redeliverCnt; i++) {
+            message = consumer.receive(delayTimeSeconds * 2, TimeUnit.SECONDS);
+            if (message == null) {
+                log.info("receive null retry message");
+                nullMsgFlag = true;
+                break;
+            }
+//            Assert.assertNotNull(message, "Consumer can't receive message in double delayTimeSeconds time "
+//                    + delayTimeSeconds * 2 + "s");
+            log.info("receive msg. reConsumeTimes: {}", message.getProperty("RECONSUMETIMES"));
+            consumer.reconsumeLater(message, delayTimeSeconds, TimeUnit.SECONDS);
+        }
+
+        if (!nullMsgFlag) {
+            Assert.fail("Currently consumer shouldn't receive all retry messages.");
+        }
+
+//        @Cleanup
+//        Consumer<byte[]> dltConsumer = pulsarClient.newConsumer()
+//                .topic(deadLetterTopic)
+//                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+//                .subscriptionName("test")
+//                .subscribe();
+//
+//        message = dltConsumer.receive(10, TimeUnit.SECONDS);
+//        Assert.assertNotNull(message, "Dead letter topic consumer can't receive message.");
+    }
+
+}

--- a/tests/integration/src/test/resources/pulsar-messaging.xml
+++ b/tests/integration/src/test/resources/pulsar-messaging.xml
@@ -24,6 +24,7 @@
         <classes>
             <class name="org.apache.pulsar.tests.integration.messaging.PersistentTopicMessagingTest" />
             <class name="org.apache.pulsar.tests.integration.messaging.NonPersistentTopicMessagingTest" />
+            <class name="org.apache.pulsar.tests.integration.messaging.DelayMessagingTest" />
             <class name="org.apache.pulsar.tests.integration.io.AvroKafkaSourceTest" />
         </classes>
     </test>


### PR DESCRIPTION
Based on the PR https://github.com/apache/pulsar/pull/10077

### Motivation

Currently, in the docker environment, if the consumer enables the retry feature and sets the retry topic in DeadLetterPolicy, the consumer will be blocked after receive retry messages many times.

The delay TimerTask may run before reaching the timeout, we could find out that the last log `Timer triggered` run after the log `Start timer in 4958 millis` but we cloud compute the duration between these two logs is `4936`, it's less than `4958`, so the hasMessageAvailable check is false, if there are no more messages to read the delay messages reading will be blocked. Please check logs below.

test environment

Macos 11.2.3 (20D91)
Docker image `apachepulsar/pulsar:2.7.1`, run standalone mode use default configuration.

```
13:29:10.220 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.17.0.1:56868] Created new producer: Producer{topic=PersistentTopic{topic=persistent://public/default/demo-RETRY}, client=/172.17.0.1:56868, producerName=standalone-1-1, producerId=1}
13:29:10.258 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:10.265 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:0 -- Delivery in 4979 ms
13:29:10.267 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4978 millis
13:29:10.271 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 100 messages for 1 consumers
13:29:15.251 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:15.253 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
13:29:15.254 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule replay of 1 messages for 1 consumers
13:29:15.272 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:15.274 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:0 -- Delivery in -30 ms
13:29:15.275 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:15.328 [pulsar-io-50-1] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.17.0.1:56868][persistent://public/default/demo-RETRY] Creating producer. producerId=2
13:29:15.332 [ForkJoinPool.commonPool-worker-3] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.17.0.1:56868] persistent://public/default/demo-RETRY configured with schema false
13:29:15.334 [ForkJoinPool.commonPool-worker-3] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.17.0.1:56868] Created new producer: Producer{topic=PersistentTopic{topic=persistent://public/default/demo-RETRY}, client=/172.17.0.1:56868, producerName=standalone-1-2, producerId=2}
13:29:15.356 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:15.356 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:1 -- Delivery in 4978 ms
13:29:15.357 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4977 millis
13:29:15.359 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 99 messages for 1 consumers
13:29:20.342 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:20.342 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
13:29:20.343 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule replay of 1 messages for 1 consumers
13:29:20.348 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:20.349 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:1 -- Delivery in -15 ms
13:29:20.349 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:20.376 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:20.377 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:2 -- Delivery in 4965 ms
13:29:20.377 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4965 millis
13:29:20.377 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 98 messages for 1 consumers
13:29:24.155 [pulsar-web-68-3] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [29/Mar/2021:13:29:24 +0000] "GET /admin/v2/persistent/public/functions/coordinate/stats?getPreciseBacklog=false&subscriptionBacklogSize=false HTTP/1.1" 200 1677 "-" "Pulsar-Java-v2.7.1" 4
13:29:25.351 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:25.351 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
13:29:25.351 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule replay of 1 messages for 1 consumers
13:29:25.357 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:25.358 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:2 -- Delivery in -16 ms
13:29:25.358 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:25.384 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:25.385 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:3 -- Delivery in 4959 ms
13:29:25.385 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4959 millis
13:29:25.385 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 97 messages for 1 consumers
13:29:30.351 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:30.352 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
13:29:30.352 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule replay of 1 messages for 1 consumers
13:29:30.356 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:30.357 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:3 -- Delivery in -13 ms
13:29:30.357 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:30.371 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:30.372 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:4 -- Delivery in 4966 ms
13:29:30.372 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4966 millis
13:29:30.372 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 96 messages for 1 consumers
13:29:32.696 [SessionTracker] INFO  org.apache.zookeeper.server.ZooKeeperServer - Expiring session 0x10014b5c5930004, timeout of 60000ms exceeded
13:29:32.706 [Curator-LeaderSelector-0] INFO  org.apache.bookkeeper.stream.storage.impl.cluster.ClusterControllerLeaderImpl - Become controller leader to monitor servers for assigning storage containers.
13:29:32.715 [main-EventThread] INFO  org.apache.bookkeeper.discover.ZKRegistrationClient - Update BookieInfoCache (writable bookie) 172.17.0.2:4181 -> BookieServiceInfo{properties={}, endpoints=[EndpointInfo{id=172.17.0.2:4181, port=4181, host=172.17.0.2, protocol=bookie-rpc, auth=[], extensions=[]}]}
13:29:32.716 [registration-service-provider-scheduler] INFO  org.apache.bookkeeper.stream.storage.impl.cluster.ClusterControllerLeaderImpl - Cluster topology is changed - new cluster : Versioned(value=[172.17.0.2:4181], version=3)
13:29:35.341 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:35.342 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
13:29:35.342 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule replay of 1 messages for 1 consumers
13:29:35.347 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:35.348 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:4 -- Delivery in -10 ms
13:29:35.348 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:35.363 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Distributing 1 messages to 1 consumers
13:29:35.364 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 21:5 -- Delivery in 4959 ms
13:29:35.365 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 4958 millis
13:29:35.366 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Schedule read of 95 messages for 1 consumers
13:29:40.301 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
13:29:40.301 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://public/default/demo-RETRY / test] Cannot schedule next read until previous one is done
13:29:54.127 [pulsar-web-68-8] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [29/Mar/2021:13:29:54 +0000] "GET /admin/v2/persistent/public/functions/coordinate/stats?getPreciseBacklog=false&subscriptionBacklogSize=false HTTP/1.1" 200 1677 "-" "Pulsar-Java-v2.7.1" 4
13:30:24.094 [pulsar-web-68-4] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [29/Mar/2021:13:30:24 +0000] "GET /admin/v2/persistent/public/functions/coordinate/stats?getPreciseBacklog=false&subscriptionBacklogSize=false HTTP/1.1" 200 1677 "-" "Pulsar-Java-v2.7.1" 8
13:30:54.054 [pulsar-web-68-5] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [29/Mar/2021:13:30:54 +0000] "GET /admin/v2/persistent/public/functions/coordinate/stats?getPreciseBacklog=false&subscriptionBacklogSize=false HTTP/1.1" 200 1677 "-" "Pulsar-Java-v2.7.1" 4
```
 
filter related logs        ▽ ▽ ▽

```
09:31:48.546 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:0 -- Delivery in 9959 ms
09:31:48.547 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9958 millis
09:31:58.549 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
09:31:58.551 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
09:31:58.602 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:0 -- Delivery in -97 ms


09:31:58.766 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:1 -- Delivery in 9914 ms
09:31:58.767 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9913 millis
09:32:09.549 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
09:32:09.549 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
09:32:09.591 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:1 -- Delivery in -911 ms


09:32:09.611 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:2 -- Delivery in 9959 ms
09:32:09.612 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9959 millis
09:32:20.515 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
09:32:20.516 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
09:32:20.541 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:2 -- Delivery in -971 ms


09:32:20.597 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:3 -- Delivery in 9954 ms
09:32:20.597 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9954 millis
09:32:31.515 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
09:32:31.516 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
09:32:31.539 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:3 -- Delivery in -988 ms


09:32:31.618 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:4 -- Delivery in 9930 ms
09:32:31.627 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9922 millis
09:32:42.515 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
09:32:42.516 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Get scheduled messages - found 1
09:32:42.523 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:4 -- Delivery in -975 ms


09:32:42.548 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Add message 12:5 -- Delivery in 9956 ms
09:32:42.549 [bookkeeper-ml-workers-OrderedExecutor-2-0] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Start timer in 9955 millis
09:32:52.480 [pulsar-delayed-delivery-59-1] DEBUG org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker - [persistent://public/default/demo-RETRY / test] Timer triggered
```

### Modifications

change the hasMessageAvailable check for delay messages

### Verifying this change

Add an integration test.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

