### PR TITLE
Fix NPE in KeyValue when the message payload is null

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/KeyValue.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/common/schema/KeyValue.java
@@ -33,6 +33,8 @@ public class KeyValue<K, V> {
     private final K key;
     private final V value;
 
+    private static final KeyValue NULL = new KeyValue(null, null);
+
     public KeyValue(K key, V value) {
         this.key = key;
         this.value = value;
@@ -130,6 +132,10 @@ public class KeyValue<K, V> {
      * @return the decoded key/value pair
      */
     public static <K, V> KeyValue<K, V> decode(byte[] data, KeyValueDecoder<K, V> decoder) {
+        if (data == null || data.length == 0) {
+            return NULL;
+        }
+
         ByteBuffer byteBuffer = ByteBuffer.wrap(data);
         int keyLength = byteBuffer.getInt();
         byte[] keyBytes = keyLength == -1 ? null : new byte[keyLength];

--- a/pulsar-client/src/test/java/org/apache/pulsar/common/schema/KeyValueTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/common/schema/KeyValueTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
@@ -103,6 +104,18 @@ public class KeyValueTest {
                 );
             }
         }
+    }
+
+    @Test
+    public void testNullPayload() {
+        KeyValue kv = KeyValue.decode(
+                null,
+                (keyBytes, valueBytes) -> new KeyValue(
+                        Schema.STRING.decode(keyBytes),
+                        Schema.STRING.decode(valueBytes)
+                )
+        );
+        assertNotNull(kv);
     }
 
     private <K, V> void testEncodeDecodeKeyValue(Schema<K> keySchema,


### PR DESCRIPTION
### Motivation

Fix a NullPointerException when decoding a KeyValue with a null message payload.

### Modifications

Return a KeyValue(null, null) when data is null or empty.

### Verifying this change

Add a unit test in org.apache.pulsar.common.schema.KeyValueTest
