### PR TITLE
Fix: seemingly equal ClientConfigurationData's objects end up not being equal

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -24,7 +24,6 @@ import java.time.Clock;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ProxyProtocol;
@@ -47,11 +46,9 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     private String serviceUrl;
     @JsonIgnore
-    @EqualsAndHashCode.Exclude
     private transient ServiceUrlProvider serviceUrlProvider;
 
     @JsonIgnore
-    @EqualsAndHashCode.Exclude
     private Authentication authentication;
     private String authPluginClassName;
 
@@ -105,12 +102,11 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean enableTransaction = false;
 
     @JsonIgnore
-    @EqualsAndHashCode.Exclude
     private Clock clock = Clock.systemDefaultZone();
 
     public Authentication getAuthentication() {
         if (authentication == null) {
-            this.authentication = new AuthenticationDisabled();
+            this.authentication = AuthenticationDisabled.INSTANCE;
         }
         return authentication;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -24,6 +24,7 @@ import java.time.Clock;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ProxyProtocol;
@@ -46,9 +47,11 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     private String serviceUrl;
     @JsonIgnore
+    @EqualsAndHashCode.Exclude
     private transient ServiceUrlProvider serviceUrlProvider;
 
     @JsonIgnore
+    @EqualsAndHashCode.Exclude
     private Authentication authentication;
     private String authPluginClassName;
 
@@ -102,6 +105,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean enableTransaction = false;
 
     @JsonIgnore
+    @EqualsAndHashCode.Exclude
     private Clock clock = Clock.systemDefaultZone();
 
     public Authentication getAuthentication() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -185,4 +185,16 @@ public class ConfigurationDataUtilsTest {
             Assert.fail();
         }
     }
+
+    @Test
+    public void testEquals() {
+        ClientConfigurationData confData1 = new ClientConfigurationData();
+        confData1.setServiceUrl("pulsar://unknown:6650");
+
+        ClientConfigurationData confData2 = new ClientConfigurationData();
+        confData2.setServiceUrl("pulsar://unknown:6650");
+
+        assertEquals(confData1, confData2);
+        assertEquals(confData1.hashCode(), confData2.hashCode());
+    }
 }


### PR DESCRIPTION
### Motivation

Found this while fixing a`CachedPulsarClientTest` test in pulsar-adapters repo.
Two effectively equal configs were not equal:

```
        ClientConfigurationData confData1 = new ClientConfigurationData();
        confData1.setServiceUrl("pulsar://unknown:6650");

        ClientConfigurationData confData2 = new ClientConfigurationData();
        confData2.setServiceUrl("pulsar://unknown:6650");

        assertEquals(confData1, confData2);
```

this results in `CachedPulsarClient.getOrCreate(conf)` creating new PulsarClient for effectively the same config.

### Modifications

Reuse AuthenticationDisabled.INSTANCE as default instead of creating new one

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added unittests 

### Does this pull request potentially affect one of the following parts:

No

### Documentation

  - Does this pull request introduce a new feature? No
