### PR TITLE
Fix some ExecutorService leaks

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
@@ -708,6 +709,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         final int Consumers = 5;
 
         List<Future<AtomicBoolean>> futures = Lists.newArrayList();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         final CyclicBarrier barrier = new CyclicBarrier(Consumers + 1);
 
@@ -1727,6 +1729,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         final int Consumers = 10;
 
         List<Future<Void>> futures = Lists.newArrayList();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         final CyclicBarrier barrier = new CyclicBarrier(Consumers + 1);
 
@@ -3465,7 +3468,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
                     } finally {
                         factory2.shutdown();
-                    }   
+                    }
                 });
 
         factory1.shutdown();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -126,7 +126,7 @@ public abstract class BookKeeperClusterTestCase {
         stopBKCluster();
         // stop zookeeper service
         stopZKCluster();
-        executor.shutdown();
+        executor.shutdownNow();
     }
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -119,10 +119,10 @@ public abstract class MockedBookKeeperTestCase {
     @AfterClass(alwaysRun = true)
     public final void tearDownClass() {
         if (executor != null) {
-            executor.shutdown();
+            executor.shutdownNow();
         }
         if (cachedExecutor != null) {
-            cachedExecutor.shutdown();
+            cachedExecutor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/MessagingServiceShutdownHook.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import lombok.Cleanup;
 import org.apache.pulsar.zookeeper.ZooKeeperSessionWatcher.ShutdownService;
 import org.apache.zookeeper.ZooKeeper.States;
 import org.slf4j.ILoggerFactory;
@@ -52,6 +53,7 @@ public class MessagingServiceShutdownHook extends Thread implements ShutdownServ
                     + service.getSafeWebServiceAddress() + ", broker url=" + service.getSafeBrokerServiceUrl());
         }
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("shutdown-thread"));
 
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -436,6 +436,11 @@ public class PulsarService implements AutoCloseable {
                 transactionBufferClient.close();
             }
 
+            if (transactionExecutor != null) {
+                transactionExecutor.shutdown();
+                transactionExecutor = null;
+            }
+
             if (coordinationService != null) {
                 coordinationService.close();
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
@@ -74,6 +74,6 @@ public class MockedBookKeeperClientFactory implements BookKeeperClientFactory {
             mockedBk.close();
         } catch (BKException | InterruptedException ignored) {
         }
-        executor.shutdown();
+        executor.shutdownNow();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -126,7 +126,7 @@ public class SLAMonitoringTest {
     @AfterClass(alwaysRun = true)
     public void shutdown() throws Exception {
         log.info("--- Shutting down ---");
-        executor.shutdown();
+        executor.shutdownNow();
         executor = null;
 
         for (int i = 0; i < BROKER_COUNT; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1346,6 +1346,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             assertEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
         }
 
+        @Cleanup("shutdownNow")
         ExecutorService executorService = Executors.newCachedThreadPool();
 
         try {
@@ -1403,7 +1404,6 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         }
 
         producer.close();
-        executorService.shutdown();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -999,6 +999,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
             assertEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
         }
 
+        @Cleanup("shutdownNow")
         ExecutorService executorService = Executors.newCachedThreadPool();
 
 
@@ -1083,7 +1084,6 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         }
 
         producer.close();
-        executorService.shutdownNow();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/ResourceQuotaCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/ResourceQuotaCacheTest.java
@@ -74,7 +74,7 @@ public class ResourceQuotaCacheTest {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception{
-        executor.shutdown();
+        executor.shutdownNow();
         zkCache.stop();
         zkc.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -151,7 +151,7 @@ public class AntiAffinityNamespaceGroupTest {
 
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
-        executor.shutdown();
+        executor.shutdownNow();
 
         admin1.close();
         admin2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -164,7 +164,7 @@ public class LoadBalancerTest {
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
         log.info("--- Shutting down ---");
-        executor.shutdown();
+        executor.shutdownNow();
 
         for (int i = 0; i < BROKER_COUNT; i++) {
             pulsarAdmins[i].close();
@@ -609,7 +609,7 @@ public class LoadBalancerTest {
     private void createNamespace(PulsarService pulsar, String namespace, int numBundles) throws Exception {
         Policies policies = new Policies();
         policies.bundles = getBundles(numBundles);
-        String zpath = AdminResource.path(POLICIES, namespace);        
+        String zpath = AdminResource.path(POLICIES, namespace);
         pulsar.getPulsarResources().getNamespaceResources().create(zpath, policies);
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -183,7 +183,7 @@ public class ModularLoadManagerImplTest {
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
         log.info("--- Shutting down ---");
-        executor.shutdown();
+        executor.shutdownNow();
 
         admin1.close();
         admin2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -158,7 +158,7 @@ public class SimpleLoadManagerImplTest {
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
         log.info("--- Shutting down ---");
-        executor.shutdown();
+        executor.shutdownNow();
 
         admin1.close();
         admin2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -120,7 +120,7 @@ public class OwnershipCacheTest {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
-        executor.shutdown();
+        executor.shutdownNow();
         zkCache.stop();
         zkc.close();
         otherZkc.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -717,7 +717,7 @@ public class BatchMessageTest extends BrokerTestBase {
         retryStrategically((test) -> dispatcher.getConsumers().get(0).getUnackedMessages() == 0, 50, 150);
         assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 0);
 
-        executor.shutdown();
+        executor.shutdownNow();
         myConsumer.close();
         producer.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -849,6 +849,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             fail(e.getMessage());
         }
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         BrokerService service = spy(pulsar.getBrokerService());
         // create topic will fail to get managedLedgerConfig
@@ -873,8 +874,6 @@ public class BrokerServiceTest extends BrokerTestBase {
             fail("there is a dead-lock and it should have been prevented");
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof NullPointerException);
-        } finally {
-            executor.shutdownNow();
         }
     }
 
@@ -892,6 +891,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             fail(e.getMessage());
         }
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         BrokerService service = spy(pulsar.getBrokerService());
         // create topic will fail to get managedLedgerConfig
@@ -926,7 +926,6 @@ public class BrokerServiceTest extends BrokerTestBase {
         } catch (ExecutionException e) {
             assertEquals(e.getCause().getClass(), PersistenceException.class);
         } finally {
-            executor.shutdownNow();
             ledgers.clear();
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -146,6 +147,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
         }
 
         List<Consumer<byte[]>> successfulConsumers = Collections.synchronizedList(Lists.newArrayList());
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(10);
         final int totalConsumers = 20;
         CountDownLatch latch = new CountDownLatch(totalConsumers);
@@ -170,7 +172,6 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
             }
         }
         pulsarClient.close();
-        executor.shutdown();
         assertNotEquals(successfulConsumers.size(), totalConsumers);
     }
 
@@ -198,6 +199,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
                 .ioThreads(20).connectionsPerBroker(20).build();
         upsertLookupPermits(100);
         List<Consumer<byte[]>> consumers = Collections.synchronizedList(Lists.newArrayList());
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(10);
         final int totalConsumers = 8;
         CountDownLatch latch = new CountDownLatch(totalConsumers);
@@ -231,8 +233,6 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
 
         }
         assertEquals(totalConnectedConsumers, totalConsumers);
-
-        executor.shutdown();
         pulsarClient.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DistributedIdGeneratorTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import lombok.Cleanup;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -82,6 +83,7 @@ public class DistributedIdGeneratorTest {
 
         CyclicBarrier barrier = new CyclicBarrier(Threads);
         CountDownLatch counter = new CountDownLatch(Threads);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         List<String> results = Collections.synchronizedList(Lists.newArrayList());
@@ -112,8 +114,6 @@ public class DistributedIdGeneratorTest {
         // Check the list contains no duplicates
         Set<String> set = Sets.newHashSet(results);
         assertEquals(set.size(), results.size());
-
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -334,6 +334,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final int recvQueueSize = 100;
         final int numConsumersThreads = 10;
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -376,7 +377,6 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // 2. flow control works the same as single consumer single thread
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertEquals(getAvailablePermits(subRef), recvQueueSize);
-        executor.shutdown();
     }
 
     @Test(enabled = false)
@@ -395,6 +395,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
         assertNotNull(topicRef);
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         CountDownLatch latch = new CountDownLatch(1);
         executor.submit(() -> {
@@ -442,8 +443,6 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         consumer.close();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertTrue(subRef.getDispatcher().isConsumerConnected());
-
-        executor.shutdown();
     }
 
     @Test
@@ -1398,7 +1397,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         field.setAccessible(true);
         ScheduledExecutorService statsUpdater = (ScheduledExecutorService) field.get(brokerService);
         // disable statsUpdate to calculate rates explicitly
-        statsUpdater.shutdown();
+        statsUpdater.shutdownNow();
 
         final String namespace = "prop/ns-abc";
         Producer<byte[]> producer = pulsarClient.newProducer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
@@ -906,6 +907,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             }
         }).when(ledgerMock).asyncDeleteCursor(matches(".*success.*"), any(DeleteCursorCallback.class), any());
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         executor.submit(() -> {
@@ -920,7 +922,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);
         }
-        executor.shutdown();
     }
 
     @Test
@@ -1168,6 +1169,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             }
         }).when(ledgerMock).asyncDelete(any(DeleteLedgerCallback.class), any());
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         executor.submit(() -> {
@@ -1205,7 +1207,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             assertTrue(ee.getCause() instanceof BrokerServiceException.TopicFencedException);
             // Expected
         }
-        executor.shutdown();
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -258,6 +258,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         replicationClients.put("r3", pulsarClient);
 
         admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2", "r3"));
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(5);
         for (int i = 0; i < 5; i++) {
             executor.submit(() -> {
@@ -274,8 +275,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 .createProducerAsync(
                         Mockito.any(ProducerConfigurationData.class),
                         Mockito.any(Schema.class), eq(null));
-
-        executor.shutdown();
     }
 
     @DataProvider(name = "namespace")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -245,7 +245,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         markCurrentSetupNumberCleaned();
         log.info("--- Shutting down ---");
         if (executor != null) {
-            executor.shutdown();
+            executor.shutdownNow();
             executor = null;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
@@ -96,7 +96,7 @@ public class ZooKeeperClientAspectJTest {
                 localZkc.close();
             }
 
-            executor.shutdown();
+            executor.shutdownNow();
         }
     }
 
@@ -195,7 +195,7 @@ public class ZooKeeperClientAspectJTest {
                 localZkc.close();
             }
 
-            executor.shutdown();
+            executor.shutdownNow();
         }
     }
 
@@ -282,7 +282,7 @@ public class ZooKeeperClientAspectJTest {
                 localZkc.close();
             }
 
-            executor.shutdown();
+            executor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -191,6 +192,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         //1 start 3 parallel consumers
         List<Consumer<String>> consumers = new ArrayList<>();
         final AtomicInteger totalReceived = new AtomicInteger(0);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(consumerCount);
         for (int i = 0; i < consumerCount; i++) {
             executor.execute(() -> {
@@ -245,7 +247,6 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         assertEquals(totalInDeadLetter, messageCount);
 
         //6 clean up
-        executor.shutdownNow();
         producer.close();
         deadLetterConsumer.close();
         for (Consumer<String> consumer : consumers) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -43,6 +43,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
@@ -683,6 +684,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         double unAckedMessagePercentage = pulsar.getConfiguration()
                 .getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked();
 
+        @Cleanup("shutdownNow")
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
         try {
@@ -863,7 +865,6 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         } finally {
             pulsar.getConfiguration().setMaxUnackedMessagesPerBroker(unAckedMessages);
             pulsar.getConfiguration().setMaxUnackedMessagesPerSubscriptionOnBrokerBlocked(unAckedMessagePercentage);
-            executor.shutdownNow();
         }
     }
 
@@ -885,6 +886,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
 
         log.info("-- Starting {} test --", methodName);
 
+        @Cleanup("shutdownNow")
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
         int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerBroker();
@@ -1032,7 +1034,6 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         } finally {
             pulsar.getConfiguration().setMaxUnackedMessagesPerBroker(unAckedMessages);
             pulsar.getConfiguration().setMaxUnackedMessagesPerSubscriptionOnBrokerBlocked(unAckedMessagePercentage);
-            executor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -347,6 +348,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             stopBroker();
             startBroker();
             // produce message concurrently
+            @Cleanup("shutdownNow")
             ExecutorService executor = Executors.newFixedThreadPool(5);
             AtomicBoolean failed = new AtomicBoolean(false);
             Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("subscriber-1")
@@ -384,7 +386,6 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             // but as message should be dropped at broker: broker should not receive the message
             assertNotEquals(messageSet.size(), totalProduceMessages);
 
-            executor.shutdown();
             producer.close();
         } finally {
             conf.setMaxConcurrentNonPersistentMessagePerConnection(defaultNonPersistentMessageRate);
@@ -849,6 +850,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
                 .enableBatching(false)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .create();
+            @Cleanup("shutdownNow")
             ExecutorService executor = Executors.newFixedThreadPool(5);
             byte[] msgData = "testData".getBytes();
             final int totalProduceMessages = 200;
@@ -876,7 +878,6 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             producer.close();
             consumer.close();
             consumer2.close();
-            executor.shutdown();
         } finally {
             conf.setMaxConcurrentNonPersistentMessagePerConnection(defaultNonPersistentMessageRate);
         }
@@ -1032,7 +1033,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
         void shutdownReplicationCluster() throws Exception {
             log.info("--- Shutting down ---");
-            executor.shutdown();
+            executor.shutdownNow();
 
             admin1.close();
             admin2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -68,7 +68,7 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
-        executor.shutdown();
+        executor.shutdownNow();
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -750,6 +750,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 .topic("persistent://my-property/my-ns/my-topic7").subscriptionName(subName)
                 .startMessageIdInclusive()
                 .receiverQueueSize(recvQueueSize).subscribe();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -837,7 +838,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
         });
         consumer.close();
-        executor.shutdown();
     }
 
     @Test
@@ -1146,6 +1146,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info(" start receiving messages :");
         CountDownLatch latch = new CountDownLatch(totalMsg);
         // receive messages
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(1);
         receiveAsync(consumer, totalMsg, 0, latch, consumeMsgs, executor);
 
@@ -1160,7 +1161,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
-        executor.shutdown();
     }
 
     @Test(timeOut = 5000)
@@ -1185,6 +1185,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info(" start receiving messages :");
         CountDownLatch latch = new CountDownLatch(totalMsg);
         // receive messages
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(1);
         receiveAsync(consumer, totalMsg, 0, latch, consumeMsgs, executor);
 
@@ -1199,7 +1200,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.EntryCacheImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -505,6 +506,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
                 .subscriptionName(subName)
                 .startMessageIdInclusive()
                 .receiverQueueSize(recvQueueSize).subscribe();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -597,8 +599,6 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
                 Assert.assertEquals(consumerImpl.getAvailablePermits(), numConsumersThreads));
         Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
         consumer.close();
-
-        executor.shutdownNow();
     }
 
     @Test
@@ -760,6 +760,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         log.info(" start receiving messages :");
         CountDownLatch latch = new CountDownLatch(totalMsg);
         // receive messages
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(1);
         receiveAsync(consumer, totalMsg, 0, latch, consumeMsgs, executor);
 
@@ -773,7 +774,6 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
         producer.close();
         consumer.close();
-        executor.shutdownNow();
         log.info("-- Exiting {} test --", methodName);
     }
 
@@ -804,6 +804,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         log.info(" start receiving messages :");
         CountDownLatch latch = new CountDownLatch(totalMsg);
         // receive messages
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(1);
         receiveAsync(consumer, totalMsg, 0, latch, consumeMsgs, executor);
 
@@ -817,7 +818,6 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
 
         producer.close();
         consumer.close();
-        executor.shutdownNow();
         log.info("-- Exiting {} test --", methodName);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -535,6 +535,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         final String topicName = "persistent://prop/usw/my-ns/newTopic";
         final int maxConccurentLookupRequest = pulsar.getConfiguration().getMaxConcurrentLookupRequest();
         final int concurrentLookupRequests = 20;
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(concurrentLookupRequests);
         try {
             stopBroker();
@@ -582,7 +583,6 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
             assertEquals(failed.get(), 1);
         } finally {
             conf.setMaxConcurrentLookupRequest(maxConccurentLookupRequest);
-            executor.shutdownNow();
         }
     }
 
@@ -607,6 +607,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         final String topicName = "persistent://prop/usw/my-ns/cocurrentLoadingTopic";
         int concurrentTopic = pulsar.getConfiguration().getMaxConcurrentTopicLoadRequest();
         final int concurrentLookupRequests = 20;
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(concurrentLookupRequests);
 
         try {
@@ -652,7 +653,6 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         } finally {
             // revert back to original value
             pulsar.getConfiguration().setMaxConcurrentTopicLoadRequest(concurrentTopic);
-            executor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -259,47 +260,44 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         final int totalMessages = 25;
         final String topicName = "persistent://my-property/my-ns/maxPending";
         final int totalProducers = 25;
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(totalProducers);
 
-        try {
-            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
-                    .subscriptionName("my-subscriber-name").acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                    .maxPendingChuckedMessage(1).autoAckOldestChunkedMessageOnQueueFull(true)
-                    .ackTimeout(5, TimeUnit.SECONDS).subscribe();
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName("my-subscriber-name").acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                .maxPendingChuckedMessage(1).autoAckOldestChunkedMessageOnQueueFull(true)
+                .ackTimeout(5, TimeUnit.SECONDS).subscribe();
 
-            ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);
 
-            Producer<byte[]>[] producers = new Producer[totalProducers];
-            int totalPublishedMessages = totalProducers;
-            List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
-            for (int i = 0; i < totalProducers; i++) {
-                producers[i] = producerBuilder.enableChunking(true).enableBatching(false).create();
-                int index = i;
-                executor.submit(() -> {
-                    futures.add(producers[index].sendAsync(createMessagePayload(45).getBytes()));
-                });
-            }
-
-            FutureUtil.waitForAll(futures).get();
-            PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
-
-            Message<byte[]> msg = null;
-            Set<String> messageSet = Sets.newHashSet();
-            for (int i = 0; i < totalMessages; i++) {
-                msg = consumer.receive(1, TimeUnit.SECONDS);
-                if (msg == null) {
-                    break;
-                }
-                String receivedMessage = new String(msg.getData());
-                log.info("Received message: [{}]", receivedMessage);
-                messageSet.add(receivedMessage);
-                consumer.acknowledge(msg);
-            }
-
-            assertNotEquals(messageSet.size(), totalPublishedMessages);
-        } finally {
-            executor.shutdown();
+        Producer<byte[]>[] producers = new Producer[totalProducers];
+        int totalPublishedMessages = totalProducers;
+        List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
+        for (int i = 0; i < totalProducers; i++) {
+            producers[i] = producerBuilder.enableChunking(true).enableBatching(false).create();
+            int index = i;
+            executor.submit(() -> {
+                futures.add(producers[index].sendAsync(createMessagePayload(45).getBytes()));
+            });
         }
+
+        FutureUtil.waitForAll(futures).get();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get().get();
+
+        Message<byte[]> msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalMessages; i++) {
+            msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+            String receivedMessage = new String(msg.getData());
+            log.info("Received message: [{}]", receivedMessage);
+            messageSet.add(receivedMessage);
+            consumer.acknowledge(msg);
+        }
+
+        assertNotEquals(messageSet.size(), totalPublishedMessages);
 
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.PublishRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -452,6 +453,7 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         }
 
         List<Callable<Void>> topicRatesCounter = Lists.newArrayListWithExpectedSize(3);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         final AtomicDouble topicsRateIn = new AtomicDouble(0);
         final AtomicInteger index = new AtomicInteger(0);
@@ -529,6 +531,5 @@ public class MessagePublishThrottlingTest extends ProducerConsumerBase {
         assertTrue(rateIn > numMessage * msgBytes);
 
         producer.close();
-        executor.shutdown();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageRedeliveryTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -77,7 +78,7 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
     /**
      * It tests that ManagedCursor tracks individually deleted messages and markDeletePosition correctly with different
      * range-set implementation and re-delivers messages as expected.
-     * 
+     *
      * @param useOpenRangeSet
      * @throws Exception
      */
@@ -87,138 +88,136 @@ public class MessageRedeliveryTest extends ProducerConsumerBase {
         this.conf.setManagedLedgerMaxEntriesPerLedger(5);
         this.conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
         this.conf.setManagedLedgerUnackedRangesOpenCacheSetEnabled(useOpenRangeSet);
+        @Cleanup("shutdownNow")
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(20,
                 new DefaultThreadFactory("pulsar"));
-        try {
-            final String ns1 = "my-property/brok-ns1";
-            final String subName = "my-subscriber-name";
-            final int numMessages = 50;
-            admin.namespaces().createNamespace(ns1, Sets.newHashSet("test"));
+        final String ns1 = "my-property/brok-ns1";
+        final String subName = "my-subscriber-name";
+        final int numMessages = 50;
+        admin.namespaces().createNamespace(ns1, Sets.newHashSet("test"));
 
-            final String topic1 = "persistent://" + ns1 + "/my-topic";
+        final String topic1 = "persistent://" + ns1 + "/my-topic";
 
-            ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic1)
-                    .subscriptionName(subName).subscriptionType(SubscriptionType.Shared).receiverQueueSize(10)
-                    .acknowledgmentGroupTime(0, TimeUnit.MILLISECONDS).subscribe();
-            ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic1)
-                    .subscriptionName(subName).subscriptionType(SubscriptionType.Shared).receiverQueueSize(10)
-                    .acknowledgmentGroupTime(0, TimeUnit.MILLISECONDS).subscribe();
-            ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topic1).create();
+        ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic1)
+                .subscriptionName(subName).subscriptionType(SubscriptionType.Shared).receiverQueueSize(10)
+                .acknowledgmentGroupTime(0, TimeUnit.MILLISECONDS).subscribe();
+        ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic1)
+                .subscriptionName(subName).subscriptionType(SubscriptionType.Shared).receiverQueueSize(10)
+                .acknowledgmentGroupTime(0, TimeUnit.MILLISECONDS).subscribe();
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topic1).create();
 
-            for (int i = 0; i < numMessages; i++) {
-                String message = "my-message-" + i;
-                producer.send(message.getBytes());
+        for (int i = 0; i < numMessages; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        CountDownLatch latch = new CountDownLatch(numMessages);
+        AtomicBoolean consume1 = new AtomicBoolean(true);
+        AtomicBoolean consume2 = new AtomicBoolean(true);
+        Set<String> ackedMessages = Sets.newConcurrentHashSet();
+        AtomicInteger counter = new AtomicInteger(0);
+
+        // (1) ack alternate message from consumer-1 which creates ack-hole.
+        executor.submit(() -> {
+            while (true) {
+                try {
+                    Message<byte[]> msg = consumer1.receive(1000, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        if (counter.getAndIncrement() % 2 == 0) {
+                            try {
+                                consumer1.acknowledge(msg);
+                                // ack alternate messages
+                                ackedMessages.add(new String(msg.getData()));
+                            } catch (PulsarClientException e1) {
+                                log.warn("Failed to ack message {}", e1.getMessage());
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                } catch (PulsarClientException e2) {
+                    // Ok
+                    break;
+                }
+                latch.countDown();
+            }
+        });
+
+        // (2) ack all the consumed messages from consumer-2
+        executor.submit(() -> {
+            while (consume2.get()) {
+                try {
+                    Message<byte[]> msg = consumer2.receive(1000, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        consumer2.acknowledge(msg);
+                        // ack alternate messages
+                        ackedMessages.add(new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                } catch (PulsarClientException e2) {
+                    // Ok
+                    break;
+                }
+                latch.countDown();
+            }
+        });
+
+        latch.await(10000, TimeUnit.MILLISECONDS);
+        consume1.set(false);
+
+        // (3) sleep so, consumer2 should timeout on it's pending read operation and not consume more messages
+        Thread.sleep(1000);
+
+        // (4) here we consume all messages but consumer1 only acked alternate messages.
+        assertNotEquals(ackedMessages.size(), numMessages);
+
+        PersistentTopic pTopic = (PersistentTopic) this.pulsar.getBrokerService().getTopicIfExists(topic1).get()
+                .get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) pTopic.getManagedLedger();
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().iterator().next();
+
+        // (5) now, close consumer1 and let broker deliver consumer1's unack messages to consumer2
+        consumer1.close();
+
+        // (6) broker should redeliver all unack messages of consumer-1 and consumer-2 should ack all of them
+        CountDownLatch latch2 = new CountDownLatch(1);
+        executor.submit(() -> {
+            while (true) {
+                try {
+                    Message<byte[]> msg = consumer2.receive(1000, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        consumer2.acknowledge(msg);
+                        // ack alternate messages
+                        ackedMessages.add(new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                } catch (PulsarClientException e2) {
+                    // Ok
+                    break;
+                }
+                if (ackedMessages.size() == numMessages)
+                    latch2.countDown();
             }
 
-            CountDownLatch latch = new CountDownLatch(numMessages);
-            AtomicBoolean consume1 = new AtomicBoolean(true);
-            AtomicBoolean consume2 = new AtomicBoolean(true);
-            Set<String> ackedMessages = Sets.newConcurrentHashSet();
-            AtomicInteger counter = new AtomicInteger(0);
+        });
 
-            // (1) ack alternate message from consumer-1 which creates ack-hole.
-            executor.submit(() -> {
-                while (true) {
-                    try {
-                        Message<byte[]> msg = consumer1.receive(1000, TimeUnit.MILLISECONDS);
-                        if (msg != null) {
-                            if (counter.getAndIncrement() % 2 == 0) {
-                                try {
-                                    consumer1.acknowledge(msg);
-                                    // ack alternate messages
-                                    ackedMessages.add(new String(msg.getData()));
-                                } catch (PulsarClientException e1) {
-                                    log.warn("Failed to ack message {}", e1.getMessage());
-                                }
-                            }
-                        } else {
-                            break;
-                        }
-                    } catch (PulsarClientException e2) {
-                        // Ok
-                        break;
-                    }
-                    latch.countDown();
-                }
-            });
+        latch2.await(20000, TimeUnit.MILLISECONDS);
 
-            // (2) ack all the consumed messages from consumer-2
-            executor.submit(() -> {
-                while (consume2.get()) {
-                    try {
-                        Message<byte[]> msg = consumer2.receive(1000, TimeUnit.MILLISECONDS);
-                        if (msg != null) {
-                            consumer2.acknowledge(msg);
-                            // ack alternate messages
-                            ackedMessages.add(new String(msg.getData()));
-                        } else {
-                            break;
-                        }
-                    } catch (PulsarClientException e2) {
-                        // Ok
-                        break;
-                    }
-                    latch.countDown();
-                }
-            });
+        consumer2.close();
 
-            latch.await(10000, TimeUnit.MILLISECONDS);
-            consume1.set(false);
+        assertEquals(ackedMessages.size(), numMessages);
 
-            // (3) sleep so, consumer2 should timeout on it's pending read operation and not consume more messages
-            Thread.sleep(1000);
+        // (7) acked message set should be empty
+        assertEquals(cursor.getIndividuallyDeletedMessagesSet().size(), 0);
 
-            // (4) here we consume all messages but consumer1 only acked alternate messages.
-            assertNotEquals(ackedMessages.size(), numMessages);
+        // markDelete position should be one position behind read position
+        assertEquals(cursor.getReadPosition(), cursor.getMarkDeletedPosition().getNext());
 
-            PersistentTopic pTopic = (PersistentTopic) this.pulsar.getBrokerService().getTopicIfExists(topic1).get()
-                    .get();
-            ManagedLedgerImpl ml = (ManagedLedgerImpl) pTopic.getManagedLedger();
-            ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().iterator().next();
+        producer.close();
+        consumer2.close();
 
-            // (5) now, close consumer1 and let broker deliver consumer1's unack messages to consumer2
-            consumer1.close();
-
-            // (6) broker should redeliver all unack messages of consumer-1 and consumer-2 should ack all of them
-            CountDownLatch latch2 = new CountDownLatch(1);
-            executor.submit(() -> {
-                while (true) {
-                    try {
-                        Message<byte[]> msg = consumer2.receive(1000, TimeUnit.MILLISECONDS);
-                        if (msg != null) {
-                            consumer2.acknowledge(msg);
-                            // ack alternate messages
-                            ackedMessages.add(new String(msg.getData()));
-                        } else {
-                            break;
-                        }
-                    } catch (PulsarClientException e2) {
-                        // Ok
-                        break;
-                    }
-                    if (ackedMessages.size() == numMessages)
-                        latch2.countDown();
-                }
-
-            });
-
-            latch2.await(20000, TimeUnit.MILLISECONDS);
-
-            consumer2.close();
-
-            assertEquals(ackedMessages.size(), numMessages);
-
-            // (7) acked message set should be empty
-            assertEquals(cursor.getIndividuallyDeletedMessagesSet().size(), 0);
-
-            // markDelete position should be one position behind read position
-            assertEquals(cursor.getReadPosition(), cursor.getMarkDeletedPosition().getNext());
-
-            producer.close();
-            consumer2.close();
-        } finally {
-            executor.shutdown();
-        }
 
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.netty.util.Timeout;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -283,6 +284,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         log.info("start async consume");
         CountDownLatch latch = new CountDownLatch(totalMessages);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(1);
         executor.execute(() -> IntStream.range(0, totalMessages).forEach(index ->
             consumer.receiveAsync()
@@ -310,7 +312,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         producer1.close();
         producer2.close();
         producer3.close();
-        executor.shutdownNow();
     }
 
     @Test(timeOut = testTimeout)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -69,7 +70,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "broker-io")
 public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
-	
+
     protected static FunctionConfig createFunctionConfig(String tenant, String namespace, String functionName, String sourceTopic, String sinkTopic, String subscriptionName) {
         String sourceTopicPattern = String.format("persistent://%s/%s/%s", tenant, namespace, sourceTopic);
 
@@ -209,6 +210,7 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
             expected.put(key, value);
         }
         // 3 Trigger compaction
+        @Cleanup("shutdownNow")
         ScheduledExecutorService compactionScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("compactor").setDaemon(true).build());
         TwoPhaseCompactor twoPhaseCompactor = new TwoPhaseCompactor(config,
@@ -243,7 +245,6 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
         Assert.assertEquals(count, maxKeys);
         Assert.assertTrue(expected.isEmpty());
 
-        compactionScheduler.shutdownNow();
         consumer.close();
         producer.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -90,6 +90,7 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
             expected.put(key, value);
         }
         // 3 Trigger compaction
+        @Cleanup("shutdownNow")
         ScheduledExecutorService compactionScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("compactor").setDaemon(true).build());
         TwoPhaseCompactor twoPhaseCompactor = new TwoPhaseCompactor(config,
@@ -117,7 +118,6 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
             }
         }, 50, 1000);
 
-        compactionScheduler.shutdownNow();
         producer.close();
     }
 
@@ -448,5 +448,5 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
         sinkConfig.setCleanupSubscription(true);
         return sinkConfig;
     }
-    
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -39,6 +39,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
@@ -94,6 +95,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
+        @Cleanup("shutdownNow")
         ExecutorService executor = newFixedThreadPool(1);
         try {
             executor.submit(() -> {
@@ -108,7 +110,6 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         } catch (Exception e) {
             log.error("failed to close clients ", e);
         }
-        executor.shutdownNow();
 
         super.internalCleanup();
         if (service != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -50,6 +50,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
@@ -825,6 +826,7 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
     }
 
     private void stopWebSocketClient(WebSocketClient... clients) {
+        @Cleanup("shutdownNow")
         ExecutorService executor = newFixedThreadPool(1);
         try {
             executor.submit(() -> {
@@ -840,7 +842,6 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
         } catch (Exception e) {
             log.error("failed to close proxy clients", e);
         }
-        executor.shutdownNow();
     }
 
     private static final Logger log = LoggerFactory.getLogger(ProxyPublishConsumeTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.TlsProducerConsumerBase;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.util.SecurityUtility;
@@ -133,6 +134,7 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
             log.error(t.getMessage());
             Assert.fail(t.getMessage());
         } finally {
+            @Cleanup("shutdownNow")
             ExecutorService executor = newFixedThreadPool(1);
             try {
                 executor.submit(() -> {
@@ -147,7 +149,6 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
             } catch (Exception e) {
                 log.error("failed to close clients ", e);
             }
-            executor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeWithoutZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeWithoutZKTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
@@ -114,6 +115,7 @@ public class ProxyPublishConsumeWithoutZKTest extends ProducerConsumerBase {
             Assert.assertTrue(produceSocket.getBuffer().size() > 0);
             Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
         } finally {
+            @Cleanup("shutdownNow")
             ExecutorService executor = newFixedThreadPool(1);
             try {
                 executor.submit(() -> {
@@ -128,7 +130,6 @@ public class ProxyPublishConsumeWithoutZKTest extends ProducerConsumerBase {
             } catch (Exception e) {
                 log.error("failed to close clients ", e);
             }
-            executor.shutdownNow();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1_ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1_ProxyAuthenticationTest.java
@@ -39,6 +39,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.v1.V1_ProducerConsumerBase;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
@@ -96,6 +97,7 @@ public class V1_ProxyAuthenticationTest extends V1_ProducerConsumerBase {
 
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
+        @Cleanup("shutdownNow")
         ExecutorService executor = newFixedThreadPool(1);
         try {
             executor.submit(() -> {
@@ -110,7 +112,6 @@ public class V1_ProxyAuthenticationTest extends V1_ProducerConsumerBase {
         } catch (Exception e) {
             log.error("failed to close clients ", e);
         }
-        executor.shutdownNow();
 
         super.internalCleanup();
         if (service != null) {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -102,6 +103,7 @@ public class IOUtilsTest {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baos));
             System.setIn(new ByteArrayInputStream(data.getBytes()));
+            @Cleanup("shutdownNow")
             ExecutorService executor = Executors.newSingleThreadExecutor();
             @SuppressWarnings("unchecked")
             Future<Void> future = (Future<Void>) executor.submit(() -> {
@@ -128,6 +130,7 @@ public class IOUtilsTest {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baos));
             System.setIn(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
+            @Cleanup("shutdownNow")
             ExecutorService executor = Executors.newSingleThreadExecutor();
             @SuppressWarnings("unchecked")
             Future<Void> future = (Future<Void>) executor.submit(() -> {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -68,6 +69,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
 
         int numberOfMessages = 10;
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
 
         CompletableFuture<Void> future = new CompletableFuture<Void>();
@@ -103,7 +105,6 @@ public class PulsarClientToolTest extends BrokerTestBase {
         Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
 
         future.get();
-        executor.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -116,6 +117,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         final String topicName = "persistent://prop/ns-abc/test/topic-" + UUID.randomUUID().toString();
 
         int numberOfMessages = 10;
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         CompletableFuture<Void> future = new CompletableFuture<>();
         executor.execute(() -> {
@@ -147,7 +149,6 @@ public class PulsarClientToolTest extends BrokerTestBase {
         Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
         Assert.assertFalse(future.isCompletedExceptionally());
         future.get();
-        executor.shutdown();
 
         while (true) {
             try {
@@ -171,6 +172,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         final String topicName = "persistent://prop/ns-abc/test/topic-" + UUID.randomUUID().toString();
 
         int numberOfMessages = 10;
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         CompletableFuture<Void> future = new CompletableFuture<>();
         executor.execute(() -> {
@@ -204,7 +206,6 @@ public class PulsarClientToolTest extends BrokerTestBase {
         Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
         Assert.assertFalse(future.isCompletedExceptionally());
         future.get();
-        executor.shutdown();
         //wait for close
         Thread.sleep(2000);
         List<String> subscriptions = admin.topics().getSubscriptions(topicName);
@@ -222,6 +223,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         final String keyUriBase = "file:../pulsar-broker/src/test/resources/certificate/";
         final int numberOfMessages = 10;
 
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
         CompletableFuture<Void> future = new CompletableFuture<>();
         executor.execute(() -> {
@@ -257,8 +259,6 @@ public class PulsarClientToolTest extends BrokerTestBase {
             Assert.assertFalse(future.isCompletedExceptionally());
         } catch (Exception e) {
             Assert.fail("consumer was unable to decrypt messages", e);
-        } finally {
-            executor.shutdown();
         }
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.cli;
 
 import java.time.Duration;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.websocket.service.ProxyServer;
@@ -61,35 +62,37 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
         final String topicName = "persistent://my-property/my-ns/test/topic-" + UUID.randomUUID();
 
         int numberOfMessages = 10;
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        executor.execute(() -> {
-            try {
-                PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
-                String[] args = {"consume", "-t", "Exclusive", "-s", "sub-name", "-n",
-                        Integer.toString(numberOfMessages), "--hex", "-m", "NonDurable", "-r", "30", topicName};
-                Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
-                future.complete(null);
-            } catch (Throwable t) {
-                future.completeExceptionally(t);
-            }
-        });
+        {
+            @Cleanup("shutdown")
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            executor.execute(() -> {
+                try {
+                    PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
+                    String[] args = {"consume", "-t", "Exclusive", "-s", "sub-name", "-n",
+                            Integer.toString(numberOfMessages), "--hex", "-m", "NonDurable", "-r", "30", topicName};
+                    Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
+                    future.complete(null);
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
 
-        // Make sure subscription has been created
-        Awaitility.await()
-                .pollInterval(Duration.ofMillis(200))
-                .ignoreExceptions().untilAsserted(() -> {
-            Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
-        });
+            // Make sure subscription has been created
+            Awaitility.await()
+                    .pollInterval(Duration.ofMillis(200))
+                    .ignoreExceptions().untilAsserted(() -> {
+                Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+            });
 
-        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+            PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
 
-        String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
-                "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
-        Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
-        future.get();
-        Assert.assertFalse(future.isCompletedExceptionally());
-        executor.shutdown();
+            String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
+                    "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
+            Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
+            future.get();
+            Assert.assertFalse(future.isCompletedExceptionally());
+        }
 
         Awaitility.await()
                 .ignoreExceptions().untilAsserted(() -> {
@@ -106,35 +109,37 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
         final String topicName = "persistent://my-property/my-ns/test/topic-" + UUID.randomUUID();
 
         int numberOfMessages = 10;
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        executor.execute(() -> {
-            try {
-                PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
-                String[] args = {"consume", "-t", "Exclusive", "-s", "sub-name", "-n",
-                        Integer.toString(numberOfMessages), "--hex", "-m", "Durable", "-r", "30", topicName};
-                Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
-                future.complete(null);
-            } catch (Throwable t) {
-                future.completeExceptionally(t);
-            }
-        });
+        {
+            @Cleanup("shutdown")
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            executor.execute(() -> {
+                try {
+                    PulsarClientTool pulsarClientToolConsumer = new PulsarClientTool(properties);
+                    String[] args = {"consume", "-t", "Exclusive", "-s", "sub-name", "-n",
+                            Integer.toString(numberOfMessages), "--hex", "-m", "Durable", "-r", "30", topicName};
+                    Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
+                    future.complete(null);
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
 
-        // Make sure subscription has been created
-        Awaitility.await()
-                .pollInterval(Duration.ofMillis(200))
-                .ignoreExceptions().untilAsserted(() -> {
-            Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
-        });
+            // Make sure subscription has been created
+            Awaitility.await()
+                    .pollInterval(Duration.ofMillis(200))
+                    .ignoreExceptions().untilAsserted(() -> {
+                Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+            });
 
-        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+            PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
 
-        String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
-                "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
-        Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
-        future.get();
-        Assert.assertFalse(future.isCompletedExceptionally());
-        executor.shutdown();
+            String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
+                    "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
+            Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
+            future.get();
+            Assert.assertFalse(future.isCompletedExceptionally());
+        }
 
         //wait for close
         Thread.sleep(2000);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
+import lombok.Cleanup;
 import org.testng.annotations.Test;
 
 public class FutureUtilTest {
@@ -50,6 +51,7 @@ public class FutureUtilTest {
     @Test
     public void testTimeoutHandling() {
         CompletableFuture<Void> future = new CompletableFuture<>();
+        @Cleanup("shutdownNow")
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
         Exception e = new Exception();
         try {
@@ -60,26 +62,22 @@ public class FutureUtilTest {
             fail("Shouldn't occur");
         } catch (ExecutionException executionException) {
             assertEquals(executionException.getCause(), e);
-        } finally {
-            executor.shutdownNow();
         }
     }
 
     @Test
     public void testTimeoutHandlingNoTimeout() throws ExecutionException, InterruptedException {
         CompletableFuture<Void> future = new CompletableFuture<>();
+        @Cleanup("shutdownNow")
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
-        try {
-            FutureUtil.addTimeoutHandling(future, Duration.ofMillis(100), executor, () -> new Exception());
-            future.complete(null);
-            future.get();
-        } finally {
-            executor.shutdownNow();
-        }
+        FutureUtil.addTimeoutHandling(future, Duration.ofMillis(100), executor, () -> new Exception());
+        future.complete(null);
+        future.get();
     }
 
     @Test
     public void testCreatingFutureWithTimeoutHandling() {
+        @Cleanup("shutdownNow")
         ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
         Exception e = new Exception();
         try {
@@ -91,8 +89,6 @@ public class FutureUtilTest {
             fail("Shouldn't occur");
         } catch (ExecutionException executionException) {
             assertEquals(executionException.getCause(), e);
-        } finally {
-            executor.shutdownNow();
         }
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongFunction;
 
+import lombok.Cleanup;
 import org.testng.annotations.Test;
 
 public class ConcurrentLongHashMapTest {
@@ -167,6 +168,7 @@ public class ConcurrentLongHashMapTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -195,13 +197,12 @@ public class ConcurrentLongHashMapTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
         ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -230,13 +231,12 @@ public class ConcurrentLongHashMapTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void stressConcurrentInsertionsAndReads() throws Throwable {
         ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(4, 1);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         final int writeThreads = 16;
         final int readThreads = 16;
@@ -282,7 +282,6 @@ public class ConcurrentLongHashMapTest {
             future.get();
         }
         assertEquals(map.size(), n * writeThreads);
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSetTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import lombok.Cleanup;
 import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet.LongPair;
 import org.testng.annotations.Test;
 
@@ -177,6 +178,7 @@ public class ConcurrentLongPairSetTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         ConcurrentLongPairSet set = new ConcurrentLongPairSet();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -204,13 +206,12 @@ public class ConcurrentLongPairSetTest {
         }
 
         assertEquals(set.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
         ConcurrentLongPairSet map = new ConcurrentLongPairSet();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -238,8 +239,6 @@ public class ConcurrentLongPairSetTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
@@ -394,7 +393,7 @@ public class ConcurrentLongPairSetTest {
         assertFalse(set.contains(t1, t1));
         assertFalse(set.contains(t1_b, t1_b));
     }
-    
+
     @Test
     public void testToString() {
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import lombok.Cleanup;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
@@ -153,6 +154,7 @@ public class ConcurrentOpenHashMapTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         ConcurrentOpenHashMap<Long, String> map = new ConcurrentOpenHashMap<>(16, 1);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -181,13 +183,12 @@ public class ConcurrentOpenHashMapTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
         ConcurrentOpenHashMap<Long, String> map = new ConcurrentOpenHashMap<>();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -216,8 +217,6 @@ public class ConcurrentOpenHashMapTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import lombok.Cleanup;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
@@ -145,6 +146,7 @@ public class ConcurrentOpenHashSetTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         ConcurrentOpenHashSet<Long> set = new ConcurrentOpenHashSet<>();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -172,13 +174,12 @@ public class ConcurrentOpenHashSetTest {
         }
 
         assertEquals(set.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
         ConcurrentOpenHashSet<Long> map = new ConcurrentOpenHashSet<>();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -206,8 +207,6 @@ public class ConcurrentOpenHashSetTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentSortedLongPairSetTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import lombok.Cleanup;
 import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet.LongPair;
 import org.testng.annotations.Test;
 
@@ -83,6 +84,7 @@ public class ConcurrentSortedLongPairSetTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         LongPairSet set = new ConcurrentSortedLongPairSet(16);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 8;
@@ -110,8 +112,6 @@ public class ConcurrentSortedLongPairSetTest {
         }
 
         assertEquals(set.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueueTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import lombok.Cleanup;
 import org.apache.pulsar.common.util.collections.GrowablePriorityLongPairQueue.LongPair;
 import org.testng.annotations.Test;
 
@@ -162,6 +163,7 @@ public class GrowablePriorityLongPairQueueTest {
     @Test
     public void concurrentInsertions() throws Throwable {
         GrowablePriorityLongPairQueue queue = new GrowablePriorityLongPairQueue();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -189,13 +191,12 @@ public class GrowablePriorityLongPairQueueTest {
         }
 
         assertEquals(queue.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test
     public void concurrentInsertionsAndReads() throws Throwable {
         GrowablePriorityLongPairQueue map = new GrowablePriorityLongPairQueue();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final int nThreads = 16;
@@ -223,8 +224,6 @@ public class GrowablePriorityLongPairQueueTest {
         }
 
         assertEquals(map.size(), N * nThreads);
-
-        executor.shutdown();
     }
 
     @Test

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.instance;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import lombok.AccessLevel;
@@ -46,7 +47,7 @@ public class JavaInstance implements AutoCloseable {
 
     // for Async function max out standing items
     private final InstanceConfig instanceConfig;
-    private final Executor executor;
+    private final ExecutorService executor;
     @Getter
     private final LinkedBlockingQueue<CompletableFuture<Void>> pendingAsyncRequests;
 
@@ -127,6 +128,7 @@ public class JavaInstance implements AutoCloseable {
     @Override
     public void close() {
         context.close();
+        executor.shutdown();
     }
 
     public Map<String, Double> getAndResetMetrics() {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.functions.api.Function;
@@ -57,6 +58,7 @@ public class JavaInstanceTest {
     @Test
     public void testAsyncFunction() throws Exception {
         InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         Function<String, CompletableFuture<String>> function = (input, context) -> {
@@ -83,7 +85,6 @@ public class JavaInstanceTest {
         assertNotNull(result.get().getResult());
         assertEquals(new String(testString + "-lambda"), result.get().getResult());
         instance.close();
-        executor.shutdownNow();
     }
 
     @Test
@@ -91,6 +92,7 @@ public class JavaInstanceTest {
         InstanceConfig instanceConfig = new InstanceConfig();
         int pendingQueueSize = 3;
         instanceConfig.setMaxPendingAsyncRequests(pendingQueueSize);
+        @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
 
         Function<String, CompletableFuture<String>> function = (input, context) -> {
@@ -134,6 +136,5 @@ public class JavaInstanceTest {
 
         log.info("start:{} end:{} during:{}", startTime, endTime, endTime - startTime);
         instance.close();
-        executor.shutdownNow();
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -49,8 +49,6 @@ public class Worker {
 
     private ZooKeeperClientFactory zkClientFactory = null;
     private final OrderedExecutor orderedExecutor = OrderedExecutor.newBuilder().numThreads(8).name("zk-cache-ordered").build();
-    private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(10,
-            new DefaultThreadFactory("zk-cache-callback"));
     private PulsarResources pulsarResources;
     private MetadataStoreExtended configMetadataStore;
     private ConfigurationMetadataCacheService configurationCacheService;
@@ -68,7 +66,7 @@ public class Worker {
         server = new WorkerServer(workerService, getAuthenticationService());
         server.start();
         log.info("/** Started worker server on port={} **/", this.workerConfig.getWorkerPort());
-        
+
         try {
             errorNotifier.waitForError();
         } catch (Throwable th) {
@@ -126,6 +124,10 @@ public class Worker {
             } catch (Exception e) {
                 log.warn("Failed to close global zk cache ", e);
             }
+        }
+
+        if (orderedExecutor != null) {
+            orderedExecutor.shutdownNow();
         }
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -139,7 +139,7 @@ public class SchedulerManagerTest {
 
     @AfterMethod(alwaysRun = true)
     public void stop() {
-        this.executor.shutdown();
+        this.executor.shutdownNow();
     }
 
     @Test
@@ -153,7 +153,7 @@ public class SchedulerManagerTest {
                 .build();
         functionMetaDataList.add(function1);
         doReturn(functionMetaDataList).when(functionMetaDataManager).getAllFunctionMetaData();
-        
+
         ThreadRuntimeFactory factory = mock(ThreadRuntimeFactory.class);
         doReturn(factory).when(functionRuntimeManager).getRuntimeFactory();
 

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -118,7 +118,7 @@ public abstract class BookKeeperClusterTestCase {
         stopBKCluster();
         // stop zookeeper service
         stopZKCluster();
-        executor.shutdown();
+        executor.shutdownNow();
     }
 
     /**

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -107,8 +107,8 @@ public abstract class MockedBookKeeperTestCase {
 
     @AfterClass(alwaysRun = true)
     public void tearDownClass() {
-        executor.shutdown();
-        cachedExecutor.shutdown();
+        executor.shutdownNow();
+        cachedExecutor.shutdownNow();
     }
 
     /**

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
@@ -107,8 +107,8 @@ public abstract class MockedBookKeeperTestCase {
 
     @AfterClass(alwaysRun = true)
     public void tearDownClass() {
-        executor.shutdown();
-        cachedExecutor.shutdown();
+        executor.shutdownNow();
+        cachedExecutor.shutdownNow();
     }
 
     /**

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperBkClientFactoryImplTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperBkClientFactoryImplTest.java
@@ -51,7 +51,7 @@ public class ZookeeperBkClientFactoryImplTest {
     @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
         localZkS.close();
-        executor.shutdown();
+        executor.shutdownNow();
     }
 
     @Test

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.zookeeper.AsyncCallback.DataCallback;
@@ -92,8 +93,8 @@ public class ZookeeperCacheTest {
 
     @AfterClass(alwaysRun = true)
     void classTeardown() throws Exception {
-        executor.shutdown();
-        scheduledExecutor.shutdown();
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
     }
 
 
@@ -411,8 +412,11 @@ public class ZookeeperCacheTest {
      */
     @Test(timeOut = 2000)
     public void testZkCallbackThreadStuck() throws Exception {
+        @Cleanup("shutdownNow")
         OrderedScheduler executor = OrderedScheduler.newSchedulerBuilder().build();
+        @Cleanup("shutdownNow")
         ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+        @Cleanup("shutdownNow")
         ExecutorService zkExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mockZk"));
         // add readOpDelayMs so, main thread will not serve zkCacahe-returned future and let zkExecutor-thread handle
         // callback-result process
@@ -445,9 +449,6 @@ public class ZookeeperCacheTest {
         });
 
         latch.await();
-        executor.shutdown();
-        zkExecutor.shutdown();
-        scheduledExecutor.shutdown();
     }
 
     /**
@@ -461,6 +462,7 @@ public class ZookeeperCacheTest {
      */
     @Test(timeOut = 10000)
     public void testInvalidateCacheOnFailure() throws Exception {
+        @Cleanup("shutdownNow")
         ExecutorService zkExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mockZk"));
         // add readOpDelayMs so, main thread will not serve zkCacahe-returned future and let zkExecutor-thread handle
         // callback-result process
@@ -515,7 +517,6 @@ public class ZookeeperCacheTest {
         Thread.sleep(1000);
         // (6) now, cache should be invalidate failed-future and should refetch the data
         assertEquals(zkCache.getAsync(key1).get().get(), value);
-        zkExecutor.shutdown();
     }
 
     /**
@@ -526,9 +527,11 @@ public class ZookeeperCacheTest {
      */
     @Test
     public void testTimedOutZKCacheRequestInvalidates() throws Exception {
-
+        @Cleanup("shutdownNow")
         OrderedScheduler executor = OrderedScheduler.newSchedulerBuilder().build();
+        @Cleanup("shutdownNow")
         ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+        @Cleanup("shutdownNow")
         ExecutorService zkExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mockZk"));
         MockZooKeeper zkSession = spy(MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService()));
 
@@ -558,22 +561,21 @@ public class ZookeeperCacheTest {
         }, 5, 1000);
 
         assertNull(zkCacheService.dataCache.getIfPresent(path));
-
-        executor.shutdown();
-        zkExecutor.shutdown();
-        scheduledExecutor.shutdown();
     }
 
     /**
      * Test to verify {@link ZooKeeperCache} renews cache data after expiry time in background.
-     * 
+     *
      * @throws Exception
      */
     @Test
     public void testZKRefreshExpiredEntry() throws Exception {
         int cacheExpiryTimeSec = 1;
+        @Cleanup("shutdownNow")
         OrderedScheduler executor = OrderedScheduler.newSchedulerBuilder().build();
+        @Cleanup("shutdownNow")
         ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+        @Cleanup("shutdownNow")
         ExecutorService zkExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mockZk"));
 
         String path = "/test";
@@ -606,10 +608,6 @@ public class ZookeeperCacheTest {
         }, 5, 1000);
 
         assertEquals(zkCache.get(path).get(), val2);
-
-        executor.shutdown();
-        zkExecutor.shutdown();
-        scheduledExecutor.shutdown();
     }
 
     static class ZooKeeperCacheTest extends ZooKeeperCache {


### PR DESCRIPTION
### Motivation

Some tests don't close all ExecutorServices created in tests. There were also a few issues in production code where ExecutorServices weren't closed.

### Modifications

- consistently close ExecutorServices created in tests
- prefer the usage of Lombok's `@Cleanup("shutdownNow")` for calling the `.shutdownNow()` method.
- In tests, use `shutdownNow()` instead of `shutdown()` so that executors are closed asap instead of waiting for in-progress tasks to complete.