### PR TITLE
[Security] Add configuration for running OWASP Dependency Check for all modules

### DIFF
--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -37,6 +37,16 @@ function ci_print_thread_dumps() {
   return 0
 }
 
+function _ci_mvn() {
+  mvn -B -ntp "$@"
+}
+
+# runs OWASP Dependency Check for all projects
+function ci_dependency_check() {
+  _ci_mvn -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl '!pulsar-client-tools-test' "$@"
+}
+
+
 if [ -z "$1" ]; then
   echo "usage: $0 [ci_tool_function_name]"
   echo "Available ci tool functions:"

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -52,7 +52,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/kafka-connect-avro-converter-shaded/pom.xml
+++ b/kafka-connect-avro-converter-shaded/pom.xml
@@ -59,7 +59,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>${shadePluginPhase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -2060,6 +2060,36 @@ flexible messaging model and an intuitive client API.</description>
         <narPluginPhase>none</narPluginPhase>
         <skipDocker>true</skipDocker>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>owasp-dependency-check</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2053,6 +2053,8 @@ flexible messaging model and an intuitive client API.</description>
         <skipSourceReleaseAssembly>true</skipSourceReleaseAssembly>
         <skipBuildDistribution>true</skipBuildDistribution>
         <spotbugs.skip>true</spotbugs.skip>
+        <license.skip>true</license.skip>
+        <rat.skip>true</rat.skip>
         <assembly.skipAssembly>true</assembly.skipAssembly>
         <shadePluginPhase>none</shadePluginPhase>
         <narPluginPhase>none</narPluginPhase>

--- a/pom.xml
+++ b/pom.xml
@@ -2058,6 +2058,7 @@ flexible messaging model and an intuitive client API.</description>
         <assembly.skipAssembly>true</assembly.skipAssembly>
         <shadePluginPhase>none</shadePluginPhase>
         <narPluginPhase>none</narPluginPhase>
+        <skipDocker>true</skipDocker>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
+    <dependency-check-maven.version>6.1.5</dependency-check-maven.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -1788,13 +1789,16 @@ flexible messaging model and an intuitive client API.</description>
         <rename.netty.native.libs>rename-netty-native-libs.cmd</rename.netty.native.libs>
       </properties>
 
-    <!-- Primary Module profile -->
     </profile>
+    <!-- Primary Module profile -->
     <profile>
       <id>main</id>
       <activation>
         <activeByDefault>true</activeByDefault>
         <jdk>[8,)</jdk>
+        <property>
+          <name>owasp-dependency-check</name>
+        </property>
       </activation>
       <modules>
         <module>buildtools</module>
@@ -2038,6 +2042,66 @@ flexible messaging model and an intuitive client API.</description>
       <modules>
         <module>tests</module>
       </modules>
+    </profile>
+    <profile>
+      <id>skip-all</id>
+      <properties>
+        <maven.main.skip>true</maven.main.skip>
+        <maven.test.skip>true</maven.test.skip>
+        <skipSourceReleaseAssembly>true</skipSourceReleaseAssembly>
+        <skipBuildDistribution>true</skipBuildDistribution>
+        <spotbugs.skip>true</spotbugs.skip>
+        <assembly.skipAssembly>true</assembly.skipAssembly>
+      </properties>
+    </profile>
+    <profile>
+      <id>owasp-dependency-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <configuration>
+              <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
+              <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+              <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>
+              <pyDistributionAnalyzerEnabled>false</pyDistributionAnalyzerEnabled>
+              <pyPackageAnalyzerEnabled>false</pyPackageAnalyzerEnabled>
+              <pipAnalyzerEnabled>false</pipAnalyzerEnabled>
+              <pipfileAnalyzerEnabled>false</pipfileAnalyzerEnabled>
+              <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
+              <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
+              <mixAuditAnalyzerEnabled>false</mixAuditAnalyzerEnabled>
+              <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+              <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <reportSets>
+              <reportSet>
+                <reports>
+                  <report>aggregate</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1798,9 +1798,6 @@ flexible messaging model and an intuitive client API.</description>
       <activation>
         <activeByDefault>true</activeByDefault>
         <jdk>[8,)</jdk>
-        <property>
-          <name>owasp-dependency-check</name>
-        </property>
       </activation>
       <modules>
         <module>buildtools</module>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ flexible messaging model and an intuitive client API.</description>
     <docker.organization>apachepulsar</docker.organization>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
+    <shadePluginPhase>package</shadePluginPhase>
 
     <!-- apache commons -->
     <commons-compress.version>1.19</commons-compress.version>
@@ -2052,6 +2053,7 @@ flexible messaging model and an intuitive client API.</description>
         <skipBuildDistribution>true</skipBuildDistribution>
         <spotbugs.skip>true</spotbugs.skip>
         <assembly.skipAssembly>true</assembly.skipAssembly>
+        <shadePluginPhase>none</shadePluginPhase>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@ flexible messaging model and an intuitive client API.</description>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
     <shadePluginPhase>package</shadePluginPhase>
+    <narPluginPhase>package</narPluginPhase>
 
     <!-- apache commons -->
     <commons-compress.version>1.19</commons-compress.version>
@@ -1592,7 +1593,7 @@ flexible messaging model and an intuitive client API.</description>
           <executions>
             <execution>
               <id>default-nar</id>
-              <phase>package</phase>
+              <phase>${narPluginPhase}</phase>
               <goals>
                 <goal>nar</goal>
               </goals>
@@ -2054,6 +2055,7 @@ flexible messaging model and an intuitive client API.</description>
         <spotbugs.skip>true</spotbugs.skip>
         <assembly.skipAssembly>true</assembly.skipAssembly>
         <shadePluginPhase>none</shadePluginPhase>
+        <narPluginPhase>none</narPluginPhase>
       </properties>
     </profile>
     <profile>

--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -97,7 +97,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
@@ -48,7 +48,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -101,7 +101,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -117,7 +117,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -112,7 +112,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>${shadePluginPhase}</phase>
             <goals>
               <goal>shade</goal>
             </goals>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -96,7 +96,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>${shadePluginPhase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -131,14 +131,6 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-presto-connector</artifactId>
-      <version>${project.version}</version>
-      <type>tar.gz</type>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
       <version>${objenesis.version}</version>
@@ -270,6 +262,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>${skipBuildDistribution}</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.3.0</version>
         <configuration>
@@ -338,4 +338,25 @@
       </extension>
     </extensions>
   </build>
+
+  <profiles>
+    <profile>
+      <id>skipBuildDistributionDisabled</id>
+      <activation>
+        <property>
+          <name>skipBuildDistribution</name>
+          <value>false</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>pulsar-presto-connector</artifactId>
+          <version>${project.version}</version>
+          <type>tar.gz</type>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -159,7 +159,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>${shadePluginPhase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>

--- a/tests/docker-images/java-test-functions/pom.xml
+++ b/tests/docker-images/java-test-functions/pom.xml
@@ -61,7 +61,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>${shadePluginPhase}</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>


### PR DESCRIPTION
### Motivation

[OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/) is a Software Composition Analysis (SCA) tool that attempts to detect publicly disclosed vulnerabilities contained within a project’s dependencies.

This PR adds basic configuration for `org.owasp:dependency-check-maven` maven plugin and makes it operational in the apache/pulsar project. This a starting point. Later on,  it's possible to improve this further and introduce a scheduled job to automate the checking and fail the job if a new critical or high vulnerability is detected.

### Modifications

Add necessary maven profiles and configuration so that it's possible to run the dependency-check independently for all projects.

This is the way to run the dependency check for manual inspection:
```
# run dependency check for all projects
./build/pulsar_ci_tool.sh dependency_check
# open the html report for all modules in a browser
open target/dependency-check-report.html
# open the html report for Pulsar server distribution (excluding Presto/Pulsar SQL) in a browser
open distribution/server/target/dependency-check-report.html
```
