### PR TITLE
Fix message buffer being copied from direct memory to heap memory

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -36,8 +36,9 @@ public interface ManagedLedgerInterceptor {
      * Intercept an OpAddEntry and return an OpAddEntry.
      * @param op an OpAddEntry to be intercepted.
      * @param numberOfMessages
+     * @return an OpAddEntry.
      */
-    void beforeAddEntry(OpAddEntry op, int numberOfMessages);
+    OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages);
 
     /**
      * Intercept when ManagedLedger is initialized.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -36,9 +36,8 @@ public interface ManagedLedgerInterceptor {
      * Intercept an OpAddEntry and return an OpAddEntry.
      * @param op an OpAddEntry to be intercepted.
      * @param numberOfMessages
-     * @return an OpAddEntry.
      */
-    OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages);
+    void beforeAddEntry(OpAddEntry op, int numberOfMessages);
 
     /**
      * Intercept when ManagedLedger is initialized.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -55,11 +55,12 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public void beforeAddEntry(OpAddEntry op, int numberOfMessages) {
+    public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
         if (op == null || numberOfMessages <= 0) {
-            return;
+            return op;
         }
         op.setData(Commands.addBrokerEntryMetadata(op.getData(), brokerEntryMetadataInterceptors, numberOfMessages));
+        return op;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -55,12 +55,11 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
-       if (op == null || numberOfMessages <= 0) {
-           return op;
-       }
+    public void beforeAddEntry(OpAddEntry op, int numberOfMessages) {
+        if (op == null || numberOfMessages <= 0) {
+            return;
+        }
         op.setData(Commands.addBrokerEntryMetadata(op.getData(), brokerEntryMetadataInterceptors, numberOfMessages));
-        return op;
     }
 
     @Override

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/CommandUtilsTests.java
@@ -149,6 +149,9 @@ public class CommandUtilsTests {
         byte [] content = new byte[dataWithBrokerEntryMetadata.readableBytes()];
         dataWithBrokerEntryMetadata.readBytes(content);
         assertTrue(new String(content, StandardCharsets.UTF_8).endsWith(data));
+        dataWithBrokerEntryMetadata.release();
+        assertEquals(byteBuf.refCnt(), 0);
+        assertEquals(dataWithBrokerEntryMetadata.refCnt(), 0);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

When I tested pulsar with `AppendIndexMetadataInterceptor` configured, i.e.

```properties
brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
```

I found the heap memory increased very fast so that GC happened frequently. After the analysis from the dump info, I found many messages, which have `BrokerEntryMetadata` in the head, are stored in heap memory instead of direct memory.

When I removed the above configuration, the heap memory became slow to increase. 

### Modifications

- Copy two buffers into a single buffer **in direct memory** instead of using `CompositeByteBuf`. Because when a `CompositeByteBuf` that has over 1 components goes to BookKeeper's checksum logic, the `nioBuffer()` method will be called and the `CompositeByteBuf`'s internal buffers will be concatenated into a single buffer **in heap memory**.
- Add the reference count check to ensure that after the change, the input and output buffers of `addBrokerEntryMetadata` will be released finally after the output buffer is released.
- Add a slightly code refactor that makes `ManagedLedgerInterceptor#beforeAddEntry`'s returned value be used.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

After this change, the heap memory increasing problem was solved.