### PR TITLE
Release procedure: fix paths for docker-build-deb.sh and docker-build-rpm.sh

### DIFF
--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -21,6 +21,7 @@
 set -e
 
 ROOT_DIR=$(dirname $0)/../../..
+ROOT_DIR=$(realpath $ROOT_DIR)
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/docker-build-deb.sh
@@ -20,8 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../..
-ROOT_DIR=$(realpath $ROOT_DIR)
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. &> /dev/null && pwd )"
 
 docker pull apachepulsar/pulsar-build:debian-9
 

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,7 +20,8 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../../..
+ROOT_DIR=$(dirname $0)/../../..
+ROOT_DIR=$(realpath $ROOT_DIR)
 
 docker pull apachepulsar/pulsar-build:centos-7
 

--- a/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
+++ b/pulsar-client-cpp/pkg/rpm/docker-build-rpm.sh
@@ -20,8 +20,7 @@
 
 set -e
 
-ROOT_DIR=$(dirname $0)/../../..
-ROOT_DIR=$(realpath $ROOT_DIR)
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. &> /dev/null && pwd )"
 
 docker pull apachepulsar/pulsar-build:centos-7
 


### PR DESCRIPTION
### Motivation
While preparing the release for Pulsar 2.7.2 I had a problem executing docker-build-rpm.sh and docker-build-deb.sh  on MacOS.

It looks like the reference to the Pulsar main directory is wrong and we are mounting the wrong directory while launching docker.

### Modifications

Use "realpath" in order to get the right directory.
