### PR TITLE
[ISSUE 10174] remove sorted logic for pulsar-function-python

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -80,7 +80,7 @@ class Record(with_metaclass(RecordMeta, object)):
             'fields': []
         }
 
-        for name in sorted(cls._fields.keys()):
+        for name in cls._fields.keys():
             field = cls._fields[name]
             field_type = field.schema() if field._required else ['null', field.schema()]
             schema['fields'].append({

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -38,6 +38,10 @@ class RecordMeta(type):
         return type.__new__(metacls, name, parents, dct)
 
     @classmethod
+    def __prepare__(cls, clsname, bases):
+        return OrderedDict()
+
+    @classmethod
     def _get_fields(cls, dct):
         # Build a set of valid fields for this record
         fields = OrderedDict()


### PR DESCRIPTION
Fixes: #10174

### Motivation
keep the order of the schema field as same as the class declared

### Modifications
prepare OrderedDict and remove sorted logic 