### PR TITLE
[Security] Upgrade commons-io to address CVE-2021-29425

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -345,7 +345,7 @@ The Apache Software License, Version 2.0
     - commons-codec-commons-codec-1.10.jar
     - commons-collections-commons-collections-3.2.2.jar
     - commons-configuration-commons-configuration-1.10.jar
-    - commons-io-commons-io-2.5.jar
+    - commons-io-commons-io-2.8.0.jar
     - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@ flexible messaging model and an intuitive client API.</description>
     <jcommander.version>1.78</jcommander.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
-    <commons-io.version>2.5</commons-io.version>
+    <commons-io.version>2.8.0</commons-io.version>
     <commons-codec.version>1.10</commons-codec.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <log4j.version>1.2.17</log4j.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -429,7 +429,7 @@ The Apache Software License, Version 2.0
     - commons-codec-1.10.jar
     - commons-collections4-4.1.jar
     - commons-configuration-1.10.jar
-    - commons-io-2.5.jar
+    - commons-io-2.8.0.jar
     - commons-lang-2.6.jar
     - commons-logging-1.2.jar
   * GSON


### PR DESCRIPTION
### Motivation

The currently used commons-io version 2.5 contains a vulnerability CVE-2021-29425 .

### Modifications

Upgrade commons-io to the most recent version, 2.8.0 .