### PR TITLE
Upgrade k8s java-client to fix dependency resolution

### DIFF
--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -111,7 +111,5 @@ jobs:
       - name: Download dependencies
         if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          # workaround issue https://github.com/sundrio/sundrio/issues/168
-          perl -0777 -i.original -pe 's/<dependency>\s+<groupId>io.sundr<\/groupId>.*?<\/dependency>//sg' pulsar-functions/runtime/pom.xml pulsar-functions/secrets/pom.xml || true
           # download dependencies, ignore errors
           mvn -B -fn -ntp ${{ matrix.mvn_arguments }} dependency:go-offline

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -325,11 +325,10 @@ The Apache Software License, Version 2.0
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
- * Joda -- org.joda-joda-convert-2.2.1.jar
- * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.2.jar
+ * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.6.jar
  * Gson
     - com.google.code.gson-gson-2.8.6.jar
-    - io.gsonfire-gson-fire-1.8.4.jar
+    - io.gsonfire-gson-fire-1.8.5.jar
  * Guava
     - com.google.guava-guava-30.1-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
@@ -447,7 +446,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.39.v20210325.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
- * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.3.4.jar
+ * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.12.0.jar
  * OkHttp and OkHttp3
      - com.squareup.okhttp-okhttp-2.7.4.jar
@@ -491,12 +490,9 @@ The Apache Software License, Version 2.0
   * @FreeBuilder
     - org.inferred-freebuilder-1.14.9.jar
   * Kubernetes Client
-    - io.kubernetes-client-java-10.0.0.jar
-    - io.kubernetes-client-java-api-10.0.0.jar
-    - io.kubernetes-client-java-proto-10.0.0.jar
-  * Joda Time
-    - joda-time-2.10.1.jar
-    - joda-time-joda-time-2.10.1.jar
+    - io.kubernetes-client-java-12.0.0.jar
+    - io.kubernetes-client-java-api-12.0.0.jar
+    - io.kubernetes-client-java-proto-12.0.0.jar
   * Dropwizard
     - io.dropwizard.metrics-metrics-core-3.2.5.jar
     - io.dropwizard.metrics-metrics-graphite-3.2.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,7 @@ flexible messaging model and an intuitive client API.</description>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>
     <jna.version>4.2.0</jna.version>
-    <kubernetesclient.version>10.0.0</kubernetesclient.version>
-    <sundr.version>0.21.0</sundr.version>
+    <kubernetesclient.version>12.0.0</kubernetesclient.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
@@ -235,6 +234,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone.version>2.5.1</errorprone.version>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
+    <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
@@ -1055,6 +1055,18 @@ flexible messaging model and an intuitive client API.</description>
         <version>${spotbugs.version}</version>
         <scope>provided</scope>
         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${errorprone.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>${j2objc-annotations.version}</version>
       </dependency>
 
     </dependencies>

--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -61,39 +61,15 @@
     </dependency>
 
     <dependency>
-    <groupId>io.kubernetes</groupId>
-    <artifactId>client-java</artifactId>
-    <version>${kubernetesclient.version}</version>
-    <scope>compile</scope>
-    <exclusions>
-      <exclusion>
-            <groupId>io.sundr</groupId>
-            <artifactId>*</artifactId>
-      </exclusion>
-      <exclusion>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-  <dependency>
-    <groupId>io.sundr</groupId>
-    <artifactId>sundr-codegen</artifactId>
-    <version>${sundr.version}</version>
-    <scope>provided</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.sundr</groupId>
-    <artifactId>sundr-core</artifactId>
-    <version>${sundr.version}</version>
-    <scope>provided</scope>
-  </dependency>
-
-      <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>pulsar-broker-common</artifactId>
-          <version>${project.version}</version>
-      </dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>${kubernetesclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-broker-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
   </dependencies>
 
@@ -130,15 +106,15 @@
         <configuration>
           <excludeFilterFile>${basedir}/src/main/resources/findbugsExclude.xml</excludeFilterFile>
         </configuration>
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>check</id>-->
-<!--            <phase>verify</phase>-->
-<!--            <goals>-->
-<!--              <goal>check</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
+        <!--        <executions>-->
+        <!--          <execution>-->
+        <!--            <id>check</id>-->
+        <!--            <phase>verify</phase>-->
+        <!--            <goals>-->
+        <!--              <goal>check</goal>-->
+        <!--            </goals>-->
+        <!--          </execution>-->
+        <!--        </executions>-->
       </plugin>
     </plugins>
   </build>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -663,7 +663,7 @@ public class KubernetesRuntime implements Runtime {
                     try {
                         response = coreClient.listNamespacedPod(jobNamespace, null, null,
                                 null, null, labels,
-                                null, null, null, null);
+                                null, null, null, null, null);
                     } catch (ApiException e) {
 
                         String errorMsg = e.getResponseBody() != null ? e.getResponseBody() : e.getMessage();
@@ -1145,7 +1145,7 @@ public class KubernetesRuntime implements Runtime {
 
     public static String createJobName(Function.FunctionDetails functionDetails, String jobName) {
         return jobName == null ? createJobName(functionDetails.getTenant(),
-                functionDetails.getNamespace(), functionDetails.getName()) : 
+                functionDetails.getNamespace(), functionDetails.getName()) :
                 	createJobName(jobName, functionDetails.getTenant(),
                         functionDetails.getNamespace(), functionDetails.getName());
     }
@@ -1157,16 +1157,16 @@ public class KubernetesRuntime implements Runtime {
     private static String toValidLabelName(String ori) {
         return left(ori.toLowerCase().replaceAll("[^a-zA-Z0-9-_\\.]", "-").replaceAll("^[^a-zA-Z0-9]", "0").replaceAll("[^a-zA-Z0-9]$", "0"), maxLabelSize);
     }
-    
+
     private static String createJobName(String jobName, String tenant, String namespace, String functionName) {
     	final String convertedJobName = toValidPodName(jobName);
-        // use of customRuntimeOptions 'jobName' may cause naming collisions, 
+        // use of customRuntimeOptions 'jobName' may cause naming collisions,
     	// add a short hash here to avoid it
     	final String hashName = String.format("%s-%s-%s-%s", jobName, tenant, namespace, functionName);
         final String shortHash = DigestUtils.sha1Hex(hashName).toLowerCase().substring(0, 8);
         return convertedJobName + "-" + shortHash;
     }
-    
+
     private static String createJobName(String tenant, String namespace, String functionName) {
     	final String jobNameBase = String.format("%s-%s-%s", tenant, namespace, functionName);
         final String jobName = "pf-" + jobNameBase;

--- a/pulsar-functions/secrets/pom.xml
+++ b/pulsar-functions/secrets/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pulsar</groupId>
@@ -31,34 +31,11 @@
   <name>Pulsar Functions :: Secrets</name>
 
   <dependencies>
-  <dependency>
-    <groupId>io.kubernetes</groupId>
-    <artifactId>client-java</artifactId>
-    <version>${kubernetesclient.version}</version>
-    <scope>compile</scope>
-    <exclusions>
-      <exclusion>
-            <groupId>io.sundr</groupId>
-            <artifactId>*</artifactId>
-      </exclusion>
-      <exclusion>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-  <dependency>
-    <groupId>io.sundr</groupId>
-    <artifactId>sundr-codegen</artifactId>
-    <version>${sundr.version}</version>
-    <scope>provided</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.sundr</groupId>
-    <artifactId>sundr-core</artifactId>
-    <version>${sundr.version}</version>
-    <scope>provided</scope>
-  </dependency>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>${kubernetesclient.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -307,7 +307,7 @@ The Apache Software License, Version 2.0
     - httpclient-4.5.13.jar
     - httpcore-4.4.13.jar
   * Error Prone Annotations
-    - error_prone_annotations-2.3.4.jar
+    - error_prone_annotations-2.5.1.jar
   * Esri Geometry API For Java
     - esri-geometry-api-2.2.2.jar
   * Failsafe

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -19,317 +19,323 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache</groupId>
-        <artifactId>apache</artifactId>
-        <version>23</version>
-    </parent>
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>23</version>
+  </parent>
 
-    <groupId>org.apache.pulsar</groupId>
-    <artifactId>pulsar-presto-distribution</artifactId>
-    <name>Pulsar SQL :: Pulsar Presto Distribution</name>
-    <version>2.8.0-SNAPSHOT</version>
+  <groupId>org.apache.pulsar</groupId>
+  <artifactId>pulsar-presto-distribution</artifactId>
+  <name>Pulsar SQL :: Pulsar Presto Distribution</name>
+  <version>2.8.0-SNAPSHOT</version>
 
-    <properties>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
-      <jersey.version>2.31</jersey.version>
-        <presto.version>332</presto.version>
-        <airlift.version>0.170</airlift.version>
-        <objenesis.version>2.6</objenesis.version>
-        <objectsize.version>0.0.12</objectsize.version>
-        <guice.version>4.2.0</guice.version>
-        <!-- Launcher properties -->
-        <main-class>io.prestosql.server.PrestoServer</main-class>
-        <process-name>${project.artifactId}</process-name>
-        <jackson.version>2.11.1</jackson.version>
-        <!--fix Security Vulnerabilities-->
-        <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-        <jackson.databind.version>2.11.1</jackson.databind.version>
-        <maven.version>3.0.5</maven.version>
-        <guava.version>30.1-jre</guava.version>
-        <asynchttpclient.version>2.12.1</asynchttpclient.version>
-    </properties>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <jersey.version>2.31</jersey.version>
+    <presto.version>332</presto.version>
+    <airlift.version>0.170</airlift.version>
+    <objenesis.version>2.6</objenesis.version>
+    <objectsize.version>0.0.12</objectsize.version>
+    <guice.version>4.2.0</guice.version>
+    <!-- Launcher properties -->
+    <main-class>io.prestosql.server.PrestoServer</main-class>
+    <process-name>${project.artifactId}</process-name>
+    <jackson.version>2.11.1</jackson.version>
+    <!--fix Security Vulnerabilities-->
+    <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
+    <jackson.databind.version>2.11.1</jackson.databind.version>
+    <maven.version>3.0.5</maven.version>
+    <guava.version>30.1-jre</guava.version>
+    <asynchttpclient.version>2.12.1</asynchttpclient.version>
+    <errorprone.version>2.5.1</errorprone.version>
+  </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet-core</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prestosql</groupId>
+      <artifactId>presto-main</artifactId>
+      <version>${presto.version}</version>
+      <exclusions>
+        <!-- exclude openjdk because of GPL license -->
+        <exclusion>
+          <groupId>org.openjdk.jol</groupId>
+          <artifactId>jol-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prestosql</groupId>
+      <artifactId>presto-cli</artifactId>
+      <version>${presto.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>launcher</artifactId>
+      <version>${airlift.version}</version>
+      <type>tar.gz</type>
+      <classifier>bin</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>launcher</artifactId>
+      <version>${airlift.version}</version>
+      <type>tar.gz</type>
+      <classifier>properties</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-presto-connector</artifactId>
+      <version>${project.version}</version>
+      <type>tar.gz</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>${objenesis.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>objectsize</artifactId>
+      <version>${objectsize.version}</version>
+    </dependency>
+
+    <!-- make sure guice is set to the correct version -->
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+      <version>${guice.version}</version>
+    </dependency>
+
+    <!-- jackson dependencies -->
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.databind.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-smile</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty</artifactId>
+        <version>3.10.6.Final</version>
+      </dependency>
 
-        <dependency>
-            <groupId>io.prestosql</groupId>
-            <artifactId>presto-main</artifactId>
-            <version>${presto.version}</version>
-            <exclusions>
-                <!-- exclude openjdk because of GPL license -->
-                <exclusion>
-                    <groupId>org.openjdk.jol</groupId>
-                    <artifactId>jol-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.prestosql</groupId>
-            <artifactId>presto-cli</artifactId>
-            <version>${presto.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>launcher</artifactId>
-            <version>${airlift.version}</version>
-            <type>tar.gz</type>
-            <classifier>bin</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>launcher</artifactId>
-            <version>${airlift.version}</version>
-            <type>tar.gz</type>
-            <classifier>properties</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>pulsar-presto-connector</artifactId>
-            <version>${project.version}</version>
-            <type>tar.gz</type>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>${objenesis.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.twitter.common</groupId>
-            <artifactId>objectsize</artifactId>
-            <version>${objectsize.version}</version>
-        </dependency>
-
-        <!-- make sure guice is set to the correct version -->
-        <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-            <version>${guice.version}</version>
-        </dependency>
-
-        <!-- jackson dependencies -->
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-smile</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-core</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-model</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-aether-provider</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-embedder</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${errorprone.version}</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>org.asynchttpclient</groupId>
-          <artifactId>async-http-client</artifactId>
-          <version>${asynchttpclient.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-          <version>3.10.6.Final</version>
-        </dependency>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <appendAssemblyId>false</appendAssemblyId>
+          <attach>true</attach>
+          <tarLongFileMode>posix</tarLongFileMode>
+          <descriptors>
+            <descriptor>src/assembly/assembly.xml</descriptor>
+          </descriptors>
+          <finalName>${project.artifactId}</finalName>
+        </configuration>
+        <executions>
+          <execution>
+            <id>package</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
-        <dependency>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-core</artifactId>
-          <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-model</artifactId>
-          <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-artifact</artifactId>
-          <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-aether-provider</artifactId>
-          <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-embedder</artifactId>
-          <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>${guava.version}</version>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <attach>true</attach>
-                    <tarLongFileMode>posix</tarLongFileMode>
-                    <descriptors>
-                        <descriptor>src/assembly/assembly.xml</descriptor>
-                    </descriptors>
-                    <finalName>${project.artifactId}</finalName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>package</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>templating-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <id>filter-src</id>
-                        <goals>
-                            <goal>filter-sources</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <sourceDirectory>${project.build.directory}/${project.artifactId}/bin/</sourceDirectory>
-                            <outputDirectory>${project.build.directory}/${project.artifactId}/bin/</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <delimiters>
-                                <delimiter>${*}</delimiter>
-                            </delimiters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-              <groupId>com.mycila</groupId>
-              <artifactId>license-maven-plugin</artifactId>
-              <version>4.0.rc2</version>
-              <configuration>
-                <licenseSets>
-                  <licenseSet>
-                    <header>../../src/license-header.txt</header>
-                  </licenseSet>
-                </licenseSets>
-                <mapping>
-                  <java>JAVADOC_STYLE</java>
-                </mapping>
-              </configuration>
-            </plugin>
-        </plugins>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh-external</artifactId>
-                <version>3.4.3</version>
-            </extension>
-        </extensions>
-    </build>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/${project.artifactId}/bin/</sourceDirectory>
+              <outputDirectory>${project.build.directory}/${project.artifactId}/bin/</outputDirectory>
+              <overwrite>true</overwrite>
+              <delimiters>
+                <delimiter>${*}</delimiter>
+              </delimiters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>4.0.rc2</version>
+        <configuration>
+          <licenseSets>
+            <licenseSet>
+              <header>../../src/license-header.txt</header>
+            </licenseSet>
+          </licenseSets>
+          <mapping>
+            <java>JAVADOC_STYLE</java>
+          </mapping>
+        </configuration>
+      </plugin>
+    </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>3.4.3</version>
+      </extension>
+    </extensions>
+  </build>
 </project>


### PR DESCRIPTION
### Motivation 

- sundr library has been upgraded to 0.22.1 version which contains a fix a dependency resolution issue, https://github.com/sundrio/sundrio/issues/168
  - various workarounds for sundr library dependency issues can be removed

- newer version of k8s java-client has fewer dependencies

### Modifications

- upgrade io.kubernetes:java-client version from 10.0.0 to 12.0.0
- add dependency management rules for com.google.errorprone:error_prone_annotations and com.google.j2objc:j2objc-annotations so that the dependency versions are consistent with the other dependencies.
- adapt license files to the modifications
- adapt usage of `coreClient.listNamespacedPod` since the api has changed (1 new parameter, passes as null)
- remove workarounds that have been in place to address issues with sundr library dependency resolution issue
- reformat `pulsar-sql/presto-distribution/pom.xml`