### PR TITLE
[Security] Upgrade vertx to 3.9.7, addresses CVE-2018-12541

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -510,10 +510,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.5.3.jar
-    - io.vertx-vertx-bridge-common-3.5.3.jar
-    - io.vertx-vertx-core-3.5.3.jar
-    - io.vertx-vertx-web-3.5.3.jar
+    - io.vertx-vertx-auth-common-3.9.7.jar
+    - io.vertx-vertx-bridge-common-3.9.7.jar
+    - io.vertx-vertx-core-3.9.7.jar
+    - io.vertx-vertx-web-3.9.7.jar
+    - io.vertx-vertx-web-common-3.9.7.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.6.2.jar
   * Snappy Java

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
-    <vertx.version>3.5.3</vertx.version>
+    <vertx.version>3.9.7</vertx.version>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
### Motivation

The current vertx version is 3.5.3 which has a vulnerability, CVE-2018-12541 .

### Changes

- Upgrade vertx version to 3.9.7 which is the most recent in 3.x releases.

Notice:
vertx is a transitive dependency of bookkeeper. There's a separate PR in apache/bookkeeper to upgrade vertx library: https://github.com/apache/bookkeeper/pull/2693 . It should be fine to upgrade vertx to 3.9.7 when using the released bookkeeper version 4.13.0 . There isn't a requirement for having a released version of bookkeeper with the upgraded vertx version.

