### PR TITLE
[CI] Add current ip address, long hostname and short hostname to /etc/hosts

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -17,33 +17,15 @@
 # under the License.
 #
 
-name: Pulsar Bot
-on:
-  issue_comment:
-    types: [created]
-  pull_request:
-    types: [closed]
-
-env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-
-jobs:
-
-  action-runner:
-    name:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: Tune Runner VM
-        uses: ./.github/actions/tune-runner-vm
-
-      - name: Execute pulsarbot command
-        id:   pulsarbot
-        if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/pulsarbot')
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
-        uses: apache/pulsar-test-infra/pulsarbot@master
+name: Tune Runner VM performance
+description: tunes the GitHub Runner VM operation system
+runs:
+  using: composite
+  steps:
+    - run: |
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Ensure that reverse lookups for current hostname are handled properly
+            # Add the current IP address, long hostname and short hostname record to /etc/hosts file
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        fi
+      shell: bash

--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Cache Maven dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -72,6 +72,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         if: ${{ github.event_name != 'schedule' }}
         id:   changes

--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
       - name: Changed files check
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master


### PR DESCRIPTION
Fixes #10232

### Motivation

The reverse lookup for the current hostname is broken in GitHub Actions Runner VMs.

### Modifications

Add the current IP address, long hostname and short hostname record to /etc/hosts file at the beginning of each GitHub Actions workflow.