### PR TITLE
[Security] Remove jackson-mapper-asl dependency to resolve multiple CVEs

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -320,8 +320,6 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.11.1.jar
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.11.1.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.11.1.jar
-     - org.codehaus.jackson-jackson-core-asl-1.9.11.jar
-     - org.codehaus.jackson-jackson-mapper-asl-1.9.11.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.1.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -148,8 +148,6 @@
                   <include>org.aspectj:*</include>
                   <include>org.apache.avro:avro</include>
                   <!-- Avro transitive dependencies-->
-                  <include>org.codehaus.jackson:jackson-core-asl</include>
-                  <include>org.codehaus.jackson:jackson-mapper-asl</include>
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.tukaani:xz</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -177,8 +177,6 @@
                   <include>org.yaml:snakeyaml</include>
                   <include>org.apache.avro:*</include>
                   <!-- Avro transitive dependencies-->
-                  <include>org.codehaus.jackson:jackson-core-asl</include>
-                  <include>org.codehaus.jackson:jackson-mapper-asl</include>
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.tukaani:xz</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -157,8 +157,6 @@
 
                   <include>org.apache.avro:*</include>
                   <!-- Avro transitive dependencies-->
-                  <include>org.codehaus.jackson:jackson-core-asl</include>
-                  <include>org.codehaus.jackson:jackson-mapper-asl</include>
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.tukaani:xz</include>


### PR DESCRIPTION
### Motivation

- jackson-mapper-asl is not required since Zookeeper 3.6.x+ no more depends
  on jackson-mapper-asl library (ZOOKEEPER-3051)
- jackson-mapper-asl was replaced in Avro 1.9.x so it's not required because of
  Avro

### Modifications

- remove dependency on jackson-mapper-asl
  - exclude it from Bookkeeper's stream-storage-server dependency

### Notice

  - there's a separate PR in Bookkeeper to remove jackson-mapper-asl dependency, apache/bookkeeper#2694