### PR TITLE
[Tests] Fix AvroSchemaTest on JDK11

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -20,39 +20,36 @@ package org.apache.pulsar.client.impl.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.FOO_FIELDS;
-import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_NOT_ALLOW_NULL;
 import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_ALLOW_NULL;
+import static org.apache.pulsar.client.impl.schema.SchemaTestUtils.SCHEMA_AVRO_NOT_ALLOW_NULL;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertSame;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.avro.Schema;
-import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.BufferedBinaryEncoder;
-import org.apache.pulsar.client.api.SchemaSerializationException;
-import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
 import org.apache.avro.SchemaValidatorBuilder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.BufferedBinaryEncoder;
 import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.Nullable;
 import org.apache.avro.reflect.ReflectData;
+import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
-import org.apache.pulsar.client.api.schema.SchemaDefinitionBuilder;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.api.schema.SchemaWriter;
 import org.apache.pulsar.client.avro.generated.NasaMission;
@@ -66,8 +63,8 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.json.JSONException;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.powermock.reflect.Whitebox;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -293,7 +290,7 @@ public class AvroSchemaTest {
         schemaLogicalType.setDecimal(new BigDecimal("12.34"));
         schemaLogicalType.setDate(LocalDate.now());
         schemaLogicalType.setTimeMicros(System.currentTimeMillis()*1000);
-        schemaLogicalType.setTimeMillis(LocalTime.now());
+        schemaLogicalType.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
 
         byte[] bytes1 = avroSchema.encode(schemaLogicalType);
         Assert.assertTrue(bytes1.length > 0);
@@ -313,7 +310,7 @@ public class AvroSchemaTest {
         schemaLogicalType.setTimestampMillis(new DateTime("2019-03-26T04:39:58.469Z", ISOChronology.getInstanceUTC()));
         schemaLogicalType.setDate(LocalDate.now());
         schemaLogicalType.setTimeMicros(System.currentTimeMillis()*1000);
-        schemaLogicalType.setTimeMillis(LocalTime.now());
+        schemaLogicalType.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
 
         byte[] bytes1 = avroSchema.encode(schemaLogicalType);
         Assert.assertTrue(bytes1.length > 0);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/JodaTimeTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/JodaTimeTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.schema;
 
 import com.google.common.collect.Sets;
+import java.time.temporal.ChronoUnit;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -113,7 +114,7 @@ public class JodaTimeTest extends PulsarTestSuite {
         forSend.setDecimal(new BigDecimal("12.34"));
         forSend.setTimeMicros(System.currentTimeMillis() * 1000);
         forSend.setTimestampMillis(new DateTime("2019-03-26T04:39:58.469Z", ISOChronology.getInstanceUTC()));
-        forSend.setTimeMillis(LocalTime.now());
+        forSend.setTimeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS));
         forSend.setTimeMicros(System.currentTimeMillis() * 1000);
         forSend.setDate(LocalDate.now());
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/SchemaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/schema/SchemaTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 import com.google.common.collect.Sets;
+import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.*;
@@ -200,7 +201,7 @@ public class SchemaTest extends PulsarTestSuite {
                 .decimal(new BigDecimal("12.34"))
                 .timestampMicros(System.currentTimeMillis() * 1000)
                 .timestampMillis(Instant.parse("2019-03-26T04:39:58.469Z"))
-                .timeMillis(LocalTime.now())
+                .timeMillis(LocalTime.now().truncatedTo(ChronoUnit.MILLIS))
                 .timeMicros(System.currentTimeMillis() * 1000)
                 .date(LocalDate.now())
                 .build();


### PR DESCRIPTION
Fixes #10122

### Motivation

- see #10122 

### Modifications

- When testing time fields at millisecond precision, use `LocalTime.now().truncatedTo(ChronoUnit.MILLIS)` instead of `LocalTime.now()` . 
 
- On Java 8, `LocalTime.now()` has millisecond precision, but on Java 11, there is microsecond precision by default. The change in JDK is https://bugs.openjdk.java.net/browse/JDK-8068730 .