### PR TITLE
[Tests] Fix cpp build flakiness by enabling gtest retries, also improve logging in CI

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -102,3 +102,11 @@ jobs:
       - name: run c++ tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
         run: pulsar-client-cpp/docker-tests.sh
+
+      - name: Upload test-logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        continue-on-error: true
+        with:
+          name: test-logs
+          path: test-logs

--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -44,7 +44,7 @@ docker pull $IMAGE
 
 CONTAINER_LABEL="pulsartests=$$"
 export GTEST_COLOR=${GTEST_COLOR:-no}
-DOCKER_CMD="docker run -e GTEST_COLOR -it -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar $IMAGE"
+DOCKER_CMD="docker run -e GTEST_COLOR -i -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar $IMAGE"
 
 
 for args in "$@"

--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -43,7 +43,8 @@ echo "---- Testing Pulsar C++ client using image $IMAGE (type --help for more op
 docker pull $IMAGE
 
 CONTAINER_LABEL="pulsartests=$$"
-DOCKER_CMD="docker run -it -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar $IMAGE"
+export GTEST_COLOR=${GTEST_COLOR:-no}
+DOCKER_CMD="docker run -e GTEST_COLOR -it -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar $IMAGE"
 
 
 for args in "$@"
@@ -60,7 +61,11 @@ done
 # Start 2 Pulsar standalone instances (one with TLS and one without)
 # and execute the tests
 set +e
-$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && ./run-unit-tests.sh ${tests}"
+DISABLE_COLOR_OUTPUT=""
+if [ "$GTEST_COLOR" = "no" ]; then
+  DISABLE_COLOR_OUTPUT="| cat"
+fi
+$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && ./run-unit-tests.sh ${tests} $DISABLE_COLOR_OUTPUT"
 RES=$?
 if [ $RES -ne 0 ]; then
   (

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -28,13 +28,20 @@ cd $ROOT_DIR/pulsar-client-cpp
 pushd tests
 
 if [ -f /gtest-parallel/gtest-parallel ]; then
-    echo "---- Run unit tests in parallel"
+    gtest_workers=10
+    # use nproc to set workers to 2 x the number of available cores if nproc is available
+    if [ -x "$(command -v nproc)" ]; then
+      gtest_workers=$(( $(nproc) * 2 ))
+    fi
+    # set maximum workers to 10
+    gtest_workers=$(( gtest_workers > 10 ? 10 : gtest_workers ))
+    echo "---- Run unit tests in parallel (workers=$gtest_workers)"
     tests=""
     if [ $# -eq 1 ]; then
         tests="--gtest_filter=$1"
         echo "Running tests: $1"
     fi
-    /gtest-parallel/gtest-parallel ./main $tests --workers=10
+    /gtest-parallel/gtest-parallel ./main $tests --workers=$gtest_workers
     RES=$?
 else
     ./main

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -27,6 +27,8 @@ cd $ROOT_DIR/pulsar-client-cpp
 
 pushd tests
 
+export RETRY_FAILED="${RETRY_FAILED:-1}"
+
 if [ -f /gtest-parallel/gtest-parallel ]; then
     gtest_workers=10
     # use nproc to set workers to 2 x the number of available cores if nproc is available
@@ -35,13 +37,15 @@ if [ -f /gtest-parallel/gtest-parallel ]; then
     fi
     # set maximum workers to 10
     gtest_workers=$(( gtest_workers > 10 ? 10 : gtest_workers ))
-    echo "---- Run unit tests in parallel (workers=$gtest_workers)"
+    echo "---- Run unit tests in parallel (workers=$gtest_workers) (retry_failed=${RETRY_FAILED})"
     tests=""
     if [ $# -eq 1 ]; then
         tests="--gtest_filter=$1"
         echo "Running tests: $1"
     fi
-    /gtest-parallel/gtest-parallel ./main $tests --workers=$gtest_workers
+    /gtest-parallel/gtest-parallel $tests --dump_json_test_results=/tmp/gtest_parallel_results.json \
+      --workers=$gtest_workers --retry_failed=$RETRY_FAILED -d /tmp \
+      ./main
     RES=$?
 else
     ./main


### PR DESCRIPTION
### Motivation

The cpp/python build is very flaky in CI. It's hard to investigate the problem when there isn't much log output or the output is hard to access. 

### Modifications

- enable gtest retries by passing `--retry_failed=1` parameter
- adjust number of parallel workers based on the number of CPU cores available. Use a formula of `min(2 * number of cores, 10)`
- capture test logs to files and upload the archive so that it can be downloaded as a zip file if the build fails
