### PR TITLE
[Broker] Remove possible error case for system topic name checking

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -130,7 +130,6 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.configuration.FieldContext;
-import org.apache.pulsar.common.events.EventsTopicNames;
 import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataUtils;
@@ -2482,7 +2481,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     public boolean isAllowAutoTopicCreation(final TopicName topicName) {
         //System topic can always be created automatically
-        if (EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicName.getLocalName())
+        if (SystemTopicClient.isSystemTopic(topicName)
                 && pulsar.getConfiguration().isSystemTopicEnabled()) {
             return true;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -306,7 +306,7 @@ public class PersistentTopic extends AbstractTopic
         checkReplicatedSubscriptionControllerState();
         TopicName topicName = TopicName.get(topic);
         if (brokerService.getPulsar().getConfiguration().isTransactionCoordinatorEnabled()
-                && !SystemTopicClient.isSystemTopic(TopicName.get(topic))
+                && !SystemTopicClient.isSystemTopic(topicName)
                 && !topicName.getEncodedLocalName().startsWith(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getLocalName())
                 && !topicName.getEncodedLocalName().startsWith(MLTransactionLogImpl.TRANSACTION_LOG_PREFIX)) {
             this.transactionBuffer = brokerService.getPulsar()
@@ -652,7 +652,6 @@ public class PersistentTopic extends AbstractTopic
         }
 
         try {
-            // TODO can all system topics have any type of subscription?
             if (!TopicName.get(topic).getLocalName().equals(EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)
                     && !checkSubscriptionTypesEnable(subType)) {
                 future.completeExceptionally(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service.persistent;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
-import static org.apache.pulsar.common.events.EventsTopicNames.checkTopicIsEventsNames;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -101,6 +100,7 @@ import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.broker.stats.ReplicationMetrics;
+import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferDisable;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
@@ -306,7 +306,7 @@ public class PersistentTopic extends AbstractTopic
         checkReplicatedSubscriptionControllerState();
         TopicName topicName = TopicName.get(topic);
         if (brokerService.getPulsar().getConfiguration().isTransactionCoordinatorEnabled()
-                && !checkTopicIsEventsNames(topic)
+                && !SystemTopicClient.isSystemTopic(TopicName.get(topic))
                 && !topicName.getEncodedLocalName().startsWith(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getLocalName())
                 && !topicName.getEncodedLocalName().startsWith(MLTransactionLogImpl.TRANSACTION_LOG_PREFIX)) {
             this.transactionBuffer = brokerService.getPulsar()
@@ -652,7 +652,8 @@ public class PersistentTopic extends AbstractTopic
         }
 
         try {
-            if (!topic.endsWith(EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)
+            // TODO can all system topics have any type of subscription?
+            if (!TopicName.get(topic).getLocalName().equals(EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)
                     && !checkSubscriptionTypesEnable(subType)) {
                 future.completeExceptionally(
                         new NotAllowedException("Topic[{" + topic + "}] don't support "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -167,8 +167,11 @@ public interface SystemTopicClient<T> {
         SystemTopicClient<T> getSystemTopic();
     }
 
+    /**
+     * A topic is a system topic if and only if its local name has the defined prefix.
+     */
     static boolean isSystemTopic(TopicName topicName) {
-        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicName.getLocalName());
+        return topicName.getLocalName().startsWith(EventsTopicNames.SYSTEM_TOPIC_LOCAL_NAME_PREFIX);
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -168,10 +168,11 @@ public interface SystemTopicClient<T> {
     }
 
     /**
-     * A topic is a system topic if and only if its local name has the defined prefix.
+     * Returns true if the topicName is a system topic and false if not.
+     * Currently, all system topics are contained in {@link EventsTopicNames}
      */
     static boolean isSystemTopic(TopicName topicName) {
-        return topicName.getLocalName().startsWith(EventsTopicNames.SYSTEM_TOPIC_LOCAL_NAME_PREFIX);
+        return EventsTopicNames.EVENTS_TOPIC_NAMES.contains(topicName.getLocalName());
     }
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
@@ -19,28 +19,24 @@
 package org.apache.pulsar.common.events;
 
 /**
- * System topic name for the event type.
+ * System topic names for each {@link EventType}.
  */
 public class EventsTopicNames {
 
+    /**
+     * All event topics are system topics.
+     * A topic is a system topic if and only if its local name has this prefix.
+     */
+    public static final String SYSTEM_TOPIC_LOCAL_NAME_PREFIX = "__";
 
     /**
      * Local topic name for the namespace events.
      */
-    public static final String NAMESPACE_EVENTS_LOCAL_NAME = "__change_events";
+    public static final String NAMESPACE_EVENTS_LOCAL_NAME = SYSTEM_TOPIC_LOCAL_NAME_PREFIX + "change_events";
 
     /**
      * Local topic name for the namespace events.
      */
-    public static final String TRANSACTION_BUFFER_SNAPSHOT = "__transaction_buffer_snapshot";
-
-    public static boolean checkTopicIsEventsNames(String topicName) {
-        if (topicName.endsWith(NAMESPACE_EVENTS_LOCAL_NAME)) {
-            return true;
-        } else if (topicName.endsWith(TRANSACTION_BUFFER_SNAPSHOT)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+    public static final String TRANSACTION_BUFFER_SNAPSHOT =
+            SYSTEM_TOPIC_LOCAL_NAME_PREFIX + "transaction_buffer_snapshot";
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
@@ -18,16 +18,19 @@
  */
 package org.apache.pulsar.common.events;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * System topic names for each {@link EventType}.
  */
 public class EventsTopicNames {
 
     /**
-     * All event topics are system topics.
-     * A topic is a system topic if and only if its local name has this prefix.
+     * All event topics are system topics, and currently, they all have this prefix.
      */
-    public static final String SYSTEM_TOPIC_LOCAL_NAME_PREFIX = "__";
+    private static final String SYSTEM_TOPIC_LOCAL_NAME_PREFIX = "__";
 
     /**
      * Local topic name for the namespace events.
@@ -39,4 +42,10 @@ public class EventsTopicNames {
      */
     public static final String TRANSACTION_BUFFER_SNAPSHOT =
             SYSTEM_TOPIC_LOCAL_NAME_PREFIX + "transaction_buffer_snapshot";
+
+    /**
+     * The set of all events topic names.
+     */
+    public static final Set<String> EVENTS_TOPIC_NAMES =
+            new HashSet<>(Arrays.asList(NAMESPACE_EVENTS_LOCAL_NAME, TRANSACTION_BUFFER_SNAPSHOT));
 }

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -255,7 +255,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.

--- a/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.0/concepts-messaging.md
@@ -198,7 +198,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics) (persistent is the default, so if you don't specify a type the topic will be persistent). With persistent topics, all messages are durably [persisted](concepts-architecture-overview.md#persistent-storage) on disk (that means on multiple disks unless the broker is standalone), whereas data for [non-persistent](#non-persistent-topics) topics isn't persisted to storage disks.
 `tenant`             | The topic's tenant within the instance. Tenants are essential to multi-tenancy in Pulsar and can be spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant can have multiple namespaces.
-`topic`              | The final part of the name. Topic names are freeform and have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names are freeform and have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 
 > **No need to explicitly create new topics**

--- a/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.1/concepts-messaging.md
@@ -222,7 +222,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.

--- a/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.2/concepts-messaging.md
@@ -222,7 +222,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.

--- a/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.6.3/concepts-messaging.md
@@ -222,7 +222,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.

--- a/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.0/concepts-messaging.md
@@ -222,7 +222,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.

--- a/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
+++ b/site2/website/versioned_docs/version-2.7.1/concepts-messaging.md
@@ -222,7 +222,7 @@ Topic name component | Description
 `persistent` / `non-persistent` | This identifies the type of topic. Pulsar supports two kind of topics: [persistent](concepts-architecture-overview.md#persistent-storage) and [non-persistent](#non-persistent-topics). The default is persistent, so if you do not specify a type, the topic is persistent. With persistent topics, all messages are durably persisted on disks (if the broker is not standalone, messages are durably persisted on multiple disks), whereas data for non-persistent topics is not persisted to storage disks.
 `tenant`             | The topic tenant within the instance. Tenants are essential to multi-tenancy in Pulsar, and spread across clusters.
 `namespace`          | The administrative unit of the topic, which acts as a grouping mechanism for related topics. Most topic configuration is performed at the [namespace](#namespaces) level. Each tenant has one or multiple namespaces.
-`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance.
+`topic`              | The final part of the name. Topic names have no special meaning in a Pulsar instance. Note that system topics begin with two underscores, e.g. `__`. Users should avoid creating topic names that start with two underscores.
 
 > **No need to explicitly create new topics**
 > You do not need to explicitly create topics in Pulsar. If a client attempts to write or receive messages to/from a topic that does not yet exist, Pulsar creates that topic under the namespace provided in the [topic name](#topics) automatically.


### PR DESCRIPTION
### Motivation

In reading through the system topic code, I noticed that there are some edge cases where normal topics might be considered system topics. This PR should remove that possibility.

I have a few questions on implementation. I will put comments on the lines where I have questions.

### Modifications

1. Updated the `isSystemTopic` method to just check for presence the system topic prefix (`__`). This change could be problematic if end users are already using topic names with the system topic prefix.
2. Use a topic's `localName` to check for equality instead of `endsWith`. In the current implementation, a user could have a topic with the local name `my__change_events`, and because it "ends with" `__change_events`, it would be considered a system topic.
3. Update the documentation on topic names to warn about the system topic prefix.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

System topics were introduced in pulsar 2.6.0. I updated the documentation for all versions since then to indicate that users should avoid creating topics that begin with `__`. This is important because if there are to be additional system topics, we want to make sure there are not accidentally naming collisions.