### PR TITLE
Reader support seek from separate messageId/time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -89,7 +89,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
 
     @Test(timeOut = 30000)
     public void testReadMessageWithoutBatching() throws Exception {
-        String topic = "persistent://my-property/my-ns/my-reader-topic";
+        String topic = "persistent://my-property/my-ns/my-reader-topic" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         testReadMessages(topic, false);
     }
@@ -116,7 +116,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
 
     @Test(timeOut = 10000)
     public void testReadMessageWithBatching() throws Exception {
-        String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching";
+        String topic = "persistent://my-property/my-ns/my-reader-topic-with-batching" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         testReadMessages(topic, true);
     }
@@ -214,7 +214,8 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
     @Test(timeOut = 10000)
     public void testRemoveSubscriptionForReaderNeedRemoveCursor() throws IOException, PulsarAdminException {
 
-        final String topic = "persistent://my-property/my-ns/testRemoveSubscriptionForReaderNeedRemoveCursor";
+        final String topic = "persistent://my-property/my-ns/testRemoveSubscriptionForReaderNeedRemoveCursor"
+                + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         @Cleanup
         Reader<byte[]> reader1 = pulsarClient.newReader()
@@ -251,7 +252,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
 
     @Test(timeOut = 10000)
     public void testMultiReaderSeek() throws Exception {
-        String topic = "persistent://my-property/my-ns/testKeyHashRangeReader";
+        String topic = "persistent://my-property/my-ns/testKeyHashRangeReader" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
         publishMessages(topic,100,false);
     }
@@ -344,7 +345,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
     @Test(timeOut = 10000)
     public void testKeyHashRangeReader() throws Exception {
         final List<String> keys = Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
-        final String topic = "persistent://my-property/my-ns/testKeyHashRangeReader";
+        final String topic = "persistent://my-property/my-ns/testKeyHashRangeReader" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
 
         try {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -600,7 +600,7 @@ public interface Consumer<T> extends Closeable {
     void seek(long timestamp) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id or message publish time.
+     * Reset the subscription associated with this consumer to a specific message ID or message publish time.
      * <p>
      * The Function input is topic+partition, and can only return timestamp or MessageId.
      * <p>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -600,7 +600,7 @@ public interface Consumer<T> extends Closeable {
     void seek(long timestamp) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id.
+     * Reset the subscription associated with this consumer to a specific message id or message publish time.
      * <p>
      * The Function input is topic+partition.
      * <p>
@@ -613,7 +613,8 @@ public interface Consumer<T> extends Closeable {
     void seek(Function<String, Object> function) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id asynchronously.
+     * Reset the subscription associated with this consumer to a specific message id
+     * or message publish time asynchronously.
      * <p>
      * The Function input is topic+partition.
      * <p>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -618,10 +618,10 @@ public interface Consumer<T> extends Closeable {
      * Reset the subscription associated with this consumer to a specific message ID
      * or message publish time asynchronously.
      * <p>
-     * The Function input is topic+partition, and can only return timestamp or MessageId.
+     * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
-     * Exception will be thrown if other types of objects are returned.
+     * Exception is thrown if other object types are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
      * Exception in a partition may affect other partitions.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -605,7 +605,7 @@ public interface Consumer<T> extends Closeable {
      * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
-     * Exception will be thrown if other types of objects are returned.
+     * Exception is thrown if other object types are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
      * Exception in a partition may affect other partitions.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -602,7 +602,7 @@ public interface Consumer<T> extends Closeable {
     /**
      * Reset the subscription associated with this consumer to a specific message ID or message publish time.
      * <p>
-     * The Function input is topic+partition, and can only return timestamp or MessageId.
+     * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
      * Exception will be thrown if other types of objects are returned.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -615,7 +615,7 @@ public interface Consumer<T> extends Closeable {
     void seek(Function<String, Object> function) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id
+     * Reset the subscription associated with this consumer to a specific message ID
      * or message publish time asynchronously.
      * <p>
      * The Function input is topic+partition, and can only return timestamp or MessageId.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -602,11 +602,13 @@ public interface Consumer<T> extends Closeable {
     /**
      * Reset the subscription associated with this consumer to a specific message id or message publish time.
      * <p>
-     * The Function input is topic+partition.
+     * The Function input is topic+partition, and can only return timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
+     * Exception will be thrown if other types of objects are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
+     * Exception in a partition may affect other partitions.
      * @param function
      * @throws PulsarClientException
      */
@@ -616,11 +618,13 @@ public interface Consumer<T> extends Closeable {
      * Reset the subscription associated with this consumer to a specific message id
      * or message publish time asynchronously.
      * <p>
-     * The Function input is topic+partition.
+     * The Function input is topic+partition, and can only return timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
+     * Exception will be thrown if other types of objects are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
+     * Exception in a partition may affect other partitions.
      * @param function
      * @return
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -160,11 +160,13 @@ public interface Reader<T> extends Closeable {
     /**
      * Reset the subscription associated with this consumer to a specific message id or message publish time.
      * <p>
-     * The Function input is topic+partition.
+     * The Function input is topic+partition, and can only return timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
+     * Exception will be thrown if other types of objects are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
+     * Exception in a partition may affect other partitions.
      * @param function
      * @throws PulsarClientException
      */
@@ -174,11 +176,13 @@ public interface Reader<T> extends Closeable {
      * Reset the subscription associated with this consumer to a specific message id
      * or message publish time asynchronously.
      * <p>
-     * The Function input is topic+partition.
+     * The Function input is topic+partition, and can only return timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
+     * Exception will be thrown if other types of objects are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
+     * Exception in a partition may affect other partitions.
      * @param function
      * @return
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -158,12 +158,12 @@ public interface Reader<T> extends Closeable {
     void seek(long timestamp) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id or message publish time.
+     * Reset the subscription associated with this consumer to a specific message ID or message publish time.
      * <p>
-     * The Function input is topic+partition, and can only return timestamp or MessageId.
+     * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
-     * Exception will be thrown if other types of objects are returned.
+     * Exception is thrown if other object types are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
      * Exception in a partition may affect other partitions.
@@ -173,13 +173,13 @@ public interface Reader<T> extends Closeable {
     void seek(Function<String, Object> function) throws PulsarClientException;
 
     /**
-     * Reset the subscription associated with this consumer to a specific message id
+     * Reset the subscription associated with this consumer to a specific message ID
      * or message publish time asynchronously.
      * <p>
-     * The Function input is topic+partition, and can only return timestamp or MessageId.
+     * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
      * The return value is the seek position/timestamp of the current partition.
-     * Exception will be thrown if other types of objects are returned.
+     * Exception is thrown if other object types are returned.
      * <p>
      * If returns null, the current partition will not do any processing.
      * Exception in a partition may affect other partitions.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.client.api;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -154,6 +156,33 @@ public interface Reader<T> extends Closeable {
      * @param timestamp the message publish time where to reposition the reader
      */
     void seek(long timestamp) throws PulsarClientException;
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id or message publish time.
+     * <p>
+     * The Function input is topic+partition.
+     * <p>
+     * The return value is the seek position/timestamp of the current partition.
+     * <p>
+     * If returns null, the current partition will not do any processing.
+     * @param function
+     * @throws PulsarClientException
+     */
+    void seek(Function<String, Object> function) throws PulsarClientException;
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id
+     * or message publish time asynchronously.
+     * <p>
+     * The Function input is topic+partition.
+     * <p>
+     * The return value is the seek position/timestamp of the current partition.
+     * <p>
+     * If returns null, the current partition will not do any processing.
+     * @param function
+     * @return
+     */
+    CompletableFuture<Void> seekAsync(Function<String, Object> function);
 
     /**
      * Reset the subscription associated with this reader to a specific message id.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -735,7 +735,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (exception != null) {
                 completableFuture.completeExceptionally(exception);
             } else {
-                completableFuture.complete(hasMessageAvailable.get());
+                completableFuture.complete(hasMessageAvailable.get() || numMessagesInQueue() > 0);
             }
         });
         return completableFuture;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -714,7 +714,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     public boolean hasMessageAvailable() throws PulsarClientException {
         try {
-            return hasMessageAvailableAsync().get();
+            return hasMessageAvailableAsync().get() || numMessagesInQueue() > 0;
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);
         }
@@ -735,7 +735,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             if (exception != null) {
                 completableFuture.completeExceptionally(exception);
             } else {
-                completableFuture.complete(hasMessageAvailable.get() || numMessagesInQueue() > 0);
+                completableFuture.complete(hasMessageAvailable.get());
             }
         });
         return completableFuture;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -714,7 +714,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     public boolean hasMessageAvailable() throws PulsarClientException {
         try {
-            return hasMessageAvailableAsync().get() || numMessagesInQueue() > 0;
+            return hasMessageAvailableAsync().get();
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -141,7 +141,7 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
 
     @Override
     public boolean hasMessageAvailable() throws PulsarClientException {
-        return multiTopicsConsumer.hasMessageAvailable();
+        return multiTopicsConsumer.hasMessageAvailable() || multiTopicsConsumer.numMessagesInQueue() > 0;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -140,7 +141,7 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
 
     @Override
     public boolean hasMessageAvailable() throws PulsarClientException {
-        return multiTopicsConsumer.hasMessageAvailable() || multiTopicsConsumer.numMessagesInQueue() > 0;
+        return multiTopicsConsumer.hasMessageAvailable();
     }
 
     @Override
@@ -164,6 +165,11 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
     }
 
     @Override
+    public void seek(Function<String, Object> function) throws PulsarClientException {
+        multiTopicsConsumer.seek(function);
+    }
+
+    @Override
     public CompletableFuture<Void> seekAsync(MessageId messageId) {
         return multiTopicsConsumer.seekAsync(messageId);
     }
@@ -171,6 +177,11 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
     @Override
     public CompletableFuture<Void> seekAsync(long timestamp) {
         return multiTopicsConsumer.seekAsync(timestamp);
+    }
+
+    @Override
+    public CompletableFuture<Void> seekAsync(Function<String, Object> function) {
+        return multiTopicsConsumer.seekAsync(function);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -185,6 +186,16 @@ public class ReaderImpl<T> implements Reader<T> {
     @Override
     public void seek(long timestamp) throws PulsarClientException {
         consumer.seek(timestamp);
+    }
+
+    @Override
+    public void seek(Function<String, Object> function) throws PulsarClientException {
+        consumer.seek(function);
+    }
+
+    @Override
+    public CompletableFuture<Void> seekAsync(Function<String, Object> function) {
+        return consumer.seekAsync(function);
     }
 
     @Override


### PR DESCRIPTION
Fixes #9301

### Motivation
Currently in ReaderConfigurationData the API allow to ‘setStartMessageId’ only from single message ID and this apply to all consumers in the `MultiTopicsReaderImpl`.

Is it possible to add start message per partition / topic.

### Modifications
Reader can seek by function

### Verifying this change
1 For partitioned topic, we can seek by time/messageId for every partition
2 For non-partitioned topic, we can seek by function