### PR TITLE
Fix compilation failure in master branch

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
@@ -242,16 +242,8 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
 
     private static final Logger log = LoggerFactory.getLogger(ResourceGroupServiceTest.class);
 
-    private static final String TEST_PRODUCE_CONSUME_TOPIC =
-            "non-persistent://prod-cons-tenant/prod-cons-ns/prod-cons-topic";
-
-    // Set up configuration that is required to be able to use the transport manager.
-    // private static final String INTERNAL_USAGE_TOPIC = "non-persistent://rusage-tenant/rusage-ns/rusage-topic";
-    private static final String INTERNAL_USAGE_TOPIC = TEST_PRODUCE_CONSUME_TOPIC;
-
     private static final int PUBLISH_INTERVAL_SECS = 500;
     private void prepareData() throws PulsarAdminException {
-        this.conf.setResourceUsageTransportPublishTopicName(INTERNAL_USAGE_TOPIC);
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
         admin.clusters().createCluster("test", new ClusterData(pulsar.getBrokerServiceUrl()));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -239,7 +239,6 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
     final String NsName = "test";
     final String TenantAndNsName = TenantName + "/" + NsName;
     final String TestProduceConsumeTopicName = "/test/prod-cons-topic";
-    final String INTERNAL_TOPIC = "non-persistent://" + TenantAndNsName + "/resource-usage-internal";
     final String PRODUCE_CONSUME_PERSISTENT_TOPIC = "persistent://" + TenantAndNsName + TestProduceConsumeTopicName;
     final String PRODUCE_CONSUME_NON_PERSISTENT_TOPIC =
                                                 "non-persistent://" + TenantAndNsName + TestProduceConsumeTopicName;
@@ -247,7 +246,6 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
 
     // Initial set up for transport manager and producer/consumer clusters/tenants/namespaces/topics.
     private void prepareData() throws PulsarAdminException {
-        this.conf.setResourceUsageTransportPublishTopicName(INTERNAL_TOPIC);
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
 
         this.conf.setAllowAutoTopicCreation(true);


### PR DESCRIPTION
### Motivation

Compiling master branch fails with errors in ResourceGroupServiceTest and ResourceGroupUsageAggregationTest.
This is possibly a merge conflict in #10201.

### Modifications

Fix compilation issues by removing references to non-existent `setResourceUsageTransportPublishTopicName` method.
