### PR TITLE
Upgrade Jetty libraries to 9.4.39.v20210325

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -428,23 +428,23 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-http-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-io-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-security-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-server-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-util-9.4.35.v20201120.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.35.v20201120.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.35.v20201120.jar
+    - org.eclipse.jetty-jetty-client-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-http-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-io-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-security-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-server-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-util-9.4.39.v20210325.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.39.v20210325.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.39.v20210325.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.3.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.60.Final</netty.version>
     <netty-tc-native.version>2.0.36.Final</netty-tc-native.version>
-    <jetty.version>9.4.35.v20201120</jetty.version>
+    <jetty.version>9.4.39.v20210325</jetty.version>
     <jersey.version>2.31</jersey.version>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -442,13 +442,13 @@ The Apache Software License, Version 2.0
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty
-    - jetty-http-9.4.35.v20201120.jar
-    - jetty-io-9.4.35.v20201120.jar
-    - jetty-security-9.4.35.v20201120.jar
-    - jetty-server-9.4.35.v20201120.jar
-    - jetty-servlet-9.4.35.v20201120.jar
-    - jetty-util-9.4.35.v20201120.jar
-    - jetty-util-ajax-9.4.35.v20201120.jar
+    - jetty-http-9.4.39.v20210325.jar
+    - jetty-io-9.4.39.v20210325.jar
+    - jetty-security-9.4.39.v20210325.jar
+    - jetty-server-9.4.39.v20210325.jar
+    - jetty-servlet-9.4.39.v20210325.jar
+    - jetty-util-9.4.39.v20210325.jar
+    - jetty-util-ajax-9.4.39.v20210325.jar
   * Java Native Access
     - jna-4.2.0.jar
     - jna-5.3.1.jar


### PR DESCRIPTION
The version of Jetty currently used by Pulsar has the following vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2021-28165
This issue has been fixed in version `9.4.39.v20210325`, so upgraded Jetty to that version.