### PR TITLE
[Broker] Suppress printing of "skip Processing" lines in startup scripts

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
+++ b/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
@@ -35,6 +35,7 @@ if len(sys.argv) < 3:
 prefix = sys.argv[1]
 conf_files = sys.argv[2:]
 
+PF_ENV_DEBUG = (os.environ.get('PF_ENV_DEBUG','0') == '1')
 
 for conf_filename in conf_files:
     lines = []  # List of config file lines
@@ -51,7 +52,8 @@ for conf_filename in conf_files:
             k,v = line.split('=', 1)
             keys[k] = len(lines) - 1
         except:
-            print("[%s] skip Processing %s" % (conf_filename, line))
+            if PF_ENV_DEBUG:
+                print("[%s] skip Processing %s" % (conf_filename, line))
 
     # Update values from Env
     for k in sorted(os.environ.keys()):

--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -35,6 +35,7 @@ if len(sys.argv) < 2:
 conf_files = sys.argv[1:]
 
 PF_ENV_PREFIX = 'PULSAR_PREFIX_'
+PF_ENV_DEBUG = (os.environ.get('PF_ENV_DEBUG','0') == '1')
 
 for conf_filename in conf_files:
     lines = []  # List of config file lines
@@ -53,7 +54,8 @@ for conf_filename in conf_files:
                 k = k[1:]
             keys[k.strip()] = len(lines) - 1
         except:
-            print("[%s] skip Processing %s" % (conf_filename, line))
+            if PF_ENV_DEBUG:
+                print("[%s] skip Processing %s" % (conf_filename, line))
 
     # Update values from Env
     for k in sorted(os.environ.keys()):


### PR DESCRIPTION
### Motivation

The startup logging of the broker (and bookie) is very verbose after the changes made in #8709 .

[example of typical output](https://github.com/apache/pulsar/runs/2378390309?check_suite_focus=true#step:13:751):
```
[conf/broker.conf] skip Processing #
[conf/broker.conf] skip Processing # Licensed to the Apache Software Foundation (ASF) under one
[conf/broker.conf] skip Processing # or more contributor license agreements.  See the NOTICE file
[conf/broker.conf] skip Processing # distributed with this work for additional information
[conf/broker.conf] skip Processing # regarding copyright ownership.  The ASF licenses this file
[conf/broker.conf] skip Processing # to you under the Apache License, Version 2.0 (the
[conf/broker.conf] skip Processing # "License"); you may not use this file except in compliance
[conf/broker.conf] skip Processing # with the License.  You may obtain a copy of the License at
[conf/broker.conf] skip Processing #
[conf/broker.conf] skip Processing #   http://www.apache.org/licenses/LICENSE-2.0
[conf/broker.conf] skip Processing #
[conf/broker.conf] skip Processing # Unless required by applicable law or agreed to in writing,
[conf/broker.conf] skip Processing # software distributed under the License is distributed on an
[conf/broker.conf] skip Processing # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
[conf/broker.conf] skip Processing # KIND, either express or implied.  See the License for the
[conf/broker.conf] skip Processing # specific language governing permissions and limitations
[conf/broker.conf] skip Processing # under the License.
[conf/broker.conf] skip Processing #
[conf/broker.conf] skip Processing ### --- General broker settings --- ###
[conf/broker.conf] skip Processing # Zookeeper quorum connection string
[conf/broker.conf] skip Processing # Configuration Store connection string
[conf/broker.conf] skip Processing # Broker data port
[conf/broker.conf] skip Processing # Broker data port for TLS - By default TLS is disabled
[conf/broker.conf] skip Processing # Port to use to server HTTP request
[conf/broker.conf] skip Processing # Port to use to server HTTPS request - By default TLS is disabled
[conf/broker.conf] skip Processing # Hostname or IP address the service binds on, default is 0.0.0.0.
```

### Modifications

Suppress printing the `skip Processing` lines unless `PF_ENV_DEBUG` environment variable is set to `1`.