### PR TITLE
[Tests] Remove ".atMost" definitions for Awaitility in most cases

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDelivery.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDelivery.java
@@ -71,7 +71,7 @@ public class AdminApiDelayedDelivery extends MockedPulsarServiceBaseTest {
         DelayedDeliveryPolicies delayedDeliveryPolicies = new DelayedDeliveryPolicies(2000, false);
         admin.namespaces().setDelayedDeliveryMessages(namespace, delayedDeliveryPolicies);
         //zk update takes time
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() ->
+        Awaitility.await().until(() ->
                 admin.namespaces().getDelayedDelivery(namespace) != null);
         assertFalse(admin.namespaces().getDelayedDelivery(namespace).isActive());
         assertEquals(2000, admin.namespaces().getDelayedDelivery(namespace).getTickTime());
@@ -125,11 +125,11 @@ public class AdminApiDelayedDelivery extends MockedPulsarServiceBaseTest {
         assertNull(admin.namespaces().getDelayedDelivery(namespace));
         DelayedDeliveryPolicies delayedDeliveryPolicies = new DelayedDeliveryPolicies(3, true);
         admin.namespaces().setDelayedDeliveryMessages(namespace, delayedDeliveryPolicies);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.namespaces().getDelayedDelivery(namespace), delayedDeliveryPolicies));
 
         admin.namespaces().removeDelayedDeliveryMessages(namespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.namespaces().getDelayedDelivery(namespace)));
     }
 
@@ -143,7 +143,7 @@ public class AdminApiDelayedDelivery extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + namespace + "/test" + UUID.randomUUID();
         admin.namespaces().createNamespace(namespace);
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         //namespace-level default value is null
         assertNull(admin.namespaces().getDelayedDelivery(namespace));
@@ -158,7 +158,7 @@ public class AdminApiDelayedDelivery extends MockedPulsarServiceBaseTest {
         DelayedDeliveryPolicies namespaceLevelPolicy =
                 new DelayedDeliveryPolicies(100, true);
         admin.namespaces().setDelayedDeliveryMessages(namespace, namespaceLevelPolicy);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.namespaces().getDelayedDelivery(namespace)));
         DelayedDeliveryPolicies policyFromBroker = admin.topics().getDelayedDeliveryPolicy(topic, true);
         assertEquals(policyFromBroker.getTickTime(), 100);
@@ -166,18 +166,18 @@ public class AdminApiDelayedDelivery extends MockedPulsarServiceBaseTest {
         // set topic-level policy
         DelayedDeliveryPolicies topicLevelPolicy = new DelayedDeliveryPolicies(200, true);
         admin.topics().setDelayedDeliveryPolicy(topic, topicLevelPolicy);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getDelayedDeliveryPolicy(topic)));
         policyFromBroker = admin.topics().getDelayedDeliveryPolicy(topic, true);
         assertEquals(policyFromBroker.getTickTime(), 200);
         assertTrue(policyFromBroker.isActive());
         //remove topic-level policy
         admin.topics().removeDelayedDeliveryPolicy(topic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getDelayedDeliveryPolicy(topic, true), namespaceLevelPolicy));
         //remove namespace-level policy
         admin.namespaces().removeDelayedDeliveryMessages(namespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getDelayedDeliveryPolicy(topic, true), brokerLevelPolicy));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessages.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessages.java
@@ -118,11 +118,11 @@ public class AdminApiMaxUnackedMessages extends MockedPulsarServiceBaseTest {
         String namespace = "max-unacked-messages/default-on-subscription";
         assertNull(admin.namespaces().getMaxUnackedMessagesPerSubscription(namespace));
         admin.namespaces().setMaxUnackedMessagesPerSubscription(namespace, 2*200000);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(2*200000, admin.namespaces().getMaxUnackedMessagesPerSubscription(namespace).intValue()));
 
         admin.namespaces().removeMaxUnackedMessagesPerSubscription(namespace);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.namespaces().getMaxUnackedMessagesPerSubscription(namespace)));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -185,7 +185,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         final String topicName = testTopic + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
         pulsarClient.newProducer().topic(topicName).create().close();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topicName)));
         OffloadPolicies offloadPolicies = admin.topics().getOffloadPolicies(topicName);
         assertNull(offloadPolicies);
@@ -193,12 +193,12 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         String path = "fileSystemPath";
         offload.setFileSystemProfilePath(path);
         admin.topics().setOffloadPolicies(topicName, offload);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getOffloadPolicies(topicName)));
         assertEquals(admin.topics().getOffloadPolicies(topicName), offload);
         assertEquals(admin.topics().getOffloadPolicies(topicName).getFileSystemProfilePath(), path);
         admin.topics().removeOffloadPolicies(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getOffloadPolicies(topicName)));
         assertNull(admin.topics().getOffloadPolicies(topicName));
     }
@@ -208,7 +208,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         final String topicName = testTopic + UUID.randomUUID().toString();
         admin.topics().createPartitionedTopic(topicName, 3);
         pulsarClient.newProducer().topic(topicName).create().close();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topicName)));
         OffloadPolicies offloadPolicies = admin.topics().getOffloadPolicies(topicName, true);
         OffloadPolicies brokerPolicies = OffloadPolicies
@@ -270,7 +270,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
             admin.topics().createNonPartitionedTopic(topicName);
         }
         pulsarClient.newProducer().topic(topicName).enableBatching(false).create().close();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topicName)));
         //2 namespace level policy should use NullLedgerOffloader by default
         if (isPartitioned) {
@@ -299,12 +299,12 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         when(topicOffloader.getOffloadDriverName()).thenReturn("mock");
         doReturn(topicOffloader).when(pulsar).createManagedLedgerOffloader(any());
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topicName)));
 
         //4 set topic level offload policies
         admin.topics().setOffloadPolicies(topicName, offloadPolicies);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getOffloadPolicies(topicName)));
         //5 name of offload should become "mock"
         if (isPartitioned) {
@@ -330,7 +330,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         doReturn(map).when(pulsar).getLedgerOffloaderMap();
 
         admin.topics().removeOffloadPolicies(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getOffloadPolicies(topicName)));
         // topic level offloader should be closed
         if (isPartitioned) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -2194,7 +2194,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(1000);
         admin.topics().expireMessages("persistent://prop-xyz/ns1/ds2", "my-sub1", 1);
         // Wait at most 2 seconds for sub1's message to expire.
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(
+        Awaitility.await().untilAsserted(() -> assertTrue(
                 admin.topics().getStats("persistent://prop-xyz/ns1/ds2").subscriptions.get("my-sub1").lastMarkDeleteAdvancedTimestamp > 0L));
         topicStats = admin.topics().getStats("persistent://prop-xyz/ns1/ds2");
         SubscriptionStats subStats1 = topicStats.subscriptions.get("my-sub1");
@@ -2209,7 +2209,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.topics().expireMessages("persistent://prop-xyz/ns1/ds2", "my-sub2",
                 messageIds.get(4), false);
         // Wait at most 2 seconds for sub2's message to expire.
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(
+        Awaitility.await().untilAsserted(() -> assertTrue(
                 admin.topics().getStats("persistent://prop-xyz/ns1/ds2").subscriptions.get("my-sub2").lastMarkDeleteAdvancedTimestamp > 0L));
         topicStats = admin.topics().getStats("persistent://prop-xyz/ns1/ds2");
         subStats1 = topicStats.subscriptions.get("my-sub1");
@@ -2229,7 +2229,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             assertTrue(e.getMessage().startsWith("Expire message by timestamp not issued on topic"));
         }
         // Wait at most 2 seconds for sub3's message to expire.
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(
+        Awaitility.await().untilAsserted(() -> assertTrue(
                 admin.topics().getStats("persistent://prop-xyz/ns1/ds2").subscriptions.get("my-sub3").lastMarkDeleteAdvancedTimestamp > 0L));
         topicStats = admin.topics().getStats("persistent://prop-xyz/ns1/ds2");
         subStats1 = topicStats.subscriptions.get("my-sub1");
@@ -2672,7 +2672,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(10000);
         // Update policy to trigger message expiry check.
         admin.namespaces().setNamespaceMessageTTL("prop-xyz/ns1", 5);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> admin.topics().getStats(topic).subscriptions.values().iterator().next().lastExpireTimestamp > 0L);
+        Awaitility.await().until(() -> admin.topics().getStats(topic).subscriptions.values().iterator().next().lastExpireTimestamp > 0L);
     }
 
     @Test(timeOut = 150000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1674,7 +1674,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.namespaces().setMaxSubscriptionsPerTopicAsync(myNamespace,200).get();
         assertEquals(admin.namespaces().getMaxSubscriptionsPerTopicAsync(myNamespace).get().intValue(),200);
         admin.namespaces().removeMaxSubscriptionsPerTopicAsync(myNamespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.namespaces().getMaxSubscriptionsPerTopicAsync(myNamespace).get()));
 
         try {
@@ -1695,7 +1695,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
         Field field = PersistentTopic.class.getSuperclass().getDeclaredField("maxSubscriptionsPerTopic");
         field.setAccessible(true);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> (int) field.get(persistentTopic) == maxSub);
+        Awaitility.await().until(() -> (int) field.get(persistentTopic) == maxSub);
 
         List<Consumer<?>> consumerList = new ArrayList<>(maxSub);
         for (int i = 0; i < maxSub; i++) {
@@ -1712,7 +1712,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         }
         //After removing the restriction, it should be able to create normally
         admin.namespaces().removeMaxSubscriptionsPerTopic(myNamespace);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> field.get(persistentTopic) == null);
+        Awaitility.await().until(() -> field.get(persistentTopic) == null);
         Consumer<?> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(UUID.randomUUID().toString())
                 .subscribe();
         consumerList.add(consumer);
@@ -1759,14 +1759,14 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
         Field field = PersistentTopic.class.getSuperclass().getDeclaredField("maxSubscriptionsPerTopic");
         field.setAccessible(true);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> (int) field.get(persistentTopic) == nsLevelMaxSub);
+        Awaitility.await().until(() -> (int) field.get(persistentTopic) == nsLevelMaxSub);
         Consumer<?> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(UUID.randomUUID().toString())
                 .subscribe();
         consumerList.add(consumer);
         assertEquals(consumerList.size(), 3);
         //After removing the restriction, it should fail again
         admin.namespaces().removeMaxSubscriptionsPerTopic(myNamespace);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> field.get(persistentTopic) == null);
+        Awaitility.await().until(() -> field.get(persistentTopic) == null);
         try {
             client.newConsumer().topic(topic).subscriptionName(UUID.randomUUID().toString()).subscribe();
             fail("should fail");
@@ -1795,7 +1795,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/testMaxProducersPerTopicUnlimited";
         //the policy is set to 0, so there will be no restrictions
         admin.namespaces().setMaxProducersPerTopic(myNamespace, 0);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxProducersPerTopic(myNamespace) == 0);
         List<Producer<byte[]>> producers = new ArrayList<>();
         for (int i = 0; i < maxProducersPerTopic + 1; i++) {
@@ -1804,7 +1804,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         }
 
         admin.namespaces().removeMaxProducersPerTopic(myNamespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxProducersPerTopic(myNamespace) == null);
         try {
             pulsarClient.newProducer().topic(topic).create();
@@ -1814,7 +1814,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         }
         //set the limit to 3
         admin.namespaces().setMaxProducersPerTopic(myNamespace, 3);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxProducersPerTopic(myNamespace) == 3);
         // should success
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
@@ -1850,7 +1850,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         assertNull(admin.namespaces().getMaxConsumersPerTopic(myNamespace));
         //the policy is set to 0, so there will be no restrictions
         admin.namespaces().setMaxConsumersPerTopic(myNamespace, 0);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxConsumersPerTopic(myNamespace) == 0);
         List<Consumer<byte[]>> consumers = new ArrayList<>();
         for (int i = 0; i < maxConsumersPerTopic + 1; i++) {
@@ -1860,7 +1860,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         }
 
         admin.namespaces().removeMaxConsumersPerTopic(myNamespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxConsumersPerTopic(myNamespace) == null);
         try {
             pulsarClient.newConsumer().subscriptionName(UUID.randomUUID().toString()).topic(topic).subscribe();
@@ -1870,7 +1870,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         }
         //set the limit to 3
         admin.namespaces().setMaxConsumersPerTopic(myNamespace, 3);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxConsumersPerTopic(myNamespace) == 3);
         // should success
         Consumer<byte[]> consumer =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -122,15 +122,15 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
 
         admin.topics().updatePartitionedTopic(partitionedTopicName, 2);
         //zk update takes some time
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 2));
 
         admin.topics().updatePartitionedTopic(partitionedTopicName, 10);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 10));
 
         admin.topics().updatePartitionedTopic(partitionedTopicName, 20);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 20));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MaxUnackedMessagesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MaxUnackedMessagesTest.java
@@ -81,11 +81,11 @@ public class MaxUnackedMessagesTest extends ProducerConsumerBase {
         assertNull(max);
 
         admin.topics().setMaxUnackedMessagesOnSubscription(topicName, 2048);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName)));
         assertEquals(admin.topics().getMaxUnackedMessagesOnSubscription(topicName).intValue(), 2048);
         admin.topics().removeMaxUnackedMessagesOnSubscription(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName)));
         assertNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName));
     }
@@ -109,7 +109,7 @@ public class MaxUnackedMessagesTest extends ProducerConsumerBase {
         List<Consumer<?>> consumers = Lists.newArrayList(consumer1, consumer2, consumer3);
         waitCacheInit(topicName);
         admin.topics().setMaxUnackedMessagesOnSubscription(topicName, unackMsgAllowed);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName)));
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
@@ -190,11 +190,11 @@ public class MaxUnackedMessagesTest extends ProducerConsumerBase {
         assertNull(max);
 
         admin.topics().setMaxUnackedMessagesOnConsumer(topicName, 2048);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName)));
         assertEquals(admin.topics().getMaxUnackedMessagesOnConsumer(topicName).intValue(), 2048);
         admin.topics().removeMaxUnackedMessagesOnConsumer(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName)));
         assertNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName));
     }
@@ -290,7 +290,7 @@ public class MaxUnackedMessagesTest extends ProducerConsumerBase {
         // 3) Set restrictions, so only part of the data can be consumed
         waitCacheInit(topicName);
         admin.topics().setMaxUnackedMessagesOnConsumer(topicName, unackMsgAllowed);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName)));
         assertEquals(admin.topics().getMaxUnackedMessagesOnConsumer(topicName).intValue(), unackMsgAllowed);
         // 4) Start 2 consumer, each consumer can only consume 100 messages
@@ -333,7 +333,7 @@ public class MaxUnackedMessagesTest extends ProducerConsumerBase {
     private void waitCacheInit(String topicName) throws Exception {
         pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe().close();
         TopicName topic = TopicName.get(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(topic));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -165,17 +165,17 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(method.invoke(persistentTopic), 3600);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 10));
         Assert.assertEquals((int)method.invoke(persistentTopic), 10);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 0));
         Assert.assertEquals((int)method.invoke(persistentTopic), 0);
 
         admin.namespaces().removeNamespaceMessageTTL(myNamespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertNull(admin.namespaces().getNamespaceMessageTTL(myNamespace)));
         Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
     }
@@ -198,26 +198,26 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(topicMessageTTLApplied, 3600);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 10);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 10));
         topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 10);
 
         admin.namespaces().setNamespaceMessageTTL(myNamespace, 0);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertEquals(admin.namespaces().getNamespaceMessageTTL(myNamespace).intValue(), 0));
         topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 0);
 
         admin.topics().setMessageTTL(topicName, 20);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertNotNull(admin.topics().getMessageTTL(topicName)));
         topicMessageTTLApplied = admin.topics().getMessageTTL(topicName, true);
         Assert.assertEquals(topicMessageTTLApplied, 20);
 
         admin.namespaces().removeNamespaceMessageTTL(myNamespace);
         admin.topics().removeMessageTTL(topicName);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertEquals(admin.topics().getMessageTTL(topicName, true).intValue(), 3600));
         Assert.assertEquals((int)method.invoke(persistentTopic), 3600);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -121,13 +121,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         BacklogQuota backlogQuota = new BacklogQuota(1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
         log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setBacklogQuota(testTopic, backlogQuota);
         log.info("Backlog quota set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage), backlogQuota));
 
@@ -144,13 +144,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         BacklogQuota backlogQuota = new BacklogQuota(1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
         log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setBacklogQuota(testTopic, backlogQuota);
         log.info("Backlog quota set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage), backlogQuota));
 
@@ -160,7 +160,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(backlogQuota, backlogQuotaInManager);
 
         admin.topics().removeBacklogQuota(testTopic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage)));
 
@@ -178,7 +178,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         String namespace = TopicName.get(testTopic).getNamespace();
         admin.namespaces().setRetention(namespace, retentionPolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getRetention(namespace), retentionPolicies));
 
         BacklogQuota backlogQuota =
@@ -207,7 +207,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setBacklogQuota(testTopic, backlogQuota);
 
         BacklogQuota finalBacklogQuota = backlogQuota;
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage), finalBacklogQuota));
 
@@ -218,7 +218,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetBacklogQuotaApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertEquals(admin.topics().getBacklogQuotaMap(topic), Maps.newHashMap());
         assertEquals(admin.namespaces().getBacklogQuotaMap(myNamespace), Maps.newHashMap());
@@ -252,7 +252,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         String namespace = TopicName.get(testTopic).getNamespace();
         admin.namespaces().setRetention(namespace, retentionPolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getRetention(namespace), retentionPolicies));
 
         BacklogQuota backlogQuota =
@@ -274,11 +274,11 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         BacklogQuota backlogQuota =
                 new BacklogQuota(10 * 1024 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setBacklogQuota(testTopic, backlogQuota);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage), backlogQuota));
 
@@ -305,7 +305,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setRetention(testTopic, retention);
 
         RetentionPolicies finalRetention = retention;
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getRetention(testTopic), finalRetention));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -316,13 +316,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         RetentionPolicies retention = new RetentionPolicies(60, 1024);
         log.info("Retention: {} will set to the topic: {}", retention, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setRetention(testTopic, retention);
         log.info("Retention set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getRetention(testTopic), retention));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -334,17 +334,17 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         RetentionPolicies retention = new RetentionPolicies(60, 1024);
         log.info("Retention: {} will set to the topic: {}", retention, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setRetention(testTopic, retention);
         log.info("Retention set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getRetention(testTopic), retention));
 
         admin.topics().removeRetention(testTopic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getRetention(testTopic)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -354,7 +354,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testRetentionAppliedApi() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         RetentionPolicies brokerPolicies =
                 new RetentionPolicies(conf.getDefaultRetentionTimeInMinutes(), conf.getDefaultRetentionSizeInMB());
@@ -383,7 +383,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetSubDispatchRateApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getSubscriptionDispatchRate(topic));
         assertNull(admin.namespaces().getSubscriptionDispatchRate(myNamespace));
@@ -415,7 +415,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testRetentionPriority() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getRetention(topic));
         assertNull(admin.namespaces().getRetention(myNamespace));
@@ -433,37 +433,37 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         //set namespace-level policy
         RetentionPolicies retentionPolicies = new RetentionPolicies(1, 1);
         admin.namespaces().setRetention(myNamespace, retentionPolicies);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.namespaces().getRetention(myNamespace)));
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         // set topic-level policy
         admin.topics().setRetention(topic, new RetentionPolicies(3, 1));
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getRetention(topic)));
         assertTrue((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         //topic-level disabled
         admin.topics().setRetention(topic, new RetentionPolicies(0, 0));
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getRetention(topic).getRetentionSizeInMB(), 0));
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         // remove topic-level policy
         admin.topics().removeRetention(topic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getRetention(topic)));
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         //namespace-level disabled
         admin.namespaces().setRetention(myNamespace, new RetentionPolicies(0, 0));
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.namespaces().getRetention(myNamespace)));
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         //change namespace-level policy
         admin.namespaces().setRetention(myNamespace, new RetentionPolicies(1, 1));
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.namespaces().getRetention(myNamespace)));
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
         // remove namespace-level policy
         admin.namespaces().removeRetention(myNamespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.namespaces().getRetention(myNamespace)));
         //the default value of the broker-level is 0, so it is not retained by default
         assertFalse((boolean) shouldTopicBeRetained.invoke(persistentTopic));
@@ -473,7 +473,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetPersistenceApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getPersistence(topic));
         assertNull(admin.namespaces().getPersistence(myNamespace));
@@ -548,18 +548,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PersistencePolicies persistencePoliciesForNamespace = new PersistencePolicies(2, 2, 2, 0.3);
         admin.namespaces().setPersistence(myNamespace, persistencePoliciesForNamespace);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getPersistence(myNamespace), persistencePoliciesForNamespace));
 
         PersistencePolicies persistencePolicies = new PersistencePolicies(3, 3, 3, 0.1);
         log.info("PersistencePolicies: {} will set to the topic: {}", persistencePolicies, persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setPersistence(persistenceTopic, persistencePolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getPersistence(persistenceTopic), persistencePolicies));
 
         admin.lookups().lookupTopic(persistenceTopic);
@@ -580,7 +580,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetDispatchRateApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getDispatchRate(topic));
         assertNull(admin.namespaces().getDispatchRate(myNamespace));
@@ -613,23 +613,23 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PersistencePolicies persistencePoliciesForNamespace = new PersistencePolicies(2, 2, 2, 0.3);
         admin.namespaces().setPersistence(myNamespace, persistencePoliciesForNamespace);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getPersistence(myNamespace), persistencePoliciesForNamespace));
 
         PersistencePolicies persistencePolicies = new PersistencePolicies(3, 3, 3, 0.1);
         log.info("PersistencePolicies: {} will set to the topic: {}", persistencePolicies, persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setPersistence(persistenceTopic, persistencePolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getPersistence(persistenceTopic), persistencePolicies));
 
         admin.topics().removePersistence(persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getPersistence(persistenceTopic)));
 
         admin.lookups().lookupTopic(persistenceTopic);
@@ -660,7 +660,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetMaxProducerApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getMaxProducers(topic));
         assertNull(admin.namespaces().getMaxProducersPerTopic(myNamespace));
@@ -686,12 +686,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Integer maxProducers = 2;
         log.info("MaxProducers: {} will set to the topic: {}", maxProducers, persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxProducers(persistenceTopic, maxProducers);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxProducers(persistenceTopic), maxProducers));
 
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
@@ -718,12 +718,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Integer maxProducers = 2;
         log.info("MaxProducers: {} will set to the topic: {}", maxProducers, persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxProducers(persistenceTopic, maxProducers);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxProducers(persistenceTopic), maxProducers));
 
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
@@ -744,14 +744,14 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         admin.topics().removeMaxProducers(persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getMaxProducers(persistenceTopic)));
 
         producer3 = pulsarClient.newProducer().topic(persistenceTopic).create();
         Assert.assertNotNull(producer3);
         admin.namespaces().setMaxProducersPerTopic(myNamespace, 3);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getMaxProducersPerTopic(myNamespace).intValue(), 3));
 
         log.info("MaxProducers: {} will set to the namespace: {}", 3, myNamespace);
@@ -776,13 +776,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate dispatchRate = new DispatchRate(100, 10000, 1, true);
         log.info("Dispatch Rate: {} will set to the topic: {}", dispatchRate, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setDispatchRate(testTopic, dispatchRate);
         log.info("Dispatch Rate set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getDispatchRate(testTopic), dispatchRate));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -793,17 +793,17 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate dispatchRate = new DispatchRate(100, 10000, 1, true);
         log.info("Dispatch Rate: {} will set to the topic: {}", dispatchRate, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setDispatchRate(testTopic, dispatchRate);
         log.info("Dispatch Rate set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getDispatchRate(testTopic), dispatchRate));
 
         admin.topics().removeDispatchRate(testTopic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getDispatchRate(testTopic)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -814,26 +814,26 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         DispatchRate dispatchRate = new DispatchRate(200, 20000, 1, true);
         admin.namespaces().setDispatchRate(myNamespace, dispatchRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getDispatchRate(myNamespace).dispatchThrottlingRateInMsg, 200));
 
         dispatchRate = new DispatchRate(100, 10000, 1, true);
         admin.topics().setDispatchRate(topic, dispatchRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNotNull(admin.topics().getDispatchRate(topic)));
 
         //1 Set ns level policy, topic level should not be overwritten
         dispatchRate = new DispatchRate(300, 30000, 2, true);
         admin.namespaces().setDispatchRate(myNamespace, dispatchRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> {
                     DispatchRateLimiter limiter = pulsar.getBrokerService().getTopicIfExists(topic).get().get().getDispatchRateLimiter().get();
                     Assert.assertEquals(limiter.getDispatchRateOnByte(), 10000);
@@ -842,11 +842,11 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         admin.topics().removeDispatchRate(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getDispatchRate(topic)));
 
         //2 Remove level policy ,DispatchRateLimiter should us ns level policy
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> {
                     DispatchRateLimiter limiter = pulsar.getBrokerService().getTopicIfExists(topic).get().get().getDispatchRateLimiter().get();
                     Assert.assertEquals(limiter.getDispatchRateOnByte(), 30000);
@@ -859,14 +859,14 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         InactiveTopicPolicies inactiveTopicPolicies =
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up,100,true);
         admin.namespaces().setInactiveTopicPolicies(myNamespace, inactiveTopicPolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getInactiveTopicPolicies(myNamespace).getInactiveTopicDeleteMode(),
                         InactiveTopicDeleteMode.delete_when_subscriptions_caught_up));
 
@@ -874,7 +874,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,200,false);
         admin.topics().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNotNull(admin.topics().getInactiveTopicPolicies(topic)));
 
         // restart broker, policy should still take effect
@@ -884,7 +884,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         InactiveTopicPolicies finalInactiveTopicPolicies = inactiveTopicPolicies;
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> {
                     PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
                     Assert.assertEquals(persistentTopic.getInactiveTopicPolicies(), finalInactiveTopicPolicies);
@@ -898,7 +898,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         DispatchRate dispatchRate = new DispatchRate(1000,
@@ -908,7 +908,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setSubscriptionDispatchRate(topic, dispatchRate);
         log.info("Subscription dispatch rate set success on topic: {}", topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscriptionDispatchRate(topic), dispatchRate));
 
         String subscriptionName = "test_subscription_rate";
@@ -929,7 +929,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         DispatchRate dispatchRate = new DispatchRate(1000,
@@ -942,7 +942,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setSubscriptionDispatchRate(topic, dispatchRate);
         log.info("Subscription dispatch rate set success on topic: {}", topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscriptionDispatchRate(topic), dispatchRate));
 
         DispatchRateLimiter dispatchRateLimiter = pulsar.getBrokerService().getTopicIfExists(topic)
@@ -960,7 +960,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         DispatchRate dispatchRate = new DispatchRate(1000,
@@ -970,7 +970,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setSubscriptionDispatchRate(topic, dispatchRate);
         log.info("Subscription dispatch rate set success on topic: {}", topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscriptionDispatchRate(topic), dispatchRate));
 
         String subscriptionName = "test_subscription_rate";
@@ -985,7 +985,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // remove subscription dispatch rate
         admin.topics().removeSubscriptionDispatchRate(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getSubscriptionDispatchRate(topic)));
 
         dispatchRateLimiter = pulsar.getBrokerService().getTopicIfExists(topic)
@@ -1002,14 +1002,14 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         // set namespace level subscription dispatch rate
         DispatchRate namespaceDispatchRate = new DispatchRate(100, 1024 * 1024, 1);
         admin.namespaces().setSubscriptionDispatchRate(myNamespace, namespaceDispatchRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getSubscriptionDispatchRate(myNamespace), namespaceDispatchRate));
 
         String subscriptionName = "test_subscription_rate";
@@ -1025,7 +1025,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate topicDispatchRate = new DispatchRate(200, 2 * 1024 * 1024, 1);
         admin.topics().setSubscriptionDispatchRate(topic, topicDispatchRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscriptionDispatchRate(topic), topicDispatchRate));
 
         // get subscription dispatch rate limiter
@@ -1037,7 +1037,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // remove topic level subscription dispatch rate limiter
         admin.topics().removeSubscriptionDispatchRate(topic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getSubscriptionDispatchRate(topic)));
 
         // get subscription dispatch rate limiter
@@ -1055,13 +1055,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Long compactionThreshold = 100000L;
         log.info("Compaction threshold: {} will set to the topic: {}", compactionThreshold, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setCompactionThreshold(testTopic, compactionThreshold);
         log.info("Compaction threshold set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getCompactionThreshold(testTopic), compactionThreshold));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1072,18 +1072,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Long compactionThreshold = 100000L;
         log.info("Compaction threshold: {} will set to the topic: {}", compactionThreshold, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setCompactionThreshold(testTopic, compactionThreshold);
         log.info("Compaction threshold set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getCompactionThreshold(testTopic), compactionThreshold));
 
         admin.topics().removeCompactionThreshold(testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getCompactionThreshold(testTopic)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1094,13 +1094,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Integer maxConsumersPerSubscription = 10;
         log.info("MaxConsumersPerSubscription: {} will set to the topic: {}", maxConsumersPerSubscription, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxConsumersPerSubscription(testTopic, maxConsumersPerSubscription);
         log.info("MaxConsumersPerSubscription set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxConsumersPerSubscription(testTopic), maxConsumersPerSubscription));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1111,18 +1111,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Integer maxConsumersPerSubscription = 10;
         log.info("MaxConsumersPerSubscription: {} will set to the topic: {}", maxConsumersPerSubscription, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxConsumersPerSubscription(testTopic, maxConsumersPerSubscription);
         log.info("MaxConsumersPerSubscription set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxConsumersPerSubscription(testTopic), maxConsumersPerSubscription));
 
         admin.topics().removeMaxConsumersPerSubscription(testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getMaxConsumersPerSubscription(testTopic)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1133,13 +1133,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PublishRate publishRate = new PublishRate(10000, 1024 * 1024 * 5);
         log.info("Publish Rate: {} will set to the topic: {}", publishRate, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setPublishRate(testTopic, publishRate);
         log.info("Publish Rate set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getPublishRate(testTopic), publishRate));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1150,18 +1150,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PublishRate publishRate = new PublishRate(10000, 1024 * 1024 * 5);
         log.info("Publish Rate: {} will set to the topic: {}", publishRate, testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setPublishRate(testTopic, publishRate);
         log.info("Publish Rate set success on topic: {}", testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getPublishRate(testTopic), publishRate));
 
         admin.topics().removePublishRate(testTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getPublishRate(testTopic)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
@@ -1184,7 +1184,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetMaxConsumersApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getMaxConsumers(topic));
         assertNull(admin.namespaces().getMaxConsumersPerTopic(myNamespace));
@@ -1208,18 +1208,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testSetMaxConsumers() throws Exception {
         admin.namespaces().setMaxConsumersPerTopic(myNamespace, 1);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getMaxConsumersPerTopic(myNamespace).intValue(), 1));
         log.info("MaxConsumers: {} will set to the namespace: {}", 1, myNamespace);
         Integer maxConsumers = 2;
         log.info("MaxConsumers: {} will set to the topic: {}", maxConsumers, persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxConsumers(persistenceTopic, maxConsumers);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxConsumers(persistenceTopic), maxConsumers));
 
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
@@ -1246,12 +1246,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testRemoveMaxConsumers() throws Exception {
         Integer maxConsumers = 2;
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         admin.topics().setMaxConsumers(persistenceTopic, maxConsumers);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getMaxConsumers(persistenceTopic), maxConsumers));
 
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
@@ -1271,7 +1271,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         admin.topics().removeMaxConsumers(persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topics().getMaxConsumers(persistenceTopic)));
 
         consumer3 = pulsarClient.newConsumer().subscriptionName("sub3").topic(persistenceTopic).subscribe();
@@ -1299,14 +1299,14 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetSetSubscribeRate() throws Exception {
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         SubscribeRate subscribeRate1 = new SubscribeRate(1, 30);
         log.info("Subscribe Rate: {} will be set to the namespace: {}", subscribeRate1, myNamespace);
         admin.namespaces().setSubscribeRate(myNamespace, subscribeRate1);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), subscribeRate1));
 
         SubscribeRate subscribeRate2 =  new SubscribeRate(2, 30);
@@ -1314,7 +1314,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setSubscribeRate(persistenceTopic, subscribeRate2);
         log.info("Subscribe Rate set success on topic: {}", persistenceTopic);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscribeRate(persistenceTopic), subscribeRate2));
 
         PulsarClient pulsarClient1 = newPulsarClient(lookupUrl.toString(), 0);
@@ -1354,7 +1354,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetSubscribeRateApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getSubscribeRate(topic));
         assertNull(admin.namespaces().getSubscribeRate(myNamespace));
@@ -1451,7 +1451,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testRemoveSubscribeRate() throws Exception {
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
              .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(persistenceTopic)));
 
         SubscribeRate subscribeRate = new SubscribeRate(2, 30);
@@ -1459,7 +1459,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().setSubscribeRate(persistenceTopic, subscribeRate);
         log.info("Subscribe Rate set success on topic: {}", persistenceTopic);
 
-         Awaitility.await().atMost(3, TimeUnit.SECONDS)
+         Awaitility.await()
                  .untilAsserted(() -> Assert.assertEquals(admin.topics().getSubscribeRate(persistenceTopic), subscribeRate));
 
         PulsarClient pulsarClient1 = newPulsarClient(lookupUrl.toString(), 0);
@@ -1490,7 +1490,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Assert.assertNull(consumer3);
 
         admin.topics().removeSubscribeRate(persistenceTopic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                  .untilAsserted(() -> Assert.assertNull(admin.topics().getSubscribeRate(persistenceTopic)));
 
         admin.topics().unload(persistenceTopic);
@@ -1534,7 +1534,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         conf.setMaxPublishRatePerTopicInBytes(50L);
         setup();
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(testTopic)));
 
         final String topicName = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
@@ -1554,7 +1554,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PublishRate publishMsgRate = new PublishRate(10, 100L);
         admin.namespaces().setPublishRate(myNamespace, publishMsgRate);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> {
                     PublishRateLimiterImpl limiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
                     return (int)publishMaxMessageRate.get(limiter) == 10;
@@ -1568,7 +1568,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PublishRate publishMsgRate2 = new PublishRate(11, 101L);
         admin.topics().setPublishRate(topicName, publishMsgRate2);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> admin.topics().getPublishRate(topicName) != null);
 
         publishRateLimiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
@@ -1578,7 +1578,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         //4 remove topic-level policy, namespace-level policy will take effect
         admin.topics().removePublishRate(topicName);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> admin.topics().getPublishRate(topicName) == null);
 
         publishRateLimiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
@@ -1588,7 +1588,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         //5 remove namespace-level policy, broker-level policy will take effect
         admin.namespaces().removePublishRate(myNamespace);
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> {
                     PublishRateLimiterImpl limiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
                     return (int)publishMaxMessageRate.get(limiter) == 5;
@@ -1601,12 +1601,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
     @Test(timeOut = 20000)
     public void testTopicMaxMessageSizeApi() throws Exception{
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(persistenceTopic)));
         assertNull(admin.topics().getMaxMessageSize(persistenceTopic));
 
         admin.topics().setMaxMessageSize(persistenceTopic,10);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(persistenceTopic)) != null);
         assertEquals(admin.topics().getMaxMessageSize(persistenceTopic).intValue(),10);
 
@@ -1640,12 +1640,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         }
         // init cache
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getMaxMessageSize(topic));
         // set msg size
         admin.topics().setMaxMessageSize(topic, 10);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
         assertEquals(admin.topics().getMaxMessageSize(topic).intValue(), 10);
 
@@ -1686,7 +1686,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         int maxSubInNamespace = 2;
         List<Consumer> consumers = new ArrayList<>();
@@ -1718,13 +1718,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         assertNull(admin.topics().getMaxSubscriptionsPerTopic(topic));
         // set max subscriptions
         admin.topics().setMaxSubscriptionsPerTopic(topic, 10);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
         assertEquals(admin.topics().getMaxSubscriptionsPerTopic(topic).intValue(), 10);
         // remove max subscriptions
@@ -1744,12 +1744,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         // Set topic-level max subscriptions
         final int topicLevelMaxSubNum = 2;
         admin.topics().setMaxSubscriptionsPerTopic(topic, topicLevelMaxSubNum);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
         List<Consumer<String>> consumerList = new ArrayList<>();
         String subName = "my-sub-";
@@ -1791,7 +1791,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // init cache
         @Cleanup
         Producer producer = pulsarClient.newProducer().topic(topic).create();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         //default value is null
         assertNull(admin.namespaces().getMaxUnackedMessagesPerSubscription(myNamespace));
@@ -1802,7 +1802,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         produceMsg(producer, msgNum);
         //set namespace-level policy, the restriction should take effect
         admin.namespaces().setMaxUnackedMessagesPerSubscription(myNamespace, maxUnackedMsgNumOnNamespace);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.namespaces().getMaxUnackedMessagesPerSubscription(myNamespace).intValue(), maxUnackedMsgNumOnNamespace));
         List<Message<?>> messages;
         String subName = "sub-" + UUID.randomUUID();
@@ -1825,11 +1825,11 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         //set topic-level and namespace-level policy, topic-level should has higher priority
         admin.namespaces().setMaxUnackedMessagesPerSubscription(myNamespace, maxUnackedMsgNumOnNamespace);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.namespaces().getMaxUnackedMessagesPerSubscription(myNamespace).intValue()
                 , maxUnackedMsgNumOnNamespace));
         admin.topics().setMaxUnackedMessagesOnSubscription(topic, maxUnackedMsgOnTopic);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getMaxUnackedMessagesOnSubscription(topic)));
         //check the value applied
         PersistentTopic persistentTopic = (PersistentTopic)pulsar.getBrokerService().getTopicIfExists(topic).get().get();
@@ -1841,7 +1841,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         //remove both namespace-level and topic-level policy, broker-level should take effect
         admin.namespaces().removeMaxUnackedMessagesPerSubscription(myNamespace);
         admin.topics().removeMaxUnackedMessagesOnSubscription(topic);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.namespaces().getMaxUnackedMessagesPerSubscription(myNamespace) == null
                         && admin.topics().getMaxUnackedMessagesOnSubscription(topic) == null);
         messages = getMsgReceived(consumer1, Integer.MAX_VALUE);
@@ -1880,12 +1880,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         // Set topic-level max subscriptions
         final int topicLevelMaxSubNum = 2;
         admin.topics().setMaxSubscriptionsPerTopic(topic, topicLevelMaxSubNum);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
 
         List<Consumer<String>> consumerList = new ArrayList<>();
@@ -1910,7 +1910,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
         Field field = PersistentTopic.class.getSuperclass().getDeclaredField("maxSubscriptionsPerTopic");
         field.setAccessible(true);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> (int) field.get(persistentTopic) == namespaceLevelMaxSub);
+        Awaitility.await().until(() -> (int) field.get(persistentTopic) == namespaceLevelMaxSub);
 
         try (PulsarClient client = PulsarClient.builder().operationTimeout(1000, TimeUnit.MILLISECONDS)
                 .serviceUrl(brokerUrl.toString()).build()) {
@@ -1937,7 +1937,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         }
         //Removed namespace-level policy, broker-level should take effect
         admin.namespaces().removeMaxSubscriptionsPerTopic(myNamespace);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> field.get(persistentTopic) == null);
+        Awaitility.await().until(() -> field.get(persistentTopic) == null);
         consumerList.add(pulsarClient.newConsumer(Schema.STRING)
                 .subscriptionName(UUID.randomUUID().toString()).topic(topic).subscribe());
         assertEquals(consumerList.size(), brokerLevelMaxSub);
@@ -1961,18 +1961,18 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
 
         assertNull(admin.topics().getReplicatorDispatchRate(topic));
 
         DispatchRate dispatchRate = new DispatchRate(100,200L,10);
         admin.topics().setReplicatorDispatchRate(topic, dispatchRate);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getReplicatorDispatchRate(topic), dispatchRate));
 
         admin.topics().removeReplicatorDispatchRate(topic);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getReplicatorDispatchRate(topic)));
     }
 
@@ -1980,7 +1980,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetReplicatorRateApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getReplicatorDispatchRate(topic));
         assertNull(admin.namespaces().getReplicatorDispatchRate(myNamespace));
@@ -2016,7 +2016,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = testTopic + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         //should not fail
         assertNull(admin.topics().getMessageTTL(topic));
@@ -2027,7 +2027,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         // use broker.conf
         pulsarClient.newConsumer().topic(topic).subscriptionName("test").subscribe().close();
@@ -2037,7 +2037,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         subscriptionTypeSet.add(SubscriptionType.Failover);
         admin.topics().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
         subscriptionTypeSet = admin.topics().getSubscriptionTypesEnabled(topic);
         assertTrue(subscriptionTypeSet.contains(SubscriptionType.Failover));
@@ -2084,7 +2084,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().createPartitionedTopic(topic, 3);
         Producer producer = pulsarClient.newProducer().topic(topic).create();
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         final String subName = "my-sub";
         ConsumerBuilder builder = pulsarClient.newConsumer()
@@ -2135,7 +2135,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetCompactionThresholdApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         assertNull(admin.topics().getCompactionThreshold(topic));
         assertNull(admin.namespaces().getCompactionThreshold(myNamespace));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
@@ -91,7 +91,7 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
         pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
                 .subscribe();
         org.apache.pulsar.broker.service.Consumer c = pulsar.getBrokerService().getTopicReference(topicName).get().getSubscription(subName).getConsumers().get(0);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> Assert.assertTrue(c.cnx().hasHAProxyMessage()));
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(c.cnx().hasHAProxyMessage()));
         TopicStats topicStats = admin.topics().getStats(topicName);
         Assert.assertEquals(topicStats.subscriptions.size(), 1);
         SubscriptionStats subscriptionStats = topicStats.subscriptions.get(subName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -86,11 +86,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         consumer.close();
         producer.close();
 
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> Assert.assertTrue(admin.topics().getList("prop/ns-abc")
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(admin.topics().getList("prop/ns-abc")
                 .contains(topic)));
 
         admin.topics().deleteSubscription(topic, "sub");
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc")
+        Awaitility.await().untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc")
                 .contains(topic)));
     }
 
@@ -106,12 +106,12 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         pulsarClient.newProducer().topic(topic).create().close();
         pulsarClient.newConsumer().topic(topic).subscriptionName("sub").subscribe().close();
 
-        Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertTrue(admin.topics().getPartitionedTopicList("prop/ns-abc")
                 .contains(topic)));
 
         admin.topics().deleteSubscription(topic, "sub");
-        Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getPartitionedTopicList("prop/ns-abc")
                 .contains(topic)));
     }
@@ -164,13 +164,13 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         pulsarClient.newConsumer().topic(topic).subscriptionName("sub").subscribe().close();
         pulsarClient.newConsumer().topic(topic2).subscriptionName("sub2").subscribe().close();
 
-        Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertTrue(admin.topics().getList(namespace).contains(topic2)));
         Assert.assertTrue(admin.topics().getPartitionedTopicList(namespace).contains(topic));
 
         admin.topics().deleteSubscription(topic, "sub");
         admin.topics().deleteSubscription(topic2, "sub2");
-        Awaitility.await().atMost(2, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic2)));
         Assert.assertTrue(admin.topics().getPartitionedTopicList(namespace).contains(topic));
         // BrokerDeleteInactivePartitionedTopicMetaDataEnabled is not enabled, so only NonPartitionedTopic will be cleaned
@@ -216,7 +216,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         InactiveTopicPolicies policies;
         //wait for zk
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> {
             InactiveTopicPolicies temp = ((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies;
             return temp.isDeleteWhileInactive();
@@ -229,7 +229,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace));
 
         admin.namespaces().removeInactiveTopicPolicies(namespace);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> {
             InactiveTopicPolicies temp = ((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies;
             return temp.getMaxInactiveDurationSeconds() == 1000;
@@ -244,7 +244,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         assertEquals(policies, admin.namespaces().getInactiveTopicPolicies(namespace2));
 
         admin.namespaces().removeInactiveTopicPolicies(namespace2);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> {
             InactiveTopicPolicies temp = ((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies;
             return temp.getMaxInactiveDurationSeconds() == 1000;
@@ -295,7 +295,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.namespaces().setInactiveTopicPolicies(namespace2, inactiveTopicPolicies);
 
         //wait for zk
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             InactiveTopicPolicies temp = ((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies;
             return temp.isDeleteWhileInactive();
         });
@@ -308,13 +308,13 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         // no backlog, trigger delete_when_subscriptions_caught_up
         admin.topics().skipAllMessages(topic2, topicToSub.remove(topic2));
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertFalse(admin.topics().getList(namespace2).contains(topic2)));
         // delete subscription, trigger delete_when_no_subscriptions
         for (Map.Entry<String, String> entry : topicToSub.entrySet()) {
             admin.topics().deleteSubscription(entry.getKey(), entry.getValue());
         }
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic)));
         Assert.assertFalse(admin.topics().getList(namespace3).contains(topic3));
     }
@@ -348,7 +348,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             .contains(topic));
 
         admin.topics().skipAllMessages(topic, "sub");
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList("prop/ns-abc").contains(topic)));
     }
 
@@ -386,7 +386,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().createPartitionedTopic(topicName, 3);
         pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe().close();
         TopicName topic = TopicName.get(topicName);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().cacheIsInitialized(topic));
 
         InactiveTopicPolicies inactiveTopicPolicies = admin.topics().getInactiveTopicPolicies(topicName);
@@ -398,12 +398,12 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         policies.setMaxInactiveDurationSeconds(10);
         admin.topics().setInactiveTopicPolicies(topicName, policies);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.topics().getInactiveTopicPolicies(topicName) != null);
         assertEquals(admin.topics().getInactiveTopicPolicies(topicName), policies);
         admin.topics().removeInactiveTopicPolicies(topicName);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNull(admin.topics().getInactiveTopicPolicies(topicName)));
     }
 
@@ -445,7 +445,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().setInactiveTopicPolicies(topic3, inactiveTopicPolicies);
 
         //wait for cache
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.topics().getInactiveTopicPolicies(topic) != null);
         InactiveTopicPolicies policies = ((PersistentTopic) pulsar.getBrokerService()
                 .getTopic(topic, false).get().get()).inactiveTopicPolicies;
@@ -457,7 +457,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().removeInactiveTopicPolicies(topic);
         //Only the broker-level policies is set, so after removing the topic-level policies
         // , the topic will use the broker-level policies
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get()).inactiveTopicPolicies
                 , defaultPolicy));
 
@@ -471,7 +471,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         // , the topic will use the namespace level policies
         admin.namespaces().setInactiveTopicPolicies(namespace, inactiveTopicPolicies);
         //wait for zk
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             InactiveTopicPolicies tempPolicies = ((PersistentTopic) pulsar.getBrokerService().getTopic(topic, false)
                     .get().get()).inactiveTopicPolicies;
             return inactiveTopicPolicies.equals(tempPolicies);
@@ -479,7 +479,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().removeInactiveTopicPolicies(topic2);
         // The cache has been updated, but the system-event may not be consumed yet
         // ，so wait for topic-policies update event
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             InactiveTopicPolicies nsPolicies = ((PersistentTopic) pulsar.getBrokerService()
                     .getTopic(topic2, false).get().get()).inactiveTopicPolicies;
             assertEquals(nsPolicies.getMaxInactiveDurationSeconds(), 999);
@@ -514,7 +514,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
             Thread.sleep(1);
         }
         //wait for cache init
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic3)));
         // "topic" use delete_when_no_subscriptions, "topic2" use delete_when_subscriptions_caught_up
         // "topic3" use default:delete_when_no_subscriptions
@@ -525,7 +525,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         admin.topics().setInactiveTopicPolicies(topic2, inactiveTopicPolicies);
 
         //wait for update
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin.topics().getInactiveTopicPolicies(topic2) != null);
         // topic should still exist
         Thread.sleep(2000);
@@ -535,13 +535,13 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
         // no backlog, trigger delete_when_subscriptions_caught_up
         admin.topics().skipAllMessages(topic2, topicToSub.remove(topic2));
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic2)));
         // delete subscription, trigger delete_when_no_subscriptions
         for (Map.Entry<String, String> entry : topicToSub.entrySet()) {
             admin.topics().deleteSubscription(entry.getKey(), entry.getValue());
         }
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic3)));
         Assert.assertFalse(admin.topics().getList(namespace).contains(topic));
     }
@@ -555,7 +555,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         final String namespace = "prop/ns-abc";
         final String topic = "persistent://prop/ns-abc/test-" + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topic)));
         //namespace-level default value is null
         assertNull(admin.namespaces().getInactiveTopicPolicies(namespace));
@@ -572,7 +572,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
                 20, false);
         admin.namespaces().setInactiveTopicPolicies(namespace, namespaceLevelPolicy);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.namespaces().getInactiveTopicPolicies(namespace)));
         InactiveTopicPolicies policyFromBroker = admin.topics().getInactiveTopicPolicies(topic, true);
         assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 20);
@@ -583,7 +583,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up,
                         30, false);
         admin.topics().setInactiveTopicPolicies(topic, topicLevelPolicy);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertNotNull(admin.topics().getInactiveTopicPolicies(topic)));
         policyFromBroker = admin.topics().getInactiveTopicPolicies(topic, true);
         assertEquals(policyFromBroker.getMaxInactiveDurationSeconds(), 30);
@@ -591,11 +591,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         assertEquals(policyFromBroker.getInactiveTopicDeleteMode(), InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
         //remove topic-level policy
         admin.topics().removeInactiveTopicPolicies(topic);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getInactiveTopicPolicies(topic, true), namespaceLevelPolicy));
         //remove namespace-level policy
         admin.namespaces().removeInactiveTopicPolicies(namespace);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(()
+        Awaitility.await().untilAsserted(()
                 -> assertEquals(admin.topics().getInactiveTopicPolicies(topic, true), brokerLevelPolicy));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -426,7 +426,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
 
         // Expire by position and verify mark delete position of cursor.
         issued = monitor.expireMessages(positions.get(15));
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
+        Awaitility.await().untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
         assertEquals(cursor.getMarkDeletedPosition(), PositionImpl.get(positions.get(15).getLedgerId(), positions.get(15).getEntryId()));
         assertTrue(issued);
         clearInvocations(monitor);
@@ -438,21 +438,21 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
 
         // Expire by position again and verify mark delete position of cursor didn't change.
         issued = monitor.expireMessages(positions.get(15));
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
+        Awaitility.await().untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
         assertEquals(cursor.getMarkDeletedPosition(), PositionImpl.get(positions.get(15).getLedgerId(), positions.get(15).getEntryId()));
         assertTrue(issued);
         clearInvocations(monitor);
 
         // Expire by position before current mark delete position and verify mark delete position of cursor didn't change.
         issued = monitor.expireMessages(positions.get(10));
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
+        Awaitility.await().untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
         assertEquals(cursor.getMarkDeletedPosition(), PositionImpl.get(positions.get(15).getLedgerId(), positions.get(15).getEntryId()));
         assertTrue(issued);
         clearInvocations(monitor);
 
         // Expire by position after current mark delete position and verify mark delete position of cursor move to new position.
         issued = monitor.expireMessages(positions.get(16));
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
+        Awaitility.await().untilAsserted(() -> verify(monitor, times(1)).findEntryComplete(any(), any()));
         assertEquals(cursor.getMarkDeletedPosition(), PositionImpl.get(positions.get(16).getLedgerId(), positions.get(16).getEntryId()));
         assertTrue(issued);
         clearInvocations(monitor);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -493,7 +493,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
             consumer1.acknowledge(msgId);
         }
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             TopicStats stats = admin.topics().getStats(topicName);
             // Unacked messages count should be 0 for both consumers at this point
             SubscriptionStats subStats = stats.subscriptions.get(subName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -1470,7 +1470,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         producer.close();
         pulsarClient.close();
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             brokerService.updateRates();
             List<Metrics> closeMetrics = brokerService.getTopicMetrics();
             Map<String, Object> closeMap = null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -97,7 +97,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .statsInterval(0, TimeUnit.SECONDS).build();
         client1.newProducer().topic(topicName).create().close();
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> pulsar1.getTopicPoliciesService().cacheIsInitialized(TopicName.get(topicName)));
 
         //use broker-level by default
@@ -108,7 +108,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         //set namespace-level policy, which should take effect
         DispatchRate nsDispatchRate = new DispatchRate(50, 60L, 70);
         admin1.namespaces().setReplicatorDispatchRate(namespace, nsDispatchRate);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate));
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 50);
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 60L);
@@ -116,7 +116,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         //set topic-level policy, which should take effect
         DispatchRate topicRate = new DispatchRate(10, 20L, 30);
         admin1.topics().setReplicatorDispatchRate(topicName, topicRate);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate));
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 10);
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 20L);
@@ -124,13 +124,13 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         //Set the namespace-level policy, which should not take effect
         DispatchRate nsDispatchRate2 = new DispatchRate(500, 600L, 700);
         admin1.namespaces().setReplicatorDispatchRate(namespace, nsDispatchRate2);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate2));
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(), 20L);
 
         //remove topic-level policy, namespace-level should take effect
         admin1.topics().removeReplicatorDispatchRate(topicName);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertNull(admin1.topics().getReplicatorDispatchRate(topicName)));
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 500);
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(),
@@ -138,7 +138,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
         //remove namespace-level policy, broker-level should take effect
         admin1.namespaces().setReplicatorDispatchRate(namespace, null);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnMsg(), 100));
         assertEquals(topic.getReplicators().values().get(0).getRateLimiter().get().getDispatchRateOnByte(),
                 200L);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -211,7 +211,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         cluster2Data.setServiceUrl(cluster2ServiceUrls);
         String cluster2 = "activeCLuster2";
         admin2.clusters().createCluster(cluster2, cluster2Data);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(()
+        Awaitility.await().until(()
                 -> admin2.clusters().getCluster(cluster2) != null);
 
         List<String> list = admin1.brokers().getActiveBrokers(cluster2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -71,11 +71,11 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         Assert.assertNotNull(transactionMetadataStoreService);
 
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(1000,  TimeUnit.MILLISECONDS).until(() ->
+        Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
         transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(1000,  TimeUnit.MILLISECONDS).until(() ->
+        Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 0);
     }
 
@@ -85,7 +85,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(1));
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(2));
-        Awaitility.await().atMost(1000,  TimeUnit.MILLISECONDS).until(() ->
+        Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 3);
         checkTransactionMetadataStoreReady((MLTransactionMetadataStore) pulsar.getTransactionMetadataStoreService()
                 .getStores().get(TransactionCoordinatorID.get(0)));
@@ -109,7 +109,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     public void testAddProducedPartitionToTxn() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(1000,  TimeUnit.MILLISECONDS).until(() ->
+        Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
         MLTransactionMetadataStore transactionMetadataStore =
@@ -133,7 +133,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     public void testAddAckedPartitionToTxn() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
         transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(1000,  TimeUnit.MILLISECONDS).until(() ->
+        Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
         MLTransactionMetadataStore transactionMetadataStore =
@@ -155,7 +155,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void testTimeoutTracker() throws Exception {
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
@@ -177,14 +177,14 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
         txnMap.forEach((txnID, txnMetaListPair) ->
                 Assert.assertEquals(txnMetaListPair.getLeft().status(), TxnStatus.OPEN));
-        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(5000, TimeUnit.MILLISECONDS)
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS)
                 .until(() -> txnMap.size() == 0);
     }
 
     @Test
     public void testTimeoutTrackerMultiThreading() throws Exception {
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
@@ -247,7 +247,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     }
 
     private void checkoutTimeout(ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>> txnMap, int time) {
-        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS)
                 .until(() -> txnMap.size() == time);
     }
 
@@ -255,7 +255,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     public void transactionTimeoutRecoverTest() throws Exception {
         int timeout = 2000;
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
@@ -269,7 +269,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
                 .removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
 
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         transactionMetadataStore =
@@ -282,7 +282,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         field.setAccessible(true);
         ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>> txnMap =
                 (ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>>) field.get(transactionMetadataStore);
-        Awaitility.await().atMost(3000, TimeUnit.MILLISECONDS).until(() -> txnMap.size() == 0);
+        Awaitility.await().until(() -> txnMap.size() == 0);
 
     }
 
@@ -295,7 +295,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     public void testEndTransactionOpRetry(TxnStatus txnStatus) throws Exception {
         int timeOut = 3000;
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
@@ -347,7 +347,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     private void checkTransactionMetadataStoreReady(MLTransactionMetadataStore transactionMetadataStore) throws NoSuchMethodException {
         Method method = TransactionMetadataStoreState.class.getDeclaredMethod("checkIfReady");
         method.setAccessible(true);
-        Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> (Boolean) method.invoke(transactionMetadataStore));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -474,9 +474,9 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         }
 
         Dispatcher dispatcher = pulsar.getBrokerService().getTopicReference(topic).get().getSubscription(subName).getDispatcher();
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), messages));
+        Awaitility.await().untilAsserted(() -> Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), messages));
 
         admin.topics().skipAllMessages(topic, subName);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), 0));
+        Awaitility.await().untilAsserted(() -> Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), 0));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
@@ -77,12 +77,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNull(enabled);
 
         admin.topics().enableDeduplication(topicName, true);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> admin.topics().getDeduplicationEnabled(topicName) != null);
         assertTrue(admin.topics().getDeduplicationEnabled(topicName));
 
         admin.topics().disableDeduplication(topicName);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> admin.topics().getMaxUnackedMessagesOnSubscription(topicName) == null);
         assertNull(admin.topics().getDeduplicationEnabled(topicName));
     }
@@ -96,12 +96,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNull(enabled);
 
         admin.topics().setDeduplicationStatus(topicName, true);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> admin.topics().getDeduplicationStatus(topicName) != null);
         assertTrue(admin.topics().getDeduplicationStatus(topicName));
 
         admin.topics().removeDeduplicationStatus(topicName);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> admin.topics().getMaxUnackedMessagesOnSubscription(topicName) == null);
         assertNull(admin.topics().getDeduplicationStatus(topicName));
     }
@@ -211,12 +211,12 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNull(interval);
 
         admin.topics().setDeduplicationSnapshotInterval(topicName, 1024);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> admin.topics().getDeduplicationSnapshotInterval(topicName) != null);
         Assert.assertEquals(admin.topics().getDeduplicationSnapshotInterval(topicName).intValue(), 1024);
 
         admin.topics().removeDeduplicationSnapshotInterval(topicName);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> admin.topics().getDeduplicationSnapshotInterval(topicName) == null);
         assertNull(admin.topics().getDeduplicationSnapshotInterval(topicName));
     }
@@ -256,7 +256,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertEquals(seqId, msgNum - 1);
         assertEquals(position.getEntryId(), msgNum - 1);
         //The first time, use topic-leve policies, 1 second delay + 3 second interval
-        Awaitility.await().atMost(5000, TimeUnit.MILLISECONDS)
+        Awaitility.await()
                 .until(() -> ((PositionImpl) persistentTopic.getMessageDeduplication().getManagedCursor()
                         .getMarkDeletedPosition()).getEntryId() == msgNum - 1);
         ManagedCursor managedCursor = persistentTopic.getMessageDeduplication().getManagedCursor();
@@ -267,7 +267,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         admin.topics().removeDeduplicationSnapshotInterval(topicName);
         producer.newMessage().value("msg").send();
         //zk update time + 5 second interval time
-        Awaitility.await().atMost( 7, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> ((PositionImpl) persistentTopic.getMessageDeduplication().getManagedCursor()
                         .getMarkDeletedPosition()).getEntryId() == msgNum);
         markDeletedPosition = (PositionImpl) managedCursor.getMarkDeletedPosition();
@@ -277,7 +277,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
 
         //4 remove namespace-level policies, broker-level should be used, interval becomes 3 seconds
         admin.namespaces().removeDeduplicationSnapshotInterval(myNamespace);
-        Awaitility.await().atMost(4, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> (admin.namespaces().getDeduplicationSnapshotInterval(myNamespace) == null));
         producer.newMessage().value("msg").send();
         //ensure that the time exceeds the scheduling interval of ns and topic, but no snapshot is generated
@@ -288,7 +288,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNotEquals(msgNum + 1, markDeletedPosition.getEntryId());
         assertNotEquals(position, markDeletedPosition);
         // wait for scheduler
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> ((PositionImpl) persistentTopic.getMessageDeduplication().getManagedCursor()
                         .getMarkDeletedPosition()).getEntryId() == msgNum + 1);
         markDeletedPosition = (PositionImpl) managedCursor.getMarkDeletedPosition();
@@ -317,7 +317,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         checkDeduplicationEnabled(producerName, messageDeduplication, maxSeq);
         //3) disable the deduplication check
         admin.topics().enableDeduplication(topicName, false);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(() -> admin.topics().getDeduplicationEnabled(topicName) != null);
         for (int i = 0; i < 100; i++) {
             producer.newMessage().value("msg-" + i).sequenceId(maxSeq + i).send();
@@ -440,7 +440,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertEquals(seqId, msgNum - 1);
         assertEquals(position.getEntryId(), msgNum - 1);
         //The first time, 1 second delay + 1 second interval
-        Awaitility.await().atMost(2500,TimeUnit.MILLISECONDS).until(()-> ((PositionImpl) persistentTopic
+        Awaitility.await().until(()-> ((PositionImpl) persistentTopic
                 .getMessageDeduplication().getManagedCursor().getMarkDeletedPosition()).getEntryId() == msgNum -1);
         ManagedCursor managedCursor = persistentTopic.getMessageDeduplication().getManagedCursor();
         PositionImpl markDeletedPosition = (PositionImpl) managedCursor.getMarkDeletedPosition();
@@ -495,7 +495,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
                 .getManagedLedger().getLastConfirmedEntry();
         assertEquals(seqId, msgNum - 1);
         assertEquals(position.getEntryId(), msgNum - 1);
-        Awaitility.await().atMost(2,TimeUnit.SECONDS).until(()-> ((PositionImpl) persistentTopic
+        Awaitility.await().until(()-> ((PositionImpl) persistentTopic
                 .getMessageDeduplication().getManagedCursor().getMarkDeletedPosition()).getEntryId() == -1);
 
         // take snapshot is disabled, so markDeletedPosition should not change
@@ -508,7 +508,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
     private void waitCacheInit(String topicName) throws Exception {
         pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe().close();
         TopicName topic = TopicName.get(topicName);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .until(()-> pulsar.getTopicPoliciesService().cacheIsInitialized(topic));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/streamingdispatch/StreamingEntryReaderTests.java
@@ -148,14 +148,14 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         ).when(mockDispatcher).readEntryComplete(any(Entry.class), any(PendingReadEntryRequest.class));
 
         streamingEntryReader.asyncReadEntries(50, 700, null);
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 50);
+        await().until(() -> entryCount.get() == 50);
         // Check cursor's read position has been properly updated
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         streamingEntryReader.asyncReadEntries(50, 700, null);
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 100);
+        await().until(() -> entryCount.get() == 100);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         streamingEntryReader.asyncReadEntries(50, 700, null);
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 150);
+        await().until(() -> entryCount.get() == 150);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
     }
 
@@ -203,7 +203,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
 
         // Only 2 entries should be read with this request.
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().until(() -> readComplete.get());
         assertEquals(entries.size(), 2);
         // Assert cursor's read position has been properly updated to the third entry, since we should only read
         // 2 retries with previous request
@@ -211,13 +211,13 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         reset(ledger);
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().until(() -> readComplete.get());
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().until(() -> readComplete.get());
         readComplete.set(false);
         streamingEntryReader.asyncReadEntries(6, size * 2 + 1, null);
-        await().atMost(1000, TimeUnit.MILLISECONDS).until(() -> readComplete.get());
+        await().until(() -> readComplete.get());
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         assertEquals(entries.size(), 8);
         for (int i = 0; i < entries.size(); i++) {
@@ -250,23 +250,23 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         ).when(mockDispatcher).readEntryComplete(any(Entry.class), any(PendingReadEntryRequest.class));
 
         streamingEntryReader.asyncReadEntries(5,  100, null);
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 5);
+        await().until(() -> entryCount.get() == 5);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         streamingEntryReader.asyncReadEntries(5, 100, null);
         // We only write 7 entries initially so only 7 entries can be read.
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryCount.get() == 7);
+        await().until(() -> entryCount.get() == 7);
         // Add new entry and await for it to be send to reader.
         entryProcessed.set(false);
         ledger.addEntry("message-7".getBytes(Encoding));
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryProcessed.get());
+        await().until(() -> entryProcessed.get());
         assertEquals(entries.size(), 8);
         entryProcessed.set(false);
         ledger.addEntry("message-8".getBytes(Encoding));
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryProcessed.get());
+        await().until(() -> entryProcessed.get());
         assertEquals(entries.size(), 9);
         entryProcessed.set(false);
         ledger.addEntry("message-9".getBytes(Encoding));
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> entryProcessed.get());
+        await().until(() -> entryProcessed.get());
         assertEquals(entries.size(), 10);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         for (int i = 0; i < entries.size(); i++) {
@@ -316,7 +316,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
 
         streamingEntryReader.asyncReadEntries(20,  200, null);
         streamingEntryReader.cancelReadRequests();
-        await().atMost(10000, TimeUnit.MILLISECONDS).until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Canceled);
+        await().until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Canceled);
         // Only have 5 entry as we make ledger only return 5 entries and cancel the request.
         assertEquals(entries.size(), 5);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
@@ -324,7 +324,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         reset(ledger);
         streamingEntryReader.asyncReadEntries(15,  200, null);
         streamingEntryReader.cancelReadRequests();
-        await().atMost(10000, TimeUnit.MILLISECONDS).until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
+        await().until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
         // Only have 5 entry as we make ledger only return 5 entries and cancel the request.
         assertEquals(entries.size(), 20);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
@@ -382,12 +382,12 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         }).when(ledger).asyncReadEntry(any(), any(), any());
 
         streamingEntryReader.asyncReadEntries(6,  100, null);
-        await().atMost(3000, TimeUnit.MILLISECONDS).until(() -> entryProcessed.get());
+        await().until(() -> entryProcessed.get());
         assertEquals(entries.size(), 6);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         entryProcessed.set(false);
         streamingEntryReader.asyncReadEntries(6, 100, null);
-        await().atMost(3000, TimeUnit.MILLISECONDS).until(() -> entryProcessed.get());
+        await().until(() -> entryProcessed.get());
         assertEquals(entries.size(), 12);
         assertEquals(cursor.getReadPosition(), ledger.getNextValidPosition((PositionImpl) positions.peek()));
         // Make sure message still returned in order
@@ -439,7 +439,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         }).when(ledger).asyncReadEntry(any(), any(), any());
 
         streamingEntryReader.asyncReadEntries(5,  100, null);
-        await().atMost(10, TimeUnit.SECONDS).until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
+        await().until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
         // Issued 5 read, should only have 3 entries as others were canceled after exhausting retries.
         assertEquals(entries.size(), 3);
         for (int i = 0; i < entries.size(); i++) {
@@ -447,7 +447,7 @@ public class StreamingEntryReaderTests extends MockedBookKeeperTestCase {
         }
         reset(ledger);
         streamingEntryReader.asyncReadEntries(5,  100, null);
-        await().atMost(500, TimeUnit.MILLISECONDS).until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
+        await().until(() -> streamingEntryReader.getState() == StreamingEntryReader.State.Completed);
         assertEquals(entries.size(), 8);
         for (int i = 0; i < entries.size(); i++) {
             assertEquals(String.format("message-%d", i), entries.get(i));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -250,8 +250,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 pulsar.getBrokerService().getTopicIfExists(topic1).get().get().getSubscription(subName);
         PersistentSubscription sub2 = (PersistentSubscription)
                 pulsar.getBrokerService().getTopicIfExists(topic2).get().get().getSubscription(subName);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> sub.getExpiredMessageRate() != 0.0);
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> sub2.getExpiredMessageRate() != 0.0);
+        Awaitility.await().until(() -> sub.getExpiredMessageRate() != 0.0);
+        Awaitility.await().until(() -> sub2.getExpiredMessageRate() != 0.0);
 
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -125,7 +125,7 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
             }
         }
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             TopicStats stats = admin.topics().getStats(topicName);
             Assert.assertEquals(stats.nonContiguousDeletedMessagesRanges, 1);
             Assert.assertEquals(stats.subscriptions.size(), 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -181,7 +181,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         assertNull(message);
         admin.topics().unload(RECOVER_COMMIT);
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             for (int i = 0; i < getPulsarServiceList().size(); i++) {
                 Field field = BrokerService.class.getDeclaredField("topics");
                 field.setAccessible(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
@@ -82,7 +82,7 @@ public class TransactionClientReconnectTest extends TransactionTestBase {
         ((PulsarClientImpl) pulsarClient).getLookup()
                 .getPartitionedTopicMetadata(TopicName.TRANSACTION_COORDINATOR_ASSIGN).get();
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             pulsarClient.newTransaction()
                     .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
             return true;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -106,7 +106,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
                 .build();
         Map<TransactionCoordinatorID, TransactionMetadataStore> stores =
                 getPulsarServiceList().get(0).getTransactionMetadataStoreService().getStores();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             if (stores.size() == 16) {
                 for (TransactionCoordinatorID transactionCoordinatorID : stores.keySet()) {
                     if (((MLTransactionMetadataStore) stores.get(transactionCoordinatorID)).getState()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
@@ -82,7 +82,7 @@ public class TransactionStablePositionTest extends TransactionTestBase {
                 .enableTransaction(true)
                 .build();
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> ((PulsarClientImpl) pulsarClient)
+        Awaitility.await().until(() -> ((PulsarClientImpl) pulsarClient)
                 .getTcClient().getState() == TransactionCoordinatorClient.State.READY);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -100,7 +100,7 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
 
         Map<TransactionCoordinatorID, TransactionMetadataStore> stores =
                 getPulsarServiceList().get(0).getTransactionMetadataStoreService().getStores();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             if (stores.size() == 16) {
                 for (TransactionCoordinatorID transactionCoordinatorID : stores.keySet()) {
                     if (((MLTransactionMetadataStore) stores.get(transactionCoordinatorID)).getState()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -928,7 +928,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             producer.newMessage().key(keys[i % 3]).value(i).send();
         }
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+        Awaitility.await().untilAsserted(() ->
                 Assert.assertEquals(received.size(), messages));
 
         Map<String, Integer> maxValueOfKeys = new HashMap<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3865,7 +3865,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             producer.sendAsync("msg" + i);
         }
         //Give some time to consume
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(consumer.getStats().getMsgNumInReceiverQueue().intValue(), receiveQueueSize));
         consumer.close();
         producer.close();
@@ -3894,7 +3894,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             producer.sendAsync("msg" + i);
         }
         //Give some time to consume
-        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(consumer.getStats().getMsgNumInReceiverQueue().intValue(), receiveQueueSize));
         consumer.close();
         producer.close();
@@ -3933,7 +3933,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
         FutureUtil.waitForAll(messageIds).get();
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             long size = ((ConsumerBase<byte[]>) consumer).getIncomingMessageSize();
             log.info("Check the incoming message size should greater that 0, current size is {}", size);
             Assert.assertTrue(size > 0);
@@ -3943,7 +3943,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             consumer.acknowledge(consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         }
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             long size = ((ConsumerBase<byte[]>) consumer).getIncomingMessageSize();
             log.info("Check the incoming message size should be 0, current size is {}", size);
             Assert.assertEquals(size, 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -199,7 +199,7 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
             final String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        await().atMost(2500, TimeUnit.MILLISECONDS).until(() -> latch.getCount() == 0);
+        await().until(() -> latch.getCount() == 0);
         Assert.assertEquals(totalReceived.get(), numProducedMessages);
 
         consumer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -361,7 +361,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         ManagedLedger ledger = topicRef.getManagedLedger();
 
         Awaitility.await()
-                .atMost(5, TimeUnit.SECONDS)
+                
                 .untilAsserted(() ->
                         Assert.assertEquals(
                                 ledger.openCursor(subscription).getProperties().get("foobar"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1185,14 +1185,14 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         admin.topics().deletePartitionedTopic(topicName, true);
         consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 0);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 0);
         });
 
         admin.topics().createPartitionedTopic(topicName, 7);
         consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 7);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 7);
         });
@@ -1218,7 +1218,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.topics().updatePartitionedTopic(topicName0, 5);
         consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
 
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 5);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 5);
         });
@@ -1229,7 +1229,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         consumer.getRecheckPatternTimeout().task().run(consumer.getRecheckPatternTimeout());
 
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 8);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 8);
         });
@@ -1237,7 +1237,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.topics().updatePartitionedTopic(topicName1, 5);
         consumer.getPartitionsAutoUpdateTimeout().task().run(consumer.getPartitionsAutoUpdateTimeout());
 
-        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 10);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 10);
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -225,7 +225,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // Cant't receive transaction messages after abort.
         message = consumer.receive(2, TimeUnit.SECONDS);
         Assert.assertNull(message);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             boolean flag = true;
             for (int partition = 0; partition < TOPIC_PARTITION; partition ++) {
                 String topic;
@@ -764,7 +764,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             }
         });
 
-        Awaitility.await().atMost(3000, TimeUnit.MILLISECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             try {
                 transactionMetadataStore.get().getTxnMeta(new TxnID(((TransactionImpl) timeoutTxn)
                         .getTxnIdMostBits(), ((TransactionImpl) timeoutTxn).getTxnIdLeastBits())).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -232,11 +232,11 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
             produceSocket.sendMessage(20);
             // Send 10 permits, should receive 10 message
             consumeSocket.sendPermits(10);
-            Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            Awaitility.await().untilAsserted(() ->
                     assertEquals(consumeSocket.getReceivedMessagesCount(), 10));
             consumeSocket.isEndOfTopic();
             // Wait till get response
-            Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            Awaitility.await().untilAsserted(() ->
                     assertEquals(consumeSocket.getBuffer().size(), 11));
             // Assert not reach end of topic yet
             assertEquals(consumeSocket.getBuffer().get(consumeSocket.getBuffer().size() - 1), "{\"endOfTopic\":false}");
@@ -244,11 +244,11 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
             // Send 20 more permits, should receive all message
             consumeSocket.sendPermits(20);
             // 31 includes previous of end of topic request.
-            Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            Awaitility.await().untilAsserted(() ->
                     assertEquals(consumeSocket.getReceivedMessagesCount(), 31));
             consumeSocket.isEndOfTopic();
             // Wait till get response
-            Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            Awaitility.await().untilAsserted(() ->
                     assertEquals(consumeSocket.getReceivedMessagesCount(), 32));
             // Assert not reached end of topic.
             assertEquals(consumeSocket.getBuffer().get(consumeSocket.getBuffer().size() - 1), "{\"endOfTopic\":false}");
@@ -256,7 +256,7 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
             admin.topics().terminateTopicAsync(topic).get();
             consumeSocket.isEndOfTopic();
             // Wait till get response
-            Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            Awaitility.await().untilAsserted(() ->
                     assertEquals(consumeSocket.getReceivedMessagesCount(), 33));
             // Assert reached end of topic.
             assertEquals(consumeSocket.getBuffer().get(consumeSocket.getBuffer().size() - 1), "{\"endOfTopic\":true}");

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -239,7 +239,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         });
 
         // Make sure subscription has been created
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().until(() -> {
             boolean isCreated = false;
             try {
                 List<String> subscriptions = admin.topics().getSubscriptions(topicName);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -133,7 +133,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
                         new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
 
-        Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        Awaitility.await().until(transactionMetadataStore::checkIfReady);
         TxnID txnID = transactionMetadataStore.newTransaction(20000).get();
         transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTING, TxnStatus.OPEN).get();
         if (isUseManagedLedger) {
@@ -146,7 +146,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         Position position = managedLedger.getLastConfirmedEntry();
 
         if (isUseManagedLedger) {
-            Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS).until(() -> {
+            Awaitility.await().until(() -> {
                 managedLedger.rollCurrentLedgerIfFull();
                 return !managedLedger.ledgerExists(position.getLedgerId());
             });
@@ -155,7 +155,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
                         new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
 
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        Awaitility.await().until(transactionMetadataStore::checkIfReady);
         txnID = transactionMetadataStore.newTransaction(100000).get();
         assertEquals(txnID.getLeastSigBits(), 1);
     }
@@ -337,7 +337,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                         new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
 
 
-        Awaitility.await().atMost(3000, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        Awaitility.await().until(transactionMetadataStore::checkIfReady);
 
         // txnID1 have not deleted from cursor, we can recover from transaction log
         TxnID txnID1 = transactionMetadataStore.newTransaction(1000).get();
@@ -353,7 +353,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                 new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
                         new TransactionTimeoutTrackerImpl(), new TransactionRecoverTrackerImpl());
 
-        Awaitility.await().atMost(3000, TimeUnit.MILLISECONDS).until(transactionMetadataStore::checkIfReady);
+        Awaitility.await().until(transactionMetadataStore::checkIfReady);
     }
 
     public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -128,7 +128,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
                         "/bin/bash",
                         "-c", "bin/pulsar-admin namespaces unload " + topicName.getNamespace());
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        Awaitility.await().untilAsserted(
                 () -> {
                     ContainerExecResult r = execQuery(
                             String.format("show tables in pulsar.\"%s\";", topicName.getNamespace()));
@@ -155,7 +155,7 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
             queryAllDataSql = String.format("select * from pulsar.\"%s\".\"%s\";", namespace, topic);
         }
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+        Awaitility.await().untilAsserted(
                 () -> {
                     ContainerExecResult containerExecResult = execQuery(queryAllDataSql);
                     assertThat(containerExecResult.getExitCode()).isEqualTo(0);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
@@ -93,7 +93,7 @@ public class TestProxyWithWebSocket extends PulsarTestSuite {
                 "  \"context\": \"1\"\n" +
                 "}");
 
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             String response = myWebSocket.getResponse();
             Assert.assertNotNull(response);
             Assert.assertTrue(response.contains("ok"));


### PR DESCRIPTION
### Motivation

Some tests are flaky because the time limits set for Awaitility are too strict.
It's better to avoid specifying the time limit and rely on the default value that is 10 seconds.
This improves the readability of the test.

### Modifications

- drop `.atMost` definitions used to configure Awaitility in tests.