### PR TITLE
[Tests] Fix flaky test TransactionMetadataStoreServiceTest.transactionTimeoutRecoverTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -282,7 +282,6 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         field.setAccessible(true);
         ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>> txnMap =
                 (ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>>) field.get(transactionMetadataStore);
-        assertEquals(txnMap.size(), 1);
         Awaitility.await().atMost(3000, TimeUnit.MILLISECONDS).until(() -> txnMap.size() == 0);
 
     }


### PR DESCRIPTION
Fixes #10310

### Motivation

Fixes a flaky test reported as #10310, see https://github.com/apache/pulsar/pull/10162/files#r617664762

### Modifications

Remove the assertion that is flaky. The next like of code asserts a different value.
