### PR TITLE
[Client][Java] Close deadLetterProducer in Java consumer client (prevent potential leak)

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -551,8 +551,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             delayTime = 0;
         }
         if (retryLetterProducer == null) {
+            createProducerLock.writeLock().lock();
             try {
-                createProducerLock.writeLock().lock();
                 if (retryLetterProducer == null) {
                     retryLetterProducer = client.newProducer(schema)
                             .topic(this.deadLetterPolicy.getRetryLetterTopic())
@@ -940,8 +940,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         if (deadLetterProducer != null) {
+            createProducerLock.writeLock().lock();
             try {
-                createProducerLock.writeLock().lock();
                 if (deadLetterProducer != null) {
                     deadLetterProducer.thenApplyAsync(Producer::closeAsync);
                     deadLetterProducer = null;
@@ -1709,8 +1709,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private void initDeadLetterProducerIfNeeded() {
         if (deadLetterProducer == null) {
+            createProducerLock.writeLock().lock();
             try {
-                createProducerLock.writeLock().lock();
                 if (deadLetterProducer == null) {
                     deadLetterProducer = client.newProducer(schema)
                             .topic(this.deadLetterPolicy.getDeadLetterTopic())


### PR DESCRIPTION
While investigating https://github.com/apache/pulsar/issues/9916, I noticed that the `deadLetterProducer` is never closed, which could lead to a leak if enough consumers are configured to deliver DLQ messages.

This change does not fix the issue raised here: https://github.com/apache/pulsar/issues/9916.

### Motivation

The `deadLetterProducer` should be closed when closing consumer tasks.

### Modifications

Added an asynchronous close to the `deadLetterProducer`.

### Alternative Implementations

The close could be synchronous, but the method, `closeConsumerTasks`, is void and contains other methods that asynchronously close resources, so I am matching that pattern. I'm happy to change the implementation if others think we want to enforce some type of ordering.