### PR TITLE
[functions] Enable custom function producer behavior - Part 1 of Proposed PIP 84

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
@@ -45,7 +45,7 @@ public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
     private volatile int partitionIndex = 0;
 
     private final int startPtnIdx;
-    private final boolean isBatchingEnabled;
+    protected boolean isBatchingEnabled;
     private final long partitionSwitchMs;
 
     private final Clock clock;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ProducerConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/ProducerConfig.java
@@ -23,6 +23,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 
 /**
  * Configuration of the producer inside the function.
@@ -38,4 +41,60 @@ public class ProducerConfig {
     private Boolean useThreadLocalProducers;
     private CryptoConfig cryptoConfig;
     private String batchBuilder;
+
+    public Boolean batchingDisabled;
+    public Boolean chunkingEnabled;
+    public Boolean blockIfQueueFullDisabled;
+    public CompressionType compressionType;
+    public HashingScheme hashingScheme;
+    public MessageRoutingMode messageRoutingMode;
+    public Long batchingMaxPublishDelay;
+    public Boolean getBatchingEnabled(){
+        return !this.getBatchingDisabled();
+    }
+    public Boolean getBlockIfQueueFullEnabled() { return !this.getBlockIfQueueFullDisabled();}
+    public ProducerConfig merge(ProducerConfig newConfig){
+        ProducerConfig mergedConfig = new ProducerConfig();
+        if(newConfig == null) {
+            mergedConfig = this;
+        }
+        else {
+            if(newConfig.getBatchingDisabled() != null){
+                mergedConfig.setBatchingDisabled(newConfig.getBatchingDisabled());
+            } else {
+                mergedConfig.setBatchingDisabled(this.getBatchingDisabled());
+            }
+            if(newConfig.getChunkingEnabled() != null){
+                mergedConfig.setChunkingEnabled(newConfig.getChunkingEnabled());
+            } else {
+                mergedConfig.setChunkingEnabled(this.getChunkingEnabled());
+            }
+            if(newConfig.getBlockIfQueueFullDisabled() != null){
+                mergedConfig.setBlockIfQueueFullDisabled(newConfig.getBlockIfQueueFullDisabled());
+            } else {
+                mergedConfig.setBlockIfQueueFullDisabled(this.getBlockIfQueueFullDisabled());
+            }
+            if(newConfig.getCompressionType() != null){
+                mergedConfig.setCompressionType(newConfig.getCompressionType());
+            } else {
+                mergedConfig.setCompressionType(this.getCompressionType());
+            }
+            if(newConfig.getHashingScheme() != null){
+                mergedConfig.setHashingScheme(newConfig.getHashingScheme());
+            } else {
+                mergedConfig.setHashingScheme(this.getHashingScheme());
+            }
+            if (newConfig.getMessageRoutingMode() != null) {
+                mergedConfig.setMessageRoutingMode(newConfig.getMessageRoutingMode());
+            } else {
+                mergedConfig.setMessageRoutingMode(this.getMessageRoutingMode());
+            }
+            if(newConfig.getBatchingMaxPublishDelay() != null){
+                mergedConfig.setBatchingMaxPublishDelay(newConfig.getBatchingMaxPublishDelay());
+            } else {
+                mergedConfig.setBatchingMaxPublishDelay(this.getBatchingMaxPublishDelay());
+            }
+        }
+        return mergedConfig;
+    }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
@@ -26,16 +26,17 @@ import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.impl.RoundRobinPartitionMessageRouterImpl;
+import org.apache.pulsar.common.functions.ProducerConfig;
 
 /**
  * Router for routing function results.
  */
 public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
 
-    private static final FunctionResultRouter INSTANCE = new FunctionResultRouter();
+    private static final FunctionRouterClock clock = FunctionRouterClock.of();
 
-    public FunctionResultRouter() {
-        this(Math.abs(ThreadLocalRandom.current().nextInt()), Clock.systemUTC());
+    public FunctionResultRouter(boolean isBatchingEnabled) {
+        this(clock.getPtnIdx(), clock.getTime(), isBatchingEnabled);
     }
 
     @VisibleForTesting
@@ -48,8 +49,17 @@ public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
             clock);
     }
 
-    public static FunctionResultRouter of() {
-        return INSTANCE;
+    public FunctionResultRouter(int startPtnIdx, Clock clock, boolean isBatchingEnabled) {
+        super(
+                HashingScheme.Murmur3_32Hash,
+                startPtnIdx,
+                isBatchingEnabled,
+                1,
+                clock);
+    }
+
+    public static FunctionResultRouter of(boolean isBatchingEnabled) {
+        return new FunctionResultRouter(isBatchingEnabled);
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionRouterClock.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionRouterClock.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance;
+
+import lombok.Getter;
+
+import java.time.Clock;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class FunctionRouterClock {
+    private static final FunctionRouterClock INSTANCE = new FunctionRouterClock();
+
+    @Getter
+    private final int PtnIdx = Math.abs(ThreadLocalRandom.current().nextInt());
+
+    @Getter
+    private final Clock time = Clock.systemUTC();
+
+    public static FunctionRouterClock of(){
+        return INSTANCE;
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -68,6 +68,7 @@ import org.apache.pulsar.functions.source.PulsarSourceConfig;
 import org.apache.pulsar.functions.source.batch.BatchSourceExecutor;
 import org.apache.pulsar.functions.utils.CryptoUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
+import org.apache.pulsar.functions.utils.functions.ProducerConfigFromProtobufConverter;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.Source;
 import org.slf4j.Logger;
@@ -744,13 +745,10 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 pulsarSinkConfig.setSchemaProperties(sinkSpec.getSchemaPropertiesMap());
 
                 if (this.instanceConfig.getFunctionDetails().getSink().getProducerSpec() != null) {
-                    org.apache.pulsar.functions.proto.Function.ProducerSpec conf = this.instanceConfig.getFunctionDetails().getSink().getProducerSpec();
-                    ProducerConfig.ProducerConfigBuilder builder = ProducerConfig.builder()
-                            .maxPendingMessages(conf.getMaxPendingMessages())
-                            .maxPendingMessagesAcrossPartitions(conf.getMaxPendingMessagesAcrossPartitions())
-                            .useThreadLocalProducers(conf.getUseThreadLocalProducers())
-                            .cryptoConfig(CryptoUtils.convertFromSpec(conf.getCryptoSpec()));
-                    pulsarSinkConfig.setProducerConfig(builder.build());
+                    org.apache.pulsar.functions.proto.Function.ProducerSpec spec = this.instanceConfig.getFunctionDetails().getSink().getProducerSpec();
+                    ProducerConfigFromProtobufConverter converter = new ProducerConfigFromProtobufConverter(spec);
+                    ProducerConfig producerConfig = converter.getProducerConfig();
+                    pulsarSinkConfig.setProducerConfig(producerConfig);
                 }
 
                 object = new PulsarSink(this.client, pulsarSinkConfig, this.properties, this.stats, this.functionClassLoader);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.state.BKStateStoreImpl;
 import org.apache.pulsar.functions.instance.state.InstanceStateManager;
+import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.secretsprovider.EnvironmentBasedSecretsProvider;
 import org.slf4j.Logger;
@@ -72,8 +73,21 @@ public class ContextImplTest {
     public void setup() {
         config = new InstanceConfig();
         config.setExposePulsarAdminClientEnabled(true);
+        Function.ProducerSpec producerSpec = Function.ProducerSpec.newBuilder()
+                .setBatchingDisabled(false)
+                .setChunkingEnabled(false)
+                .setBlockIfQueueFullDisabled(false)
+                .setCompressionType(Function.CompressionType.LZ4)
+                .setHashingScheme(Function.HashingScheme.MURMUR3_32HASH)
+                .setMessageRoutingMode(Function.MessageRoutingMode.CUSTOM_PARTITION)
+                .setBatchingMaxPublishDelay(10L)  // This is the default case.
+                .build();
+        Function.SinkSpec sink = Function.SinkSpec.newBuilder()
+                .setProducerSpec(producerSpec)
+                .build();
         FunctionDetails functionDetails = FunctionDetails.newBuilder()
             .setUserConfig("")
+            .setSink(sink)
             .build();
         config.setFunctionDetails(functionDetails);
         logger = mock(Logger.class);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -45,15 +45,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerBuilder;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerBuilder;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 import org.apache.pulsar.client.api.schema.GenericSchema;
@@ -63,6 +55,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees;
+import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.api.SerDe;
@@ -149,6 +142,16 @@ public class PulsarSinkTest {
         pulsarConfig.setTopic(TOPIC);
         pulsarConfig.setSerdeClassName(TopicSchema.DEFAULT_SERDE);
         pulsarConfig.setTypeClassName(String.class.getName());
+        ProducerConfig producerConfig = new ProducerConfig();
+        producerConfig.setBatchingDisabled(false);
+        producerConfig.setChunkingEnabled(false);
+        producerConfig.setBlockIfQueueFullDisabled(true);
+        producerConfig.setCompressionType(CompressionType.SNAPPY);
+        producerConfig.setHashingScheme(HashingScheme.Murmur3_32Hash);
+        producerConfig.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
+        producerConfig.setBatchingMaxPublishDelay(12L);
+
+        pulsarConfig.setProducerConfig(producerConfig);
         return pulsarConfig;
     }
 

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -40,6 +40,25 @@ enum SubscriptionPosition {
     EARLIEST = 1;
 }
 
+enum CompressionType {
+    LZ4 = 0;
+    NONE = 1;
+    ZLIB = 2;
+    ZSTD = 3;
+    SNAPPY = 4;
+}
+
+enum HashingScheme {
+    MURMUR3_32HASH = 0;
+    JAVA_STRING_HASH = 1;
+}
+
+enum MessageRoutingMode {
+    CUSTOM_PARTITION = 0;
+    SINGLE_PARTITION = 1;
+    ROUND_ROBIN_PARTITION = 2;
+}
+
 message Resources {
     double cpu = 1;
     int64 ram = 2;
@@ -110,6 +129,13 @@ message ProducerSpec {
     bool useThreadLocalProducers = 3;
     CryptoSpec cryptoSpec = 4;
     string batchBuilder = 5;
+    bool batchingDisabled = 6;
+    bool chunkingEnabled = 7;
+    bool blockIfQueueFullDisabled = 8;
+    CompressionType compressionType = 9;
+    HashingScheme hashingScheme = 10;
+    MessageRoutingMode messageRoutingMode = 11;
+    int64 batchingMaxPublishDelay = 12;
 }
 
 message CryptoSpec {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -944,6 +944,11 @@ public class FunctionConfigUtils {
         if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
             mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
         }
+        if(existingConfig.getProducerConfig() != null){
+            mergedConfig.setProducerConfig(existingConfig.getProducerConfig().merge(newConfig.getProducerConfig()));
+        } else {
+            mergedConfig.setProducerConfig(newConfig.getProducerConfig());
+        }
         return mergedConfig;
     }
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ProducerConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ProducerConfigUtils.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.utils;
 
 import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.utils.functions.ProducerConfigFromProtobufConverter;
+import org.apache.pulsar.functions.utils.functions.ProducerConfigToProtobufConverter;
 
 public class ProducerConfigUtils {
     public static Function.ProducerSpec convert(ProducerConfig conf) {
@@ -37,7 +39,14 @@ public class ProducerConfigUtils {
         if (conf.getBatchBuilder() != null) {
             pbldr.setBatchBuilder(conf.getBatchBuilder());
         }
-
+        pbldr.setBatchingDisabled(conf.getBatchingDisabled());
+        pbldr.setChunkingEnabled(conf.getChunkingEnabled());
+        pbldr.setBlockIfQueueFullDisabled(conf.getBlockIfQueueFullDisabled());
+        pbldr.setBatchingMaxPublishDelay(conf.getBatchingMaxPublishDelay());
+        ProducerConfigToProtobufConverter converter = new ProducerConfigToProtobufConverter(conf);
+        pbldr.setCompressionType(converter.getCompressionType());
+        pbldr.setHashingScheme(converter.getHashingScheme());
+        pbldr.setMessageRoutingMode(converter.getMessageRoutingMode());
         return pbldr.build();
     }
 
@@ -53,6 +62,23 @@ public class ProducerConfigUtils {
             producerConfig.setBatchBuilder(spec.getBatchBuilder());
         }
         producerConfig.setUseThreadLocalProducers(spec.getUseThreadLocalProducers());
+
+        producerConfig.setBatchingDisabled(spec.getBatchingDisabled());
+        producerConfig.setChunkingEnabled(spec.getChunkingEnabled());
+        producerConfig.setBlockIfQueueFullDisabled(spec.getBlockIfQueueFullDisabled());
+        producerConfig.setBatchingMaxPublishDelay(spec.getBatchingMaxPublishDelay());
+
+        ProducerConfigFromProtobufConverter converter = new ProducerConfigFromProtobufConverter(spec);
+        if (spec.getCompressionType() != null){
+            producerConfig.setCompressionType(converter.getCompressionType());
+        }
+        if (spec.getHashingScheme() != null){
+            producerConfig.setHashingScheme(converter.getHashingScheme());
+        }
+        if (spec.getMessageRoutingMode() != null){
+            producerConfig.setMessageRoutingMode(converter.getMessageRoutingMode());
+        }
+
         return producerConfig;
     }
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/ProducerConfigFromProtobufConverter.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/ProducerConfigFromProtobufConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils.functions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.common.functions.CryptoConfig;
+import org.apache.pulsar.common.functions.ProducerConfig;
+import org.apache.pulsar.functions.proto.Function;
+import org.apache.pulsar.functions.utils.CryptoUtils;
+
+@Getter
+@AllArgsConstructor
+public class ProducerConfigFromProtobufConverter {
+    private Function.ProducerSpec spec;
+
+    public CompressionType getCompressionType() {
+        Function.CompressionType compressionType = spec.getCompressionType();
+        switch (compressionType){
+            case NONE:
+                return CompressionType.NONE;
+            case ZLIB:
+                return CompressionType.ZLIB;
+            case ZSTD:
+                return CompressionType.ZSTD;
+            case SNAPPY:
+                return CompressionType.SNAPPY;
+            case LZ4:
+            default:
+                return CompressionType.LZ4;
+        }
+    }
+    public HashingScheme getHashingScheme() {
+        Function.HashingScheme hashingScheme = spec.getHashingScheme();
+        switch (hashingScheme){
+            case JAVA_STRING_HASH:
+                return HashingScheme.JavaStringHash;
+            case MURMUR3_32HASH:
+            default:
+                return HashingScheme.Murmur3_32Hash;
+        }
+    }
+    public MessageRoutingMode getMessageRoutingMode() {
+        Function.MessageRoutingMode messageRoutingMode = spec.getMessageRoutingMode();
+        switch (messageRoutingMode){
+            case SINGLE_PARTITION:
+                return MessageRoutingMode.SinglePartition;
+            case ROUND_ROBIN_PARTITION:
+                return MessageRoutingMode.RoundRobinPartition;
+            case CUSTOM_PARTITION:
+            default:
+                return MessageRoutingMode.CustomPartition;
+
+        }
+    }
+
+    public boolean getBatchingDisabled(){
+        return spec.getBatchingDisabled();
+    }
+    public boolean getBatchingEnabled(){
+        return !this.getBatchingDisabled();
+    }
+    public boolean getChunkingEnabled(){
+        return spec.getChunkingEnabled();
+    }
+    public boolean getChunkingDisabled(){
+        return !this.getChunkingEnabled();
+    }
+    public boolean getBlockIfQueueFullDisabled(){
+        return spec.getBlockIfQueueFullDisabled();
+    }
+    public boolean getBlockIfQueueFullEnabled(){
+        return !this.getBlockIfQueueFullDisabled();
+    }
+    public long getBatchingMaxPublishDelay(){
+        return spec.getBatchingMaxPublishDelay() == 0L ? 10L : spec.getBatchingMaxPublishDelay();
+    }
+    public int getMaxPendingMessages(){
+        return spec.getMaxPendingMessages();
+    }
+    public int getMaxPendingMessagesAcrossPartitions(){
+        return spec.getMaxPendingMessagesAcrossPartitions();
+    }
+    public boolean getUseThreadLocalProducers(){
+        return spec.getUseThreadLocalProducers();
+    }
+    public CryptoConfig getCryptoConfig(){
+        return CryptoUtils.convertFromSpec(spec.getCryptoSpec());
+    }
+
+
+    public ProducerConfig getProducerConfig(){
+        ProducerConfig.ProducerConfigBuilder builder = ProducerConfig
+                .builder()
+                .batchingDisabled(this.getBatchingDisabled())
+                .chunkingEnabled(this.getChunkingEnabled())
+                .blockIfQueueFullDisabled(this.getBlockIfQueueFullDisabled())
+                .compressionType(this.getCompressionType())
+                .hashingScheme(this.getHashingScheme())
+                .messageRoutingMode(this.getMessageRoutingMode())
+                .batchingMaxPublishDelay(this.getBatchingMaxPublishDelay())
+                .maxPendingMessages(this.getMaxPendingMessages())
+                .maxPendingMessagesAcrossPartitions(this.getMaxPendingMessagesAcrossPartitions())
+                .useThreadLocalProducers(this.getUseThreadLocalProducers())
+                .cryptoConfig(this.getCryptoConfig());
+        return builder.build();
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/ProducerConfigToProtobufConverter.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/ProducerConfigToProtobufConverter.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils.functions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.common.functions.ProducerConfig;
+import org.apache.pulsar.functions.proto.Function;
+
+@Getter
+@AllArgsConstructor
+public class ProducerConfigToProtobufConverter {
+    private ProducerConfig config;
+
+    public Function.CompressionType getCompressionType() {
+        CompressionType compressionType = config.getCompressionType();
+        switch (compressionType){
+            case NONE:
+                return Function.CompressionType.NONE;
+            case ZLIB:
+                return Function.CompressionType.ZLIB;
+            case ZSTD:
+                return Function.CompressionType.ZSTD;
+            case SNAPPY:
+                return Function.CompressionType.SNAPPY;
+            default:
+                return Function.CompressionType.LZ4;
+        }
+    }
+    public Function.HashingScheme getHashingScheme() {
+        HashingScheme hashingScheme = config.getHashingScheme();
+        switch (hashingScheme){
+            case JavaStringHash:
+                return Function.HashingScheme.JAVA_STRING_HASH;
+            default:
+                return Function.HashingScheme.MURMUR3_32HASH;
+        }
+    }
+    public Function.MessageRoutingMode getMessageRoutingMode() {
+        MessageRoutingMode messageRoutingMode = config.getMessageRoutingMode();
+        switch (messageRoutingMode){
+            case SinglePartition:
+                return Function.MessageRoutingMode.SINGLE_PARTITION;
+            case RoundRobinPartition:
+                return Function.MessageRoutingMode.ROUND_ROBIN_PARTITION;
+            default:
+                return Function.MessageRoutingMode.CUSTOM_PARTITION;
+        }
+    }
+    public boolean getBatchingDisabled(){
+        return config.getBatchingDisabled();
+    }
+    public boolean getBatchingEnabled(){
+        return !this.getBatchingDisabled();
+    }
+    public boolean getChunkingDisabled(){
+        return config.getChunkingEnabled();
+    }
+    public boolean getBlockIfQueueFullDisabled(){
+        return config.getBlockIfQueueFullDisabled();
+    }
+    public boolean getBlockIfQueueFullEnabled(){
+        return !this.getBlockIfQueueFullDisabled();
+    }
+    public long getBatchingMaxPublishDelay(){
+        return config.getBatchingMaxPublishDelay();
+    }
+}

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -22,6 +22,9 @@ import com.google.gson.Gson;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.functions.Resources;
@@ -367,6 +370,13 @@ public class SourceConfigUtilsTest extends PowerMockTestCase {
         configs.put("consumerConfigProperties", consumerConfigs);
 
         ProducerConfig producerConfig = new ProducerConfig();
+        producerConfig.setBatchingDisabled(true);
+        producerConfig.setChunkingEnabled(false);
+        producerConfig.setBlockIfQueueFullDisabled(true);
+        producerConfig.setCompressionType(CompressionType.SNAPPY);
+        producerConfig.setHashingScheme(HashingScheme.JavaStringHash);
+        producerConfig.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        producerConfig.setBatchingMaxPublishDelay(12L);
         producerConfig.setMaxPendingMessages(100);
         producerConfig.setMaxPendingMessagesAcrossPartitions(1000);
         producerConfig.setUseThreadLocalProducers(true);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplTest.java
@@ -25,7 +25,11 @@ import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Tenants;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.common.functions.FunctionConfig;
+import org.apache.pulsar.common.functions.ProducerConfig;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.functions.api.Context;
@@ -359,6 +363,17 @@ public class FunctionsImplTest {
         functionConfig.setOutput(outputTopic);
         functionConfig.setOutputSerdeClassName(outputSerdeClassName);
         functionConfig.setRuntime(FunctionConfig.Runtime.JAVA);
+
+        ProducerConfig producerConfig = new ProducerConfig();
+        producerConfig.setBatchingDisabled(false);
+        producerConfig.setChunkingEnabled(false);
+        producerConfig.setBlockIfQueueFullDisabled(false);
+        producerConfig.setCompressionType(CompressionType.SNAPPY);
+        producerConfig.setHashingScheme(HashingScheme.Murmur3_32Hash);
+        producerConfig.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        producerConfig.setBatchingMaxPublishDelay(21L);
+
+        functionConfig.setProducerConfig(producerConfig);
         return functionConfig;
     }
 


### PR DESCRIPTION
Part 1 of [Proposal] PIP 84: Cluster-Wide and Function-Specific Producer Defaults
For details, see the [mailing list discussion](https://lists.apache.org/thread.html/rc58361593fbd20bb6ca714aed0d84ffbaf54c305c0824d3bfed0c8ef%40%3Cdev.pulsar.apache.org%3E)

Fixes #9986

This PR adds these properties to `ProducerConfig`:
```
    public Boolean batchingDisabled;
    public Boolean chunkingEnabled;
    public Boolean blockIfQueueFullDisabled;
    public CompressionType compressionType;
    public HashingScheme hashingScheme;
    public MessageRoutingMode messageRoutingMode;
    public Long batchingMaxPublishDelay;
```

It updates the methods that convert between the `ProducerConfig` and the protobuf `ProducerSpec`. 
It adds logic to use the new function producer settings when they are provided; otherwise, it reverts to the prior behavior. 
It also refactors the `FunctionResultRouter` to prevent a race condition on `isBatchingEnabled`. 

It adds these properties to `ProducerSpec` in `Function.proto`:
```
    bool batchingDisabled = 6;
    bool chunkingEnabled = 7;
    bool blockIfQueueFullDisabled = 8;
    CompressionType compressionType = 9;
    HashingScheme hashingScheme = 10;
    MessageRoutingMode messageRoutingMode = 11;
    int64 batchingMaxPublishDelay = 12;
```

and adds these new enums to Function.proto:

```
enum CompressionType {
    LZ4 = 0;
    NONE = 1;
    ZLIB = 2;
    ZSTD = 3;
    SNAPPY = 4;
}

enum HashingScheme {
    MURMUR3_32HASH = 0;
    JAVA_STRING_HASH = 1;
}

enum MessageRoutingMode {
    CUSTOM_PARTITION = 0;
    SINGLE_PARTITION = 1;
    ROUND_ROBIN_PARTITION = 2;
}
```

The new protobuf files have not yet been generated for Python and Go functions, but those changes are planned in a subsequent PR. 

Existing tests have been updated to include the new properties, and additional tests have been provided to ensure that new configs merge properly into existing configs during function registration/update. 

Changes did not need to be made to the Admin CLI parameters because the Admin CLI already provides a way for the `ProducerConfig` to be provided as a JSON string. 

Docs will be provided in a subsequent PR. 
