### PR TITLE
Fix C++ client cannot be built with Boost <=1.53

### DIFF
--- a/.github/workflows/ci-cpp-build-centos7.yaml
+++ b/.github/workflows/ci-cpp-build-centos7.yaml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - CPP build on CentOS 7
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - branch-*
+
+jobs:
+
+  cpp-build-centos7:
+    name:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Changed files check
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
+        with:
+          filters: |
+            # pattern syntax: https://github.com/micromatch/picomatch
+            all:
+              - 'pulsar-client-cpp/**'
+            docs:
+              - 'site2/**'
+              - 'deployment/**'
+              - '.asf.yaml'
+              - '*.md'
+              - '**/*.md'
+
+      - name: build cpp client on centos 7
+        if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
+        run: |
+          echo "Build C++ client library on CentOS 7"
+          pulsar-client-cpp/docker-build-centos7.sh

--- a/pulsar-client-cpp/docker-build-centos7.sh
+++ b/pulsar-client-cpp/docker-build-centos7.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Build Pulsar C++ client in CentOS 7 container
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd $ROOT_DIR/pulsar-client-cpp
+
+IMAGE="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-cpp-build-centos7}"
+cd ./docker/centos-7
+docker build -t "${IMAGE}" .
+cd -
+
+VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
+COMMAND="cd /pulsar/pulsar-client-cpp && mkdir -p _builds && cd _builds &&
+ /opt/cmake/cmake-3.4.0-Linux-x86_64/bin/cmake .. -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF && make"
+
+DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
+
+rm -rf _builds
+$DOCKER_CMD bash -c "${COMMAND}"

--- a/pulsar-client-cpp/docker/centos-7/Dockerfile
+++ b/pulsar-client-cpp/docker/centos-7/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+FROM centos:7.6.1810
+
+RUN yum install -y gcc gcc-c++ make \
+  protobuf-devel.x86_64 protobuf-lite-devel.x86_64 \
+  libcurl-devel openssl-devel \
+  boost boost-devel
+
+RUN mkdir -p /opt/cmake
+WORKDIR /opt/cmake
+RUN curl -L -O https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.tar.gz \
+  && tar zxf cmake-3.4.0-Linux-x86_64.tar.gz

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -189,7 +189,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
 #if BOOST_VERSION >= 105400
         boost::asio::ssl::context ctx(boost::asio::ssl::context::tlsv12_client);
 #else
-        boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv1_client);
+        boost::asio::ssl::context ctx(*executor_->io_service_, boost::asio::ssl::context::tlsv1_client);
 #endif
         Url serviceUrl;
         Url::parse(physicalAddress, serviceUrl);

--- a/pulsar-client-cpp/lib/Murmur3_32Hash.cc
+++ b/pulsar-client-cpp/lib/Murmur3_32Hash.cc
@@ -23,7 +23,11 @@
 // the orignal MurmurHash3 source code.
 #include "Murmur3_32Hash.h"
 
+#if BOOST_VERSION >= 105500
 #include <boost/predef.h>
+#else
+#include <boost/detail/endian.hpp>
+#endif
 #include <limits>
 
 #if BOOST_COMP_MSVC
@@ -33,16 +37,18 @@
 #define ROTATE_LEFT(x, y) rotate_left(x, y)
 #endif
 
-#if BOOST_ENDIAN_LITTLE_BYTE
+#if defined(BOOST_ENDIAN_LITTLE_BYTE) || defined(BOOST_LITTLE_ENDIAN)
 #define BYTESPWAP(x) (x)
-#elif BOOST_ENDIAN_BIG_BYTE
+#elif defined(BOOST_ENDIAN_BIG_BYTE) || defined(BOOST_BIG_ENDIAN)
 #if BOOST_COMP_CLANG || BOOST_COMP_GNUC
 #define BYTESPWAP(x) __builtin_bswap32(x)
 #elif BOOST_COMP_MSVC
 #define BYTESPWAP(x) _byteswap_uint32(x)
 #else
+#error "No BOOST_COMP_XXX macro found"
 #endif
 #else
+#error "No byte order found"
 #endif
 
 #define MACRO_CHUNK_SIZE 4

--- a/pulsar-client-cpp/lib/Murmur3_32Hash.cc
+++ b/pulsar-client-cpp/lib/Murmur3_32Hash.cc
@@ -23,6 +23,7 @@
 // the orignal MurmurHash3 source code.
 #include "Murmur3_32Hash.h"
 
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 105500
 #include <boost/predef.h>
 #else

--- a/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
@@ -15,8 +15,11 @@
  ******************************************************************************/
 #include "crc32c_sse42.h"
 
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 105500
 #include <boost/predef.h>
+#else
+#warning "Boost version is < 1.55, disable CRC32C"
 #endif
 
 #include <assert.h>
@@ -25,6 +28,8 @@
 #if BOOST_ARCH_X86_64
 #include <nmmintrin.h>  // SSE4.2
 #include <wmmintrin.h>  // PCLMUL
+#else
+#warning "BOOST_ARCH_X86_64 is not defined, CRC32C will be disabled"
 #endif
 
 #ifdef _MSC_VER

--- a/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
+++ b/pulsar-client-cpp/lib/checksum/crc32c_sse42.cc
@@ -15,7 +15,9 @@
  ******************************************************************************/
 #include "crc32c_sse42.h"
 
+#if BOOST_VERSION >= 105500
 #include <boost/predef.h>
+#endif
 
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
### Motivation

CentOS 7 is a wide-used Linux system though its softwares of yum source are usually very old. The default Boost version is 1.53 on CentOS 7. However, currently C++ client cannot be built with Boost 1.53 or lower versions.

First, the `boost::asio::ssl::context` was constructed with a `std::shared_ptr<io_service>` as its first argument when the Boost version is < 1.54. However, it accepts a `io_service&` argument. This code error was not exposed because we use higher version Boost when cpp tests were performed.

Second, for Boost < 1.55, there's no `boost/predef.h` header. The header is used for detecting the byte order of OS and the architecture of CPU.

### Modifications

- Fix the wrong construction of `boost::asio::ssl::context` for Boost < 1.54
- Use conditional macro to exclude the `boost/predef.h` and use `boost/detail/endian.hpp` to check byte order. As for the architecture, just use the common case.
- Add a docker build to CI, which builds a docker image with dependencies based on CentOS 7 and build C++ client after it. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Add a CI to build C++ client on CentOS and dependencies from its default source.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
