### PR TITLE
[C++] Reduce log level for ack-grouping tracker

### DIFF
--- a/pulsar-client-cpp/lib/AckGroupingTrackerEnabled.cc
+++ b/pulsar-client-cpp/lib/AckGroupingTrackerEnabled.cc
@@ -97,7 +97,7 @@ void AckGroupingTrackerEnabled::close() {
 void AckGroupingTrackerEnabled::flush() {
     auto handler = handlerWeakPtr_.lock();
     if (!handler) {
-        LOG_WARN("Reference to the HandlerBase is not valid.");
+        LOG_DEBUG("Reference to the HandlerBase is not valid.");
         return;
     }
     auto cnx = handler->getCnx().lock();


### PR DESCRIPTION
### Motivation

The warning log occurs when the ACK grouping tracker tries to send ACKs while the connection is closed. This case is common to see because of the current timer's design in C++ client. So the log level should be changed to debug.

### Modifications

Changed the log level to debug when the connection is not ready for `AckGroupingTrackerEnabled::flush`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.