### PR TITLE
[pulsar-broker] Enable sticky read by default

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -767,9 +767,7 @@ bookkeeperClientMinAvailableBookiesInIsolationGroups=
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.
-#
-# Disable Sticy Read until {@link https://github.com/apache/bookkeeper/issues/1970} is fixed
-bookkeeperEnableStickyReads=false
+bookkeeperEnableStickyReads=true
 
 # Set the client security provider factory class name.
 # Default: org.apache.bookkeeper.tls.TLSContextFactory

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -694,9 +694,7 @@ bookkeeperClientMinAvailableBookiesInIsolationGroups=
 # Enable/disable having read operations for a ledger to be sticky to a single bookie.
 # If this flag is enabled, the client will use one single bookie (by preference) to read
 # all entries for a ledger.
-#
-# Disable Sticy Read until {@link https://github.com/apache/bookkeeper/issues/1970} is fixed
-bookkeeperEnableStickyReads=false
+bookkeeperEnableStickyReads=true
 
 # Set the client security provider factory class name.
 # Default: org.apache.bookkeeper.tls.TLSContextFactory

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1223,7 +1223,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + "a single bookie.\n" +
             "If this flag is enabled, the client will use one single bookie (by " +
             "preference) to read all entries for a ledger.")
-    private boolean bookkeeperEnableStickyReads = false;
+    private boolean bookkeeperEnableStickyReads = true;
 
     @FieldContext(category = CATEGORY_STORAGE_BK, doc = "Set the client security provider factory class name. "
             + "Default: org.apache.bookkeeper.tls.TLSContextFactory")


### PR DESCRIPTION
### Motivation

the issue https://github.com/apache/bookkeeper/issues/1970  was fixed with https://github.com/apache/bookkeeper/pull/2111 , and we use the bookkeeper 4.13.0

### Modifications

update bookkeeperEnableStickyReads=true by default


Signed-off-by: YANGLiiN <ielin@qq.com>