### PR TITLE
Use https for packages.confluent.io Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2028,7 +2028,7 @@ flexible messaging model and an intuitive client API.</description>
     </repository>
     <repository>
       <id>confluent</id>
-      <url>http://packages.confluent.io/maven/</url>
+      <url>https://packages.confluent.io/maven/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Modifications:
   Use only https protocol to access third party Maven repositories, in particular packages.confluent.io

Context:
Since Maven 3.8.1 it is no more possible to use non-https repositories due to security reasons.
I have found this problem while building Pulsar with Maven 3.8.1 (release candidate)

```
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project kafka-connect-avro-converter-shaded: Could not resolve dependencies for project org.apache.pulsar:kafka-connect-avro-converter-shaded:jar:2.8.0-SNAPSHOT: Failed to collect dependencies at io.confluent:kafka-connect-avro-converter:jar:5.2.2: Failed to read artifact descriptor for io.confluent:kafka-connect-avro-converter:jar:5.2.2: Could not transfer artifact io.confluent:kafka-connect-avro-converter:pom:5.2.2 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [confluent (http://packages.confluent.io/maven/, default, releases)] -> [Help 1]
```
