### PR TITLE
[Issue 10161] Fix missing LoggerFactoryPtr type.

### DIFF
--- a/pulsar-client-cpp/lib/Log4CxxLogger.h
+++ b/pulsar-client-cpp/lib/Log4CxxLogger.h
@@ -28,11 +28,12 @@ namespace pulsar {
 
 class PULSAR_PUBLIC Log4CxxLoggerFactory : public LoggerFactory {
    public:
-    static LoggerFactoryPtr create();
-    static LoggerFactoryPtr create(const std::string& log4cxxConfFile);
+    static std::unique_ptr<LoggerFactory> create();
+    static std::unique_ptr<LoggerFactory> create(const std::string& log4cxxConfFile);
 
     Logger* getLogger(const std::string& fileName);
 };
+
 }  // namespace pulsar
 
 #endif

--- a/pulsar-client-cpp/lib/Log4cxxLogger.cc
+++ b/pulsar-client-cpp/lib/Log4cxxLogger.cc
@@ -62,7 +62,7 @@ class Log4CxxLogger : public Logger {
     }
 };
 
-LoggerFactoryPtr Log4CxxLoggerFactory::create() {
+std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create() {
     if (!LogManager::getLoggerRepository()->isConfigured()) {
         LogManager::getLoggerRepository()->setConfigured(true);
         LoggerPtr root = log4cxx::Logger::getRootLogger();
@@ -73,10 +73,10 @@ LoggerFactoryPtr Log4CxxLoggerFactory::create() {
         root->addAppender(appender);
     }
 
-    return LoggerFactoryPtr(new Log4CxxLoggerFactory());
+    return std::unique_ptr<LoggerFactory>(new Log4CxxLoggerFactory());
 }
 
-LoggerFactoryPtr Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile) {
+std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile) {
     try {
         log4cxx::PropertyConfigurator::configure(log4cxxConfFile);
     } catch (const std::exception &e) {
@@ -87,7 +87,7 @@ LoggerFactoryPtr Log4CxxLoggerFactory::create(const std::string &log4cxxConfFile
                   << std::endl;
     }
 
-    return LoggerFactoryPtr(new Log4CxxLoggerFactory());
+    return std::unique_ptr<LoggerFactory>(new Log4CxxLoggerFactory());
 }
 
 Logger *Log4CxxLoggerFactory::getLogger(const std::string &fileName) { return new Log4CxxLogger(fileName); }


### PR DESCRIPTION
Fixes #10161.

### Motivation

With issue #7132 the LoggerFactoryPtr was removed in favour of relevant memory-safe(r) pointers.

This change forgot to also change the Log4Cxx implementation, fix this by returning (as with
the other LoggerFactory's) a std::unique_ptr<LoggerFactory>.

### Modifications

Change remaining LoggerFactoryPtr in Log4Cxx factory to std::unique_ptr<LoggerFactory> to conform to #7132.

### Verifying this change

  - Visual inspection of changes to comply with the ones from #7132.
  - pulsar-client-cpp builds now with USE_LOG4CXX.