### PR TITLE
[C++] Fixed releasing semaphore and memory quota after send timeout

### DIFF
--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -255,12 +255,14 @@ std::shared_ptr<ProducerImpl::PendingCallbacks> ProducerImpl::getPendingCallback
     // without holding producer mutex.
     for (auto& op : pendingMessagesQueue_) {
         callbacks->opSendMsgs.push_back(op);
+        releaseSemaphoreForSendOp(op);
     }
 
     if (batchMessageContainer_) {
         OpSendMsg opSendMsg;
         if (batchMessageContainer_->createOpSendMsg(opSendMsg) == ResultOk) {
             callbacks->opSendMsgs.emplace_back(opSendMsg);
+            releaseSemaphoreForSendOp(opSendMsg);
         }
         batchMessageContainer_->clear();
     }

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -262,8 +262,9 @@ std::shared_ptr<ProducerImpl::PendingCallbacks> ProducerImpl::getPendingCallback
         OpSendMsg opSendMsg;
         if (batchMessageContainer_->createOpSendMsg(opSendMsg) == ResultOk) {
             callbacks->opSendMsgs.emplace_back(opSendMsg);
-            releaseSemaphoreForSendOp(opSendMsg);
         }
+
+        releaseSemaphoreForSendOp(opSendMsg);
         batchMessageContainer_->clear();
     }
     pendingMessagesQueue_.clear();


### PR DESCRIPTION
### Motivation

C++ client is not releasing the semaphore and reserved memory correctly in case of send timeouts. This is a regression introduced in #9676, since the previous code was using the queue itself for accounting for the available spots (hence: emptying the queue was enough).