### PR TITLE
[Issue 10046] Update chuckedMessageRate to chunkedMessageRate without breaking public api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -81,7 +81,7 @@ public class Consumer {
 
     private long lastConsumedTimestamp;
     private long lastAckedTimestamp;
-    private Rate chuckedMessageRate;
+    private Rate chunkedMessageRate;
 
     // Represents how many messages we can safely send to the consumer without
     // overflowing its receiving queue. The consumer will use Flow commands to
@@ -142,7 +142,7 @@ public class Consumer {
         this.keySharedMeta = keySharedMeta;
         this.cnx = cnx;
         this.msgOut = new Rate();
-        this.chuckedMessageRate = new Rate();
+        this.chunkedMessageRate = new Rate();
         this.msgRedeliver = new Rate();
         this.bytesOutCounter = new LongAdder();
         this.msgOutCounter = new LongAdder();
@@ -250,7 +250,7 @@ public class Consumer {
         msgOut.recordMultipleEvents(totalMessages, totalBytes);
         msgOutCounter.add(totalMessages);
         bytesOutCounter.add(totalBytes);
-        chuckedMessageRate.recordMultipleEvents(totalChunkedMessages, 0);
+        chunkedMessageRate.recordMultipleEvents(totalChunkedMessages, 0);
 
 
         return cnx.getCommandSender().sendMessagesToConsumer(consumerId, topicName, subscription, partitionIdx,
@@ -570,12 +570,13 @@ public class Consumer {
 
     public void updateRates() {
         msgOut.calculateRate();
-        chuckedMessageRate.calculateRate();
+        chunkedMessageRate.calculateRate();
         msgRedeliver.calculateRate();
         stats.msgRateOut = msgOut.getRate();
         stats.msgThroughputOut = msgOut.getValueRate();
         stats.msgRateRedeliver = msgRedeliver.getRate();
-        stats.chuckedMessageRate = chuckedMessageRate.getRate();
+        stats.chuckedMessageRate = chunkedMessageRate.getRate();
+        stats.chunkedMessageRate = chunkedMessageRate.getRate();
     }
 
     public void updateStats(ConsumerStats consumerStats) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -66,7 +66,7 @@ public class Producer {
     private final long producerId;
     private final String appId;
     private Rate msgIn;
-    private Rate chuckedMessageRate;
+    private Rate chunkedMessageRate;
     // it records msg-drop rate only for non-persistent topic
     private final Rate msgDrop;
 
@@ -104,7 +104,7 @@ public class Producer {
         this.closeFuture = new CompletableFuture<>();
         this.appId = appId;
         this.msgIn = new Rate();
-        this.chuckedMessageRate = new Rate();
+        this.chunkedMessageRate = new Rate();
         this.isNonPersistentTopic = topic instanceof NonPersistentTopic;
         this.msgDrop = this.isNonPersistentTopic ? new Rate() : null;
 
@@ -422,7 +422,7 @@ public class Producer {
                     ledgerId, entryId);
             producer.cnx.completedSendOperation(producer.isNonPersistentTopic, msgSize);
             if (this.chunked) {
-                producer.chuckedMessageRate.recordEvent();
+                producer.chunkedMessageRate.recordEvent();
             }
             producer.publishOperationCompleted();
             recycle();
@@ -570,12 +570,12 @@ public class Producer {
 
     public void updateRates() {
         msgIn.calculateRate();
-        chuckedMessageRate.calculateRate();
+        chunkedMessageRate.calculateRate();
         stats.msgRateIn = msgIn.getRate();
         stats.msgThroughputIn = msgIn.getValueRate();
         stats.averageMsgSize = msgIn.getAverageValue();
-        stats.chunkedMessageRate = chuckedMessageRate.getRate();
-        if (chuckedMessageRate.getCount() > 0 && this.topic instanceof PersistentTopic) {
+        stats.chunkedMessageRate = chunkedMessageRate.getRate();
+        if (chunkedMessageRate.getCount() > 0 && this.topic instanceof PersistentTopic) {
             ((PersistentTopic) this.topic).msgChunkPublished = true;
         }
         if (this.isNonPersistentTopic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -940,6 +940,7 @@ public class PersistentSubscription implements Subscription {
                 subStats.msgOutCounter += consumerStats.msgOutCounter;
                 subStats.msgRateRedeliver += consumerStats.msgRateRedeliver;
                 subStats.chuckedMessageRate += consumerStats.chuckedMessageRate;
+                subStats.chunkedMessageRate += consumerStats.chunkedMessageRate;
                 subStats.unackedMessages += consumerStats.unackedMessages;
                 subStats.lastConsumedTimestamp =
                         Math.max(subStats.lastConsumedTimestamp, consumerStats.lastConsumedTimestamp);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -265,7 +265,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
 
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                 .subscriptionName("my-subscriber-name").acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                .maxPendingChuckedMessage(1).autoAckOldestChunkedMessageOnQueueFull(true)
+                .maxPendingChunkedMessage(1).autoAckOldestChunkedMessageOnQueueFull(true)
                 .ackTimeout(5, TimeUnit.SECONDS).subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topicName);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -681,12 +681,37 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *
      * @param maxPendingChuckedMessage
      * @return
+     * @deprecated use {@link #maxPendingChunkedMessage(int)}
      */
+    @Deprecated
     ConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage);
 
     /**
+     * Consumer buffers chunk messages into memory until it receives all the chunks of the original message. While
+     * consuming chunk-messages, chunks from same message might not be contiguous in the stream and they might be mixed
+     * with other messages' chunks. so, consumer has to maintain multiple buffers to manage chunks coming from different
+     * messages. This mainly happens when multiple publishers are publishing messages on the topic concurrently or
+     * publisher failed to publish all chunks of the messages.
+     *
+     * <pre>
+     * eg: M1-C1, M2-C1, M1-C2, M2-C2
+     * Here, Messages M1-C1 and M1-C2 belong to original message M1, M2-C1 and M2-C2 messages belong to M2 message.
+     * </pre>
      * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
-     * guarded by providing this @maxPendingChuckedMessage threshold. Once, consumer reaches this threshold, it drops
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once, consumer reaches this threshold, it drops
+     * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
+     * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
+     *
+     * @default 100
+     *
+     * @param maxPendingChunkedMessage
+     * @return
+     */
+    ConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage);
+
+    /**
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once, consumer reaches this threshold, it drops
      * the outstanding unchunked-messages by silently acking if autoAckOldestChunkedMessageOnQueueFull is true else it
      * marks them for redelivery.
      *

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -335,7 +335,7 @@ public interface ProducerBuilder<T> extends Cloneable {
      * so, consumer will not be able to consume and ack those messages. So, those messages can
      * be only discared by msg ttl) Or configure
      * {@link ConsumerBuilder#expireTimeOfIncompleteChunkedMessage()}
-     * 5. Consumer configuration: consumer should also configure receiverQueueSize and maxPendingChuckedMessage
+     * 5. Consumer configuration: consumer should also configure receiverQueueSize and maxPendingChunkedMessage
      * </pre>
      * @param enableChunking
      * @return

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -108,7 +108,7 @@ public class CmdConsume {
     private int receiverQueueSize = 0;
 
     @Parameter(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
-    private int maxPendingChuckedMessage = 0;
+    private int maxPendingChunkedMessage = 0;
 
     @Parameter(names = { "-ac",
             "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
@@ -251,8 +251,8 @@ public class CmdConsume {
                 builder.topic(topic);
             }
 
-            if (this.maxPendingChuckedMessage > 0) {
-                builder.maxPendingChuckedMessage(this.maxPendingChuckedMessage);
+            if (this.maxPendingChunkedMessage > 0) {
+                builder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
             }
             if (this.receiverQueueSize > 0) {
                 builder.receiverQueueSize(this.receiverQueueSize);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -300,7 +300,13 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage) {
-        conf.setMaxPendingChuckedMessage(maxPendingChuckedMessage);
+        conf.setMaxPendingChunkedMessage(maxPendingChuckedMessage);
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage) {
+        conf.setMaxPendingChunkedMessage(maxPendingChunkedMessage);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -246,7 +246,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.negativeAcksTracker = new NegativeAcksTracker(this, conf);
         this.resetIncludeHead = conf.isResetIncludeHead();
         this.createTopicIfDoesNotExist = createTopicIfDoesNotExist;
-        this.maxPendingChunkedMessage = conf.getMaxPendingChuckedMessage();
+        this.maxPendingChunkedMessage = conf.getMaxPendingChunkedMessage();
         this.pendingChunkedMessageUuidQueue = new GrowableArrayBlockingQueue<>();
         this.expireTimeOfIncompleteChunkedMessageMillis = conf.getExpireTimeOfIncompleteChunkedMessageMillis();
         this.autoAckOldestChunkedMessageOnQueueFull = conf.isAutoAckOldestChunkedMessageOnQueueFull();
@@ -1145,7 +1145,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             log.debug("Chunked message completed chunkId {}, total-chunks {}, msgId {} sequenceId {}",
                     msgMetadata.getChunkId(), msgMetadata.getNumChunksFromMsg(), msgId, msgMetadata.getSequenceId());
         }
-        // remove buffer from the map, add chucked messageId to unack-message tracker, and reduce pending-chunked-message count
+        // remove buffer from the map, add chunked messageId to unack-message tracker, and reduce pending-chunked-message count
         chunkedMessagesMap.remove(msgMetadata.getUuid());
         unAckedChunkedMessageIdSequenceMap.put(msgId, chunkedMsgCtx.chunkedMessageIds);
         pendingChunkedMessageCount--;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -85,8 +85,24 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private int priorityLevel = 0;
 
-    // max pending chunked message to avoid sitting incomplete message into the queue and memory
-    private int maxPendingChuckedMessage = 10;
+    /**
+     * @deprecated use {@link #setMaxPendingChunkedMessage(int)}
+     */
+    @Deprecated
+    public void setMaxPendingChuckedMessage(int maxPendingChuckedMessage) {
+        this.maxPendingChunkedMessage = maxPendingChuckedMessage;
+    }
+
+    /**
+     * @deprecated use {@link #getMaxPendingChunkedMessage()}
+     */
+    @Deprecated
+    public int getMaxPendingChuckedMessage() {
+        return maxPendingChunkedMessage;
+    }
+
+    // max pending chunked message to avoid sending incomplete message into the queue and memory
+    private int maxPendingChunkedMessage = 10;
 
     private boolean autoAckOldestChunkedMessageOnQueueFull = false;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -41,8 +41,15 @@ public class ConsumerStats {
     /** Total rate of messages redelivered by this consumer (msg/s). */
     public double msgRateRedeliver;
 
-    /** Total chunked messages dispatched. */
+    /**
+     * Total chunked messages dispatched.
+     * @deprecated use {@link chunkedMessageRate)}
+     */
+    @Deprecated
     public double chuckedMessageRate;
+
+    /** Total chunked messages dispatched. */
+    public double chunkedMessageRate;
 
     /** Name of the consumer. */
     public String consumerName;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -44,8 +44,15 @@ public class SubscriptionStats {
     /** Total rate of messages redelivered on this subscription (msg/s). */
     public double msgRateRedeliver;
 
-    /** Chunked message dispatch rate. */
+    /**
+     * Chunked message dispatch rate.
+     * @deprecated use {@link chunkedMessageRate)}
+     */
+    @Deprecated
     public int chuckedMessageRate;
+
+    /** Chunked message dispatch rate. */
+    public int chunkedMessageRate;
 
     /** Number of messages in the subscription backlog. */
     public long msgBacklog;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -128,7 +128,7 @@ public class PerformanceConsumer {
         String listenerName = null;
 
         @Parameter(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
-        private int maxPendingChuckedMessage = 0;
+        private int maxPendingChunkedMessage = 0;
 
         @Parameter(names = { "-ac",
                 "--auto_ack_chunk_q_full" }, description = "Auto ack for oldest message on queue is full")
@@ -328,8 +328,8 @@ public class PerformanceConsumer {
                 .autoAckOldestChunkedMessageOnQueueFull(arguments.autoAckOldestChunkedMessageOnQueueFull)
                 .enableBatchIndexAcknowledgment(arguments.batchIndexAck)
                 .replicateSubscriptionState(arguments.replicatedSubscription);
-        if (arguments.maxPendingChuckedMessage > 0) {
-            consumerBuilder.maxPendingChuckedMessage(arguments.maxPendingChuckedMessage);
+        if (arguments.maxPendingChunkedMessage > 0) {
+            consumerBuilder.maxPendingChunkedMessage(arguments.maxPendingChunkedMessage);
         }
         if (arguments.expireTimeOfIncompleteChunkedMessageMs > 0) {
             consumerBuilder.expireTimeOfIncompleteChunkedMessage(arguments.expireTimeOfIncompleteChunkedMessageMs,

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1019,6 +1019,8 @@ admin.topics().getList(namespace);
 
 You can check the current statistics of a given partitioned topic. The following is an example. For description of each stats, refer to [get stats](#get-stats).
 
+Note that in the subscription JSON object, `chuckedMessageRate` is deprecated. Please use `chunkedMessageRate`. Both will be sent in the JSON for now.
+
 ```json
 {
   "msgRateIn" : 999.992947159793,
@@ -1048,6 +1050,7 @@ You can check the current statistics of a given partitioned topic. The following
       "msgOutCounter" : 0,
       "msgRateRedeliver" : 0.0,
       "chuckedMessageRate" : 0,
+      "chunkedMessageRate" : 0,
       "msgBacklog" : 144318,
       "msgBacklogNoDelayed" : 144318,
       "blockedSubscriptionOnUnackedMsgs" : false,

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -103,7 +103,7 @@ When chunking is enabled (`chunkingEnabled=true`), if the message size is greate
 
 The consumer consumes the chunked messages and buffers them until the consumer receives all the chunks of a message. And then the consumer stitches chunked messages together and places them into the receiver-queue. Clients consume messages from the receiver-queue. Once the consumer consumes the entire large message and acknowledges it, the consumer internally sends acknowledgement of all the chunk messages associated to that large message. You can set the `maxPendingChuckedMessage` parameter on the consumer. When the threshold is reached, the consumer drops the unchunked messages by silently acknowledging them or asking the broker to redeliver them later by marking them unacknowledged.
 
- The broker does not require any changes to support chunking for non-shared subscription. The broker only uses `chuckedMessageRate` to record chunked message rate on the topic.
+The broker does not require any changes to support chunking for non-shared subscription. The broker only uses `chunkedMessageRate` to record chunked message rate on the topic.
 
 #### Handle chunked messages with one producer and one ordered consumer
 


### PR DESCRIPTION
Fixes #10046  

### Motivation

As described in #10046, there is a typo where `chuck` is used instead of `chunk` in several locations, including in the public API. This PR fixes that typo without introducing any breaking changes. Instead, it adds some new methods while deprecating ones that contain typos.

### Modifications

1. Update several internal pulsar references. Given that these are private, there is no need to worry about breaking changes.
2. Update `ConsumerBuilder` interface by first deprecating the `maxPendingChuckedMessage` method and adding the `maxPendingChunkedMessage` method. We'll need to choose when to actually remove the deprecated method.
3. Update `SubscriptionStats` to return both `chuckedMessageRate` and `chunkedMessageRate`. Given that this POJO is sent as JSON, the only way to give users the chance to transition is to deliver both fields.
4. Update `ConsumerStats` to return both `chuckedMessageRate` and `chunkedMessageRate`. Given that this POJO is sent as JSON, the only way to give users the chance to transition is to deliver both fields.
5. Update `ConsumerConfigurationData` by changing the private variable from `maxPendingChuckedMessage` to `maxPendingChunkedMessage`. Then, add the previously generated getter and setter for `maxPendingChuckedMessage` that actually update `maxPendingChunkedMessage`.

### Verifying this change

I updated several tests but didn't add any. I'm not sure what the protocol is for these types of changes. The public API is not changing, and in the case of deprecated methods, any affected tests are updated to use the new methods.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes 
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

The changes to the public API are only additive.

### Documentation

There is updated documentation associated with this change. If we want to merge this change to the 2.7 branch, we'll want to update that documentation as well.