### PR TITLE
[Build] Fix core-modules profile on JDK11

### DIFF
--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - name: build package
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q install -Pcore-modules,-main -DskipTests
 
       - name: build cpp artifacts
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -95,15 +95,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -95,15 +95,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -95,15 +95,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -95,15 +95,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -93,13 +93,13 @@ jobs:
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration function
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -94,15 +94,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -93,13 +93,13 @@ jobs:
         run: mvn -q -B -ntp clean install -DskipTests
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
       - name: build artifacts and docker image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run integration tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -66,7 +66,7 @@ jobs:
           - name: core-modules
             runs-on: ubuntu-latest
             cache_name: 'm2-dependencies-core-modules'
-            mvn_arguments: '-Pcore-modules'
+            mvn_arguments: '-Pcore-modules,-main'
 
     steps:
       - name: checkout

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -95,15 +95,15 @@ jobs:
 
       - name: build pulsar image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build pulsar-all image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker -DskipTests -Ddocker.nocache=true
+        run: mvn -B -f docker/pulsar-all/pom.xml install -am -Pdocker,-main -DskipTests -Ddocker.nocache=true
 
       - name: build artifacts and docker pulsar latest test image
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker -DskipTests
+        run: mvn -B -f tests/docker-images/pom.xml install -am -Pdocker,-main -DskipTests
 
       - name: run shade tests
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q clean install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'BROKER_GROUP_1'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q clean install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'BROKER_GROUP_2'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_API'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'BROKER_CLIENT_IMPL'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q clean install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q clean install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'BROKER_FLAKY'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: build modules pulsar-proxy
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}
-        run: mvn -B -ntp -q install -Pcore-modules -DskipTests
+        run: mvn -B -ntp -q install -Pcore-modules,-main -DskipTests
 
       - name: run unit test 'PROXY'
         if: ${{ steps.changes.outputs.all_count }} > ${{ steps.changes.outputs.docs_count }}

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ mvn install -DskipTests
 
 ## Minimal build (This skips most of external connectors and tiered storage handlers)
 ```
-mvn install -Pcore-modules
+mvn install -Pcore-modules,-main
 ```
 
 Run Unit Tests:

--- a/build/build_java_test_image.sh
+++ b/build/build_java_test_image.sh
@@ -26,5 +26,5 @@ SQUASH_PARAM=""
 if [[ "$(docker version -f '{{.Server.Experimental}}' 2>/dev/null)" == "true" ]]; then
   SQUASH_PARAM="-Ddockerfile.build.squash=true"
 fi
-mvn -am -pl tests/docker-images/java-test-image install -Pcore-modules,integrationTests,docker \
+mvn -am -pl tests/docker-images/java-test-image install -Pcore-modules,-main,integrationTests,docker \
   -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true $SQUASH_PARAM "$@"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -21,5 +21,5 @@
 ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/docker
 
-mvn -f ../dashboard/pom.xml package -Pdocker
-mvn package -Pdocker
+mvn -f ../dashboard/pom.xml package -Pdocker,-main
+mvn package -Pdocker,-main

--- a/pom.xml
+++ b/pom.xml
@@ -1822,8 +1822,9 @@ flexible messaging model and an intuitive client API.</description>
     <profile>
       <id>main</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
-        <jdk>[8,)</jdk>
+        <!-- always activate this profile by default. Use "-main" or "!main" in the "-P" parameter to exclude it -->
+        <!-- for example use "-Pcore-modules,-main" to activate the core-modules profile -->
+        <file><exists>pom.xml</exists></file>
       </activation>
       <modules>
         <module>buildtools</module>

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,7 @@ The integration tests use a framework called [Test Containers](https://www.testc
 The tests require that docker is installed and running. Tests will only run if the integrationTests system property is defined. To run the tests:
 ```shell
 # in the top level directory
-pulsar/ $ mvn install -DskipTests -Pdocker # builds the docker images
+pulsar/ $ mvn install -DskipTests -Pdocker,-main # builds the docker images
 ...
 pulsar/ $ mvn -f tests/pom.xml test -DintegrationTests
 ```

--- a/tests/compose/README.md
+++ b/tests/compose/README.md
@@ -21,7 +21,7 @@
 
 This are docker compose files to quickly bring up a pulsar
 cluster. They use the pulsar testing docker image. To generate this,
-run ```mvn install -DskipTests -Pdocker``` in the top-level directory
+run ```mvn install -DskipTests -Pdocker,-main``` in the top-level directory
 of the project.
 
 To run, change directory into multi or simple, and run:


### PR DESCRIPTION
### Motivation

"core-modules" profile is broken on JDK11. core-modules profile allows building a subset of the modules. It is used in the unit test builds. 
The current Pulsar build is designed in a way that main profile shouldn't be active when core-modules or docker profile is active.

### Modifications

- Fix the usages of core-modules and docker profiles so that the main profile is explicitly de-activated from the command line by passing `-main` (same as `!main`, but doesn't require quotes in a unix shell) to the list of profiles for `-P` on the maven command line.
  - For example:
    - `-Pcore-modules,-main` to activate core-modules
    - `-Pdocker,-main` to activate the docker profile.

- make the "always activate" solution for `main` profile more explicit and add comments in `pom.xml` about it