### PR TITLE
[Broker] Fix replicated subscriptions related LightProto issues

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1059,7 +1059,7 @@ public class PersistentSubscription implements Subscription {
     public void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
         ReplicatedSubscriptionSnapshotCache snapshotCache = this.replicatedSubscriptionSnapshotCache;
         if (snapshotCache != null) {
-            snapshotCache.addNewSnapshot(snapshot);
+            snapshotCache.addNewSnapshot(new ReplicatedSubscriptionsSnapshot().copyFrom(snapshot));
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
@@ -90,7 +90,7 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
                     response.getCluster().getCluster());
         }
         String cluster = response.getCluster().getCluster();
-        responses.putIfAbsent(cluster, response.getCluster().getMessageId());
+        responses.putIfAbsent(cluster, new MarkersMessageIdData().copyFrom(response.getCluster().getMessageId()));
         missingClusters.remove(cluster);
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

While investigating the issue about geo replication, #10054 , I came across some issues with handling of some deserialized replicated subscriptions related messages. LightProto reuses thread local instances and therefore a copy must be made before sharing with other threads.

### Modifications

- Make a copy of `ReplicatedSubscriptionsSnapshot` before adding it to `ReplicatedSubscriptionSnapshotCache`
- Make a copy of `MarkersMessageIdData` before adding it to `responses` map in `ReplicatedSubscriptionsSnapshotBuilder`