### PR TITLE
Downgrade vertx to 3.5.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -504,11 +504,10 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.9.7.jar
-    - io.vertx-vertx-bridge-common-3.9.7.jar
-    - io.vertx-vertx-core-3.9.7.jar
-    - io.vertx-vertx-web-3.9.7.jar
-    - io.vertx-vertx-web-common-3.9.7.jar
+    - io.vertx-vertx-auth-common-3.5.4.jar
+    - io.vertx-vertx-bridge-common-3.5.4.jar
+    - io.vertx-vertx-core-3.5.4.jar
+    - io.vertx-vertx-web-3.5.4.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.6.2.jar
   * Snappy Java

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <aspectj.version>1.9.2</aspectj.version>
-    <vertx.version>3.9.7</vertx.version>
+    <vertx.version>3.5.4</vertx.version>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
Fixes #10295

### Motivation

- vertx 3.9.7 isn't compatible with Netty 4.1.63.Final

### Modifications

- downgrade vertx from 3.9.7 to 3.5.4 
  - 3.5.4 fixes CVE-2018-12541, but contains  [CVE-2019-17640](https://nvd.nist.gov/vuln/detail/CVE-2019-17640)