### PR TITLE
[Python schema] Support python avro schema set default value.

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -87,6 +87,10 @@ class JsonSchema(Schema):
 
     def encode(self, obj):
         self._validate_object_type(obj)
+        del obj.__dict__['_default']
+        del obj.__dict__['_required']
+        del obj.__dict__['_required_default']
+
         return json.dumps(obj.__dict__, default=self._get_serialized_value, indent=True).encode('utf-8')
 
     def decode(self, data):

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -180,9 +180,6 @@ class SchemaTest(TestCase):
             # Expected
             pass
 
-        try:
-            Record('xyz', a=1, b=2)
-            self.fail('Should have failed')
         except TypeError:
             # Expected
             pass
@@ -410,7 +407,7 @@ class SchemaTest(TestCase):
 
         r = Example()
         self.assertEqual(r.a, 5)
-        self.assertEqual(r.b, 0)
+        self.assertEqual(r.b, None)
         self.assertEqual(r.c, 'hello')
 
     ####
@@ -667,11 +664,174 @@ class SchemaTest(TestCase):
 
         client.close()
 
+    def test_avro_required_default(self):
+        class MySubRecord(Record):
+            x = Integer()
+            y = Long()
+            z = String()
+
+        class Example(Record):
+            a = Integer()
+            b = Boolean()
+            c = Long()
+            d = Float()
+            e = Double()
+            f = String()
+            g = Bytes()
+            h = Array(String())
+            i = Map(String())
+            j = MySubRecord()
+
+        class ExampleRequiredDefault(Record):
+            a = Integer(required_default=True)
+            b = Boolean(required_default=True)
+            c = Long(required_default=True)
+            d = Float(required_default=True)
+            e = Double(required_default=True)
+            f = String(required_default=True)
+            g = Bytes(required_default=True)
+            h = Array(String(), required_default=True)
+            i = Map(String(), required_default=True)
+            j = MySubRecord(required_default=True)
+        self.assertEqual(ExampleRequiredDefault.schema(), {
+                "name": "ExampleRequiredDefault",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "a",
+                        "type": [
+                            "null",
+                            "int"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "b",
+                        "type": [
+                            "null",
+                            "boolean"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "c",
+                        "type": [
+                            "null",
+                            "long"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "d",
+                        "type": [
+                            "null",
+                            "float"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "e",
+                        "type": [
+                            "null",
+                            "double"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "f",
+                        "type": [
+                            "null",
+                            "string"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "g",
+                        "type": [
+                            "null",
+                            "bytes"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "h",
+                        "type": [
+                            "null",
+                            {
+                                "type": "array",
+                                "items": "string"
+                            }
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "i",
+                        "type": [
+                            "null",
+                            {
+                                "type": "map",
+                                "values": "string"
+                            }
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "j",
+                        "type": [
+                            "null",
+                            {
+                                "name": "MySubRecord",
+                                "type": "record",
+                                "fields": [
+                                    {
+                                        "name": "x",
+                                        "type": [
+                                            "null",
+                                            "int"
+                                        ]
+                                    },
+                                    {
+                                        "name": "y",
+                                        "type": [
+                                            "null",
+                                            "long"
+                                        ],
+                                    },
+                                    {
+                                        "name": "z",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "default": None
+                    }
+                ]
+            })
+
+        client = pulsar.Client(self.serviceUrl)
+        producer = client.create_producer(
+            'my-avro-python-default-topic',
+            schema=AvroSchema(Example))
+
+        producer_default = client.create_producer(
+            'my-avro-python-default-topic',
+            schema=AvroSchema(ExampleRequiredDefault))
+
+        producer.close()
+        producer_default.close()
+
+        client.close()
+
+
     def test_default_value(self):
         class MyRecord(Record):
             A = Integer()
             B = String()
-            C = Boolean()
+            C = Boolean(default=False)
             D = Double(default=6.4)
 
         topic = "my-default-value-topic"

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -672,7 +672,7 @@ class SchemaTest(TestCase):
 
         class Example(Record):
             a = Integer()
-            b = Boolean()
+            b = Boolean(required=True)
             c = Long()
             d = Float()
             e = Double()
@@ -684,7 +684,7 @@ class SchemaTest(TestCase):
 
         class ExampleRequiredDefault(Record):
             a = Integer(required_default=True)
-            b = Boolean(required_default=True)
+            b = Boolean(required=True, required_default=True)
             c = Long(required_default=True)
             d = Float(required_default=True)
             e = Double(required_default=True)
@@ -707,11 +707,8 @@ class SchemaTest(TestCase):
                     },
                     {
                         "name": "b",
-                        "type": [
-                            "null",
-                            "boolean"
-                        ],
-                        "default": None
+                        "type": "boolean",
+                        "default": False
                     },
                     {
                         "name": "c",
@@ -831,7 +828,7 @@ class SchemaTest(TestCase):
         class MyRecord(Record):
             A = Integer()
             B = String()
-            C = Boolean(default=False)
+            C = Boolean(default=True, required=True)
             D = Double(default=6.4)
 
         topic = "my-default-value-topic"
@@ -849,7 +846,7 @@ class SchemaTest(TestCase):
         msg = consumer.receive()
         self.assertEqual(msg.value().A, 5)
         self.assertEqual(msg.value().B, u'text')
-        self.assertEqual(msg.value().C, False)
+        self.assertEqual(msg.value().C, True)
         self.assertEqual(msg.value().D, 6.4)
 
         producer.close()


### PR DESCRIPTION
## Motivation
now python avro schema don't support set default value, it led to the python schema can't update.
## implement
1. add `required` field to control the type of schema can set `null`.
2. add `required_default` filed to control to control the schema has default attribute wether or not.
3. add `default` field to control the default value of schema.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

