### PR TITLE
[Functions] Added more details to error message to assist with debugging exceptions

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -35,6 +35,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.CompressionType;
@@ -75,6 +77,7 @@ import static org.apache.pulsar.functions.instance.stats.FunctionStatsManager.US
 /**
  * This class implements the Context interface exposed to the user.
  */
+@ToString
 class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
     private InstanceConfig config;
     private Logger logger;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -711,7 +711,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                         }.getType()), contextImpl);
             }
         } catch (Exception e) {
-            log.error("Source open produced uncaught exception: ", e);
+            log.error("Source open produced uncaught exception with ContextImpl of {}. "
+                            + "sourceSpec is {}. Exception is {}.",
+                    contextImpl.toString(), sourceSpec.toString(), e);
             throw e;
         } finally {
             Thread.currentThread().setContextClassLoader(this.instanceClassLoader);


### PR DESCRIPTION
After updating the brokers in a test cluster from 2.6.3 to an image built from master, all functions in the cluster are restarting with the error "Source open produced uncaught exception". The purpose of this commit is to add additional debugging detail to assist with troubleshooting this error because heap dumps don't provide the contents of ContextImpl at the point of the failure. 