### PR TITLE
Reduce redundant logs on Producer/Consumer create/close operations

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1193,7 +1193,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 topic.addProducer(producer, producerQueuedFuture).thenAccept(newTopicEpoch -> {
                                     if (isActive()) {
                                         if (producerFuture.complete(producer)) {
-                                            log.info("[{}] Created new producer: {}", remoteAddress, producer);
+                                            log.debug("[{}] Created new producer: {}", remoteAddress, producer);
                                             commandSender.sendProducerSuccessResponse(requestId, producerName,
                                                     producer.getLastSequenceId(), producer.getSchemaVersion(),
                                                     newTopicEpoch, true /* producer is ready now */);
@@ -1208,11 +1208,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                         }
                                         } else {
                                             producer.closeNow(true);
-                                        log.info("[{}] Cleared producer created after connection was closed: {}",
-                                                remoteAddress, producer);
-                                        producerFuture.completeExceptionally(
-                                                new IllegalStateException(
-                                                        "Producer created after connection was closed"));
+                                            log.info("[{}] Cleared producer created after connection was closed: {}",
+                                                    remoteAddress, producer);
+                                            producerFuture.completeExceptionally(
+                                                    new IllegalStateException(
+                                                            "Producer created after connection was closed"));
                                         }
 
                                         producers.remove(producerId, producerFuture);
@@ -1522,7 +1522,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                  producer.getTopic(), producer.getProducerName(), remoteAddress, producerId);
 
         producer.close(true).thenAccept(v -> {
-            log.info("[{}][{}] Closed producer on cnx {}. producerId={}",
+            log.debug("[{}][{}] Closed producer on cnx {}. producerId={}",
                      producer.getTopic(), producer.getProducerName(),
                      remoteAddress, producerId);
             commandSender.sendSuccessResponse(requestId);
@@ -1569,7 +1569,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             consumer.close();
             consumers.remove(consumerId, consumerFuture);
             commandSender.sendSuccessResponse(requestId);
-            log.info("[{}] Closed consumer, consumerId={}", remoteAddress, consumerId);
+            log.debug("[{}] Closed consumer, consumerId={}", remoteAddress, consumerId);
         } catch (BrokerServiceException e) {
             log.warn("[{]] Error closing consumer {} : {}", remoteAddress, consumer, e);
             commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(e), e.getMessage());
@@ -1923,7 +1923,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return topic.addSchema(schema);
         } else {
             return topic.hasSchema().thenCompose((hasSchema) -> {
-                log.info("[{}] {} configured with schema {}",
+                log.debug("[{}] {} configured with schema {}",
                          remoteAddress, topic.getName(), hasSchema);
                 CompletableFuture<SchemaVersion> result = new CompletableFuture<>();
                 if (hasSchema && (schemaValidationEnforced || topic.getSchemaValidationEnforced())) {


### PR DESCRIPTION
### Motivation
When you create and close a consumer or a producer on the Broker logs you will see duplicated messages like:
```
12:48:27.177 [ForkJoinPool.commonPool-worker-1] INFO  org.apache.pulsar.broker.service.ServerCnx - [/10.244.3.6:35520] Created new producer: Producer{topic=PersistentTopic{topic=persistent://public/default/test-partition-174}, client=/10.244.3.6:35520, producerName=pulsar-0-869, producerId=174}
12:48:27.177 [ForkJoinPool.commonPool-worker-1] INFO  org.apache.pulsar.broker.service.ServerCnx - [/10.244.3.6:35520] persistent://public/default/test-partition-175 configured with schema false
```

Those logs are at "info" level.
For systems that index the logs and have many consumers/producers that are connecting/disconnecting this amount of logs is a cost that we could save.

### Modifications
Switch to "debug" level some log lines that are redundant. The log lines switched to "debug" level are only on the happy path, we are not losing important information in case of errors.


### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
