### PR TITLE
[Build] Specify release in maven-compiler-plugin configuration on JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@ flexible messaging model and an intuitive client API.</description>
   </issueManagement>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
 
     <!--config keys to congiure test selection -->
     <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1667,13 +1667,30 @@ flexible messaging model and an intuitive client API.</description>
 
   <profiles>
     <profile>
-      <id>jdk11-tests</id>
+      <id>jdk11</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
       <properties>
+        <!-- prevents silent NoSuchMethodErrors that happen at runtime on Java 8 -->
+        <!-- see https://github.com/apache/pulsar/issues/8445 -->
+        <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
+        <!-- required for running tests on JDK11+ -->
         <test.additional.args> --add-opens java.base/jdk.internal.loader=ALL-UNNAMED </test.additional.args>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <!-- for some reason, setting maven.compiler.release property alone doesn't work -->
+                <release>${maven.compiler.release}</release>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>coverage</id>


### PR DESCRIPTION
Fixes #8445

### Motivation

Specifying "release" parameter for maven-compiler-plugin is required on JDK11 to fix binary compatibility with JDK 8. 
This blog post describes the problem and the solution: https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/

### Modifications

- rename jdk11-tests profile to jdk11
- add maven.compiler.release property that matches the maven.compiler.target property value
- add a workaround for configuring the maven-compiler-plugin since setting maven.compiler.release property alone didn't configure the plugin properly