### PR TITLE
Pulsar Client Tools: handle every data type with 'pulsar-client consume'

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -23,6 +23,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -34,6 +35,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -47,8 +49,10 @@ import org.apache.commons.io.HexDump;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.RemoteEndpoint;
@@ -161,15 +165,9 @@ public class CmdConsume {
             data = "null";
         } else if (value instanceof byte[]) {
             byte[] msgData = (byte[]) value;
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            if (!displayHex) {
-                data = new String(msgData);
-            } else {
-                HexDump.dump(msgData, 0, out, 0);
-                data = new String(out.toByteArray());
-            }
-        } else if (value instanceof GenericRecord) {
-            Map<String, Object> asMap = genericRecordToMap((GenericRecord) value);
+            data = interpretByteArray(displayHex, msgData);
+        } else if (value instanceof GenericObject) {
+            Map<String, Object> asMap = genericObjectToMap((GenericObject) value, displayHex);
             data = asMap.toString();
         } else {
             data = value.toString();
@@ -189,19 +187,65 @@ public class CmdConsume {
         return sb.toString();
     }
 
-    private static Map<String, Object> genericRecordToMap(GenericRecord value) {
-        return value.getFields()
-                .stream()
-                .collect(Collectors.toMap(Field::getName, f -> {
-                    Object fieldValue = value.getField(f);
-                    if (fieldValue instanceof GenericRecord) {
-                        return genericRecordToMap((GenericRecord) fieldValue);
-                    } else if (fieldValue == null) {
-                        return "null";
-                    } else {
-                        return fieldValue;
-                    }
-                }));
+    private static String interpretByteArray(boolean displayHex, byte[] msgData) throws IOException {
+        String data;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (!displayHex) {
+            return new String(msgData);
+        } else {
+            HexDump.dump(msgData, 0, out, 0);
+            return  new String(out.toByteArray());
+        }
+    }
+
+    private static Map<String, Object> genericObjectToMap(GenericObject value, boolean displayHex) throws IOException {
+        switch (value.getSchemaType()) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF_NATIVE:
+                    return genericRecordToMap((GenericRecord) value, displayHex);
+            case KEY_VALUE:
+                    return keyValueToMap((KeyValue) value.getNativeObject(), displayHex);
+            default:
+                return primitiveValueToMap(value.getNativeObject(), displayHex);
+        }
+    }
+
+    private static Map<String, Object> keyValueToMap(KeyValue value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return ImmutableMap.of("value", "NULL");
+        }
+        return ImmutableMap.of("key", primitiveValueToMap(value.getKey(), displayHex),
+                "value", primitiveValueToMap(value.getValue(), displayHex));
+    }
+
+    private static Map<String, Object> primitiveValueToMap(Object value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return ImmutableMap.of("value", "NULL");
+        }
+        if (value instanceof GenericObject) {
+            return genericObjectToMap((GenericObject) value, displayHex);
+        }
+        if (value instanceof byte[]) {
+            value = interpretByteArray(displayHex, (byte[]) value);
+        }
+        return ImmutableMap.of("value", value.toString(), "type", value.getClass());
+    }
+
+    private static Map<String, Object> genericRecordToMap(GenericRecord value, boolean displayHex) throws IOException {
+        Map<String, Object> res = new HashMap<>();
+        for (Field f : value.getFields()) {
+            Object fieldValue = value.getField(f);
+            if (fieldValue instanceof GenericRecord) {
+                fieldValue = genericRecordToMap((GenericRecord) fieldValue, displayHex);
+            } else if (fieldValue == null) {
+                fieldValue =  "NULL";
+            } else if (fieldValue instanceof byte[]) {
+                fieldValue = interpretByteArray(displayHex, (byte[]) fieldValue);
+            }
+            res.put(f.getName(), fieldValue);
+        }
+        return res;
     }
 
     /**


### PR DESCRIPTION
### Motivation
Now with AutoConsumeSchema we are able to handle every data type, so when you use "--schema-type auto_consume" in "pulsar-client consume" you are going to receive any Java object.

### Modifications

Handle every data type (wrapped by GenericObject) in "pulsar-client consume --schema-type auto_consume"
