### PR TITLE
Make java-test-image usable for testing in k8s

### DIFF
--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i '1 s/.*/#!\/usr\/bin\/python3/' /pulsar/bin/watch-znode.py /pulsar/bi
 # required by gen-yml-from-env.py
 RUN apt-get install -y python-yaml
 
-RUN apt-get install -y supervisor procps curl less
+RUN apt-get install -y supervisor procps curl less netcat dnsutils iputils-ping
 
 
 RUN mkdir -p /var/log/pulsar \


### PR DESCRIPTION
### Motivation

When developing and testing Pulsar, it is very slow to build the pulsar-all image. 
The java-test-image can be built in less than 1.5 minutes on most laptops.
When attempting to use the apachepulsar/java-test-image:latest with a local k8s setup (microk8s), it was found out that startup fails since the Pulsar helm charts expect that `nc` and `nslookup` are installed.

### Modifications

Make `nc` and `nslookup` available to the java-test-image by adding netcat, dnsutils and iputils-ping to the packages to be installed. These packages are installed to the pulsar image and were missing from the java-test-image.
This change makes java-test-image usable for k8s installations (for developing and testing Pulsar itself).