### PR TITLE
Upgrade Lombok to 1.18.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@ flexible messaging model and an intuitive client API.</description>
     <hppc.version>0.7.3</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.18.1</assertj-core.version>
-    <lombok.version>1.18.18</lombok.version>
+    <lombok.version>1.18.20</lombok.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
### Motivation

- see https://projectlombok.org/changelog
- 1.18.20 fixes compilation on JDK 16

### Modifications

- upgrade Lombok version from 1.18.18 to 1.18.20