### PR TITLE
[Issue-10269] [pulsar-io] Pulsar IO Sink errors are not bubbled up correctly

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -181,7 +181,7 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
             remainingMessagesToReceive.add(messageBody);
         }
 
-        //4 All messages should enter DLQ
+        // 4 All messages should enter DLQ
         for (int i = 0; i < totalMsgs; i++) {
             Message<String> message = consumer.receive(10, TimeUnit.SECONDS);
             assertNotNull(message);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -91,14 +91,14 @@ public class JavaInstance implements AutoCloseable {
     
     /**
      * If the Function code returns a CompletableFuture object, then this method is used to handle that by
-     * adding the async request to the internal pendingAsyncRequests queue, specifying the logic to be executed
-     * once the function execution is complete.
+     * adding the async request to the internal pendingAsyncRequests queue, and specifying the logic to be 
+     * executed once the function execution is complete.
      * 
      * @param future
      * @param executionResult
      */
-    @SuppressWarnings("unchecked")
-	private void handleAsync(@SuppressWarnings("rawtypes") CompletableFuture future, JavaExecutionResult executionResult) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	private void handleAsync(CompletableFuture future, JavaExecutionResult executionResult) {
     	try {
             pendingAsyncRequests.put(future);
         } catch (InterruptedException ie) {
@@ -108,17 +108,14 @@ public class JavaInstance implements AutoCloseable {
 
         future.whenCompleteAsync((obj, throwable) -> {
             if (log.isDebugEnabled()) {
-                log.debug("Got result async: object: {}, throwable: {}", obj, throwable);
+              log.debug("Got result async: object: {}, throwable: {}", obj, throwable);
             }
             
-            pendingAsyncRequests.remove(future);
-
             if (throwable != null) {
-                executionResult.setUserException(new Exception((Throwable)throwable));      
-                future.completeExceptionally((Throwable) throwable);
-                return;
+              executionResult.setUserException(new Exception((Throwable)throwable));      
             }
           
+            pendingAsyncRequests.remove(future);
             future.complete(obj);
             
         }, executor);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -326,6 +326,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                         srcRecord, t);
                 stats.incrUserExceptions(t);
                 srcRecord.fail();
+                throw new RuntimeException(t);
             } else {
                 if (result1.getResult() != null) {
                     sendOutputMessage(srcRecord, result1.getResult());

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -241,7 +241,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             stateStoreProvider = StateStoreProvider.NULL;
         } else {
             stateStoreProvider = new BKStateStoreProviderImpl();
-            Map<String, Object> stateStoreProviderConfig = new HashMap();
+            Map<String, Object> stateStoreProviderConfig = new HashMap<String, Object>();
             stateStoreProviderConfig.put(BKStateStoreProviderImpl.STATE_STORAGE_SERVICE_URL, stateStorageServiceUrl);
             stateStoreProvider.init(stateStoreProviderConfig, instanceConfig.getFunctionDetails());
 
@@ -378,6 +378,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 				   }
 				   output.set(obj);
 				});
+				future.join();
 			} else {
 				output.set(result.getResult());
 			}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -341,21 +341,23 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             }
     	} else { 
     		
-    		try {
-				Object output = (result.getResult() instanceof CompletableFuture) ?
-					((CompletableFuture)result.getResult()).get() : result.getResult();
-				
-				sendOutputMessage(srcRecord, output);
+    		try {			
+				sendOutputMessage(srcRecord, result.getResult());
 				
 				if (instanceConfig.getFunctionDetails().getAutoAck()) {
 					srcRecord.ack();
 				}
 				stats.incrTotalProcessedSuccessfully();
 				
-			} catch (InterruptedException | ExecutionException e) {
+			} catch (InterruptedException iEx) {
 				log.warn("Encountered exception when processing message {}",
-	                    srcRecord, e);
-	            stats.incrSysExceptions(e);
+	                    srcRecord, iEx);
+	            stats.incrSysExceptions(iEx);
+	            Thread.currentThread().interrupt();
+			} catch (ExecutionException eEx) {
+				log.warn("Encountered exception when processing message {}",
+	                    srcRecord, eEx);
+	            stats.incrSysExceptions(eEx.getCause());
 			} catch (Exception ex) {
 				throw ex;
 			}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -279,9 +279,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
                 addLogTopicHandler();
                 
-                // Not always a future...
-                JavaExecutionResult result;
-
                 // set last invocation time
                 stats.setLastInvocation(System.currentTimeMillis());
 
@@ -290,7 +287,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
                 // process the message
                 Thread.currentThread().setContextClassLoader(functionClassLoader);
-                result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
+                JavaExecutionResult result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
                 Thread.currentThread().setContextClassLoader(instanceClassLoader);
 
                 // register end time
@@ -329,14 +326,12 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     		log.warn("Encountered exception when processing message {}",
                     srcRecord, result.getUserException());
             stats.incrUserExceptions(result.getUserException());
-            throw result.getUserException();
     	} 
     	
     	if (result.getSystemException() != null) {
     		log.warn("Encountered exception when processing message {}",
                     srcRecord, result.getSystemException());
             stats.incrSysExceptions(result.getSystemException());
-            throw result.getSystemException();
     	}
     	
     	if (result.getResult() == null) {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -23,8 +23,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -49,9 +49,9 @@ public class JavaInstanceTest {
                 (Function<String, String>) (input, context) -> input + "-lambda",
                 new InstanceConfig());
         String testString = "ABC123";
-        CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
-        assertNotNull(result.get().getResult());
-        assertEquals(new String(testString + "-lambda"), result.get().getResult());
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+        assertNotNull(result.getResult());
+        assertEquals(new String(testString + "-lambda"), result.getResult());
         instance.close();
     }
 
@@ -81,9 +81,9 @@ public class JavaInstanceTest {
                 function,
                 instanceConfig);
         String testString = "ABC123";
-        CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
-        assertNotNull(result.get().getResult());
-        assertEquals(new String(testString + "-lambda"), result.get().getResult());
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+        assertNotNull(result.getResult());
+        assertEquals(((CompletableFuture)result.getResult()).get(), new String(testString + "-lambda"));
         instance.close();
     }
 
@@ -118,20 +118,20 @@ public class JavaInstanceTest {
 
         long startTime = System.currentTimeMillis();
         assertEquals(pendingQueueSize, instance.getPendingAsyncRequests().remainingCapacity());
-        CompletableFuture<JavaExecutionResult> result1 = instance.handleMessage(mock(Record.class), testString);
+        JavaExecutionResult result1 = instance.handleMessage(mock(Record.class), testString);
         assertEquals(pendingQueueSize - 1, instance.getPendingAsyncRequests().remainingCapacity());
-        CompletableFuture<JavaExecutionResult> result2 = instance.handleMessage(mock(Record.class), testString);
+        JavaExecutionResult result2 = instance.handleMessage(mock(Record.class), testString);
         assertEquals(pendingQueueSize - 2, instance.getPendingAsyncRequests().remainingCapacity());
-        CompletableFuture<JavaExecutionResult> result3 = instance.handleMessage(mock(Record.class), testString);
+        JavaExecutionResult result3 = instance.handleMessage(mock(Record.class), testString);
         // no space left
         assertEquals(0, instance.getPendingAsyncRequests().remainingCapacity());
 
         instance.getPendingAsyncRequests().remainingCapacity();
-        assertNotNull(result1.get().getResult());
-        assertNotNull(result2.get().getResult());
-        assertNotNull(result3.get().getResult());
+        assertNotNull(result1.getResult());
+        assertNotNull(result2.getResult());
+        assertNotNull(result3.getResult());
 
-        assertEquals(new String(testString + "-lambda"), result1.get().getResult());
+        assertEquals(((CompletableFuture)result1.getResult()).get(), new String(testString + "-lambda"));
         long endTime = System.currentTimeMillis();
 
         log.info("start:{} end:{} during:{}", startTime, endTime, endTime - startTime);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.instance;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -52,6 +54,52 @@ public class JavaInstanceTest {
         assertEquals(new String(testString + "-lambda"), result.getResult());
         instance.close();
     }
+    
+    @Test
+    public void testNullReturningFunction() {
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                (Function<String, String>) (input, context) -> null,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.getResult());
+    	instance.close();
+    }
+    
+    @Test
+    public void testUserExceptionThrowingFunction() {
+    	Function<String, String> func = (input, context) -> {
+    		throw new UserException("Boom");
+    	};
+    	
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                func,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.getResult());
+    	assertNotNull(result.getUserException());
+    	instance.close();
+    }
+    
+    @Test
+    public void testSystemExceptionThrowingFunction() {
+    	Function<String, String> func = (input, context) -> {
+    		throw new InterruptedException("Boom");
+    	};
+    	
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                func,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.getResult());
+    	assertNotNull(result.getUserException());
+    	instance.close();
+    }
 
     @Test
     public void testAsyncFunction() throws Exception {
@@ -82,6 +130,95 @@ public class JavaInstanceTest {
         JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
         assertNotNull(result.getResult());
         assertEquals(((CompletableFuture)result.getResult()).get(), new String(testString + "-lambda"));
+        instance.close();
+    }
+    
+    @Test
+    public void testNullReturningAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+                try {
+                    Thread.sleep(500);
+                    result.complete(null);
+                } catch (Exception e) {
+                    result.completeExceptionally(e);
+                }
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+        assertNotNull(result.getResult());
+        instance.close();
+    }
+    
+    @Test
+    public void testSystemExceptionThrowingAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+            	result.completeExceptionally(new InterruptedException(""));
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+        assertNotNull(result.getResult());
+        
+        awaitCompletion((CompletableFuture)result.getResult());
+        assertTrue(((CompletableFuture)result.getResult()).isCompletedExceptionally());
+        assertNotNull(result.getSystemException());
+        instance.close();
+    }
+    
+    @Test
+    public void testUserExceptionThrowingAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+            	result.completeExceptionally(new UserException("Boom"));
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
+        assertNotNull(result.getResult());
+        awaitCompletion((CompletableFuture)result.getResult());
+        assertNotNull(result.getUserException());
         instance.close();
     }
 
@@ -134,5 +271,21 @@ public class JavaInstanceTest {
 
         log.info("start:{} end:{} during:{}", startTime, endTime, endTime - startTime);
         instance.close();
+    }
+    
+    private static void awaitCompletion(CompletableFuture future) {
+    	try {
+            Thread.sleep(1000);
+            future.join();
+            Thread.sleep(1000);  // Give the whenCompleteAsync stage some time to execute
+          } catch (final Exception ex) {
+          	// Ignore
+          }
+    }
+    
+    private static class UserException extends Exception {
+    	public UserException(String msg) {
+    		super(msg);
+    	}
     }
 }


### PR DESCRIPTION
Fixes #10269 

### Motivation

When an Error or Exception occurs in write() method of the sink, the error is logged but no actions are performed.  We need the exception to be re-thrown so that the user/framework can be made aware of the underlying issue rather than having the Sink continuously failing silently, e.g. zombie sink instances that are running but not making any progress.

### Modifications

Added logic to re-throw an exception if one is encountered inside the processResult() method of the JavaInstanceRunnable class 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? This is a bug fix to correct the behavior of a Sink when an exception is thrown
