### PR TITLE
Optimize code path for functions that only read from one topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -232,7 +232,6 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
         inputSpecs.put(sourceTopic, consumerConfig);
         functionConfig.setInputSpecs(inputSpecs);
         String jarFilePathUrl = getPulsarApiExamplesJar().toURI().toString();
-        log.info("FunctionConfig: {}", functionConfig);
         admin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
 
         // 5 Function should only read compacted value，so we will only receive compacted messages

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -21,10 +21,11 @@ package org.apache.pulsar.functions.instance;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import io.prometheus.client.CollectorRegistry;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -64,8 +65,11 @@ import org.apache.pulsar.functions.secretsprovider.SecretsProvider;
 import org.apache.pulsar.functions.sink.PulsarSink;
 import org.apache.pulsar.functions.sink.PulsarSinkConfig;
 import org.apache.pulsar.functions.sink.PulsarSinkDisable;
-import org.apache.pulsar.functions.source.PulsarSource;
+import org.apache.pulsar.functions.source.MultiConsumerPulsarSourceConfig;
+import org.apache.pulsar.functions.source.MultiConsumerPulsarSource;
 import org.apache.pulsar.functions.source.PulsarSourceConfig;
+import org.apache.pulsar.functions.source.SingleConsumerPulsarSource;
+import org.apache.pulsar.functions.source.SingleConsumerPulsarSourceConfig;
 import org.apache.pulsar.functions.source.batch.BatchSourceExecutor;
 import org.apache.pulsar.functions.utils.CryptoUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
@@ -338,7 +342,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     }
 
     private void sendOutputMessage(Record srcRecord, Object output) {
-        if (!(this.sink instanceof PulsarSink)) {
+        if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK) {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
         }
         try {
@@ -354,7 +358,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
     private Record readInput() throws Exception {
         Record record;
-        if (!(this.source instanceof PulsarSource)) {
+        if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SOURCE) {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
         }
         try {
@@ -393,7 +397,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
 
         if (source != null) {
-            if (!(this.source instanceof PulsarSource)) {
+            if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SOURCE) {
                 Thread.currentThread().setContextClassLoader(functionClassLoader);
             }
             try {
@@ -407,7 +411,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
 
         if (sink != null) {
-            if (!(this.sink instanceof PulsarSink)) {
+            if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK) {
                 Thread.currentThread().setContextClassLoader(functionClassLoader);
             }
             try {
@@ -602,7 +606,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         Object object;
         // If source classname is not set, we default pulsar source
         if (sourceSpec.getClassName().isEmpty()) {
-            PulsarSourceConfig pulsarSourceConfig = new PulsarSourceConfig();
+            Map<String, ConsumerConfig> topicSchema = new TreeMap<>();
             sourceSpec.getInputSpecsMap().forEach((topic, conf) -> {
                 ConsumerConfig consumerConfig = ConsumerConfig.builder().isRegexPattern(conf.getIsRegexPattern()).build();
                 if (conf.getSchemaType() != null && !conf.getSchemaType().isEmpty()) {
@@ -619,11 +623,11 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     consumerConfig.setCryptoConfig(CryptoUtils.convertFromSpec(conf.getCryptoSpec()));
                 }
 
-                pulsarSourceConfig.getTopicSchema().put(topic, consumerConfig);
+                topicSchema.put(topic, consumerConfig);
             });
 
             sourceSpec.getTopicsToSerDeClassNameMap().forEach((topic, serde) -> {
-                pulsarSourceConfig.getTopicSchema().put(topic,
+                topicSchema.put(topic,
                         ConsumerConfig.builder()
                                 .serdeClassName(serde)
                                 .isRegexPattern(false)
@@ -631,7 +635,21 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             });
 
             if (!StringUtils.isEmpty(sourceSpec.getTopicsPattern())) {
-                pulsarSourceConfig.getTopicSchema().get(sourceSpec.getTopicsPattern()).setRegexPattern(true);
+                topicSchema.get(sourceSpec.getTopicsPattern()).setRegexPattern(true);
+            }
+
+            PulsarSourceConfig pulsarSourceConfig;
+            // we can use a single consumer to read
+            if (topicSchema.size() == 1) {
+                SingleConsumerPulsarSourceConfig singleConsumerPulsarSourceConfig = new SingleConsumerPulsarSourceConfig();
+                Map.Entry<String, ConsumerConfig> entry = topicSchema.entrySet().iterator().next();
+                singleConsumerPulsarSourceConfig.setTopic(entry.getKey());
+                singleConsumerPulsarSourceConfig.setConsumerConfig(entry.getValue());
+                pulsarSourceConfig = singleConsumerPulsarSourceConfig;
+            } else {
+                MultiConsumerPulsarSourceConfig multiConsumerPulsarSourceConfig = new MultiConsumerPulsarSourceConfig();
+                multiConsumerPulsarSourceConfig.setTopicSchema(topicSchema);
+                pulsarSourceConfig = multiConsumerPulsarSourceConfig;
             }
 
             pulsarSourceConfig.setSubscriptionName(
@@ -675,7 +693,14 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 pulsarSourceConfig.setMaxMessageRetries(this.instanceConfig.getFunctionDetails().getRetryDetails().getMaxMessageRetries());
                 pulsarSourceConfig.setDeadLetterTopic(this.instanceConfig.getFunctionDetails().getRetryDetails().getDeadLetterTopic());
             }
-            object = new PulsarSource(this.client, pulsarSourceConfig, this.properties, this.functionClassLoader);
+
+            // Use SingleConsumerPulsarSource if possible because it will have higher performance since it is not a push source
+            // that require messages to be put into an immediate queue
+            if (pulsarSourceConfig instanceof SingleConsumerPulsarSourceConfig) {
+                object = new SingleConsumerPulsarSource(this.client, (SingleConsumerPulsarSourceConfig) pulsarSourceConfig, this.properties, this.functionClassLoader);
+            } else {
+                object = new MultiConsumerPulsarSource(this.client, (MultiConsumerPulsarSourceConfig) pulsarSourceConfig, this.properties, this.functionClassLoader);
+            }
         } else {
 
             // check if source is a batch source
@@ -699,7 +724,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
         this.source = (Source<?>) object;
 
-        if (!(this.source instanceof PulsarSource)) {
+        if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SOURCE) {
             Thread.currentThread().setContextClassLoader(this.functionClassLoader);
         }
         try {
@@ -767,7 +792,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             throw new RuntimeException("Sink does not implement correct interface");
         }
 
-        if (!(this.sink instanceof PulsarSink)) {
+        if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK) {
             Thread.currentThread().setContextClassLoader(this.functionClassLoader);
         }
         try {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.source;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.util.Reflections;
+import org.apache.pulsar.io.core.SourceContext;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class MultiConsumerPulsarSource<T> extends PushPulsarSource<T> implements MessageListener<T> {
+
+    private final MultiConsumerPulsarSourceConfig pulsarSourceConfig;
+    private final ClassLoader functionClassLoader;
+    private List<Consumer<T>> inputConsumers = new LinkedList<>();
+
+    public MultiConsumerPulsarSource(PulsarClient pulsarClient,
+                                     MultiConsumerPulsarSourceConfig pulsarSourceConfig,
+                                     Map<String, String> properties,
+                                     ClassLoader functionClassLoader) {
+        super(pulsarClient, pulsarSourceConfig, properties, functionClassLoader);
+        this.pulsarSourceConfig = pulsarSourceConfig;
+        this.functionClassLoader = functionClassLoader;
+    }
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+        log.info("Opening pulsar source with config: {}", pulsarSourceConfig);
+        Map<String, PulsarSourceConsumerConfig<T>> configs = setupConsumerConfigs();
+
+        for (Map.Entry<String, PulsarSourceConsumerConfig<T>> e : configs.entrySet()) {
+            String topic = e.getKey();
+            PulsarSourceConsumerConfig<T> conf = e.getValue();
+            log.info("Creating consumers for topic : {}, schema : {}, schemaInfo: {}",
+                    topic, conf.getSchema(), conf.getSchema().getSchemaInfo());
+
+            ConsumerBuilder<T> cb = createConsumeBuilder(topic, conf);
+
+            //messageListener is annotated with @JsonIgnore,so setting messageListener should be put behind loadConf
+            cb.messageListener(this);
+
+            Consumer<T> consumer = cb.subscribeAsync().join();
+            inputConsumers.add(consumer);
+        }
+    }
+
+    @Override
+    public void received(Consumer<T> consumer, Message<T> message) {
+        consume(buildRecord(consumer, message));
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (inputConsumers != null ) {
+            inputConsumers.forEach(consumer -> {
+                try {
+                    consumer.close();
+                } catch (PulsarClientException e) {
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, PulsarSourceConsumerConfig<T>> setupConsumerConfigs() throws ClassNotFoundException {
+        Map<String, PulsarSourceConsumerConfig<T>> configs = new TreeMap<>();
+
+        Class<?> typeArg = Reflections.loadClass(this.pulsarSourceConfig.getTypeClassName(),
+                this.functionClassLoader);
+
+        checkArgument(!Void.class.equals(typeArg), "Input type of Pulsar Function cannot be Void");
+
+        // Check new config with schema types or classnames
+        pulsarSourceConfig.getTopicSchema().forEach((topic, conf) -> {
+            configs.put(topic, buildPulsarSourceConsumerConfig(topic, conf, typeArg));
+        });
+
+        return configs;
+    }
+
+    @VisibleForTesting
+    List<Consumer<T>> getInputConsumers() {
+        return inputConsumers;
+    }
+
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSourceConfig.java
@@ -16,33 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.functions.source;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+import org.apache.pulsar.common.functions.ConsumerConfig;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 
-import lombok.Data;
-
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.common.functions.FunctionConfig;
-
 @Data
-public abstract class PulsarSourceConfig {
+public class MultiConsumerPulsarSourceConfig extends PulsarSourceConfig {
 
-    private FunctionConfig.ProcessingGuarantees processingGuarantees;
-    SubscriptionType subscriptionType;
-    private String subscriptionName;
-    private SubscriptionInitialPosition subscriptionPosition;
-    // Whether the subscriptions the functions created/used should be deleted when the functions is deleted
-    private Integer maxMessageRetries = -1;
-    private String deadLetterTopic;
+    private Map<String, ConsumerConfig> topicSchema = new TreeMap<>();
 
-    private String typeClassName;
-    private Long timeoutMs;
-    private Long negativeAckRedeliveryDelayMs;
+    public static MultiConsumerPulsarSourceConfig load(Map<String, Object> map) throws IOException {
+        ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
+        return mapper.readValue(new ObjectMapper().writeValueAsString(map), MultiConsumerPulsarSourceConfig.class);
+    }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.functions.source;
 
 import org.apache.pulsar.client.api.Consumer;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -1,134 +1,90 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.apache.pulsar.functions.source;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import com.google.common.annotations.VisibleForTesting;
-
-import java.security.Security;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import lombok.Builder;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageImpl;
-import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.TopicMessageImpl;
-import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
-import org.apache.pulsar.common.util.Reflections;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.utils.CryptoUtils;
-import org.apache.pulsar.io.core.PushSource;
-import org.apache.pulsar.io.core.SourceContext;
+import org.apache.pulsar.io.core.Source;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-@Slf4j
-public class PulsarSource<T> extends PushSource<T> implements MessageListener<T> {
+import java.security.Security;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-    private final PulsarClient pulsarClient;
-    private final PulsarSourceConfig pulsarSourceConfig;
-    private final Map<String, String> properties;
-    private final ClassLoader functionClassLoader;
-    private List<String> inputTopics;
-    private List<Consumer<T>> inputConsumers = new LinkedList<>();
-    private final TopicSchema topicSchema;
+public abstract class PulsarSource<T> implements Source<T> {
+    protected final PulsarClient pulsarClient;
+    protected final PulsarSourceConfig pulsarSourceConfig;
+    protected final Map<String, String> properties;
+    protected final ClassLoader functionClassLoader;
+    protected final TopicSchema topicSchema;
 
-    public PulsarSource(PulsarClient pulsarClient, PulsarSourceConfig pulsarConfig, Map<String, String> properties,
-                        ClassLoader functionClassLoader) {
+    protected PulsarSource(PulsarClient pulsarClient,
+                           PulsarSourceConfig pulsarSourceConfig,
+                           Map<String, String> properties,
+                           ClassLoader functionClassLoader) {
         this.pulsarClient = pulsarClient;
-        this.pulsarSourceConfig = pulsarConfig;
+        this.pulsarSourceConfig = pulsarSourceConfig;
         this.topicSchema = new TopicSchema(pulsarClient);
         this.properties = properties;
         this.functionClassLoader = functionClassLoader;
     }
 
-    @Override
-    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
-        // Setup schemas
-        log.info("Opening pulsar source with config: {}", pulsarSourceConfig);
-        Map<String, ConsumerConfig<T>> configs = setupConsumerConfigs();
+    protected ConsumerBuilder<T> createConsumeBuilder(String topic, PulsarSourceConsumerConfig conf) {
 
-        for (Map.Entry<String, ConsumerConfig<T>> e : configs.entrySet()) {
-            String topic = e.getKey();
-            ConsumerConfig<T> conf = e.getValue();
-            log.info("Creating consumers for topic : {}, schema : {}, schemaInfo: {}",
-                    topic, conf.getSchema(), conf.getSchema().getSchemaInfo());
+        ConsumerBuilder<T> cb = pulsarClient.newConsumer(conf.getSchema())
+                .subscriptionName(pulsarSourceConfig.getSubscriptionName())
+                .subscriptionInitialPosition(pulsarSourceConfig.getSubscriptionPosition())
+                .subscriptionType(pulsarSourceConfig.getSubscriptionType());
 
-            ConsumerBuilder<T> cb = pulsarClient.newConsumer(conf.getSchema())
-                    .subscriptionName(pulsarSourceConfig.getSubscriptionName())
-                    .subscriptionInitialPosition(pulsarSourceConfig.getSubscriptionPosition())
-                    .subscriptionType(pulsarSourceConfig.getSubscriptionType());
-
-            if (conf.getConsumerProperties() != null && !conf.getConsumerProperties().isEmpty()) {
-                cb.loadConf(new HashMap<>(conf.getConsumerProperties()));
-            }
-            //messageListener is annotated with @JsonIgnore,so setting messageListener should be put behind loadConf
-            cb.messageListener(this);
-
-            if (conf.isRegexPattern) {
-                cb = cb.topicsPattern(topic);
-            } else {
-                cb = cb.topics(Collections.singletonList(topic));
-            }
-            if (conf.getReceiverQueueSize() != null) {
-                cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
-            }
-            if (conf.getCryptoKeyReader() != null) {
-                cb = cb.cryptoKeyReader(conf.getCryptoKeyReader());
-            }
-            if (conf.getConsumerCryptoFailureAction() != null) {
-                cb = cb.cryptoFailureAction(conf.getConsumerCryptoFailureAction());
-            }
-            cb = cb.properties(properties);
-            if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
-                    && pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() > 0) {
-                cb.negativeAckRedeliveryDelay(pulsarSourceConfig.getNegativeAckRedeliveryDelayMs(), TimeUnit.MILLISECONDS);
-            }
-            if (pulsarSourceConfig.getTimeoutMs() != null) {
-                cb = cb.ackTimeout(pulsarSourceConfig.getTimeoutMs(), TimeUnit.MILLISECONDS);
-            }
-            if (pulsarSourceConfig.getMaxMessageRetries() != null && pulsarSourceConfig.getMaxMessageRetries() >= 0) {
-                DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicyBuilder = DeadLetterPolicy.builder();
-                deadLetterPolicyBuilder.maxRedeliverCount(pulsarSourceConfig.getMaxMessageRetries());
-                if (pulsarSourceConfig.getDeadLetterTopic() != null && !pulsarSourceConfig.getDeadLetterTopic().isEmpty()) {
-                    deadLetterPolicyBuilder.deadLetterTopic(pulsarSourceConfig.getDeadLetterTopic());
-                }
-                cb = cb.deadLetterPolicy(deadLetterPolicyBuilder.build());
-            }
-
-            Consumer<T> consumer = cb.subscribeAsync().join();
-            inputConsumers.add(consumer);
+        if (conf.getConsumerProperties() != null && !conf.getConsumerProperties().isEmpty()) {
+            cb.loadConf(new HashMap<>(conf.getConsumerProperties()));
         }
 
-        inputTopics = inputConsumers.stream().flatMap(c -> {
-            return (c instanceof MultiTopicsConsumerImpl) ? ((MultiTopicsConsumerImpl<?>) c).getTopics().stream()
-                    : Collections.singletonList(c.getTopic()).stream();
-        }).collect(Collectors.toList());
+        if (conf.isRegexPattern()) {
+            cb = cb.topicsPattern(topic);
+        } else {
+            cb = cb.topics(Collections.singletonList(topic));
+        }
+        if (conf.getReceiverQueueSize() != null) {
+            cb = cb.receiverQueueSize(conf.getReceiverQueueSize());
+        }
+        if (conf.getCryptoKeyReader() != null) {
+            cb = cb.cryptoKeyReader(conf.getCryptoKeyReader());
+        }
+        if (conf.getConsumerCryptoFailureAction() != null) {
+            cb = cb.cryptoFailureAction(conf.getConsumerCryptoFailureAction());
+        }
+        cb = cb.properties(properties);
+        if (pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() != null
+                && pulsarSourceConfig.getNegativeAckRedeliveryDelayMs() > 0) {
+            cb.negativeAckRedeliveryDelay(pulsarSourceConfig.getNegativeAckRedeliveryDelayMs(), TimeUnit.MILLISECONDS);
+        }
+        if (pulsarSourceConfig.getTimeoutMs() != null) {
+            cb = cb.ackTimeout(pulsarSourceConfig.getTimeoutMs(), TimeUnit.MILLISECONDS);
+        }
+        if (pulsarSourceConfig.getMaxMessageRetries() != null && pulsarSourceConfig.getMaxMessageRetries() >= 0) {
+            DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicyBuilder = DeadLetterPolicy.builder();
+            deadLetterPolicyBuilder.maxRedeliverCount(pulsarSourceConfig.getMaxMessageRetries());
+            if (pulsarSourceConfig.getDeadLetterTopic() != null && !pulsarSourceConfig.getDeadLetterTopic().isEmpty()) {
+                deadLetterPolicyBuilder.deadLetterTopic(pulsarSourceConfig.getDeadLetterTopic());
+            }
+            cb = cb.deadLetterPolicy(deadLetterPolicyBuilder.build());
+        }
+
+        return cb;
     }
 
-    @Override
-    public void received(Consumer<T> consumer, Message<T> message) {
+    protected Record<T> buildRecord(Consumer<T> consumer, Message<T> message) {
         Schema<T> schema = null;
         if (message instanceof MessageImpl) {
             MessageImpl impl = (MessageImpl) message;
@@ -137,7 +93,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
             TopicMessageImpl impl = (TopicMessageImpl) message;
             schema = impl.getSchema();
         }
-        Record<T> record = PulsarRecord.<T>builder()
+        return PulsarRecord.<T>builder()
                 .message(message)
                 .schema(schema)
                 .topicName(message.getTopicName())
@@ -155,81 +111,33 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
                     consumer.negativeAcknowledge(message);
                 })
                 .build();
-
-        consume(record);
     }
 
-    @Override
-    public void close() throws Exception {
-        if (inputConsumers != null ) {
-            inputConsumers.forEach(consumer -> {
-                try {
-                    consumer.close();
-                } catch (PulsarClientException e) {
-                }
-            });
+    protected PulsarSourceConsumerConfig<T> buildPulsarSourceConsumerConfig(String topic, ConsumerConfig conf, Class<?> typeArg) {
+        PulsarSourceConsumerConfig.PulsarSourceConsumerConfigBuilder<T> consumerConfBuilder
+                = PulsarSourceConsumerConfig.<T>builder().isRegexPattern(conf.isRegexPattern())
+                .receiverQueueSize(conf.getReceiverQueueSize())
+                .consumerProperties(conf.getConsumerProperties());
+
+        Schema<T> schema;
+        if (conf.getSerdeClassName() != null && !conf.getSerdeClassName().isEmpty()) {
+            schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf.getSerdeClassName(), true);
+        } else {
+            schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf, true);
         }
-    }
+        consumerConfBuilder.schema(schema);
 
-    @SuppressWarnings("unchecked")
-    @VisibleForTesting
-    Map<String, ConsumerConfig<T>> setupConsumerConfigs() throws ClassNotFoundException {
-        Map<String, ConsumerConfig<T>> configs = new TreeMap<>();
-
-        Class<?> typeArg = Reflections.loadClass(this.pulsarSourceConfig.getTypeClassName(),
-                this.functionClassLoader);
-
-        checkArgument(!Void.class.equals(typeArg), "Input type of Pulsar Function cannot be Void");
-
-        // Check new config with schema types or classnames
-        pulsarSourceConfig.getTopicSchema().forEach((topic, conf) -> {
-            ConsumerConfig.ConsumerConfigBuilder<T> consumerConfBuilder =  ConsumerConfig.<T> builder().
-                    isRegexPattern(conf.isRegexPattern()).
-                    receiverQueueSize(conf.getReceiverQueueSize()).
-                    consumerProperties(conf.getConsumerProperties());
-
-            Schema<T> schema;
-            if (conf.getSerdeClassName() != null && !conf.getSerdeClassName().isEmpty()) {
-                schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf.getSerdeClassName(), true);
-            } else {
-                schema = (Schema<T>) topicSchema.getSchema(topic, typeArg, conf, true);
-            }
-            consumerConfBuilder.schema(schema);
-
-            if (conf.getCryptoConfig() != null) {
-                // add provider only if it's not in the JVM
-                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-                    Security.addProvider(new BouncyCastleProvider());
-                }
-
-                consumerConfBuilder.consumerCryptoFailureAction(conf.getCryptoConfig().getConsumerCryptoFailureAction());
-                consumerConfBuilder.cryptoKeyReader(CryptoUtils.getCryptoKeyReaderInstance(
-                        conf.getCryptoConfig().getCryptoKeyReaderClassName(),
-                        conf.getCryptoConfig().getCryptoKeyReaderConfig(), functionClassLoader));
+        if (conf.getCryptoConfig() != null) {
+            // add provider only if it's not in the JVM
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.addProvider(new BouncyCastleProvider());
             }
 
-            configs.put(topic, consumerConfBuilder.build());
-        });
-
-        return configs;
-    }
-
-    public List<String> getInputTopics() {
-        return inputTopics;
-    }
-
-    public List<Consumer<T>> getInputConsumers() {
-        return inputConsumers;
-    }
-
-    @Data
-    @Builder
-    private static class ConsumerConfig<T> {
-        private Schema<T> schema;
-        private boolean isRegexPattern;
-        private Integer receiverQueueSize;
-        private Map<String, String> consumerProperties;
-        private CryptoKeyReader cryptoKeyReader;
-        private ConsumerCryptoFailureAction consumerCryptoFailureAction;
+            consumerConfBuilder.consumerCryptoFailureAction(conf.getCryptoConfig().getConsumerCryptoFailureAction());
+            consumerConfBuilder.cryptoKeyReader(CryptoUtils.getCryptoKeyReaderInstance(
+                    conf.getCryptoConfig().getCryptoKeyReaderClassName(),
+                    conf.getCryptoConfig().getCryptoKeyReaderConfig(), functionClassLoader));
+        }
+        return consumerConfBuilder.build();
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConsumerConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConsumerConfig.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.source;
+
+import lombok.Builder;
+import lombok.Data;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.Schema;
+
+import java.util.Map;
+
+@Data
+@Builder
+class PulsarSourceConsumerConfig<T> {
+    private Schema<T> schema;
+    private boolean isRegexPattern;
+    private Integer receiverQueueSize;
+    private Map<String, String> consumerProperties;
+    private CryptoKeyReader cryptoKeyReader;
+    private ConsumerCryptoFailureAction consumerCryptoFailureAction;
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PushPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PushPulsarSource.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.functions.source;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public abstract class PushPulsarSource<T> extends PulsarSource<T> {
+
+    private LinkedBlockingQueue<Record<T>> queue;
+    private static final int DEFAULT_QUEUE_LENGTH = 1000;
+
+    public PushPulsarSource(PulsarClient pulsarClient,
+                            PulsarSourceConfig pulsarSourceConfig,
+                            Map<String, String> properties,
+                            ClassLoader functionClassLoader) {
+        super(pulsarClient, pulsarSourceConfig, properties, functionClassLoader);
+        this.queue = new LinkedBlockingQueue<>(this.getQueueLength());
+    }
+
+    @Override
+    public Record<T> read() throws Exception {
+        return queue.take();
+    }
+
+    /**
+     * Open connector with configuration.
+     *
+     * @param config initialization config
+     * @param sourceContext environment where the source connector is running
+     * @throws Exception IO type exceptions when opening a connector
+     */
+    abstract public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception;
+
+    /**
+     * Attach a consumer function to this Source. This is invoked by the implementation
+     * to pass messages whenever there is data to be pushed to Pulsar.
+     *
+     * @param record next message from source which should be sent to a Pulsar topic
+     */
+    public void consume(Record<T> record) {
+        try {
+            queue.put(record);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get length of the queue that records are push onto
+     * Users can override this method to customize the queue length
+     * @return queue length
+     */
+    public int getQueueLength() {
+        return DEFAULT_QUEUE_LENGTH;
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSource.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.source;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.util.Reflections;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class SingleConsumerPulsarSource<T> extends PulsarSource<T> {
+
+    private final PulsarClient pulsarClient;
+    private final SingleConsumerPulsarSourceConfig pulsarSourceConfig;
+    private final Map<String, String> properties;
+    private final ClassLoader functionClassLoader;
+    private final TopicSchema topicSchema;
+    private Consumer<T> consumer;
+
+    public SingleConsumerPulsarSource(PulsarClient pulsarClient,
+                                      SingleConsumerPulsarSourceConfig pulsarSourceConfig,
+                                      Map<String, String> properties,
+                                      ClassLoader functionClassLoader) {
+        super(pulsarClient, pulsarSourceConfig, properties, functionClassLoader);
+        this.pulsarClient = pulsarClient;
+        this.pulsarSourceConfig = pulsarSourceConfig;
+        this.topicSchema = new TopicSchema(pulsarClient);
+        this.properties = properties;
+        this.functionClassLoader = functionClassLoader;
+    }
+
+    @Override
+    public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
+        log.info("Opening pulsar source with config: {}", pulsarSourceConfig);
+
+        Class<?> typeArg = Reflections.loadClass(this.pulsarSourceConfig.getTypeClassName(),
+                this.functionClassLoader);
+
+        checkArgument(!Void.class.equals(typeArg), "Input type of Pulsar Function cannot be Void");
+
+        String topic = pulsarSourceConfig.getTopic();
+        PulsarSourceConsumerConfig<T> pulsarSourceConsumerConfig
+                = buildPulsarSourceConsumerConfig(topic, pulsarSourceConfig.getConsumerConfig(), typeArg);
+
+        log.info("Creating consumer for topic : {}, schema : {}, schemaInfo: {}", topic, pulsarSourceConsumerConfig.getSchema(), pulsarSourceConsumerConfig.getSchema().getSchemaInfo());
+
+        ConsumerBuilder<T> cb = createConsumeBuilder(topic, pulsarSourceConsumerConfig);
+        consumer = cb.subscribeAsync().join();
+    }
+
+    @Override
+    public Record<T> read() throws Exception {
+        Message<T> message = consumer.receive();
+        return buildRecord(consumer, message);
+    }
+
+    @VisibleForTesting
+    Consumer<T> getInputConsumer() {
+        return consumer;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (consumer != null ) {
+            consumer.close();
+        }
+    }
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSourceConfig.java
@@ -16,33 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.functions.source;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+import org.apache.pulsar.common.functions.ConsumerConfig;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.TreeMap;
-
-import lombok.Data;
-
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.common.functions.FunctionConfig;
 
 @Data
-public abstract class PulsarSourceConfig {
+public class SingleConsumerPulsarSourceConfig extends PulsarSourceConfig {
 
-    private FunctionConfig.ProcessingGuarantees processingGuarantees;
-    SubscriptionType subscriptionType;
-    private String subscriptionName;
-    private SubscriptionInitialPosition subscriptionPosition;
-    // Whether the subscriptions the functions created/used should be deleted when the functions is deleted
-    private Integer maxMessageRetries = -1;
-    private String deadLetterTopic;
+    private String topic;
+    private ConsumerConfig consumerConfig;
 
-    private String typeClassName;
-    private Long timeoutMs;
-    private Long negativeAckRedeliveryDelayMs;
+    public static SingleConsumerPulsarSourceConfig load(Map<String, Object> map) throws IOException {
+        ObjectMapper mapper = ObjectMapperFactory.getThreadLocal();
+        return mapper.readValue(new ObjectMapper().writeValueAsString(map), SingleConsumerPulsarSourceConfig.class);
+    }
 }

--- a/pulsar-functions/instance/src/main/resources/findbugsExclude.xml
+++ b/pulsar-functions/instance/src/main/resources/findbugsExclude.xml
@@ -61,6 +61,14 @@
         <Bug pattern="SE_BAD_FIELD"/>
     </Match>
     <Match>
+        <Class name="org.apache.pulsar.functions.source.MultiConsumerPulsarSource"/>
+        <Bug pattern="SE_BAD_FIELD"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.pulsar.functions.source.SingleConsumerPulsarSource"/>
+        <Bug pattern="SE_BAD_FIELD"/>
+    </Match>
+    <Match>
         <Class name="org.apache.pulsar.functions.source.batch.BatchSourceExecutor"/>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -21,11 +21,11 @@ package org.apache.pulsar.functions.source;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,15 +55,22 @@ import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.io.core.SourceContext;
 import org.mockito.ArgumentMatcher;
 import static org.testng.Assert.assertSame;
+
+import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
 public class PulsarSourceTest {
 
+
+    private final static String TOPIC = "persistent://sample/ns1/test_result";
+    private final static ConsumerConfig CONSUMER_CONFIG =  ConsumerConfig.builder()
+            .serdeClassName(TopicSchema.DEFAULT_SERDE).isRegexPattern(false).build();
+
     private static Map<String, ConsumerConfig> consumerConfigs = new HashMap<>();
     static {
-        consumerConfigs.put("persistent://sample/ns1/test_result", ConsumerConfig.builder()
-                .serdeClassName(TopicSchema.DEFAULT_SERDE).isRegexPattern(false).build());
+        consumerConfigs.put(TOPIC,CONSUMER_CONFIG);
     }
 
     private static Map<String, ConsumerConfig> multipleConsumerConfigs = new HashMap<>();
@@ -89,41 +96,48 @@ public class PulsarSourceTest {
         }
     }
 
+    @DataProvider (name = "sourceImpls")
+    public static Object[] getPulsarSourceImpls() {
+        MultiConsumerPulsarSourceConfig multiConsumerPulsarSourceConfig = getMultiConsumerPulsarConfigs(false);
+        SingleConsumerPulsarSourceConfig singleConsumerPulsarSourceConfig = getSingleConsumerPulsarConfigs();
+        return new Object[]{singleConsumerPulsarSourceConfig, multiConsumerPulsarSourceConfig};
+    }
+
     /**
      * Verify that JavaInstance does not support functions that take Void type as input.
      */
     private static PulsarClientImpl getPulsarClient() throws PulsarClientException {
-        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
-        ConsumerBuilder<?> goodConsumerBuilder = mock(ConsumerBuilder.class);
-        ConsumerBuilder<?> badConsumerBuilder = mock(ConsumerBuilder.class);
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(argThat(new TopicMatcher("persistent://sample/ns1/test_result")));
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(argThat(new TopicMatcher("persistent://sample/ns1/test_result1")));
-        doReturn(badConsumerBuilder).when(goodConsumerBuilder).topics(argThat(new TopicMatcher("persistent://sample/ns1/test_result2")));
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(argThat(new TopicMatcher("persistent://sample/ns1/test_result3")));
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).cryptoFailureAction(any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionName(any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionInitialPosition(any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionType(any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).ackTimeout(anyLong(), any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).messageListener(any());
-        doReturn(goodConsumerBuilder).when(goodConsumerBuilder).properties(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).cryptoFailureAction(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionName(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionInitialPosition(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionType(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).ackTimeout(anyLong(), any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).messageListener(any());
-        doReturn(badConsumerBuilder).when(badConsumerBuilder).properties(any());
+        PulsarClientImpl pulsarClient = Mockito.mock(PulsarClientImpl.class);
+        ConsumerBuilder<?> goodConsumerBuilder = Mockito.mock(ConsumerBuilder.class);
+        ConsumerBuilder<?> badConsumerBuilder = Mockito.mock(ConsumerBuilder.class);
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(Mockito.argThat(new TopicMatcher("persistent://sample/ns1/test_result")));
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(Mockito.argThat(new TopicMatcher("persistent://sample/ns1/test_result1")));
+        Mockito.doReturn(badConsumerBuilder).when(goodConsumerBuilder).topics(Mockito.argThat(new TopicMatcher("persistent://sample/ns1/test_result2")));
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).topics(Mockito.argThat(new TopicMatcher("persistent://sample/ns1/test_result3")));
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).cryptoFailureAction(any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionName(any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionInitialPosition(any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).subscriptionType(any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).ackTimeout(anyLong(), any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).messageListener(any());
+        Mockito.doReturn(goodConsumerBuilder).when(goodConsumerBuilder).properties(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).cryptoFailureAction(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionName(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionInitialPosition(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).subscriptionType(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).ackTimeout(anyLong(), any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).messageListener(any());
+        Mockito.doReturn(badConsumerBuilder).when(badConsumerBuilder).properties(any());
 
-        Consumer<?> consumer = mock(Consumer.class);
-        doReturn(consumer).when(goodConsumerBuilder).subscribe();
-        doReturn(goodConsumerBuilder).when(pulsarClient).newConsumer(any());
-        doReturn(CompletableFuture.completedFuture(consumer)).when(goodConsumerBuilder).subscribeAsync();
+        Consumer<?> consumer = Mockito.mock(Consumer.class);
+        Mockito.doReturn(consumer).when(goodConsumerBuilder).subscribe();
+        Mockito.doReturn(goodConsumerBuilder).when(pulsarClient).newConsumer(any());
+        Mockito.doReturn(CompletableFuture.completedFuture(consumer)).when(goodConsumerBuilder).subscribeAsync();
         CompletableFuture<Consumer<?>> badFuture = new CompletableFuture<>();
         badFuture.completeExceptionally(new PulsarClientException("Some Error"));
-        doReturn(badFuture).when(badConsumerBuilder).subscribeAsync();
-        doThrow(PulsarClientException.class).when(badConsumerBuilder).subscribe();
-        doReturn(CompletableFuture.completedFuture(Optional.empty())).when(pulsarClient).getSchema(anyString());
+        Mockito.doReturn(badFuture).when(badConsumerBuilder).subscribeAsync();
+        Mockito.doThrow(PulsarClientException.class).when(badConsumerBuilder).subscribe();
+        Mockito.doReturn(CompletableFuture.completedFuture(Optional.empty())).when(pulsarClient).getSchema(anyString());
         return pulsarClient;
     }
 
@@ -141,14 +155,25 @@ public class PulsarSourceTest {
     }
 
 
-    private static PulsarSourceConfig getPulsarConfigs(boolean multiple) {
-        PulsarSourceConfig pulsarConfig = new PulsarSourceConfig();
+    private static MultiConsumerPulsarSourceConfig getMultiConsumerPulsarConfigs(boolean multiple) {
+        MultiConsumerPulsarSourceConfig pulsarConfig = new MultiConsumerPulsarSourceConfig();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
         if (multiple) {
             pulsarConfig.setTopicSchema(multipleConsumerConfigs);
         } else {
             pulsarConfig.setTopicSchema(consumerConfigs);
         }
+        pulsarConfig.setTypeClassName(String.class.getName());
+        pulsarConfig.setSubscriptionPosition(SubscriptionInitialPosition.Latest);
+        pulsarConfig.setSubscriptionType(SubscriptionType.Shared);
+        return pulsarConfig;
+    }
+
+    private static SingleConsumerPulsarSourceConfig getSingleConsumerPulsarConfigs() {
+        SingleConsumerPulsarSourceConfig pulsarConfig = new SingleConsumerPulsarSourceConfig();
+        pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE);
+        pulsarConfig.setTopic(TOPIC);
+        pulsarConfig.setConsumerConfig(CONSUMER_CONFIG);
         pulsarConfig.setTypeClassName(String.class.getName());
         pulsarConfig.setSubscriptionPosition(SubscriptionInitialPosition.Latest);
         pulsarConfig.setSubscriptionType(SubscriptionType.Shared);
@@ -174,18 +199,36 @@ public class PulsarSourceTest {
         }
     }
 
+    private PulsarSource getPulsarSource(PulsarSourceConfig pulsarSourceConfig) throws PulsarClientException {
+        PulsarSource<?> pulsarSource;
+        if (pulsarSourceConfig instanceof SingleConsumerPulsarSourceConfig) {
+            pulsarSource = new SingleConsumerPulsarSource<>(getPulsarClient(), (SingleConsumerPulsarSourceConfig) pulsarSourceConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        } else {
+            pulsarSource = new MultiConsumerPulsarSource<>(getPulsarClient(), (MultiConsumerPulsarSourceConfig) pulsarSourceConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        }
 
-    @Test
-    public void testVoidInputClasses() throws Exception {
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(false);
+        return pulsarSource;
+    }
+
+    private void setTopicAndConsumerConfig(
+            PulsarSourceConfig pulsarSourceConfig, String topic, ConsumerConfig consumerConfig) {
+        if (pulsarSourceConfig instanceof MultiConsumerPulsarSourceConfig) {
+            ((MultiConsumerPulsarSourceConfig) pulsarSourceConfig).setTopicSchema(Collections.singletonMap(topic, consumerConfig));
+        } else {
+            ((SingleConsumerPulsarSourceConfig) pulsarSourceConfig).setTopic(topic);
+            ((SingleConsumerPulsarSourceConfig) pulsarSourceConfig).setConsumerConfig(consumerConfig);
+        }
+    }
+
+    @Test(dataProvider = "sourceImpls")
+    public void testVoidInputClasses(PulsarSourceConfig pulsarSourceConfig) throws Exception {
         // set type to void
-        pulsarConfig.setTypeClassName(Void.class.getName());
+        pulsarSourceConfig.setTypeClassName(Void.class.getName());
 
         @Cleanup
-        PulsarSource<?> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
-
+        PulsarSource<?> pulsarSource = getPulsarSource(pulsarSourceConfig);
         try {
-            pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
+            pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
             fail();
         } catch (RuntimeException ex) {
             log.error("RuntimeException: {}", ex, ex);
@@ -199,20 +242,18 @@ public class PulsarSourceTest {
     /**
      * Verify that function input type should be consistent with input serde type.
      */
-    @Test
-    public void testInconsistentInputType() throws Exception {
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(false);
+    @Test(dataProvider = "sourceImpls")
+    public void testInconsistentInputType(PulsarSourceConfig pulsarSourceConfig) throws Exception {
         // set type to be inconsistent to that of SerDe
-        pulsarConfig.setTypeClassName(Integer.class.getName());
-        Map<String, ConsumerConfig> topicSerdeClassNameMap = new HashMap<>();
-        topicSerdeClassNameMap.put("persistent://sample/ns1/test_result",
-                ConsumerConfig.builder().serdeClassName(TestSerDe.class.getName()).build());
-        pulsarConfig.setTopicSchema(topicSerdeClassNameMap);
+        pulsarSourceConfig.setTypeClassName(Integer.class.getName());
+        String topic = "persistent://sample/ns1/test_result";
+        ConsumerConfig consumerConfig =  ConsumerConfig.builder().serdeClassName(TestSerDe.class.getName()).build();
+        setTopicAndConsumerConfig(pulsarSourceConfig, topic, consumerConfig);
 
         @Cleanup
-        PulsarSource<?> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        PulsarSource<?> pulsarSource = getPulsarSource(pulsarSourceConfig);
         try {
-            pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
+            pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
         } catch (RuntimeException ex) {
             log.error("RuntimeException: {}", ex, ex);
@@ -226,44 +267,40 @@ public class PulsarSourceTest {
     /**
      * Verify that Default Serializer works fine.
      */
-    @Test
-    public void testDefaultSerDe() throws Exception {
-
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(false);
+    @Test(dataProvider = "sourceImpls")
+    public void testDefaultSerDe(PulsarSourceConfig pulsarSourceConfig) throws Exception {
         // set type to void
-        pulsarConfig.setTypeClassName(String.class.getName());
+        pulsarSourceConfig.setTypeClassName(String.class.getName());
         consumerConfigs.put("persistent://sample/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(TopicSchema.DEFAULT_SERDE).build());
-        pulsarConfig.setTopicSchema(consumerConfigs);
+        setTopicAndConsumerConfig(pulsarSourceConfig, TOPIC, CONSUMER_CONFIG);
 
         @Cleanup
-        PulsarSource<?> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        PulsarSource<?> pulsarSource = getPulsarSource(pulsarSourceConfig);
 
-        pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
+        pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
     }
 
-    @Test
-    public void testComplexOuputType() throws Exception {
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(false);
+    @Test(dataProvider = "sourceImpls")
+    public void testComplexOutputType(PulsarSourceConfig pulsarSourceConfig) throws Exception {
         // set type to void
-        pulsarConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
+        pulsarSourceConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
         consumerConfigs.put("persistent://sample/ns1/test_result",
                 ConsumerConfig.builder().serdeClassName(ComplexSerDe.class.getName()).build());
-        pulsarConfig.setTopicSchema(consumerConfigs);
+        setTopicAndConsumerConfig(pulsarSourceConfig, TOPIC, CONSUMER_CONFIG);
 
         @Cleanup
-        PulsarSource<?> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
-
-        pulsarSource.setupConsumerConfigs();
+        PulsarSource<?> pulsarSource = getPulsarSource(pulsarSourceConfig);
+        pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
     }
 
     @Test
     public void testDanglingSubscriptions() throws Exception {
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(true);
+        MultiConsumerPulsarSourceConfig pulsarConfig = getMultiConsumerPulsarConfigs(true);
 
-        PulsarSource<?> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        MultiConsumerPulsarSource<?> pulsarSource = new MultiConsumerPulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
         try {
-            pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
+            pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
             fail();
         } catch (CompletionException e) {
             pulsarSource.close();
@@ -274,21 +311,23 @@ public class PulsarSourceTest {
 
     }
 
-    @Test
-    public void testPreserveOriginalSchema() throws Exception {
-        PulsarSourceConfig pulsarConfig = getPulsarConfigs(false);
-        pulsarConfig.setTypeClassName(GenericRecord.class.getName());
+    @Test(dataProvider = "sourceImpls")
+    public void testPreserveOriginalSchema(PulsarSourceConfig pulsarSourceConfig) throws Exception {
+        pulsarSourceConfig.setTypeClassName(GenericRecord.class.getName());
 
-        @Cleanup
-        PulsarSource<GenericRecord> pulsarSource = new PulsarSource<>(getPulsarClient(), pulsarConfig, new HashMap<>(), Thread.currentThread().getContextClassLoader());
+        PulsarSource<GenericRecord> pulsarSource = getPulsarSource(pulsarSourceConfig);
 
-        pulsarSource.open(new HashMap<>(), mock(SourceContext.class));
-        Consumer consumer = mock(Consumer.class);
-        MessageImpl messageImpl = mock(MessageImpl.class);
-        Schema schema = mock(Schema.class);
-        when(messageImpl.getSchema()).thenReturn(schema);
-        pulsarSource.received(consumer, (Message) messageImpl);
-        verify(messageImpl.getSchema(), times(1));
+        pulsarSource.open(new HashMap<>(), Mockito.mock(SourceContext.class));
+        Consumer consumer = Mockito.mock(Consumer.class);
+        MessageImpl messageImpl = Mockito.mock(MessageImpl.class);
+        Schema schema = Mockito.mock(Schema.class);
+        Mockito.when(messageImpl.getSchema()).thenReturn(schema);
+        if (pulsarSource instanceof MultiConsumerPulsarSource) {
+            ((MultiConsumerPulsarSource) pulsarSource).received(consumer, messageImpl);
+        } else {
+            Mockito.doReturn(messageImpl).when(((SingleConsumerPulsarSource) pulsarSource).getInputConsumer()).receive();
+        }
+        Mockito.verify(messageImpl.getSchema(), Mockito.times(1));
         Record<GenericRecord> pushed = pulsarSource.read();
         assertSame(pushed.getSchema(), schema);
     }

--- a/pulsar-io/hbase/src/test/java/org/apache/pulsar/io/hbase/sink/HbaseGenericRecordSinkTest.java
+++ b/pulsar-io/hbase/src/test/java/org/apache/pulsar/io/hbase/sink/HbaseGenericRecordSinkTest.java
@@ -117,7 +117,7 @@ public class HbaseGenericRecordSinkTest {
         AutoConsumeSchema autoConsumeSchema = new AutoConsumeSchema();
         autoConsumeSchema.setSchema(GenericSchemaImpl.of(schema.getSchemaInfo()));
 
-        PulsarSourceConfig pulsarSourceConfig = new PulsarSourceConfig();
+        PulsarSourceConfig pulsarSourceConfig = mock(PulsarSourceConfig.class);
         Consumer consumer = mock(Consumer.class);
 
         Record<GenericRecord> record = PulsarRecord.<GenericRecord>builder()


### PR DESCRIPTION
### Motivation

Currently, the internal PulsarSource used in the Pulsar Function framework used to read from topics extend the PushSource.  This is done to support the use case in which multiple consumers have to be created to read from multiple topics with different consumer settings.  While this approach is necessary for reading from multiple topics with consumers with different settings, it is inefficient for reading a single topic or list of topics with the same consumer settings (not address in this PR).  The inefficiency is due to the fact that for PushSource all messages are push onto an intermediate queue and then pop off to be processed.  This intermediate queueing is unnecessary for reading from one topic.

By removing having to enqueue and dequeue everyone message from this intermediate queue performance can improve around 20%

### Modifications

Create separate code paths for when reading from one topic vs multiple topics.

Two different PulsarSource implementations are introduced.  SingleConsumerPulsarSource, which is used when only one consumer is needed to be created i.e. reading from one topic.  MultiConsumerPulsarSource, which is used when multiple consumers are needed to be created i.e. reading from multiple topics with different consumer settings.

