### PR TITLE
Fix AutoConsumeSchema KeyValue encoding

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -209,7 +209,8 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
                     KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo);
                 Schema<?> keySchema = getSchema(kvSchemaInfo.getKey());
                 Schema<?> valueSchema = getSchema(kvSchemaInfo.getValue());
-                return KeyValueSchema.of(keySchema, valueSchema);
+                return KeyValueSchema.of(keySchema, valueSchema,
+                        KeyValueSchemaInfo.decodeKeyValueEncodingType(schemaInfo));
             default:
                 throw new IllegalArgumentException("Retrieve schema instance from schema info for type '"
                     + schemaInfo.getType() + "' is not supported yet");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
@@ -388,4 +388,13 @@ public class KeyValueSchemaTest {
         assertEquals(foo, fooBack);
         assertEquals(bar, barBack);
     }
+
+    @Test
+    public void testKeyValueSchemaSeparatedEncoding() {
+        KeyValueSchema<String, String> keyValueSchema = (KeyValueSchema<String,String>)
+                KeyValueSchema.of(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+        KeyValueSchema<String, String> keyValueSchema2 = (KeyValueSchema<String,String>)
+                AutoConsumeSchema.getSchema(keyValueSchema.getSchemaInfo());
+        assertEquals(keyValueSchema.getKeyValueEncodingType(), keyValueSchema2.getKeyValueEncodingType());
+    }
 }


### PR DESCRIPTION
### Motivation

Keep the KeyValueEncodingType when auto-consuming a KeyValue schema.

### Modifications

see the single commit. 

### Verifying this change

Add a unit test org.apache.pulsar.client.impl.schema.KeyValueSchemaTest.testKeyValueSchemaSeparatedEncoding 
checking that the encoding type is preserved.
