### PR TITLE
[Java Client] Fix concurrency issue in client's producer epoch handling

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.impl;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -35,7 +37,9 @@ public class ConnectionHandler {
 
     protected final HandlerState state;
     protected final Backoff backoff;
-    protected long epoch = 0L;
+    private static final AtomicLongFieldUpdater<ConnectionHandler> EPOCH_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(ConnectionHandler.class, "epoch");
+    private volatile long epoch = 0L;
     protected volatile long lastConnectionClosedTimestamp = 0L;
 
     interface Connection {
@@ -104,9 +108,13 @@ public class ConnectionHandler {
         state.setState(State.Connecting);
         state.client.timer().newTimeout(timeout -> {
             log.info("[{}] [{}] Reconnecting after connection was closed", state.topic, state.getHandlerName());
-            ++epoch;
+            incrementEpoch();
             grabCnx();
         }, delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    protected long incrementEpoch() {
+        return EPOCH_UPDATER.incrementAndGet(this);
     }
 
     @VisibleForTesting
@@ -124,7 +132,7 @@ public class ConnectionHandler {
                     delayMs / 1000.0);
             state.client.timer().newTimeout(timeout -> {
                 log.info("[{}] [{}] Reconnecting after timeout", state.topic, state.getHandlerName());
-                ++epoch;
+                incrementEpoch();
                 grabCnx();
             }, delayMs, TimeUnit.MILLISECONDS);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1312,7 +1312,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
         cnx.sendRequestWithId(
                 Commands.newProducer(topic, producerId, requestId, producerName, conf.isEncryptionEnabled(), metadata,
-                       schemaInfo, connectionHandler.epoch, userProvidedProducerName,
+                       schemaInfo, connectionHandler.getEpoch(), userProvidedProducerName,
                        conf.getAccessMode(), topicEpoch),
                 requestId).thenAccept(response -> {
                     String producerName = response.getProducerName();


### PR DESCRIPTION
Fixes #9792 

### Motivation

Client's producer epoch handling was added #5571 . An issue has been reported as #9792 where this solution hasn't worked.
When looking at the code, it seems that there's a concurrency issue. 
The epoc field is incremented in the timer thread, but read in another thread. There is no synchronization / volatile field in place.
In Java, updating double or long values isn't thread safe.
Explained in [JLS 17.7](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7)
> For the purposes of the Java programming language memory model, a single write to a non-volatile long or double value is treated as two separate writes: one to each 32-bit half. This can result in a situation where a thread sees the first 32 bits of a 64-bit value from one write, and the second 32 bits from another write.

### Modifications

- use volatile field for epoch
- use AtomicLongFieldUpdater for incrementing the value (although it would be fine to omit it when a single timer thread is updating the value. However this method isn't a final method and subclasses can override the reconnectLater method.)