### PR TITLE
Fixed bug in permits log message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -495,7 +495,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             if (log.isDebugEnabled() && !c.isWritable()) {
                 log.debug("[{}-{}] consumer is not writable. dispatching only 1 message to {}; "
                                 + "availablePermits are {}", topic.getName(), name,
-                        c, availablePermits);
+                        c, c.getAvailablePermits());
             }
             int messagesForC = Math.min(
                     Math.min(entriesToDispatch, availablePermits),


### PR DESCRIPTION
The debug log statement in this PR was logging the wrong value (which always equals 1 instead of actually showing the available permits.) This PR fixes that.