### PR TITLE
[Broker] Close namespace clients when PulsarService is closed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -397,7 +397,10 @@ public class PulsarService implements AutoCloseable {
                 client = null;
             }
 
-            nsService = null;
+            if (nsService != null) {
+                nsService.close();
+                nsService = null;
+            }
 
             if (compactorExecutor != null) {
                 compactorExecutor.shutdown();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -114,7 +115,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see org.apache.pulsar.broker.PulsarService
  */
-public class NamespaceService {
+public class NamespaceService implements AutoCloseable {
 
     public enum AddressType {
         BROKER_URL, LOOKUP_URL
@@ -1385,6 +1386,17 @@ public class NamespaceService {
                         ownedBundle.getNamespaceBundle(), ex);
                     pulsar.getShutdownService().shutdown(-1);
                 }
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        namespaceClients.forEach((cluster, client) -> {
+            try {
+                client.shutdown();
+            } catch (PulsarClientException e) {
+                LOG.warn("Error shutting down namespace client for cluster {}", cluster, e);
             }
         });
     }


### PR DESCRIPTION
### Motivation

The broker leaks some PulsarClient instances since the PulsarClient instances created in NamespaceService don't get closed.

### Modifications

Add handling for closing PulsarClient instances created in NamespaceService. A similar logic for closing is used as there is currently for [closing the PulsarClients of replication clients](https://github.com/apache/pulsar/blob/5fcd0d18f8b33474fd8fb5faa3e2330fd88c554a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L680-L686).