### PR TITLE
Fix thread safety issue in ManagedLedgerImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -195,11 +195,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final static CompletableFuture<PositionImpl> NULL_OFFLOAD_PROMISE = CompletableFuture
             .completedFuture(PositionImpl.latest);
     private volatile LedgerHandle currentLedger;
-    private long currentLedgerEntries = 0;
-    private long currentLedgerSize = 0;
-    private long lastLedgerCreatedTimestamp = 0;
-    private long lastLedgerCreationFailureTimestamp = 0;
-    private long lastLedgerCreationInitiationTimestamp = 0;
+    private volatile long currentLedgerEntries = 0;
+    private volatile long currentLedgerSize = 0;
+    private volatile long lastLedgerCreatedTimestamp = 0;
+    private volatile long lastLedgerCreationFailureTimestamp = 0;
+    private volatile long lastLedgerCreationInitiationTimestamp = 0;
 
     private static final Random random = new Random(System.currentTimeMillis());
     private final long maximumRolloverTimeMs;


### PR DESCRIPTION
### Motivation

In Java, updating double or long values isn't atomic and thread safe.
Explained in [JLS 17.7](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7)
> For the purposes of the Java programming language memory model, a single write to a non-volatile long or double value is treated as two separate writes: one to each 32-bit half. This can result in a situation where a thread sees the first 32 bits of a 64-bit value from one write, and the second 32 bits from another write.

There are several mutable non-volatile `long` fields in `ManagedLedgerImpl` which are accessed from multiple threads.

### Modifications

Make the fields volatile to fix the thread safety issues.


