### PR TITLE
[Security] Use dependency management to enforce vertx version

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -115,23 +115,23 @@
     </dependency>
 
     <dependency>
-       <groupId>io.dropwizard.metrics</groupId>
-       <artifactId>metrics-core</artifactId>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>
-       <groupId>io.dropwizard.metrics</groupId>
-       <artifactId>metrics-graphite</artifactId>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
     </dependency>
 
     <dependency>
-       <groupId>io.dropwizard.metrics</groupId>
-       <artifactId>metrics-jvm</artifactId>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
     </dependency>
 
     <dependency>
-       <groupId>org.xerial.snappy</groupId>
-       <artifactId>snappy-java</artifactId>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
     </dependency>
 
     <dependency>
@@ -242,41 +242,16 @@
           <groupId>io.netty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
-        <!--TODO: When pulsar uses https://github.com/apache/bookkeeper/pull/2410 in -->
-        <!--      the next bk version, please remove the following content.-->
-        <exclusion>
-          <groupId>io.vertx</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
-    <!--TODO: When pulsar uses https://github.com/apache/bookkeeper/pull/2410 in -->
-    <!--      the next bk version, please remove the following content.-->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -339,7 +314,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,17 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-core</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+
+      <dependency>
          <groupId>org.apache.curator</groupId>
          <artifactId>curator-recipes</artifactId>
          <version>${curator.version}</version>


### PR DESCRIPTION
### Motivation

OWASP Dependency Checker still shows that the vulnerable vertx 3.5.3 version is used although #10261 was already merged to fix the issue. The previous solution didn't properly use dependency management to enforce a specific vertx version.

### Modifications

- use dependency management to enforce vertx version

