### PR TITLE
Fix the inconsistency of AdvertisedAddress

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2220,7 +2220,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         }
     }
 
-    public String getAdvertisedAddress() {
+    public String getAppliedAdvertisedAddress() {
         Map<String, AdvertisedListener> result = MultipleListenerValidator
                 .validateAndAnalysisAdvertisedListener(this);
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2220,29 +2220,4 @@ public class ServiceConfiguration implements PulsarConfiguration {
         }
     }
 
-    /**
-     * Get the address of Broker, first try to get it from AdvertisedAddress.
-     * If it is not set, try to get the address set by advertisedListener.
-     * If it is still not set, get it through InetAddress.getLocalHost().
-     * @return
-     */
-    public String getAppliedAdvertisedAddress() {
-        Map<String, AdvertisedListener> result = MultipleListenerValidator
-                .validateAndAnalysisAdvertisedListener(this);
-
-        if (advertisedAddress != null) {
-            return advertisedAddress;
-        }
-
-        AdvertisedListener advertisedListener = result.get(internalListenerName);
-        if (advertisedListener != null) {
-            String address = advertisedListener.getBrokerServiceUrl().getHost();
-            if (address != null) {
-                return address;
-            }
-        }
-
-        return ServiceConfigurationUtils.getDefaultOrConfiguredAddress(advertisedAddress);
-
-    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2220,6 +2220,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         }
     }
 
+    /**
+     * Get the address of Broker, first try to get it from AdvertisedAddress.
+     * If it is not set, try to get the address set by advertisedListener.
+     * If it is still not set, get it through InetAddress.getLocalHost().
+     * @return
+     */
     public String getAppliedAdvertisedAddress() {
         Map<String, AdvertisedListener> result = MultipleListenerValidator
                 .validateAndAnalysisAdvertisedListener(this);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2228,9 +2228,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
             return advertisedAddress;
         }
 
-        String address = result.get(internalListenerName).getBrokerServiceUrl().getHost();
-        if (address != null) {
-            return address;
+        AdvertisedListener advertisedListener = result.get(internalListenerName);
+        if (advertisedListener != null) {
+            String address = advertisedListener.getBrokerServiceUrl().getHost();
+            if (address != null) {
+                return address;
+            }
         }
 
         return ServiceConfigurationUtils.getDefaultOrConfiguredAddress(advertisedAddress);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -33,6 +34,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
+import org.apache.pulsar.broker.validator.MultipleListenerValidator;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
@@ -43,6 +45,7 @@ import org.apache.pulsar.common.policies.data.OffloadPolicies;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.sasl.SaslConstants;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 
 /**
  * Pulsar service configuration object.
@@ -2215,5 +2218,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
         } else {
             return brokerDeleteInactiveTopicsMaxInactiveDurationSeconds;
         }
+    }
+
+    public String getAdvertisedAddress() {
+        Map<String, AdvertisedListener> result = MultipleListenerValidator
+                .validateAndAnalysisAdvertisedListener(this);
+
+        if (advertisedAddress != null) {
+            return advertisedAddress;
+        }
+
+        String address = result.get(internalListenerName).getBrokerServiceUrl().getHost();
+        if (address != null) {
+            return address;
+        }
+
+        return ServiceConfigurationUtils.getDefaultOrConfiguredAddress(advertisedAddress);
+
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pulsar.broker;
 
+import org.apache.pulsar.broker.validator.MultipleListenerValidator;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -45,6 +48,32 @@ public class ServiceConfigurationUtils {
             LOG.error(ex.getMessage(), ex);
             throw new IllegalStateException("Failed to resolve localhost name.", ex);
         }
+    }
+
+    /**
+     * Get the address of Broker, first try to get it from AdvertisedAddress.
+     * If it is not set, try to get the address set by advertisedListener.
+     * If it is still not set, get it through InetAddress.getLocalHost().
+     * @return
+     */
+    public static String getAppliedAdvertisedAddress(ServiceConfiguration configuration) {
+        Map<String, AdvertisedListener> result = MultipleListenerValidator
+                .validateAndAnalysisAdvertisedListener(configuration);
+
+        String advertisedAddress = configuration.getAdvertisedAddress();
+        if (advertisedAddress != null) {
+            return advertisedAddress;
+        }
+
+        AdvertisedListener advertisedListener = result.get(configuration.getInternalListenerName());
+        if (advertisedListener != null) {
+            String address = advertisedListener.getBrokerServiceUrl().getHost();
+            if (address != null) {
+                return address;
+            }
+        }
+
+        return getDefaultOrConfiguredAddress(advertisedAddress);
     }
 
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -19,9 +19,12 @@
 package org.apache.pulsar.broker.validator;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * testcase for MultipleListenerValidator.
@@ -36,6 +39,24 @@ public class MultipleListenerValidatorTest {
         config.setInternalListenerName("internal");
         MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
     }
+
+    @Test
+    public void testGetAppliedAdvertised() throws Exception {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setAdvertisedListeners("internal:pulsar://192.0.0.1:6660, internal:pulsar+ssl://192.0.0.1:6651");
+        config.setInternalListenerName("internal");
+        assertEquals(config.getAppliedAdvertisedAddress(), "192.0.0.1");
+
+        config = new ServiceConfiguration();
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setAdvertisedAddress("192.0.0.2");
+        assertEquals(config.getAppliedAdvertisedAddress(), "192.0.0.2");
+
+        config.setAdvertisedAddress(null);
+        assertEquals(config.getAppliedAdvertisedAddress(), ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null));
+    }
+
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testListenerDuplicate_1() {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -46,15 +46,16 @@ public class MultipleListenerValidatorTest {
         config.setBrokerServicePortTls(Optional.of(6651));
         config.setAdvertisedListeners("internal:pulsar://192.0.0.1:6660, internal:pulsar+ssl://192.0.0.1:6651");
         config.setInternalListenerName("internal");
-        assertEquals(config.getAppliedAdvertisedAddress(), "192.0.0.1");
+        assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config), "192.0.0.1");
 
         config = new ServiceConfiguration();
         config.setBrokerServicePortTls(Optional.of(6651));
         config.setAdvertisedAddress("192.0.0.2");
-        assertEquals(config.getAppliedAdvertisedAddress(), "192.0.0.2");
+        assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config), "192.0.0.2");
 
         config.setAdvertisedAddress(null);
-        assertEquals(config.getAppliedAdvertisedAddress(), ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null));
+        assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
+                ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null));
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -272,7 +272,7 @@ public class PulsarService implements AutoCloseable {
         PulsarConfigurationLoader.isComplete(config);
         // validate `advertisedAddress`, `advertisedListeners`, `internalListenerName`
         this.advertisedListeners = MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
-        this.advertisedAddress = config.getAdvertisedAddress();
+        this.advertisedAddress = config.getAppliedAdvertisedAddress();
         state = State.Init;
         // use `internalListenerName` listener as `advertisedAddress`
         this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getBindAddress());
@@ -1317,7 +1317,7 @@ public class PulsarService implements AutoCloseable {
 
     private String brokerUrl(ServiceConfiguration config) {
         if (config.getBrokerServicePort().isPresent()) {
-            return brokerUrl(config.getAdvertisedAddress(), getBrokerListenPort().get());
+            return brokerUrl(config.getAppliedAdvertisedAddress(), getBrokerListenPort().get());
         } else {
             return null;
         }
@@ -1329,7 +1329,7 @@ public class PulsarService implements AutoCloseable {
 
     public String brokerUrlTls(ServiceConfiguration config) {
         if (config.getBrokerServicePortTls().isPresent()) {
-            return brokerUrlTls(config.getAdvertisedAddress(), getBrokerListenPortTls().get());
+            return brokerUrlTls(config.getAppliedAdvertisedAddress(), getBrokerListenPortTls().get());
         } else {
             return null;
         }
@@ -1341,7 +1341,7 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddress(ServiceConfiguration config) {
         if (config.getWebServicePort().isPresent()) {
-            return webAddress(config.getAdvertisedAddress(), getListenPortHTTP().get());
+            return webAddress(config.getAppliedAdvertisedAddress(), getListenPortHTTP().get());
         } else {
             return null;
         }
@@ -1353,7 +1353,7 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddressTls(ServiceConfiguration config) {
         if (config.getWebServicePortTls().isPresent()) {
-            return webAddressTls(config.getAdvertisedAddress(), getListenPortHTTPS().get());
+            return webAddressTls(config.getAppliedAdvertisedAddress(), getListenPortHTTPS().get());
         } else {
             return null;
         }
@@ -1494,7 +1494,7 @@ public class PulsarService implements AutoCloseable {
 
         // worker talks to local broker
         String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
-            brokerConfig.getAdvertisedAddress());
+            brokerConfig.getAppliedAdvertisedAddress());
         workerConfig.setWorkerHostname(hostname);
         // inherit broker authorization setting
         workerConfig.setAuthenticationEnabled(brokerConfig.isAuthenticationEnabled());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -272,7 +272,7 @@ public class PulsarService implements AutoCloseable {
         PulsarConfigurationLoader.isComplete(config);
         // validate `advertisedAddress`, `advertisedListeners`, `internalListenerName`
         this.advertisedListeners = MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
-        this.advertisedAddress = config.getAppliedAdvertisedAddress();
+        this.advertisedAddress = ServiceConfigurationUtils.getAppliedAdvertisedAddress(config);
         state = State.Init;
         // use `internalListenerName` listener as `advertisedAddress`
         this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getBindAddress());
@@ -1317,7 +1317,8 @@ public class PulsarService implements AutoCloseable {
 
     private String brokerUrl(ServiceConfiguration config) {
         if (config.getBrokerServicePort().isPresent()) {
-            return brokerUrl(config.getAppliedAdvertisedAddress(), getBrokerListenPort().get());
+            return brokerUrl(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
+                    getBrokerListenPort().get());
         } else {
             return null;
         }
@@ -1329,7 +1330,8 @@ public class PulsarService implements AutoCloseable {
 
     public String brokerUrlTls(ServiceConfiguration config) {
         if (config.getBrokerServicePortTls().isPresent()) {
-            return brokerUrlTls(config.getAppliedAdvertisedAddress(), getBrokerListenPortTls().get());
+            return brokerUrlTls(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
+                    getBrokerListenPortTls().get());
         } else {
             return null;
         }
@@ -1341,7 +1343,8 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddress(ServiceConfiguration config) {
         if (config.getWebServicePort().isPresent()) {
-            return webAddress(config.getAppliedAdvertisedAddress(), getListenPortHTTP().get());
+            return webAddress(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
+                    getListenPortHTTP().get());
         } else {
             return null;
         }
@@ -1353,7 +1356,8 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddressTls(ServiceConfiguration config) {
         if (config.getWebServicePortTls().isPresent()) {
-            return webAddressTls(config.getAppliedAdvertisedAddress(), getListenPortHTTPS().get());
+            return webAddressTls(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
+                    getListenPortHTTPS().get());
         } else {
             return null;
         }
@@ -1494,7 +1498,7 @@ public class PulsarService implements AutoCloseable {
 
         // worker talks to local broker
         String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
-            brokerConfig.getAppliedAdvertisedAddress());
+                ServiceConfigurationUtils.getAppliedAdvertisedAddress(brokerConfig));
         workerConfig.setWorkerHostname(hostname);
         // inherit broker authorization setting
         workerConfig.setAuthenticationEnabled(brokerConfig.isAuthenticationEnabled());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -105,6 +105,7 @@ import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
+import org.apache.pulsar.broker.validator.MultipleListenerValidator;
 import org.apache.pulsar.broker.web.WebService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -270,6 +271,7 @@ public class PulsarService implements AutoCloseable {
         // Validate correctness of configuration
         PulsarConfigurationLoader.isComplete(config);
         // validate `advertisedAddress`, `advertisedListeners`, `internalListenerName`
+        this.advertisedListeners = MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
         this.advertisedAddress = config.getAdvertisedAddress();
         state = State.Init;
         // use `internalListenerName` listener as `advertisedAddress`

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1315,7 +1315,7 @@ public class PulsarService implements AutoCloseable {
         return shutdownService;
     }
 
-    private String brokerUrl(ServiceConfiguration config) {
+    protected String brokerUrl(ServiceConfiguration config) {
         if (config.getBrokerServicePort().isPresent()) {
             return brokerUrl(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
                     getBrokerListenPort().get());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -105,7 +105,6 @@ import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
-import org.apache.pulsar.broker.validator.MultipleListenerValidator;
 import org.apache.pulsar.broker.web.WebService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -1314,18 +1313,9 @@ public class PulsarService implements AutoCloseable {
         return shutdownService;
     }
 
-    /**
-     * Advertised service address.
-     *
-     * @return Hostname or IP address the service advertises to the outside world.
-     */
-    public static String advertisedAddress(ServiceConfiguration config) {
-        return config.getAdvertisedAddress();
-    }
-
     private String brokerUrl(ServiceConfiguration config) {
         if (config.getBrokerServicePort().isPresent()) {
-            return brokerUrl(advertisedAddress(config), getBrokerListenPort().get());
+            return brokerUrl(config.getAdvertisedAddress(), getBrokerListenPort().get());
         } else {
             return null;
         }
@@ -1337,7 +1327,7 @@ public class PulsarService implements AutoCloseable {
 
     public String brokerUrlTls(ServiceConfiguration config) {
         if (config.getBrokerServicePortTls().isPresent()) {
-            return brokerUrlTls(advertisedAddress(config), getBrokerListenPortTls().get());
+            return brokerUrlTls(config.getAdvertisedAddress(), getBrokerListenPortTls().get());
         } else {
             return null;
         }
@@ -1349,7 +1339,7 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddress(ServiceConfiguration config) {
         if (config.getWebServicePort().isPresent()) {
-            return webAddress(advertisedAddress(config), getListenPortHTTP().get());
+            return webAddress(config.getAdvertisedAddress(), getListenPortHTTP().get());
         } else {
             return null;
         }
@@ -1361,7 +1351,7 @@ public class PulsarService implements AutoCloseable {
 
     public String webAddressTls(ServiceConfiguration config) {
         if (config.getWebServicePortTls().isPresent()) {
-            return webAddressTls(advertisedAddress(config), getListenPortHTTPS().get());
+            return webAddressTls(config.getAdvertisedAddress(), getListenPortHTTPS().get());
         } else {
             return null;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -271,22 +271,10 @@ public class PulsarService implements AutoCloseable {
         // Validate correctness of configuration
         PulsarConfigurationLoader.isComplete(config);
         // validate `advertisedAddress`, `advertisedListeners`, `internalListenerName`
-        Map<String, AdvertisedListener> result =
-                MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
-        if (result != null) {
-            this.advertisedListeners = Collections.unmodifiableMap(result);
-        } else {
-            this.advertisedListeners = Collections.unmodifiableMap(Collections.emptyMap());
-        }
+        this.advertisedAddress = config.getAdvertisedAddress();
         state = State.Init;
         // use `internalListenerName` listener as `advertisedAddress`
         this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getBindAddress());
-        if (!this.advertisedListeners.isEmpty()) {
-            this.advertisedAddress = this.advertisedListeners.get(
-                    config.getInternalListenerName()).getBrokerServiceUrl().getHost();
-        } else {
-            this.advertisedAddress = advertisedAddress(config);
-        }
         this.brokerVersion = PulsarVersion.getVersion();
         this.config = config;
         this.shutdownService = new MessagingServiceShutdownHook(this, processTerminator);
@@ -1332,7 +1320,7 @@ public class PulsarService implements AutoCloseable {
      * @return Hostname or IP address the service advertises to the outside world.
      */
     public static String advertisedAddress(ServiceConfiguration config) {
-        return ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        return config.getAdvertisedAddress();
     }
 
     private String brokerUrl(ServiceConfiguration config) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -974,7 +974,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         List<Metrics> metrics = Lists.newArrayList();
         Map<String, String> dimensions = new HashMap<>();
 
-        dimensions.put("broker", conf.getAdvertisedAddress());
+        dimensions.put("broker", conf.getAppliedAdvertisedAddress());
         dimensions.put("metric", "loadBalancing");
 
         Metrics m = Metrics.create(dimensions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.broker.BundleData;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.broker.TimeAverageBrokerData;
 import org.apache.pulsar.broker.TimeAverageMessageData;
 import org.apache.pulsar.broker.loadbalance.BrokerFilter;
@@ -974,7 +975,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         List<Metrics> metrics = Lists.newArrayList();
         Map<String, String> dimensions = new HashMap<>();
 
-        dimensions.put("broker", conf.getAppliedAdvertisedAddress());
+        dimensions.put("broker", ServiceConfigurationUtils.getAppliedAdvertisedAddress(conf));
         dimensions.put("metric", "loadBalancing");
 
         Metrics m = Metrics.create(dimensions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -974,7 +974,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         List<Metrics> metrics = Lists.newArrayList();
         Map<String, String> dimensions = new HashMap<>();
 
-        dimensions.put("broker", pulsar.getAdvertisedAddress());
+        dimensions.put("broker", conf.getAdvertisedAddress());
         dimensions.put("metric", "loadBalancing");
 
         Metrics m = Metrics.create(dimensions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -974,7 +974,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         List<Metrics> metrics = Lists.newArrayList();
         Map<String, String> dimensions = new HashMap<>();
 
-        dimensions.put("broker", conf.getAdvertisedAddress());
+        dimensions.put("broker", pulsar.getAdvertisedAddress());
         dimensions.put("metric", "loadBalancing");
 
         Metrics m = Metrics.create(dimensions);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.BookKeeperClientFactoryImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
@@ -100,13 +101,15 @@ public class CompactorTool {
             log.info("Found `brokerServicePortTls` in configuration file. \n"
                     + "Will connect pulsar use TLS.");
             clientBuilder
-                    .serviceUrl(PulsarService.brokerUrlTls(brokerConfig.getAppliedAdvertisedAddress(),
+                    .serviceUrl(PulsarService.brokerUrlTls(ServiceConfigurationUtils
+                                    .getAppliedAdvertisedAddress(brokerConfig),
                             brokerConfig.getBrokerServicePortTls().get()))
                     .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
                     .tlsTrustCertsFilePath(brokerConfig.getTlsCertificateFilePath());
 
         } else {
-            clientBuilder.serviceUrl(PulsarService.brokerUrl(brokerConfig.getAppliedAdvertisedAddress(),
+            clientBuilder.serviceUrl(PulsarService.brokerUrl(ServiceConfigurationUtils
+                            .getAppliedAdvertisedAddress(brokerConfig),
                     brokerConfig.getBrokerServicePort().get()));
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -100,13 +100,13 @@ public class CompactorTool {
             log.info("Found `brokerServicePortTls` in configuration file. \n"
                     + "Will connect pulsar use TLS.");
             clientBuilder
-                    .serviceUrl(PulsarService.brokerUrlTls(brokerConfig.getAdvertisedAddress(),
+                    .serviceUrl(PulsarService.brokerUrlTls(brokerConfig.getAppliedAdvertisedAddress(),
                             brokerConfig.getBrokerServicePortTls().get()))
                     .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
                     .tlsTrustCertsFilePath(brokerConfig.getTlsCertificateFilePath());
 
         } else {
-            clientBuilder.serviceUrl(PulsarService.brokerUrl(brokerConfig.getAdvertisedAddress(),
+            clientBuilder.serviceUrl(PulsarService.brokerUrl(brokerConfig.getAppliedAdvertisedAddress(),
                     brokerConfig.getBrokerServicePort().get()));
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -100,13 +100,13 @@ public class CompactorTool {
             log.info("Found `brokerServicePortTls` in configuration file. \n"
                     + "Will connect pulsar use TLS.");
             clientBuilder
-                    .serviceUrl(PulsarService.brokerUrlTls(PulsarService.advertisedAddress(brokerConfig),
+                    .serviceUrl(PulsarService.brokerUrlTls(brokerConfig.getAdvertisedAddress(),
                             brokerConfig.getBrokerServicePortTls().get()))
                     .allowTlsInsecureConnection(brokerConfig.isTlsAllowInsecureConnection())
                     .tlsTrustCertsFilePath(brokerConfig.getTlsCertificateFilePath());
 
         } else {
-            clientBuilder.serviceUrl(PulsarService.brokerUrl(PulsarService.advertisedAddress(brokerConfig),
+            clientBuilder.serviceUrl(PulsarService.brokerUrl(brokerConfig.getAdvertisedAddress(),
                     brokerConfig.getBrokerServicePort().get()));
         }
 


### PR DESCRIPTION

### Motivation
There is an `advertisedAddress` in PusarService and an `advertisedAddress` in conf. When `advertisedListener` is set, the values of the two `advertisedAddress` will be inconsistent. 
In the current code, `PusarService.getAdvertisedAddress` is used in some places, and `conf.getAdvertisedAddress` is used in other places.

### Modifications
Put this logic into the config to keep the values in all places consistent.

### Verifying this change
