### PR TITLE
[CI] Tune GitHub Runner VM options to increase working RAM and improve performance

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -27,5 +27,31 @@ runs:
             # Ensure that reverse lookups for current hostname are handled properly
             # Add the current IP address, long hostname and short hostname record to /etc/hosts file
             echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+
+            # The default vm.swappiness setting is 60 which has a tendency to start swapping when memory
+            # consumption is high.
+            # Set vm.swappiness=1 to avoid swapping and allow high RAM usage
+            echo 1 | sudo tee /proc/sys/vm/swappiness
+
+            # use "madvise" Linux Transparent HugePages (THP) setting
+            # https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html
+            # "madvise" is generally a better option than the default "always" setting
+            echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+
+            # tune filesystem mount options, https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
+            # commit=999999, effectively disables automatic syncing to disk (default is every 5 seconds)
+            # nobarrier/barrier=0, loosen data consistency on system crash (no negative impact to empheral CI nodes)
+            sudo mount -o remount,nodiscard,commit=999999,barrier=0 /
+            sudo mount -o remount,nodiscard,commit=999999,barrier=0 /mnt
+            # disable discard/trim at device level since remount with nodiscard doesn't seem to be effective
+            # https://www.spinics.net/lists/linux-ide/msg52562.html
+            for i in /sys/block/sd*/queue/discard_max_bytes; do
+              echo 0 | sudo tee $i
+            done
+            # disable any background jobs that run SSD discard/trim
+            sudo systemctl disable fstrim.timer || true
+            sudo systemctl stop fstrim.timer || true
+            sudo systemctl disable fstrim.service || true
+            sudo systemctl stop fstrim.service || true
         fi
       shell: bash


### PR DESCRIPTION
### Motivation

The GitHub Runner VMs seem to start swapping to disk under high memory utilization. The GitHub VMs have 7GB RAM available. There is 4GB swap space enabled by default.

In Pulsar CI, integration tests already disable swapping completely with `sudo swapoff -a` command in the "clean disk" step, for example:
https://github.com/apache/pulsar/blob/4c434adb6b0aab91f9d3f7c151a8e6b75bee34f1/.github/workflows/ci-integration-process.yaml#L82-L89

However, a more optimal setting in general would be to apply the Linux kernel setting `vm.swappiness=1` which avoids swapping when there is available RAM. 
For Pulsar CI unit test jobs, the defaults are used. The default `vm.swappiness` setting is `60` which indicates that it is very likely that unit test jobs currently start swapping. This is a source of more flakiness to test runs.
The goal of this PR is to fine tune the GitHub Runner VM options to better defaults to increase available working RAM and to improve filesystems performance by applying a few configuration settings.

### Modifications

- The default `vm.swappiness` setting is `60` which has a tendency to start swapping when memory
  consumption is high.
  - Set `vm.swappiness=1` to avoid swapping and allow high RAM usage

- Use `madvise` [Linux Transparent HugePages (THP)](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html) setting
  - `madvise` is generally a better option than the default "always" setting

- Tune filesystem mount options, https://www.kernel.org/doc/Documentation/filesystems/ext4.txt
  - `commit=999999`, effectively disables automatic syncing to disk (default is every 5 seconds)
  - `nobarrier` / `barrier=0`, loosen data consistency on system crash (no negative impact to empheral CI nodes)

- disable discard/trim at device level since remount with `nodiscard` doesn't seem to be effective

- disable any background jobs that run SSD discard/trim
  - SSD discard/trim has negative performance impact, ([Azure reference](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/attach-disk-portal#trimunmap-support-for-linux-in-azure))
    - On Azure VMs, the reason to use discard/trim is to optimize storage cost on virtual disks.
    - This isn't useful on empheral CI nodes