### PR TITLE
[Build] Fix warning about parent.relativePath in buildtools/pom.xml

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -26,6 +26,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>23</version>
+    <relativePath></relativePath>
   </parent>
 
   <groupId>org.apache.pulsar</groupId>


### PR DESCRIPTION
### Motivation

The `relativePath` setting is invalid in `buildtools/pom.xml`.

Reproducing the issue:
```
$ cd buildtools
$ mvn verify
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:buildtools:jar:2.8.0-SNAPSHOT
[WARNING] 'parent.relativePath' of POM org.apache.pulsar:buildtools:2.8.0-SNAPSHOT (/home/lari/workspace-pulsar/pulsar/buildtools/pom.xml) points at org.apache.pulsar:pulsar instead of org.apache:apache, please verify your project structure @ line 25, column 11
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
...
```

### Modifications

Set `relativePath` to an empty string. This solution is also recommended in this StackOverflow answer: https://stackoverflow.com/a/6006098 .