### PR TITLE
Reduce flakiness of ReplicatorTest.testConfigChange

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -82,8 +82,7 @@ public class ReplicatorTestBase extends TestRetrySupport {
 
     ZookeeperServerTest globalZkS;
 
-    ExecutorService executor = new ThreadPoolExecutor(5, 20, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
-            new DefaultThreadFactory("ReplicatorTestBase"));
+    ExecutorService executor;
 
     static final int TIME_TO_CHECK_BACKLOG_QUOTA = 5;
 
@@ -104,6 +103,9 @@ public class ReplicatorTestBase extends TestRetrySupport {
         incrementSetupNumber();
 
         log.info("--- Starting ReplicatorTestBase::setup ---");
+        executor = new ThreadPoolExecutor(5, 20, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+                new DefaultThreadFactory("ReplicatorTestBase"));
+
         globalZkS = new ZookeeperServerTest(0);
         globalZkS.start();
 
@@ -266,7 +268,10 @@ public class ReplicatorTestBase extends TestRetrySupport {
     protected void cleanup() throws Exception {
         markCurrentSetupNumberCleaned();
         log.info("--- Shutting down ---");
-        executor.shutdown();
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
 
         admin1.close();
         admin2.close();


### PR DESCRIPTION
### Motivation

org.apache.pulsar.broker.service.ReplicatorTest.testConfigChange is one of the most flaky tests. A solution was put in place that fixes retries for most ReplicatorTests by #9823  . Retries failed for testConfigChange with this kind of exception
```
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@68598b0a rejected
 from java.util.concurrent.ThreadPoolExecutor@691c61c7[Terminated, pool size = 0, active threads = 0, q
ueued tasks = 0, completed tasks = 0]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.jav
a:2063)
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
        at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
        at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134)
        at org.apache.pulsar.broker.service.ReplicatorTest.testConfigChange(ReplicatorTest.java:133)
```
The problem is that executor is shutdown in cleanup, but not initialized in the setup method.

### Modifications

- fix test retries by initializing the executor in the setup method