### PR TITLE
[Tests] Fix TCP port conflicts in tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance;
 import com.google.common.collect.Sets;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +49,7 @@ public class LeaderElectionServiceTest {
 
     private LocalBookkeeperEnsemble bkEnsemble;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
@@ -62,48 +63,61 @@ public class LeaderElectionServiceTest {
     }
 
     @Test
-    public void anErrorShouldBeThrowBeforeLeaderElected() throws PulsarServerException, PulsarClientException, PulsarAdminException {
+    public void anErrorShouldBeThrowBeforeLeaderElected() throws PulsarServerException, PulsarClientException,
+            PulsarAdminException {
         final String clusterName = "elect-test";
         ServiceConfiguration config = new ServiceConfiguration();
-        config.setBrokerServicePort(Optional.of(6650));
-        config.setWebServicePort(Optional.of(8080));
+        config.setBrokerServicePort(Optional.of(0));
+        config.setWebServicePort(Optional.of(0));
         config.setClusterName(clusterName);
         config.setAdvertisedAddress("localhost");
         config.setZookeeperServers("127.0.0.1" + ":" + bkEnsemble.getZookeeperPort());
+        @Cleanup
         PulsarService pulsar = Mockito.spy(new MockPulsarService(config));
         pulsar.start();
 
+        // mock pulsar.getLeaderElectionService() in a thread safe way
+        AtomicReference<LeaderElectionService> leaderElectionServiceReference = new AtomicReference<>();
+        Mockito.doAnswer(invocation -> leaderElectionServiceReference.get())
+                .when(pulsar).getLeaderElectionService();
+
         // broker and webService is started, but leaderElectionService not ready
-        Mockito.doReturn(null).when(pulsar).getLeaderElectionService();
         final String tenant = "elect";
         final String namespace = "ns";
-        PulsarAdmin adminClient = PulsarAdmin.builder().serviceHttpUrl("http://localhost:8080").build();
-        adminClient.clusters().createCluster(clusterName, new ClusterData("http://localhost:8080"));
-        adminClient.tenants().createTenant(tenant, new TenantInfo(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(clusterName)));
+        @Cleanup
+        PulsarAdmin adminClient = PulsarAdmin.builder().serviceHttpUrl(pulsar.getWebServiceAddress()).build();
+        adminClient.clusters().createCluster(clusterName, new ClusterData(pulsar.getWebServiceAddress()));
+        adminClient.tenants().createTenant(tenant, new TenantInfo(Sets.newHashSet("appid1", "appid2"),
+                Sets.newHashSet(clusterName)));
         adminClient.namespaces().createNamespace(tenant + "/" + namespace, 16);
         @Cleanup
         PulsarClient client = PulsarClient.builder()
-                .serviceUrl("pulsar://localhost:6650")
+                .serviceUrl(pulsar.getBrokerServiceUrl())
                 .startingBackoffInterval(1, TimeUnit.MILLISECONDS)
                 .maxBackoffInterval(100, TimeUnit.MILLISECONDS)
                 .operationTimeout(1000, TimeUnit.MILLISECONDS)
                 .build();
         checkLookupException(tenant, namespace, client);
 
-        // broker, webService and leaderElectionService is started, but elect not ready;
+        // setup LeaderElectionService mock in a thread safe way
         LeaderElectionService leaderElectionService = Mockito.mock(LeaderElectionService.class);
-        Mockito.doReturn(leaderElectionService).when(pulsar).getLeaderElectionService();
+        AtomicReference<LeaderBroker> leaderBrokerReference = new AtomicReference<>();
+        Mockito.when(leaderElectionService.isLeader()).thenAnswer(invocation ->
+                leaderBrokerReference.get() != null);
+        Mockito.when(leaderElectionService.getCurrentLeader())
+                .thenAnswer(invocation -> Optional.ofNullable(leaderBrokerReference.get()));
+        leaderElectionServiceReference.set(leaderElectionService);
+
+        // broker, webService and leaderElectionService is started, but elect not ready;
         checkLookupException(tenant, namespace, client);
 
         // broker, webService and leaderElectionService is started, and elect is done;
-        Mockito.when(leaderElectionService.isLeader()).thenReturn(true);
-        Mockito.when(leaderElectionService.getCurrentLeader()).thenReturn(Optional.of(new LeaderBroker("http://localhost:8080")));
+        leaderBrokerReference.set(new LeaderBroker(pulsar.getWebServiceAddress()));
 
         Producer<byte[]> producer = client.newProducer()
                 .topic("persistent://" + tenant + "/" + namespace + "/1p")
                 .create();
         producer.getTopic();
-
     }
 
     private void checkLookupException(String tenant, String namespace, PulsarClient client) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -94,7 +94,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         clientBuilder.listenerName("internal");
     }
 
-    @Test(groups = "quarantine")
+    @Test
     public void testFindBrokerWithListenerName() throws Throwable {
         admin.clusters().createCluster("localhost", new ClusterData(pulsar.getWebServiceAddress()));
         TenantInfo tenantInfo = new TenantInfo();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithoutInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithoutInternalListenerNameTest.java
@@ -18,92 +18,13 @@
  */
 package org.apache.pulsar.client.api;
 
-import com.google.common.collect.Sets;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.client.impl.BinaryProtoLookupService;
-import org.apache.pulsar.client.impl.LookupService;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
 @Test(groups = "broker-api")
-public class PulsarMultiListenersWithoutInternalListenerNameTest extends MockedPulsarServiceBaseTest {
+public class PulsarMultiListenersWithoutInternalListenerNameTest extends
+        PulsarMultiListenersWithInternalListenerNameTest {
 
-    private ExecutorService executorService;
-    //
-    private LookupService lookupService;
-    //
-    private String host;
-
-    @BeforeMethod(alwaysRun = true)
-    @Override
-    protected void setup() throws Exception {
-        this.executorService = Executors.newFixedThreadPool(1);
-        this.isTcpLookup = true;
-        super.internalSetup();
+    public PulsarMultiListenersWithoutInternalListenerNameTest() {
+        super(false);
     }
-
-    protected void doInitConf() throws Exception {
-        this.host = InetAddress.getLocalHost().getHostAddress();
-        super.doInitConf();
-        this.conf.setClusterName("localhost");
-        this.conf.setAdvertisedAddress(null);
-        this.conf.setAdvertisedListeners(String.format("internal:pulsar://%s:6650,internal:pulsar+ssl://%s:6651", host, host));
-    }
-
-    @Override
-    protected void customizeNewPulsarClientBuilder(ClientBuilder clientBuilder) {
-        clientBuilder.listenerName("internal");
-    }
-
-    @Test(groups = "quarantine")
-    public void testFindBrokerWithListenerName() throws Throwable {
-        admin.clusters().createCluster("localhost", new ClusterData(pulsar.getWebServiceAddress()));
-        TenantInfo tenantInfo = new TenantInfo();
-        tenantInfo.setAllowedClusters(Sets.newHashSet("localhost"));
-        this.admin.tenants().createTenant("public", tenantInfo);
-        this.admin.namespaces().createNamespace("public/default");
-        this.lookupService = new BinaryProtoLookupService((PulsarClientImpl) this.pulsarClient, lookupUrl.toString(),
-                "internal", false, this.executorService);
-        // test request 1
-        {
-            CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> future = lookupService.getBroker(TopicName.get("persistent://public/default/test"));
-            Pair<InetSocketAddress, InetSocketAddress> result = future.get(10, TimeUnit.SECONDS);
-            Assert.assertEquals(result.getKey().toString(), String.format("%s:6650", this.host));
-            Assert.assertEquals(result.getValue().toString(), String.format("%s:6650", this.host));
-        }
-        // test request 2
-        {
-            CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> future = lookupService.getBroker(TopicName.get("persistent://public/default/test"));
-            Pair<InetSocketAddress, InetSocketAddress> result = future.get(10, TimeUnit.SECONDS);
-            Assert.assertEquals(result.getKey().toString(), String.format("%s:6650", this.host));
-            Assert.assertEquals(result.getValue().toString(), String.format("%s:6650", this.host));
-        }
-    }
-
-    @AfterMethod(alwaysRun = true)
-    @Override
-    protected void cleanup() throws Exception {
-        if (this.lookupService != null) {
-            this.lookupService.close();
-        }
-        if (this.executorService != null) {
-            this.executorService.shutdown();
-        }
-        super.internalCleanup();
-    }
-
 }


### PR DESCRIPTION
### Motivation

There are some tests that fail because of port conflicts. Fixed ports 6650, 6651 and 8080 get used in a few tests.

### Modifications

- Change the tests to use dynamic ports.
- While making changes to LeaderElectionServiceTest, make it thread safe
  - It's not thread safe to modify Mockito mocks after they have been published to another thread. Change the logic to use AtomicBoolean and AtomicReference classes to achieve the desired result. 
- While making changes to PulsarMultiListenersWith*InternalListenerNameTests, make PulsarMultiListenersWithoutInternalListenerNameTest class extend PulsarMultiListenersWithInternalListenerNameTest class to reduce test code duplication.