### PR TITLE
[Tests] Fix KeyStoreTlsTest on JDK11

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsTest.java
@@ -19,9 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import static org.apache.pulsar.common.util.SecurityUtility.getProvider;
-
 import java.security.Provider;
-import javax.net.ssl.SSLContext;
 import org.apache.pulsar.common.util.keystoretls.KeyStoreSSLContext;
 import org.apache.pulsar.common.util.keystoretls.SSLContextValidatorEngine;
 import org.testng.annotations.Test;
@@ -60,7 +58,7 @@ public class KeyStoreTlsTest {
                 true,
                 null,
                 null);
-        SSLContext serverCnx = serverSSLContext.createSSLContext();
+        serverSSLContext.createSSLContext();
 
         KeyStoreSSLContext clientSSLContext = new KeyStoreSSLContext(KeyStoreSSLContext.Mode.CLIENT,
                 null,
@@ -74,8 +72,8 @@ public class KeyStoreTlsTest {
                 false,
                 null,
                 null);
-        SSLContext clientCnx = clientSSLContext.createSSLContext();
+        clientSSLContext.createSSLContext();
 
-        SSLContextValidatorEngine.validate(clientCnx, serverCnx);
+        SSLContextValidatorEngine.validate(clientSSLContext::createSSLEngine, serverSSLContext::createSSLEngine);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -76,7 +76,6 @@ public class KeyStoreSSLContext {
     private boolean needClientAuth;
     private Set<String> ciphers;
     private Set<String> protocols;
-    @Getter
     private SSLContext sslContext;
 
     private String protocol = DEFAULT_SSL_PROTOCOL;
@@ -168,12 +167,19 @@ public class KeyStoreSSLContext {
         return sslContext;
     }
 
+    public SSLContext getSslContext() {
+        if (sslContext == null) {
+            throw new IllegalStateException("createSSLContext hasn't been called.");
+        }
+        return sslContext;
+    }
+
     public SSLEngine createSSLEngine() {
-        return configureSSLEngine(sslContext.createSSLEngine());
+        return configureSSLEngine(getSslContext().createSSLEngine());
     }
 
     public SSLEngine createSSLEngine(String peerHost, int peerPort) {
-        return configureSSLEngine(sslContext.createSSLEngine(peerHost, peerPort));
+        return configureSSLEngine(getSslContext().createSSLEngine(peerHost, peerPort));
     }
 
     private SSLEngine configureSSLEngine(SSLEngine sslEngine) {


### PR DESCRIPTION
### Motivation

KeyStoreTlsTest hangs on JDK11 currently. It seems that the internal state engine is different than what SSLContextValidatorEngine expects.

### Modifications

- This fix requires #10336 as prerequisite.
- Remove duplicate SSLEngine configuration from SSLContextValidatorEngine. Refactor the classes to support this.
- adjust the state machine such that when the handshake completes, store the result in a field. This fixes the issue that caused the execution to go in an infinite loop. 