### PR TITLE
Fix test retries for shade and backwards compat tests

### DIFF
--- a/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -41,6 +41,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup(){
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -77,6 +78,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 

--- a/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_0_1/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -41,6 +41,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup(){
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -77,6 +78,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 

--- a/tests/bc_2_6_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/bc_2_6_0/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -41,6 +41,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup(){
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -77,6 +78,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 

--- a/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -69,6 +69,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
+        incrementSetupNumber();
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
         pulsarContainer = new PulsarContainer();
@@ -89,6 +90,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         if (pulsarClient != null) {
             pulsarClient.close();
             pulsarClient = null;

--- a/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -45,6 +45,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup() {
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -90,6 +91,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 

--- a/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -65,6 +65,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
+        incrementSetupNumber();
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
@@ -84,6 +85,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         if (pulsarClient != null) {
             pulsarClient.close();
             pulsarClient = null;

--- a/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -45,6 +45,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup(){
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -90,6 +91,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 

--- a/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -69,6 +69,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
+        incrementSetupNumber();
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
@@ -88,6 +89,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         if (pulsarClient != null) {
             pulsarClient.close();
             pulsarClient = null;

--- a/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -41,6 +41,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @BeforeClass(alwaysRun = true)
     public final void setup(){
+        incrementSetupNumber();
         pulsarContainer = new PulsarContainer();
         pulsarContainer.start();
     }
@@ -77,6 +78,7 @@ public class SmokeTest extends TestRetrySupport {
     @Override
     @AfterClass(alwaysRun = true)
     public final void cleanup(){
+        markCurrentSetupNumberCleaned();
         pulsarContainer.stop();
     }
 


### PR DESCRIPTION
### Motivation

Test retries were added in PR #10191 for integration tests, shade tests and backwards compat tests. There was some relevant code missing for handling retries in shade and backwards compat tests.

### Modifications

- add `TestRetrySupport.incrementSetupNumber()` and `TestRetrySupport.markCurrentSetupNumberCleaned()` calls to tests so that the state tracking in org.apache.pulsar.tests.TestRetrySupport will be able to detect retries and call `cleanup` and `setup` before a retry.
