### PR TITLE
[C++] Allow to configure memory limit from C API

### DIFF
--- a/pulsar-client-cpp/examples/SampleProducerCApi.c
+++ b/pulsar-client-cpp/examples/SampleProducerCApi.c
@@ -24,6 +24,7 @@
 
 int main() {
     pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_configuration_set_memory_limit(conf, 64 * 1024 * 1024);
     pulsar_client_t *client = pulsar_client_create("pulsar://localhost:6650", conf);
 
     pulsar_producer_configuration_t* producer_conf = pulsar_producer_configuration_create();

--- a/pulsar-client-cpp/include/pulsar/c/client_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/client_configuration.h
@@ -46,6 +46,21 @@ PULSAR_PUBLIC void pulsar_client_configuration_set_auth(pulsar_client_configurat
                                                         pulsar_authentication_t *authentication);
 
 /**
+ * Configure a limit on the amount of memory that will be allocated by this client instance.
+ * Setting this to 0 will disable the limit. By default this is disabled.
+ *
+ * @param memoryLimitBytes the memory limit
+ */
+PULSAR_PUBLIC void pulsar_client_configuration_set_memory_limit(pulsar_client_configuration_t *conf,
+                                                                unsigned long long memoryLimitBytes);
+
+/**
+ * @return the client memory limit in bytes
+ */
+PULSAR_PUBLIC unsigned long long pulsar_client_configuration_get_memory_limit(
+    pulsar_client_configuration_t *conf);
+
+/**
  * Set timeout on client operations (subscribe, create producer, close, unsubscribe)
  * Default is 30 seconds.
  *

--- a/pulsar-client-cpp/lib/c/c_ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ClientConfiguration.cc
@@ -146,3 +146,15 @@ const unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
     pulsar_client_configuration_t *conf) {
     return conf->conf.getStatsIntervalInSeconds();
 }
+
+void pulsar_client_configuration_set_memory_limit(pulsar_client_configuration_t *conf,
+                                                  unsigned long long memoryLimitBytes) {
+    conf->conf.setMemoryLimit(memoryLimitBytes);
+}
+
+/**
+ * @return the client memory limit in bytes
+ */
+unsigned long long pulsar_client_configuration_get_memory_limit(pulsar_client_configuration_t *conf) {
+    return conf->conf.getMemoryLimit();
+}


### PR DESCRIPTION
### Motivation

The client memory limit was introduced in C++ in  #9676. Adding here the C wrapper to allow applications to use the feature.