### PR TITLE
[CI] Move flaky tests that fail very often to "quarantine" test group

### DIFF
--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -34,7 +34,7 @@ jobs:
   unit-tests:
     name:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - name: checkout
@@ -83,6 +83,10 @@ jobs:
       - name: run unit test 'BROKER_GROUP_1'
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_1
+
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
 
       - name: package surefire artifacts
         if: failure()

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -84,6 +84,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_2
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -84,6 +84,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_API
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -84,6 +84,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -84,6 +84,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_FLAKY
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -84,6 +84,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh PROXY
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -80,6 +80,10 @@ jobs:
         if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh OTHER
 
+      - name: print JVM thread dumps when cancelled
+        if: cancelled()
+        run: ./build/pulsar_ci_tool.sh print_thread_dumps
+
       - name: package surefire artifacts
         if: failure()
         run: |

--- a/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
+++ b/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
@@ -44,7 +44,7 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
     protected final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/authentication/tls/broker-key.pem";
     private final String clusterName = "use";
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         // TLS configuration for Broker

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# shell function library for Pulsar CI builds
+
+# lists all available functions in this tool
+function ci_list_functions() {
+  declare -F | awk '{print $NF}' | sort | egrep '^ci_' | sed 's/^ci_//'
+}
+
+# prints thread dumps for all running JVMs
+# used in CI when a job gets cancelled because of a job timeout
+function ci_print_thread_dumps() {
+  for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
+    echo "----------------------- pid $java_pid -----------------------"
+    cat /proc/$java_pid/cmdline | xargs -0 echo
+    jcmd $java_pid Thread.print -l
+    jcmd $java_pid GC.heap_info
+  done
+  return 0
+}
+
+if [ -z "$1" ]; then
+  echo "usage: $0 [ci_tool_function_name]"
+  echo "Available ci tool functions:"
+  ci_list_functions
+  exit 1
+fi
+ci_function_name="ci_$1"
+shift
+
+if [[ "$(LC_ALL=C type -t $ci_function_name)" == "function" ]]; then
+  eval "$ci_function_name" "$@"
+else
+  echo "Invalid ci tool function"
+  echo "Available ci tool functions:"
+  ci_list_functions
+  exit 1
+fi

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -19,11 +19,20 @@
 #
 
 set -e
-set -x
 set -o pipefail
 set -o errexit
 
-MVN_TEST_COMMAND='build/retry.sh mvn -B -ntp test'
+# solution for printing output in "set -x" trace mode without tracing the echo calls
+shopt -s expand_aliases
+echo_and_restore_trace() {
+  builtin echo "$@"
+  [ $trace_enabled -eq 1 ] && set -x || true
+}
+alias echo='{ [[ $- =~ .*x.* ]] && trace_enabled=1 || trace_enabled=0; set +x; } 2> /dev/null; echo_and_restore_trace'
+
+MVN_COMMAND='mvn -B -ntp'
+MVN_COMMAND_WITH_RETRY="build/retry.sh ${MVN_COMMAND}"
+MVN_TEST_COMMAND="${MVN_COMMAND_WITH_RETRY} test"
 
 echo -n "Test Group : $TEST_GROUP"
 
@@ -44,16 +53,64 @@ function broker_client_impl() {
   $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='broker-impl'
 }
 
+# prints summaries of failed tests to console
+# by using the targer/surefire-reports files
+# works only when testForkCount > 1 since that is when surefire will create reports for individual test classes
+function print_testng_failures() {
+  (
+    { set +x; } 2>/dev/null
+    local testng_failed_file="$1"
+    local report_prefix="${2:-Test failure in}"
+    local group_title="${3:-Detailed test failures}"
+    if [ -f "$testng_failed_file" ]; then
+      local testng_report_dir=$(dirname "$testng_failed_file")
+      local failed_count=0
+      for failed_test_class in $(cat "$testng_failed_file" | grep 'class name=' | perl -p -e 's/.*\"(.*?)\".*/$1/'); do
+        ((failed_count += 1))
+        if [ $failed_count -eq 1 ]; then
+          echo "::endgroup::"
+          echo "::group::${group_title}"
+        fi
+        local test_report_file="${testng_report_dir}/${failed_test_class}.txt"
+        if [ -f "${test_report_file}" ]; then
+          local test_report="$(cat "${test_report_file}" | egrep "^Tests run: " | perl -p -se 's/^(Tests run: .*) <<< FAILURE! - in (.*)$/::warning::$report_prefix $2 - $1/' -- -report_prefix="${report_prefix}")"
+          echo "$test_report"
+          cat "${test_report_file}"
+        fi
+      done
+    fi
+  )
+}
+
 function broker_flaky() {
+  echo "::endgroup::"
+  echo "::group::Running quarantined tests"
+  $MVN_COMMAND test -pl pulsar-broker -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false \
+    -DtestForkCount=2 -Dexclude='**/Replicator*Test.java' ||
+    print_testng_failures pulsar-broker/target/surefire-reports/testng-failed.xml "Quarantined test failure in" "Quarantined test failures"
+  # run quarantined Replicator tests separately
+  $MVN_COMMAND test -pl pulsar-broker -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false \
+    -DtestForkCount=1 -DtestReuseFork=false -Dinclude='**/Replicator*Test.java' || \
+    print_testng_failures pulsar-broker/target/surefire-reports/testng-failed.xml "Quarantined test failure in" "Quarantined Replicator*Test failures"
+  echo "::endgroup::"
+  echo "::group::Running flaky tests"
   $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='flaky' -DtestForkCount=1 -DtestReuseFork=false
+  echo "::endgroup::"
 }
 
 function proxy() {
+  echo "::endgroup::"
+  echo "::group::Running quarantined pulsar-proxy tests"
+  $MVN_COMMAND test -pl pulsar-proxy -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false ||
+    print_testng_failures pulsar-proxy/target/surefire-reports/testng-failed.xml "Quarantined test failure in" "Quarantined test failures"
+  echo "::endgroup::"
+  echo "::group::Running pulsar-proxy tests"
   $MVN_TEST_COMMAND -pl pulsar-proxy
+  echo "::endgroup::"
 }
 
 function other() {
-  build/retry.sh mvn -B -ntp install -PbrokerSkipTest \
+  $MVN_COMMAND_WITH_RETRY clean install -PbrokerSkipTest \
                                      -Dexclude='org/apache/pulsar/proxy/**/*.java,
                                                 **/ManagedLedgerTest.java,
                                                 **/TestPulsarKeyValueSchemaHandler.java,
@@ -61,25 +118,34 @@ function other() {
                                                 BlobStoreManagedLedgerOffloaderTest.java'
 
   $MVN_TEST_COMMAND -pl managed-ledger -Dinclude='**/ManagedLedgerTest.java,
-                                                  **/OffloadersCacheTest.java' \
-                                       -DtestForkCount=1 \
-                                       -DtestReuseFork=true
+                                                  **/OffloadersCacheTest.java'
 
-  $MVN_TEST_COMMAND -pl pulsar-sql/presto-pulsar-plugin -Dinclude='**/TestPulsarKeyValueSchemaHandler.java' \
-                                                        -DtestForkCount=1
+  $MVN_TEST_COMMAND -pl pulsar-sql/presto-pulsar-plugin -Dinclude='**/TestPulsarKeyValueSchemaHandler.java'
 
-  $MVN_TEST_COMMAND -pl pulsar-client -Dinclude='**/PrimitiveSchemaTest.java' \
-                                      -DtestForkCount=1
+  $MVN_TEST_COMMAND -pl pulsar-client -Dinclude='**/PrimitiveSchemaTest.java'
 
-  $MVN_TEST_COMMAND -pl tiered-storage/jcloud -Dinclude='**/BlobStoreManagedLedgerOffloaderTest.java' \
-                                              -DtestForkCount=1
+  $MVN_TEST_COMMAND -pl tiered-storage/jcloud -Dinclude='**/BlobStoreManagedLedgerOffloaderTest.java'
+
+  echo "::endgroup::"
+  local modules_with_quarantined_tests=$(git grep -l '@Test.*"quarantine"' | grep '/src/test/java/' | \
+    awk -F '/src/test/java/' '{ print $1 }' | egrep -v 'pulsar-broker|pulsar-proxy' | sort | uniq | \
+    perl -0777 -p -e 's/\n(\S)/,$1/g')
+  if [ -n "${modules_with_quarantined_tests}" ]; then
+    echo "::group::Running quarantined tests outside of pulsar-broker & pulsar-proxy (if any)"
+    $MVN_COMMAND -pl "${modules_with_quarantined_tests}" test -Dgroups='quarantine' -DexcludedGroups='' \
+      -DfailIfNoTests=false || \
+        echo "::warning::There were test failures in the 'quarantine' test group."
+    echo "::endgroup::"
+  fi
 }
 
 # Test Groups  -- end --
 
 TEST_GROUP=$1
 
-echo -n "Test Group : $TEST_GROUP"
+echo "Test Group : $TEST_GROUP"
+
+set -x
 
 case $TEST_GROUP in
 

--- a/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
@@ -40,7 +40,7 @@ public abstract class TestRetrySupport {
     private int failedSetupNumber = -1;
     private int cleanedUpSetupNumber;
 
-    @BeforeMethod(groups = { "setup", "flaky", "extra" })
+    @BeforeMethod(alwaysRun = true)
     public final void stateCheck(Method method) throws Exception {
         // run cleanup and setup if the current setup number is the one where a failure happened
         // this is to cleanup state before retrying
@@ -59,7 +59,7 @@ public abstract class TestRetrySupport {
         }
     }
 
-    @AfterMethod(alwaysRun = true, groups = { "setup", "flaky", "extra" })
+    @AfterMethod(alwaysRun = true)
     public final void failureCheck(ITestResult testResult, Method method) {
         // track the setup number where the failure happened
         if (!testResult.isSuccess()) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -48,9 +48,8 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
     ManagedLedgerImpl ml1;
     ManagedLedgerImpl ml2;
 
-    @BeforeMethod
-    public void setup(Method method) throws Exception {
-        super.setUp(method);
+    @Override
+    protected void setUpTestCase() throws Exception {
         OrderedScheduler executor = OrderedScheduler.newSchedulerBuilder().numThreads(1).build();
 
         ml1 = mock(ManagedLedgerImpl.class);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
@@ -52,9 +52,8 @@ public class EntryCacheTest extends MockedBookKeeperTestCase {
 
     private ManagedLedgerImpl ml;
 
-    @BeforeMethod
-    public void setUp(Method method) throws Exception {
-        super.setUp(method);
+    @Override
+    protected void setUpTestCase() throws Exception {
         ml = mock(ManagedLedgerImpl.class);
         when(ml.getName()).thenReturn("name");
         when(ml.getExecutor()).thenReturn(executor);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -93,7 +93,7 @@ public abstract class BookKeeperClusterTestCase {
         this.numBookies = numBookies;
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
         // enable zookeeper `zookeeper.4lw.commands.whitelist`
         System.setProperty("zookeeper.4lw.commands.whitelist", "*");
@@ -211,7 +211,7 @@ public abstract class BookKeeperClusterTestCase {
         tmpDirs.add(f);
         f.delete();
         f.mkdir();
-        
+
         int port = 0;
         return newServerConfiguration(port, zkUtil.getZooKeeperConnectString(), f, new File[] { f }, ledgerRootPath);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -36,7 +36,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 /**
  * A class runs several bookie servers for testing.
@@ -66,8 +65,8 @@ public abstract class MockedBookKeeperTestCase {
         this.numBookies = numBookies;
     }
 
-    @BeforeMethod(groups = { "broker" })
-    public void setUp(Method method) throws Exception {
+    @BeforeMethod(alwaysRun = true)
+    public final void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
         try {
             // start bookkeeper service
@@ -81,10 +80,20 @@ public abstract class MockedBookKeeperTestCase {
         factory = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
 
         zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        setUpTestCase();
     }
 
-    @AfterMethod(alwaysRun = true, groups = { "broker" })
-    public void tearDown(Method method) {
+    protected void setUpTestCase() throws Exception {
+
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void tearDown(Method method) {
+        try {
+            cleanUpTestCase();
+        } catch (Exception e) {
+            LOG.error("tearDown Error", e);
+        }
         try {
             LOG.info("@@@@@@@@@ stopping " + method);
             factory.shutdown();
@@ -97,14 +106,18 @@ public abstract class MockedBookKeeperTestCase {
         }
     }
 
-    @BeforeClass(groups = { "broker" })
-    public void setUpClass() {
+    protected void cleanUpTestCase() throws Exception {
+
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public final void setUpClass() {
         executor = OrderedScheduler.newSchedulerBuilder().numThreads(2).name("test").build();
         cachedExecutor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass(alwaysRun = true, groups = { "broker" })
-    public void tearDownClass() {
+    @AfterClass(alwaysRun = true)
+    public final void tearDownClass() {
         if (executor != null) {
             executor.shutdown();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,10 @@ flexible messaging model and an intuitive client API.</description>
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!--config keys to congiure test selection -->
-    <include>*</include>
+    <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>
     <exclude/>
     <groups/>
-    <excludedGroups/>
+    <excludedGroups>quarantine</excludedGroups>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -53,12 +53,7 @@ import org.testng.annotations.Test;
 public class SLAMonitoringTest {
     LocalBookkeeperEnsemble bkEnsemble;
 
-    ExecutorService executor =
-            new ThreadPoolExecutor(5,
-                    20,
-                    30,
-                    TimeUnit.SECONDS,
-                    new LinkedBlockingQueue<>());
+    ExecutorService executor;
 
     private static final int BROKER_COUNT = 5;
     private final int[] brokerWebServicePorts = new int[BROKER_COUNT];
@@ -68,8 +63,14 @@ public class SLAMonitoringTest {
     private final PulsarAdmin[] pulsarAdmins = new PulsarAdmin[BROKER_COUNT];
     private final ServiceConfiguration[] configurations = new ServiceConfiguration[BROKER_COUNT];
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     void setup() throws Exception {
+        executor =
+                new ThreadPoolExecutor(5,
+                        20,
+                        30,
+                        TimeUnit.SECONDS,
+                        new LinkedBlockingQueue<>());
         log.info("---- Initializing SLAMonitoringTest -----");
         // Start local bookkeeper ensemble
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
@@ -126,6 +127,7 @@ public class SLAMonitoringTest {
     public void shutdown() throws Exception {
         log.info("--- Shutting down ---");
         executor.shutdown();
+        executor = null;
 
         for (int i = 0; i < BROKER_COUNT; i++) {
             pulsarAdmins[i].close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -99,6 +99,10 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         resetConfig();
     }
 
+    protected PulsarService getPulsar() {
+        return pulsar;
+    }
+
     protected final void resetConfig() {
         this.conf = getDefaultConf();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -113,9 +113,18 @@ public class BacklogQuotaManagerTest {
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
         try {
-            admin.close();
-            pulsar.close();
-            bkEnsemble.stop();
+            if (admin != null) {
+                admin.close();
+                admin = null;
+            }
+            if (pulsar != null) {
+                pulsar.close();
+                pulsar = null;
+            }
+            if (bkEnsemble != null) {
+                bkEnsemble.stop();
+                bkEnsemble = null;
+            }
         } catch (Throwable t) {
             LOG.error("Error cleaning up broker test setup state", t);
             fail("Broker test cleanup failed");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -38,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
  * Test base for tests requires a bk ensemble.
  */
 @Slf4j
-public abstract class BkEnsemblesTestBase {
+public abstract class BkEnsemblesTestBase extends TestRetrySupport {
 
     protected PulsarService pulsar;
     protected ServiceConfiguration config;
@@ -61,8 +62,10 @@ public abstract class BkEnsemblesTestBase {
         //overridable by subclasses
     }
 
-    @BeforeMethod(groups = {"broker-impl", "broker"})
+    @Override
+    @BeforeMethod(alwaysRun = true)
     protected void setup() throws Exception {
+        incrementSetupNumber();
         try {
             // start local bookie and zookeeper
             bkEnsemble = new LocalBookkeeperEnsemble(numberOfBookies, 0, () -> 0);
@@ -98,8 +101,10 @@ public abstract class BkEnsemblesTestBase {
         }
     }
 
-    @AfterMethod(alwaysRun = true, groups = {"broker-impl", "broker"})
-    protected void shutdown() throws Exception {
+    @Override
+    @AfterMethod(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         admin.close();
         pulsar.close();
         bkEnsemble.stop();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -33,10 +33,6 @@ import java.util.Random;
 public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
     protected static final int ASYNC_EVENT_COMPLETION_WAIT = 100;
 
-    protected PulsarService getPulsar() {
-        return pulsar;
-    }
-
     public void baseSetup() throws Exception {
         super.internalSetup();
         baseSetupCommon();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
@@ -43,13 +43,13 @@ public class DistributedIdGeneratorTest {
     private MetadataStoreExtended store;
     private CoordinationService coordinationService;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         store  = MetadataStoreExtended.create("memory://local", MetadataStoreConfig.builder().build());
         coordinationService = new CoordinationServiceImpl(store);
     }
 
-    @AfterMethod(alwaysRun = true, groups = "broker")
+    @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
         coordinationService.close();
         store.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/NonPersistentTopicE2ETest.java
@@ -49,7 +49,7 @@ import static org.testng.Assert.assertTrue;
 
 public class NonPersistentTopicE2ETest extends BrokerTestBase {
 
-    @BeforeMethod(groups = "broker")
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.baseSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -93,7 +93,7 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class PersistentTopicE2ETest extends BrokerTestBase {
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.baseSetup();
@@ -1429,7 +1429,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertTrue(msgInRate > 0);
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testBrokerConnectionStats() throws Exception {
 
         BrokerService brokerService = this.pulsar.getBrokerService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -29,7 +29,6 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.conf.ServerConfiguration;
-import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -51,7 +50,7 @@ public class RackAwareTest extends BkEnsemblesTestBase {
         super(0);
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     protected void setup() throws Exception {
         super.setup();
 
@@ -81,8 +80,8 @@ public class RackAwareTest extends BkEnsemblesTestBase {
     }
 
     @AfterClass(alwaysRun = true)
-    protected void shutdown() throws Exception {
-        super.shutdown();
+    protected void cleanup() throws Exception {
+        super.cleanup();
 
         for (BookieServer bs : bookies) {
             bs.shutdown();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
-@Test(groups = "broker")
+@Test(groups = "quarantine")
 public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
 
     protected String methodName;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -46,7 +46,7 @@ import org.testng.annotations.Test;
 /**
  * Starts 3 brokers that are in 3 different clusters
  */
-@Test(groups = "broker")
+@Test(groups = "quarantine")
 public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
     protected String methodName;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -90,12 +90,12 @@ import org.testng.collections.Lists;
 /**
  * Starts 3 brokers that are in 3 different clusters
  */
-@Test(groups = "flaky")
+@Test(groups = "quarantine")
 public class ReplicatorTest extends ReplicatorTestBase {
 
     protected String methodName;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void beforeMethod(Method m) throws Exception {
         methodName = m.getName();
         admin1.namespaces().removeBacklogQuota("pulsar/ns");
@@ -104,7 +104,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     }
 
     @Override
-    @BeforeClass(timeOut = 300000)
+    @BeforeClass(alwaysRun = true, timeOut = 300000)
     public void setup() throws Exception {
         super.setup();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -54,7 +54,7 @@ import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReplicatorTestBase extends TestRetrySupport {
+public abstract class ReplicatorTestBase extends TestRetrySupport {
     URL url1;
     URL urlTls1;
     ServiceConfiguration config1 = new ServiceConfiguration();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -52,7 +52,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
     private NamespaceEventsSystemTopicFactory systemTopicFactory;
     private SystemTopicBasedTopicPoliciesService systemTopicBasedTopicPoliciesService;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         conf.setSystemTopicEnabled(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherFailoverConsumerStreamingDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherFailoverConsumerStreamingDispatcherTest.java
@@ -28,8 +28,8 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "broker")
 public class PersistentDispatcherFailoverConsumerStreamingDispatcherTest extends PersistentDispatcherFailoverConsumerTest {
-    
-    @BeforeMethod
+
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         super.setup();
         pulsar.getConfiguration().setStreamingDispatch(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicStreamingDispatcherE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicStreamingDispatcherE2ETest.java
@@ -29,10 +29,9 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class PersistentTopicStreamingDispatcherE2ETest extends PersistentTopicE2ETest {
 
-    @BeforeMethod
     @Override
-    protected void setup() throws Exception {
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
         conf.setStreamingDispatch(true);
-        super.baseSetup();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -50,7 +50,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class PersistentTopicTest extends BrokerTestBase {
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.baseSetup();
@@ -64,7 +64,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     /**
      * Test validates that broker cleans up topic which failed to unload while bundle unloading.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -96,7 +96,7 @@ public class PersistentTopicTest extends BrokerTestBase {
 
     /**
      * Test validates if topic's dispatcher is stuck then broker can doscover and unblock it.
-     * 
+     *
      * @throws Exception
      */
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
@@ -91,19 +91,8 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
     private ManagedLedgerImpl ledger;
     private ManagedCursor cursor;
 
-    @BeforeClass
-    public void setUpClass() {
-        super.setUpClass();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDownClass() {
-        super.tearDownClass();
-    }
-
-    @BeforeMethod
-    public void setup(Method method) throws Exception {
-        super.setUp(method);
+    @Override
+    protected void setUpTestCase() throws Exception {
         scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
         orderedExecutor = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(1)
@@ -125,9 +114,16 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         }).when(mockDispatcher).notifyConsumersEndOfTopic();
     }
 
-    @AfterMethod(alwaysRun = true)
-    public void tearDown(Method method) {
-        super.tearDown(method);
+    @Override
+    protected void cleanUpTestCase() {
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+            scheduledExecutorService = null;
+        }
+        if (orderedExecutor != null) {
+            orderedExecutor.shutdownNow();
+            orderedExecutor = null;
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedCursorMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedCursorMetricsTest.java
@@ -33,10 +33,10 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-@Test(groups = "broker")
+@Test(groups = "quarantine")
 public class ManagedCursorMetricsTest extends MockedPulsarServiceBaseTest {
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -48,7 +48,6 @@ public class ManagedCursorMetricsTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
-    @Test
     public void testManagedCursorMetrics() throws Exception {
         final String subName = "my-sub";
         final String topicName = "persistent://my-namespace/use/my-ns/my-topic1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -61,7 +61,7 @@ public class TransactionConsumeTest extends TransactionTestBase {
     private final static String NORMAL_MSG_CONTENT = "Normal - ";
     private final static String TXN_MSG_CONTENT = "Txn - ";
 
-    @BeforeMethod(groups = "broker")
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         setBrokerCount(1);
         super.internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
@@ -58,7 +59,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 
 @Slf4j
-public class TransactionTestBase {
+public abstract class TransactionTestBase extends TestRetrySupport {
 
     public final static String CLUSTER_NAME = "test";
 
@@ -79,6 +80,7 @@ public class TransactionTestBase {
     private NonClosableMockBookKeeper mockBookKeeper;
 
     public void internalSetup() throws Exception {
+        incrementSetupNumber();
         init();
 
         admin = spy(PulsarAdmin.builder().serviceHttpUrl(pulsarServiceList.get(0).getWebServiceAddress()).build());
@@ -222,6 +224,7 @@ public class TransactionTestBase {
     };
 
     protected final void internalCleanup() {
+        markCurrentSetupNumberCleaned();
         try {
             // if init fails, some of these could be null, and if so would throw
             // an NPE in shutdown, obscuring the real error

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -18,9 +18,16 @@
  */
 package org.apache.pulsar.broker.transaction.buffer;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import com.google.common.collect.Sets;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -37,18 +44,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import org.testng.annotations.AfterClass;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 
 @Test(groups = "broker")
 public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
@@ -59,9 +55,8 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
     int partitions = 10;
     BrokerService[] brokerServices;
 
-    @BeforeClass
-    void init() throws Exception {
-        super.setup();
+    @Override
+    protected void afterSetup() throws Exception {
         pulsarAdmins[0].clusters().createCluster("my-cluster", new ClusterData(pulsarServices[0].getWebServiceAddress()));
         pulsarAdmins[0].tenants().createTenant("public", new TenantInfo(Sets.newHashSet(), Sets.newHashSet("my-cluster")));
         pulsarAdmins[0].namespaces().createNamespace("public/test", 10);
@@ -74,8 +69,8 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
                 new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")));
     }
 
-    @AfterClass(alwaysRun = true)
-    public void shutdownClient() throws Exception {
+    @Override
+    protected void cleanup() throws Exception {
         if (tbClient != null) {
             tbClient.close();
         }
@@ -85,11 +80,11 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
             }
             brokerServices = null;
         }
+        super.cleanup();
     }
 
     @Override
-    public void afterPulsarStart() throws Exception {
-        super.afterPulsarStart();
+    protected void afterPulsarStart() throws Exception {
         brokerServices = new BrokerService[pulsarServices.length];
         for (int i = 0; i < pulsarServices.length; i++) {
             Subscription mockSubscription = Mockito.mock(Subscription.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -79,7 +79,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
     private final static String NAMESPACE1 = TENANT + "/ns1";
     private final static String TOPIC = NAMESPACE1 + "/test-topic";
 
-    @BeforeMethod(groups = "broker")
+    @BeforeMethod(alwaysRun = true)
     protected void setup() throws Exception {
         setBrokerCount(1);
         internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
@@ -20,8 +20,9 @@ package org.apache.pulsar.broker.transaction.coordinator;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-
 import com.google.common.collect.Lists;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
@@ -32,19 +33,13 @@ import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientExce
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.lang.reflect.Field;
-import java.util.concurrent.CompletableFuture;
 
 @Test(groups = "broker")
 public class TransactionCoordinatorClientTest extends TransactionMetaStoreTestBase {
 
-    @BeforeClass
-    public void init() throws Exception {
-        super.setup();
-
+    @Override
+    protected void afterSetup() throws Exception {
         for (PulsarService pulsarService : pulsarServices) {
             TransactionBufferClient tbClient = Mockito.mock(TransactionBufferClientImpl.class);
             Mockito.when(tbClient.commitTxnOnTopic(anyString(), anyLong(), anyLong(), anyLong()))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
@@ -24,16 +24,10 @@ import java.util.List;
 import org.apache.pulsar.broker.PulsarService;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class TransactionMetaStoreAssignmentTest extends TransactionMetaStoreTestBase {
-
-    @BeforeClass(groups = "broker")
-    public void init() throws Exception {
-        super.setup();
-    }
 
     @Test(groups = "broker")
     public void testTransactionMetaStoreAssignAndFailover() throws IOException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperSessionExpireRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperSessionExpireRecoveryTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class ZooKeeperSessionExpireRecoveryTest extends MockedPulsarServiceBaseTest {
 
-    @BeforeMethod(groups = "broker")
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
@@ -56,7 +56,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "broker-api")
+@Test(groups = "quarantine")
 public class ClientDeduplicationFailureTest {
     LocalBookkeeperEnsemble bkEnsemble;
 
@@ -69,7 +69,7 @@ public class ClientDeduplicationFailureTest {
     final String tenant = "external-repl-prop";
     String primaryHost;
 
-    @BeforeMethod(timeOut = 300000)
+    @BeforeMethod(timeOut = 300000, alwaysRun = true)
     void setup(Method method) throws Exception {
         log.info("--- Setting up method {} ---", method.getName());
 
@@ -180,7 +180,7 @@ public class ClientDeduplicationFailureTest {
         }
     }
 
-    @Test(timeOut = 300000)
+    @Test(timeOut = 300000, groups = "quarantine")
     public void testClientDeduplicationCorrectnessWithFailure() throws Exception {
         final String namespacePortion = "dedup";
         final String replNamespace = tenant + "/" + namespacePortion;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -49,15 +49,17 @@ public class ClientErrorsTest {
 
     private final String ASSERTION_ERROR = "AssertionError";
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setup() {
         mockBrokerService = new MockBrokerService();
         mockBrokerService.start();
     }
 
-    @AfterClass(alwaysRun = true, groups = "broker-api")
+    @AfterClass(alwaysRun = true)
     public void teardown() {
-        mockBrokerService.stop();
+        if (mockBrokerService != null) {
+            mockBrokerService.stop();
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -32,10 +32,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
-@Test(groups = "flaky")
+@Test(groups = "quarantine")
 public class ConsumerBatchReceiveTest extends ProducerConsumerBase {
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -45,7 +45,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
 
     private static final Logger log = LoggerFactory.getLogger(DeadLetterTopicTest.class);
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -58,7 +58,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testDeadLetterTopic() throws Exception {
         final String topic = "persistent://my-property/my-ns/dead-letter-topic";
 
@@ -336,7 +336,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         checkConsumer.close();
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testDeadLetterTopicByCustomTopicName() throws Exception {
         final String topic = "persistent://my-property/my-ns/dead-letter-topic";
         final int maxRedeliveryCount = 2;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -70,14 +70,14 @@ import com.google.common.collect.Sets;
 public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(DispatcherBlockConsumerTest.class);
 
-    @BeforeMethod(groups = { "broker" })
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
         super.producerBaseSetup();
     }
 
-    @AfterMethod(alwaysRun = true, groups = { "broker" })
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -93,7 +93,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         };
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -630,7 +630,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         assertTrue(readPosition.getEntryId() < 1000);
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testRemoveFirstConsumer() throws Exception {
         this.conf.setSubscriptionKeySharedEnable(true);
         String topic = "testReadAheadWhenAddingConsumers-" + UUID.randomUUID();
@@ -885,7 +885,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Assert.assertNotNull(consumer3.receive(1, TimeUnit.SECONDS));
     }
 
-    @Test(dataProvider = "partitioned")
+    @Test(dataProvider = "partitioned", groups = "quarantine")
     public void testOrderingWithConsumerListener(boolean partitioned) throws Exception {
         final String topic = "persistent://public/default/key_shared-" + UUID.randomUUID();
         if (partitioned) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MutualAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MutualAuthenticationTest.java
@@ -182,7 +182,7 @@ public class MutualAuthenticationTest extends ProducerConsumerBase {
         }
     }
 
-    @BeforeMethod(groups = "broker-api")
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         mutualAuth = new MutualAuthentication();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
@@ -33,7 +33,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class ProducerConsumerBase extends MockedPulsarServiceBaseTest {
     protected String methodName;
 
-    @BeforeMethod(groups = { "broker", "websocket", "broker-api", "broker-discovery", "broker-impl", "extra", "flaky" })
+    @BeforeMethod(alwaysRun = true)
     public void beforeMethod(Method m) throws Exception {
         methodName = m.getName();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -48,7 +48,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     //
     private String host;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         this.executorService = Executors.newFixedThreadPool(1);
@@ -70,7 +70,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         clientBuilder.listenerName("internal");
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testFindBrokerWithListenerName() throws Throwable {
         admin.clusters().createCluster("localhost", new ClusterData(pulsar.getWebServiceAddress()));
         TenantInfo tenantInfo = new TenantInfo();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithoutInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithoutInternalListenerNameTest.java
@@ -48,7 +48,7 @@ public class PulsarMultiListenersWithoutInternalListenerNameTest extends MockedP
     //
     private String host;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         this.executorService = Executors.newFixedThreadPool(1);
@@ -69,7 +69,7 @@ public class PulsarMultiListenersWithoutInternalListenerNameTest extends MockedP
         clientBuilder.listenerName("internal");
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testFindBrokerWithListenerName() throws Throwable {
         admin.clusters().createCluster("localhost", new ClusterData(pulsar.getWebServiceAddress()));
         TenantInfo tenantInfo = new TenantInfo();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -112,7 +112,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 100;
     private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 500;
 
-    @BeforeMethod(groups = { "broker", "flaky" })
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -140,7 +140,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         return new Object[][] { { true }, { false } };
     }
 
-    @AfterMethod(alwaysRun = true, groups = { "broker" })
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
@@ -740,7 +740,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     // This is to test that the flow control counter doesn't get corrupted while concurrent receives during
     // reconnections
-    @Test(dataProvider = "batch")
+    @Test(dataProvider = "batch", groups = "quarantine")
     public void testConcurrentConsumerReceiveWhileReconnect(int batchMessageDelayMs) throws Exception {
         final int recvQueueSize = 100;
         final int numConsumersThreads = 10;
@@ -2335,7 +2335,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test(dataProvider = "ackReceiptEnabled")
+    @Test(dataProvider = "ackReceiptEnabled", groups = "quarantine")
     public void testRedeliveryFailOverConsumer(boolean ackReceiptEnabled) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -2718,7 +2718,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer4.unsubscribe();
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testRedeliveryOfFailedMessages() throws Exception {
         log.info("-- Starting {} test --", methodName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -63,7 +63,7 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
     // Credentials File, which contains "client_id" and "client_secret"
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         conf.setAuthenticationEnabled(true);
@@ -109,7 +109,7 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
                 .authentication(authentication));
     }
 
-    @AfterMethod(alwaysRun = true, groups = "broker-api")
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerBase.java
@@ -32,7 +32,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class V1_ProducerConsumerBase extends MockedPulsarServiceBaseTest {
     protected String methodName;
 
-    @BeforeMethod(groups = {"broker-api, websocket"})
+    @BeforeMethod(alwaysRun = true)
     public void beforeMethod(Method m) throws Exception {
         methodName = m.getName();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -92,7 +92,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(V1_ProducerConsumerTest.class);
     private static final long BATCHING_MAX_PUBLISH_DELAY_THRESHOLD = 1;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -361,7 +361,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
         }
-        
+
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/my-ns/my-topic6")
                 .subscriptionName("my-subscriber-name")
@@ -630,7 +630,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test
+    @Test(groups = "quarantine")
     public void testActiveAndInActiveConsumerEntryCacheBehavior() throws Exception {
         log.info("-- Starting {} test --", methodName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerUnsubscribeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerUnsubscribeTest.java
@@ -32,15 +32,18 @@ public class ConsumerUnsubscribeTest {
 
     MockBrokerService mockBrokerService;
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setup() {
         mockBrokerService = new MockBrokerService();
         mockBrokerService.start();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void teardown() {
-        mockBrokerService.stop();
+        if (mockBrokerService != null) {
+            mockBrokerService.stop();
+            mockBrokerService = null;
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -62,7 +62,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
 
     private static final String subscription = "reader-multi-topics-sub";
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -91,7 +91,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         testReadMessages(topic, false);
     }
 
-    @Test(timeOut = 10000)
+    @Test(timeOut = 10000, groups = "quarantine")
     public void testReadMessageWithoutBatchingWithMessageInclusive() throws Exception {
         String topic = "persistent://my-property/my-ns/my-reader-topic-inclusive";
         int topicNum = 3;
@@ -116,7 +116,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         testReadMessages(topic, true);
     }
 
-    @Test(timeOut = 10000)
+    @Test(timeOut = 10000, groups = "quarantine")
     public void testReadMessageWithBatchingWithMessageInclusive() throws Exception {
         String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching-inclusive";
         int topicNum = 3;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -19,13 +19,11 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
-
 import java.util.Collections;
-
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.pulsar.broker.ManagedLedgerClientFactory;
-import org.apache.pulsar.broker.service.BrokerBkEnsemblesTests;
+import org.apache.pulsar.broker.service.BkEnsemblesTestBase;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -34,8 +32,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.testng.annotations.Test;
 
-@Test(groups = "broker-impl")
-public class SequenceIdWithErrorTest extends BrokerBkEnsemblesTests {
+@Test(groups = "quarantine")
+public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
 
     /**
      * Test that sequence id from a producer is correct when there are send errors
@@ -77,15 +75,5 @@ public class SequenceIdWithErrorTest extends BrokerBkEnsemblesTests {
         }
 
         client.close();
-    }
-
-    @Test(enabled = false)
-    public void testCrashBrokerWithoutCursorLedgerLeak() {
-        // Ignore test
-    }
-
-    @Test(enabled = false)
-    public void testSkipCorruptDataLedger() {
-        // Ignore test
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleTest.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
 import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.BoundType;
@@ -41,7 +42,12 @@ import com.google.common.hash.Hashing;
 
 @Test(groups = "broker-naming")
 public class NamespaceBundleTest {
-    private final NamespaceBundleFactory factory = getNamespaceBundleFactory();
+    private NamespaceBundleFactory factory;
+
+    @BeforeClass(alwaysRun = true)
+    protected void initializeFactory() {
+        factory = getNamespaceBundleFactory();
+    }
 
     @Test
     public void testConstructor() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
@@ -52,7 +53,12 @@ import com.google.common.hash.Hashing;
 @Test(groups = "broker-naming")
 public class NamespaceBundlesTest {
 
-    private final NamespaceBundleFactory factory = getNamespaceBundleFactory();
+    private NamespaceBundleFactory factory;
+
+    @BeforeMethod(alwaysRun = true)
+    protected void initializeFactory() {
+        factory = getNamespaceBundleFactory();
+    }
 
     @SuppressWarnings("unchecked")
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -161,7 +161,7 @@ public class PulsarFunctionLocalRunTest {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     void loadPulsarApiExamples() throws MalformedURLException, ClassNotFoundException {
         pulsarApiExamplesClassLoader = new URLClassLoader(new URL[]{getPulsarApiExamplesJar().toURI().toURL()},
                 Thread.currentThread().getContextClassLoader());
@@ -176,7 +176,7 @@ public class PulsarFunctionLocalRunTest {
         }
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     void setup(Method method) throws Exception {
         log.info("--- Setting up method {} ---", method.getName());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
@@ -84,7 +84,7 @@ public class PulsarFunctionAdminTest {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarFunctionAdminTest.class);
 
-    @BeforeMethod(groups = "broker")
+    @BeforeMethod(alwaysRun = true)
     void setup(Method method) throws Exception {
 
         log.info("--- Setting up method {} ---", method.getName());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -39,18 +39,20 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ConsumerImplTest {
 
 
-    private final ExecutorProvider executorProvider = new ExecutorProvider(1,"ConsumerImplTest");
+    private ExecutorProvider executorProvider;
     private ConsumerImpl<byte[]> consumer;
     private ConsumerConfigurationData consumerConf;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp() {
+        executorProvider = new ExecutorProvider(1, "ConsumerImplTest");
         consumerConf = new ConsumerConfigurationData<>();
         PulsarClientImpl client = ClientTestFixtures.createPulsarClientMock();
         ClientConfigurationData clientConf = client.getConfiguration();
@@ -64,6 +66,14 @@ public class ConsumerImplTest {
                 executorProvider, -1, false, subscribeFuture, null, null, null,
                 true);
         consumer.setState(HandlerState.State.Ready);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        if (executorProvider != null) {
+            executorProvider.shutdownNow();
+            executorProvider = null;
+        }
     }
 
     @Test(invocationTimeOut = 1000)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -69,7 +69,7 @@ public class PulsarClientImplTest {
     private PulsarClientImpl clientImpl;
     private EventLoopGroup eventLoopGroup;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws PulsarClientException {
         ClientConfigurationData conf = new ClientConfigurationData();
         conf.setServiceUrl("pulsar://localhost:6650");
@@ -78,10 +78,16 @@ public class PulsarClientImplTest {
         clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
-        clientImpl.close();
-        eventLoopGroup.shutdownGracefully().get();
+        if (clientImpl != null) {
+            clientImpl.close();
+            clientImpl = null;
+        }
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully().get();
+            eventLoopGroup = null;
+        }
     }
 
     @Test

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
@@ -56,7 +56,7 @@ public abstract class AbstractFileTests {
 
     protected Path directory;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void init() throws IOException {
         // Create the directory we are going to read from
         directory = Files.createTempDirectory("pulsar-io-file-tests", getPermissions());

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestAbstractZooKeeperConfigurationProvider.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestAbstractZooKeeperConfigurationProvider.java
@@ -52,7 +52,7 @@ public abstract class TestAbstractZooKeeperConfigurationProvider {
     protected TestingServer zkServer;
     protected CuratorFramework client;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
         // start the instance without the admin server!
         InstanceSpec serverSpec = new InstanceSpec(null, -1, -1, -1, true, -1, -1, -1, Collections.singletonMap("zookeeper.admin.enableServer", "false"));

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestApplication.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestApplication.java
@@ -46,14 +46,17 @@ public class TestApplication {
 
     private File baseDir;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         baseDir = Files.createTempDir();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
-        FileUtils.deleteDirectory(baseDir);
+        if (baseDir != null) {
+            FileUtils.deleteDirectory(baseDir);
+            baseDir = null;
+        }
     }
 
     private <T extends LifecycleAware> T mockLifeCycle(Class<T> klass) {

--- a/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/AbstractHdfsSinkTest.java
+++ b/pulsar-io/hdfs2/src/test/java/org/apache/pulsar/io/hdfs2/sink/AbstractHdfsSinkTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractHdfsSinkTest<K, V> {
     protected HdfsAbstractSink<K, V> sink;
     
     @SuppressWarnings("unchecked")
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public final void setUp() throws Exception {
         map = new HashMap<String, Object> ();
         map.put("hdfsConfigResources", "../pulsar/pulsar-io/hdfs2/src/test/resources/hadoop/core-site.xml,"

--- a/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/AbstractHdfsSinkTest.java
+++ b/pulsar-io/hdfs3/src/test/java/org/apache/pulsar/io/hdfs3/sink/AbstractHdfsSinkTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractHdfsSinkTest<K, V> {
     protected HdfsAbstractSink<K, V> sink;
     
     @SuppressWarnings("unchecked")
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public final void setUp() throws Exception {
         map = new HashMap<String, Object> ();
         map.put("hdfsConfigResources", "../pulsar/pulsar-io/hdfs/src/test/resources/hadoop/core-site.xml,"

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.DataProvider;
 public abstract class BaseMetadataStoreTest {
     protected TestZKServer zks;
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     void setup() throws Exception {
         zks = new TestZKServer();
     }

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -92,7 +92,7 @@ public abstract class BookKeeperClusterTestCase {
         this.numBookies = numBookies;
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
         executor = Executors.newCachedThreadPool();
         InMemoryMetaStore.reset();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -68,7 +68,7 @@ public abstract class MockedBookKeeperTestCase {
         this.numBookies = numBookies;
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
         try {
@@ -99,7 +99,7 @@ public abstract class MockedBookKeeperTestCase {
         }
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setUpClass() {
         executor = OrderedScheduler.newSchedulerBuilder().numThreads(2).name("test").build();
         cachedExecutor = Executors.newCachedThreadPool();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyLookupThrottlingTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyLookupThrottlingTest.java
@@ -47,7 +47,7 @@ public class ProxyLookupThrottlingTest extends MockedPulsarServiceBaseTest {
     private ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
     @Override
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     protected void setup() throws Exception {
         internalSetup();
 
@@ -70,10 +70,12 @@ public class ProxyLookupThrottlingTest extends MockedPulsarServiceBaseTest {
     @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
-        proxyService.close();
+        if (proxyService != null) {
+            proxyService.close();
+        }
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testLookup() throws Exception {
         @Cleanup
         PulsarClient client = PulsarClient.builder()

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
@@ -68,7 +68,7 @@ public abstract class MockedBookKeeperTestCase {
         this.numBookies = numBookies;
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
         try {
@@ -99,7 +99,7 @@ public abstract class MockedBookKeeperTestCase {
         }
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     public void setUpClass() {
         executor = OrderedScheduler.newSchedulerBuilder().numThreads(2).name("test").build();
         cachedExecutor = Executors.newCachedThreadPool();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -74,7 +74,7 @@ public class ZookeeperCacheTest {
     private OrderedScheduler executor;
     private ScheduledExecutorService scheduledExecutor;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     void setup() throws Exception {
         zkClient = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
     }
@@ -84,7 +84,7 @@ public class ZookeeperCacheTest {
         zkClient.shutdown();
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     void classSetup() throws Exception {
         executor = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("ZookeeperCacheTest").build();
         scheduledExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/FileStoreTestBase.java
@@ -31,14 +31,14 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.Properties;
 
-public class FileStoreTestBase {
+public abstract class FileStoreTestBase {
     protected FileSystemManagedLedgerOffloader fileSystemManagedLedgerOffloader;
     protected OrderedScheduler scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(1).name("offloader").build();
     protected final String basePath = "pulsar";
     private MiniDFSCluster hdfsCluster;
     private String hdfsURI;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void start() throws Exception {
         File baseDir = Files.createTempDirectory(basePath).toFile().getAbsoluteFile();
         Configuration conf = new Configuration();

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-public class BlobStoreTestBase {
+public abstract class BlobStoreTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(BlobStoreTestBase.class);
     public final static String BUCKET = "pulsar-unittest";
@@ -36,7 +36,7 @@ public class BlobStoreTestBase {
     protected BlobStoreContext context = null;
     protected BlobStore blobStore = null;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void start() throws Exception {
         if (Boolean.parseBoolean(System.getProperty("testRealAWS", "false"))) {
             log.info("TestReal AWS S3, bucket: {}", BUCKET);


### PR DESCRIPTION
### Motivation

There are a few tests that fail very often. This is blocking the merging of PRs currently. 

### Modifications

Move the problematic tests to "quarantine" test group. This test group will be run, but the test failures will be ignored.
- Configure "excludedGroups" property with "quarantine" default value
- Make modifications so that tests in the quarantine group can be run. It is required to make changes to "BeforeMethod/BeforeClass" annotations so that the method will get run for the quarantine group. `alwaysRun=true` should be used instead of listing individual groups in the Before* annotations.
- Add reporting for quarantined tests so that the PR reviewer can check if there's a sudden change in Quarantined test results
Test result will be visible directly in GitHub Actions UI, [example](https://github.com/lhotari/pulsar/actions/runs/726717497).
![image](https://user-images.githubusercontent.com/66864/113923302-1464e080-97f1-11eb-8719-a25f854b7f8e.png)
[Detailed quarantined test results](https://github.com/lhotari/pulsar/runs/2289519905?check_suite_focus=true#step:8:165):
![image](https://user-images.githubusercontent.com/66864/113923589-5f7ef380-97f1-11eb-9179-8fc0e960f9fa.png)

### Issue reports for quarantined tests

* #10150
* #9916
* #10151
* #10117
* #10152
* #6300