### PR TITLE
[Cursor] add return statement to exit asyncMarkDelete early on failure

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1609,6 +1609,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     new ManagedLedgerException("Reset cursor in progress - unable to mark delete position "
                             + position.toString()),
                     ctx);
+            return;
         }
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

In reading through the message expiration code, I noticed that there is a case where we call `markDeleteFailed` on a callback, but don't subsequently return from the method.

For background, any other time we call the `markDeleteFailed` method, we either call return or exit the method because it is part of a callback.

### Verifying this change

None. I think this change is obvious enough that it doesn't require any validation. Please let me know if more validation is required.