### PR TITLE
[Security] Upgrade Netty to 4.1.63.Final to address CVE-2021-21409

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.60.Final</version>
+      <version>4.1.63.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -355,24 +355,24 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.19.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.60.Final.jar
-    - io.netty-netty-codec-4.1.60.Final.jar
-    - io.netty-netty-codec-dns-4.1.60.Final.jar
-    - io.netty-netty-codec-http-4.1.60.Final.jar
-    - io.netty-netty-codec-http2-4.1.60.Final.jar
-    - io.netty-netty-codec-socks-4.1.60.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.60.Final.jar
-    - io.netty-netty-common-4.1.60.Final.jar
-    - io.netty-netty-handler-4.1.60.Final.jar
-    - io.netty-netty-handler-proxy-4.1.60.Final.jar
-    - io.netty-netty-resolver-4.1.60.Final.jar
-    - io.netty-netty-resolver-dns-4.1.60.Final.jar
-    - io.netty-netty-transport-4.1.60.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.60.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.60.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.60.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.60.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.36.Final.jar
+    - io.netty-netty-buffer-4.1.63.Final.jar
+    - io.netty-netty-codec-4.1.63.Final.jar
+    - io.netty-netty-codec-dns-4.1.63.Final.jar
+    - io.netty-netty-codec-http-4.1.63.Final.jar
+    - io.netty-netty-codec-http2-4.1.63.Final.jar
+    - io.netty-netty-codec-socks-4.1.63.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.63.Final.jar
+    - io.netty-netty-common-4.1.63.Final.jar
+    - io.netty-netty-handler-4.1.63.Final.jar
+    - io.netty-netty-handler-proxy-4.1.63.Final.jar
+    - io.netty-netty-resolver-4.1.63.Final.jar
+    - io.netty-netty-resolver-dns-4.1.63.Final.jar
+    - io.netty-netty-transport-4.1.63.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.63.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.63.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.63.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.38.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.60.Final</netty.version>
-    <netty-tc-native.version>2.0.36.Final</netty-tc-native.version>
+    <netty.version>4.1.63.Final</netty.version>
+    <netty-tc-native.version>2.0.38.Final</netty-tc-native.version>
     <jetty.version>9.4.39.v20210325</jetty.version>
     <jersey.version>2.31</jersey.version>
     <athenz.version>1.10.9</athenz.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -233,21 +233,21 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.60.Final.jar
-    - netty-codec-4.1.60.Final.jar
-    - netty-codec-dns-4.1.60.Final.jar
-    - netty-codec-http-4.1.60.Final.jar
-    - netty-codec-haproxy-4.1.60.Final.jar
-    - netty-common-4.1.60.Final.jar
-    - netty-handler-4.1.60.Final.jar
+    - netty-buffer-4.1.63.Final.jar
+    - netty-codec-4.1.63.Final.jar
+    - netty-codec-dns-4.1.63.Final.jar
+    - netty-codec-http-4.1.63.Final.jar
+    - netty-codec-haproxy-4.1.63.Final.jar
+    - netty-common-4.1.63.Final.jar
+    - netty-handler-4.1.63.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.60.Final.jar
-    - netty-resolver-dns-4.1.60.Final.jar
-    - netty-tcnative-boringssl-static-2.0.36.Final.jar
-    - netty-transport-4.1.60.Final.jar
-    - netty-transport-native-epoll-4.1.60.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.60.Final.jar
-    - netty-transport-native-unix-common-4.1.60.Final-linux-x86_64.jar
+    - netty-resolver-4.1.63.Final.jar
+    - netty-resolver-dns-4.1.63.Final.jar
+    - netty-tcnative-boringssl-static-2.0.38.Final.jar
+    - netty-transport-4.1.63.Final.jar
+    - netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.63.Final.jar
+    - netty-transport-native-unix-common-4.1.63.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.10.5.jar
     - joda-time-2.10.1.jar


### PR DESCRIPTION
### Motivation

Upgrade Netty to 4.1.63.Final to address CVE-2021-21409 .

### Modifications

- Upgrade Netty to 4.1.63.Final
- Upgrade netty-tcnative-boringssl-static to 2.0.38.Final
