### PR TITLE
[Tests] Hide FailFastSkipExceptions and mark the test as skipped

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
@@ -75,6 +75,11 @@ public class FailFastNotifier
     @Override
     public void onTestFailure(ITestResult result) {
         FailFastNotifier.FailFastEventsSingleton.getInstance().setSkipOnNextTest();
+        // Hide FailFastSkipExceptions and mark the test as skipped
+        if (result.getThrowable() instanceof FailFastSkipException) {
+            result.setThrowable(null);
+            result.setStatus(ITestResult.SKIP);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Hiding FailFastSkipExceptions makes it easier to find the actual test failure in the log output when the test fails.
Fail fast testing mode was introduced in #10195 .

### Modifications

- remove the exception and set the status of the test result to skip in the TestNG listener