### PR TITLE
[PIP-82] [pulsar-broker] incorporate review feedback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone.version>2.5.1</errorprone.version>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
-    <lightproto-maven-plugin.version>0.2</lightproto-maven-plugin.version>
+    <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -688,12 +688,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String resourceUsageTransportClassName = "";
 
     @FieldContext(
-            category = CATEGORY_POLICIES,
-            doc = "Topic to publish usage reports to if resourceUsagePublishToTopic is enabled."
-    )
-    private String resourceUsageTransportPublishTopicName = "non-persistent://pulsar/system/resource-usage";
-
-    @FieldContext(
             dynamic = true,
             category = CATEGORY_POLICIES,
             doc = "Default interval to publish usage reports if resourceUsagePublishToTopic is enabled."

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -491,6 +491,8 @@
         <version>${lightproto-maven-plugin.version}</version>
         <configuration>
           <sources>${project.basedir}/src/main/proto/ResourceUsage.proto</sources>
+          <targetSourcesSubDir>generated-sources/lightproto/java</targetSourcesSubDir>
+          <targetTestSourcesSubDir>generated-sources/lightproto/java</targetTestSourcesSubDir>
         </configuration>
         <executions>
           <execution>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -329,6 +329,11 @@ public class PulsarService implements AutoCloseable {
             }
 
             // close the service in reverse order v.s. in which they are started
+            if (this.resourceUsageTransportManager != null) {
+                this.resourceUsageTransportManager.close();
+                this.resourceUsageTransportManager = null;
+            }
+
             if (this.webService != null) {
                 try {
                     this.webService.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTransportManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTransportManagerTest.java
@@ -34,7 +34,6 @@ import static org.testng.Assert.assertNotNull;
 
 public class ResourceUsageTransportManagerTest extends MockedPulsarServiceBaseTest {
 
-    private static final String INTERNAL_TOPIC = "non-persistent://pulsar-test/test/resource-usage";
     private static final int PUBLISH_INTERVAL_SECS = 1;
 
     @BeforeClass
@@ -53,11 +52,10 @@ public class ResourceUsageTransportManagerTest extends MockedPulsarServiceBaseTe
     @Test
     public void testNamespaceCreation() throws Exception {
         ResourceUsageTransportManager tManager = new ResourceUsageTransportManager(pulsar);
-        TopicName topicName = TopicName.get(INTERNAL_TOPIC);
+        TopicName topicName = TopicName.get(ResourceUsageTransportManager.RESOURCE_USAGE_TOPIC_NAME);
 
         assertTrue(admin.tenants().getTenants().contains(topicName.getTenant()));
         assertTrue(admin.namespaces().getNamespaces(topicName.getTenant()).contains(topicName.getNamespace()));
-
     }
     
     @Test
@@ -116,7 +114,6 @@ public class ResourceUsageTransportManagerTest extends MockedPulsarServiceBaseTe
 
     private void prepareData() throws PulsarAdminException {
         this.conf.setResourceUsageTransportClassName("org.apache.pulsar.broker.resourcegroup.ResourceUsageTransportManager");
-        this.conf.setResourceUsageTransportPublishTopicName(INTERNAL_TOPIC);
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
         admin.clusters().createCluster("test", new ClusterData(pulsar.getBrokerServiceUrl()));
     }


### PR DESCRIPTION
### Motivation

Follow up and incorporate the review feedback.

### Modifications

- Have lightproto generate sources to a different directory so it doesn't come in the way of protobuf generated sources.
- make resourceUsageTransportPublishTopicName internal(remove from config)
- drop old/stale resource-usage messages
- fix a race condition in creating tenant/namespace for resource-usage when multiple brokers attempt to do it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.