### PR TITLE
[Tests] Unregister JettyStatisticsCollector to fix memory leak in Broker shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -339,6 +339,8 @@ public class PulsarService implements AutoCloseable {
                 }
             }
 
+            metricsServlet = null;
+
             if (this.webSocketService != null) {
                 this.webSocketService.close();
             }


### PR DESCRIPTION
### Motivation

There's a memory leak in tests via Prometheus client default CollectorRegistry. This has an impact in tests when a lot of Pulsar broker instances are created during tests.

### Modifications

- Unregister JettyStatisticsCollector from Prometheus client's default
  Collector registry at shutdown

- Clear metricsServlet reference at shutdown of PulsarService
  - Unrelated to the collector unregister fix. 
  - In tests: helps release the Jetty webserver parts for GC when there are references preventing PulsarService from being GCed.
