### PR TITLE
Avoid spammy logs in case of BK problems

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -132,6 +132,7 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
+import org.apache.pulsar.functions.utils.Exceptions;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.slf4j.Logger;
@@ -1245,7 +1246,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 cause = new TopicNotFoundException("Topic Not Found.");
                             }
 
-                            if (!(cause instanceof ServiceUnitNotReadyException)) {
+                            if (!(cause instanceof ServiceUnitNotReadyException)
+                                && (!Exceptions.isExceptionPresentInChain(cause, ManagedLedgerException.class))) {
                                 // Do not print stack traces for expected exceptions
                                 log.error("[{}] Failed to create topic {}, producerId={}",
                                           remoteAddress, topicName, producerId, exception);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1246,7 +1246,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 cause = new TopicNotFoundException("Topic Not Found.");
                             }
 
-                            if (!Exceptions.areExceptionsPresentInChain(cause, ServiceUnitNotReadyException.class, ManagedLedgerException.class)) {
+                            if (!Exceptions.areExceptionsPresentInChain(cause,
+                                    ServiceUnitNotReadyException.class, ManagedLedgerException.class)) {
                                 // Do not print stack traces for expected exceptions
                                 log.error("[{}] Failed to create topic {}, producerId={}",
                                           remoteAddress, topicName, producerId, exception);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1246,8 +1246,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 cause = new TopicNotFoundException("Topic Not Found.");
                             }
 
-                            if (!(cause instanceof ServiceUnitNotReadyException)
-                                && (!Exceptions.isExceptionPresentInChain(cause, ManagedLedgerException.class))) {
+                            if (!Exceptions.areExceptionsPresentInChain(cause, ServiceUnitNotReadyException.class, ManagedLedgerException.class)) {
                                 // Do not print stack traces for expected exceptions
                                 log.error("[{}] Failed to create topic {}, producerId={}",
                                           remoteAddress, topicName, producerId, exception);

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Exceptions.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Exceptions.java
@@ -48,11 +48,12 @@ public class Exceptions {
         return sw.toString();
     }
 
-    public static boolean isExceptionPresentInChain(Throwable error, Class type) {
+    public static boolean areExceptionsPresentInChain(Throwable error, Class ... types) {
         while (error != null) {
-
-            if (type.isInstance(error)) {
-                return true;
+            for (Class type : types) {
+                if (type.isInstance(error)) {
+                    return true;
+                }
             }
             error = error.getCause();
         }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Exceptions.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Exceptions.java
@@ -48,4 +48,15 @@ public class Exceptions {
         return sw.toString();
     }
 
+    public static boolean isExceptionPresentInChain(Throwable error, Class type) {
+        while (error != null) {
+
+            if (type.isInstance(error)) {
+                return true;
+            }
+            error = error.getCause();
+        }
+        return false;
+    }
+
 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ExceptionsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ExceptionsTest.java
@@ -80,23 +80,28 @@ public class ExceptionsTest {
     }
 
     @Test
-    public void testIsExceptionPresentInChain() {
-        assertFalse(Exceptions.isExceptionPresentInChain(null, IllegalStateException.class));
+    public void testAreExceptionsPresentInChain() {
+        assertFalse(Exceptions.areExceptionsPresentInChain(null, IllegalStateException.class));
     }
 
     @Test
-    public void testIsExceptionPresentInChain2() {
-        assertTrue(Exceptions.isExceptionPresentInChain(new IllegalStateException(), IllegalStateException.class));
+    public void testAreExceptionsPresentInChain2() {
+        assertTrue(Exceptions.areExceptionsPresentInChain(new IllegalStateException(), IllegalStateException.class));
     }
 
     @Test
-    public void testIsExceptionPresentInChain3() {
-        assertTrue(Exceptions.isExceptionPresentInChain(new IllegalArgumentException(new IllegalStateException()), IllegalStateException.class));
+    public void testAreExceptionsPresentInChain3() {
+        assertTrue(Exceptions.areExceptionsPresentInChain(new IllegalArgumentException(new IllegalStateException()), IllegalStateException.class));
     }
 
     @Test
-    public void testIsExceptionPresentInChain4() {
-        assertFalse(Exceptions.isExceptionPresentInChain(new IllegalArgumentException(new IllegalArgumentException()), IllegalStateException.class));
+    public void testAreExceptionsPresentInChain4() {
+        assertTrue(Exceptions.areExceptionsPresentInChain(new IllegalArgumentException(new IllegalStateException()), UnsupportedOperationException.class, IllegalStateException.class));
+    }
+
+    @Test
+    public void testAreExceptionsPresentInChain5() {
+        assertFalse(Exceptions.areExceptionsPresentInChain(new IllegalArgumentException(new IllegalArgumentException()), IllegalStateException.class));
     }
 
 }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ExceptionsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ExceptionsTest.java
@@ -21,7 +21,9 @@ package org.apache.pulsar.functions.utils;
 
 import static org.apache.pulsar.functions.utils.Exceptions.rethrowIOException;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
@@ -75,6 +77,26 @@ public class ExceptionsTest {
             assertEquals("test", ioe.getMessage());
             assertSame(e, ioe.getCause());
         }
+    }
+
+    @Test
+    public void testIsExceptionPresentInChain() {
+        assertFalse(Exceptions.isExceptionPresentInChain(null, IllegalStateException.class));
+    }
+
+    @Test
+    public void testIsExceptionPresentInChain2() {
+        assertTrue(Exceptions.isExceptionPresentInChain(new IllegalStateException(), IllegalStateException.class));
+    }
+
+    @Test
+    public void testIsExceptionPresentInChain3() {
+        assertTrue(Exceptions.isExceptionPresentInChain(new IllegalArgumentException(new IllegalStateException()), IllegalStateException.class));
+    }
+
+    @Test
+    public void testIsExceptionPresentInChain4() {
+        assertFalse(Exceptions.isExceptionPresentInChain(new IllegalArgumentException(new IllegalArgumentException()), IllegalStateException.class));
     }
 
 }


### PR DESCRIPTION
### Motivation
When there are not enough writable bookies or other BK level temporary error, you can see the broker logs spammed of this kind of exception.
The error is already logged, so it is useless to write the full stack trace.

The problem is that you are going to fill up the disks of the broker, adding a new problem to the existing problems on the BK machines. 

This is especially problematic when you have some health probe that try to create and write to a persistent topic.

### Modifications

Do not log the problems related to ManagedLedger in ServerCnx, they are already logged in BrokerService.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
