### PR TITLE
Add debug logging when consumer fails to send permits to Broker

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -853,18 +853,19 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Adding {} additional permits", topic, subscription, numMessages);
             }
-
-            cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
-                    .addListener(writeFuture -> {
-                        if (log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
+                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
+                        .addListener(writeFuture -> {
                             if (!writeFuture.isSuccess()) {
                                 log.debug("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
                                         writeFuture.cause().getMessage());
                             } else {
                                 log.debug("Consumer {} sent {} permits to broker", consumerId, numMessages);
                             }
-                        }
-                    });
+                        });
+            } else {
+                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages), cnx.ctx().voidPromise());
+            }
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -854,7 +854,13 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 log.debug("[{}] [{}] Adding {} additional permits", topic, subscription, numMessages);
             }
 
-            cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages), cnx.ctx().voidPromise());
+            cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
+                    .addListener(writeFuture -> {
+                        if (!writeFuture.isSuccess()) {
+                            log.warn("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
+                                    writeFuture.cause().getMessage());
+                        }
+                    });
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -857,8 +857,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
                     .addListener(writeFuture -> {
                         if (!writeFuture.isSuccess()) {
-                            log.warn("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
-                                    writeFuture.cause().getMessage());
+                            if (log.isWarnEnabled()){
+                                log.warn("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
+                                        writeFuture.cause().getMessage());
+                            }
                         }
                     });
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -856,10 +856,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
             cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
                     .addListener(writeFuture -> {
-                        if (!writeFuture.isSuccess()) {
-                            if (log.isDebugEnabled()){
+                        if (log.isDebugEnabled()) {
+                            if (!writeFuture.isSuccess()) {
                                 log.debug("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
                                         writeFuture.cause().getMessage());
+                            } else {
+                                log.debug("Consumer {} sent {} permits to broker", consumerId, numMessages);
                             }
                         }
                     });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -857,8 +857,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
                     .addListener(writeFuture -> {
                         if (!writeFuture.isSuccess()) {
-                            if (log.isWarnEnabled()){
-                                log.warn("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
+                            if (log.isDebugEnabled()){
+                                log.debug("Consumer {} failed to send {} permits to broker: {}", consumerId, numMessages,
                                         writeFuture.cause().getMessage());
                             }
                         }


### PR DESCRIPTION
This PR adds additional logging to help identify/troubleshoot permit issues.
Currently, when the consumer sends its permits to the broker, we zero the client's permits but never check if the broker command (i.e. `Commands.newFlow(consumerId, numMessages)`) was successfully submitted. 
If a communication problem causes the broker to not receive the permits, it's possible for the consumer's permits to get out of sync with the broker. The log statement in this PR will help debugging efforts when permit issues are suspected to be the cause of other problems, such as those documented in Issue #6054 