### PR TITLE
[docs] Fix mismatch in retention size examples.

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -572,7 +572,7 @@ Each namespace contains multiple topics and the retention size (storage size) of
 <!--pulsar-admin-->
 
 ```
-$ pulsar-admin set-retention --size 10 --time 100 test-tenant/ns1
+$ pulsar-admin set-retention --size 100 --time 10 test-tenant/ns1
 ```
 
 ```


### PR DESCRIPTION
Currently, there's a mismatch in the examples provided for setting namespace retention size and getting said retention size. Since the docs show these examples together, it seems like they were intended to be consistent between examples.

This proposed change assumes that the "Get retention" `pulsar-admin` example is correct, and modifies the "Set retention" `pulsar-admin` example to match.

### Motivation

Reduce confusion from what appears to be a typo in documentation.

### Modifications

One-line change to an example.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations:no
  - The wire protocol: no
  - The rest endpoints:no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
  - If a feature is not applicable for documentation, explain why? not applicable 
