### PR TITLE
Upgrade jclouds to 2.3.0 to fix security vulnerabilities

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -550,7 +550,7 @@ Protocol Buffers License
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
-    - javax.annotation-javax.annotation-api-1.2.jar
+    - javax.annotation-javax.annotation-api-1.3.2.jar
     - com.sun.activation-javax.activation-1.2.0.jar
     - javax.xml.bind-jaxb-api-2.3.1.jar
  * Java Servlet API -- javax.servlet-javax.servlet-api-3.1.0.jar

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -68,6 +68,7 @@
                   <include>com.google.inject.extensions:guice-assistedinject</include>
                   <include>com.google.inject:guice</include>
                   <include>com.google.inject.extensions:guice-multibindings</include>
+                  <include>com.google.code.gson:gson</include>
                   <include>javax.ws.rs:*</include>
                   <include>com.jamesmurty.utils:*</include>
                   <include>net.iharder:*</include>
@@ -79,10 +80,6 @@
               </artifactSet>
 
               <relocations>
-                <relocation>
-                  <pattern>com.google.gson.internal</pattern>
-                  <shadedPattern>org.jclouds.json.gson.internal</shadedPattern>
-                </relocation>
                 <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>org.apache.pulsar.jcloud.shade.com.google</shadedPattern>

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>jclouds-allblobstore</artifactId>
       <version>${jclouds.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -41,17 +41,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- JClouds still is using Guava 18.0 and it won't work with newer versions -->
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>18.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ flexible messaging model and an intuitive client API.</description>
     <aws-sdk.version>1.11.774</aws-sdk.version>
     <avro.version>1.10.2</avro.version>
     <joda.version>2.10.1</joda.version>
-    <jclouds.version>2.2.1</jclouds.version>
+    <jclouds.version>2.3.0</jclouds.version>
     <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
     <postgresql-jdbc.version>42.2.12</postgresql-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@ flexible messaging model and an intuitive client API.</description>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.18.1</assertj-core.version>
     <lombok.version>1.18.18</lombok.version>
-    <javax.annotation-api.version>1.2</javax.annotation-api.version>
+    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>
     <jna.version>4.2.0</jna.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -508,7 +508,6 @@ CDDL - 1.0
 
 CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
-   - javax.annotation-api-1.2.jar
    - javax.annotation-api-1.3.2.jar
    - javax.activation-1.2.0.jar
    - javax.activation-api-1.2.0.jar


### PR DESCRIPTION
### Motivation

Currently jclouds uses Guava 18 which contains vulnerabilities CVE-2020-8908 and CVE-2018-10237 . 

### Modifications

- Upgrade jclouds version to 2.3.0 which supports newer Guava versions.
- Use the Guava version managed in pom.xml (30.1-jre)
- Upgrade javax.annotation:javax.annotation-api from 1.2 to 1.3.2
- Add gson and javax:annotation-api to the shaded jclouds jar to fix classloading