### PR TITLE
[GitHub Actions] Fix logic that was incorrectly skipping tests

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,12 +71,12 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -85,20 +85,20 @@ jobs:
           df -h
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build package
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: build cpp artifacts
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           echo "Build C++ client library"
           export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so"
           pulsar-client-cpp/docker-build.sh
 
       - name: run c++ tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: pulsar-client-cpp/docker-tests.sh

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -68,26 +68,26 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: InstallTool
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.18.0
           ./bin/golangci-lint --version
 
       - name: Build
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           go build ./...
 
       - name: CheckStyle
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           ./bin/golangci-lint run -c ./golangci.yml ./pf

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -70,13 +70,13 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v2
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Run tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           cd pulsar-function-go
           go test -v $(go list ./... | grep -v examples)

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,17 +71,17 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 1.8
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -90,23 +90,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh BACKWARDS_COMPAT
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -72,16 +72,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -90,23 +90,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh CLI
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -72,16 +72,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -90,23 +90,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh FUNCTION
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -72,16 +72,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -90,23 +90,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh MESSAGING
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh PULSAR_CONNECTORS_PROCESS
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,20 +89,20 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SCHEMA
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SQL
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh STANDALONE
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration function
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh PULSAR_CONNECTORS_THREAD
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TIERED_FILESYSTEM
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,23 +89,23 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TIERED_JCLOUD
 
       - name: Upload container logs

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -58,7 +58,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -89,20 +89,20 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run integration tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh TRANSACTION
 
       - name: Upload container logs

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,26 +71,26 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 1.8
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       # license check fails with 3.6.2 so we have to downgrade
       - name: Set up Maven
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: apache/pulsar-test-infra/setup-maven@master
         with:
           maven-version: 3.6.1
 
       - name: build and check license
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp -DskipTests apache-rat:check initialize license:check install
 
       - name: license check
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: src/check-binary-license ./distribution/server/target/apache-pulsar-*-bin.tar.gz

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -72,16 +72,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: clean disk
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: |
           sudo swapoff -a
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
@@ -90,21 +90,21 @@ jobs:
           df -h
 
       - name: run install by skip tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -q -B -ntp clean install -DskipTests
 
       - name: build pulsar image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
 
       - name: run shade tests
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_integration_group.sh SHADE

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_1'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_1
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_GROUP_2'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_GROUP_2
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_API'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_API
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_IMPL'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_CLIENT_IMPL
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
 
       - name: run unit test 'BROKER_FLAKY'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh BROKER_FLAKY
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,20 +71,20 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: build modules pulsar-proxy
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: mvn -B -ntp -q install -Pcore-modules -DskipTests
 
       - name: run unit test 'PROXY'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh PROXY
 
       - name: print JVM thread dumps when cancelled

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -59,7 +59,7 @@ jobs:
               - '**/*.md'
 
       - name: Cache local Maven repository
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         uses: actions/cache@v2
         with:
           path: |
@@ -71,16 +71,16 @@ jobs:
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         with:
           java-version: 1.8
 
       - name: Replace maven's wagon-http version
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: sudo ./build/replace_maven-wagon-http-version.sh
 
       - name: run unit test 'OTHER'
-        if: ${{ steps.changes.outputs.all_count > steps.changes.outputs.docs_count }}
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: ./build/run_unit_group.sh OTHER
 
       - name: print JVM thread dumps when cancelled


### PR DESCRIPTION
### Motivation

Currently, when there are changes made to code and documentation in the same PR, many of the tests are skipped because the conditional logic is not being parsed as expected.

@jerrypeng noticed this issue on this PR: https://github.com/apache/pulsar/pull/10254.

### Modifications

Fix the usage of `${{}}`.

### Verifying this change

I ran tests in my personal GitHub repository to validate this change. Here is the PR that shows it: https://github.com/michaeljmarshall/pulsar/pull/2/checks. I used echo to validate what changed. (Note that the PR uses the base of https://github.com/apache/pulsar/pull/10254 to reproduce the problem.)

### Does this pull request potentially affect one of the following parts:

This affects all tests that run for PRs that include changes to documentation and code.
