### PR TITLE
[C++] Add isConnected() method

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -385,6 +385,11 @@ class PULSAR_PUBLIC Consumer {
      */
     virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
 
+    /**
+     * @return Whether the consumer is currently connected to the broker
+     */
+    bool isConnected() const;
+
    private:
     ConsumerImplBasePtr impl_;
     explicit Consumer(ConsumerImplBasePtr);

--- a/pulsar-client-cpp/include/pulsar/Producer.h
+++ b/pulsar-client-cpp/include/pulsar/Producer.h
@@ -154,6 +154,11 @@ class PULSAR_PUBLIC Producer {
      */
     void closeAsync(CloseCallback callback);
 
+    /**
+     * @return Whether the producer is currently connected to the broker
+     */
+    bool isConnected() const;
+
    private:
     explicit Producer(ProducerImplBasePtr);
 

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -132,6 +132,11 @@ class PULSAR_PUBLIC Reader {
      */
     void seekAsync(uint64_t timestamp, ResultCallback callback);
 
+    /**
+     * @return Whether the reader is currently connected to the broker
+     */
+    bool isConnected() const;
+
    private:
     typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;
     ReaderImplPtr impl_;

--- a/pulsar-client-cpp/lib/Consumer.cc
+++ b/pulsar-client-cpp/lib/Consumer.cc
@@ -248,4 +248,6 @@ Result Consumer::seek(uint64_t timestamp) {
     return result;
 }
 
+bool Consumer::isConnected() const { return impl_ && impl_->isConnected(); }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -1225,4 +1225,9 @@ void ConsumerImpl::trackMessage(const Message& msg) {
     }
 }
 
+bool ConsumerImpl::isConnected() const {
+    Lock lock(mutex_);
+    return getCnx().expired() && state_ == Ready;
+}
+
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -1227,7 +1227,7 @@ void ConsumerImpl::trackMessage(const Message& msg) {
 
 bool ConsumerImpl::isConnected() const {
     Lock lock(mutex_);
-    return getCnx().expired() && state_ == Ready;
+    return !getCnx().expired() && state_ == Ready;
 }
 
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -81,7 +81,6 @@ class ConsumerImpl : public ConsumerImplBase,
     void messageProcessed(Message& msg);
     inline proto::CommandSubscribe_SubType getSubType();
     inline proto::CommandSubscribe_InitialPosition getInitialPosition();
-    void unsubscribeAsync(ResultCallback callback);
     void handleUnsubscribe(Result result, ResultCallback callback);
 
     /**
@@ -99,49 +98,56 @@ class ConsumerImpl : public ConsumerImplBase,
      *      always provided with ResultOk.
      */
     void doAcknowledgeCumulative(const MessageId& messageId, ResultCallback callback);
-    virtual void disconnectConsumer();
-    virtual Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture();
-    virtual const std::string& getSubscriptionName() const;
-    virtual const std::string& getTopic() const;
-    virtual Result receive(Message& msg);
-    virtual Result receive(Message& msg, int timeout);
-    virtual void receiveAsync(ReceiveCallback& callback);
-    Result fetchSingleMessageFromBroker(Message& msg);
-    virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback);
 
-    virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback);
+    // overrided methods from ConsumerImplBase
+    Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture() override;
+    const std::string& getSubscriptionName() const override;
+    const std::string& getTopic() const override;
+    Result receive(Message& msg) override;
+    Result receive(Message& msg, int timeout) override;
+    void receiveAsync(ReceiveCallback& callback) override;
+    void unsubscribeAsync(ResultCallback callback) override;
+    void acknowledgeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void closeAsync(ResultCallback callback) override;
+    void start() override;
+    void shutdown() override;
+    bool isClosed() override;
+    bool isOpen() override;
+    Result pauseMessageListener() override;
+    Result resumeMessageListener() override;
+    void redeliverUnacknowledgedMessages() override;
+    void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds) override;
+    const std::string& getName() const override;
+    int getNumOfPrefetchedMessages() const override;
+    void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) override;
+    void seekAsync(const MessageId& msgId, ResultCallback callback) override;
+    void seekAsync(uint64_t timestamp, ResultCallback callback) override;
+    void negativeAcknowledge(const MessageId& msgId) override;
+    bool isConnected() const override;
+
+    virtual void disconnectConsumer();
+    Result fetchSingleMessageFromBroker(Message& msg);
+
     virtual bool isCumulativeAcknowledgementAllowed(ConsumerType consumerType);
 
     virtual void redeliverMessages(const std::set<MessageId>& messageIds);
-    virtual void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds);
-    virtual void negativeAcknowledge(const MessageId& msgId);
 
-    virtual void closeAsync(ResultCallback callback);
-    virtual void start();
-    virtual void shutdown();
-    virtual bool isClosed();
-    virtual bool isOpen();
-    virtual Result pauseMessageListener();
-    virtual Result resumeMessageListener();
-    virtual void redeliverUnacknowledgedMessages();
-    virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
     void handleSeek(Result result, ResultCallback callback);
-    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
     virtual bool isReadCompacted();
     virtual void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
     virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback);
 
    protected:
-    void connectionOpened(const ClientConnectionPtr& cnx);
-    void connectionFailed(Result result);
+    // overrided methods from HandlerBase
+    void connectionOpened(const ClientConnectionPtr& cnx) override;
+    void connectionFailed(Result result) override;
+    HandlerBaseWeakPtr get_weak_from_this() override { return shared_from_this(); }
+
     void handleCreateConsumer(const ClientConnectionPtr& cnx, Result result);
 
     void internalListener();
     void handleClose(Result result, ResultCallback callback, ConsumerImplPtr consumer);
-    virtual HandlerBaseWeakPtr get_weak_from_this() { return shared_from_this(); }
-    virtual const std::string& getName() const;
-    virtual int getNumOfPrefetchedMessages() const;
     ConsumerStatsBasePtr consumerStatsBasePtr_;
 
    private:
@@ -165,7 +171,7 @@ class ConsumerImpl : public ConsumerImplBase,
     void statsCallback(Result, ResultCallback, proto::CommandAck_AckType);
     void notifyPendingReceivedCallback(Result result, Message& message, const ReceiveCallback& callback);
     void failPendingReceiveCallback();
-    virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled);
+    void setNegativeAcknowledgeEnabledForTesting(bool enabled) override;
     void trackMessage(const Message& msg);
 
     Optional<MessageId> clearReceiveQueue();

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -55,6 +55,7 @@ class ConsumerImplBase {
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback) = 0;
     virtual void seekAsync(uint64_t timestamp, ResultCallback callback) = 0;
     virtual void negativeAcknowledge(const MessageId& msgId) = 0;
+    virtual bool isConnected() const = 0;
 
    private:
     virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled) = 0;

--- a/pulsar-client-cpp/lib/HandlerBase.h
+++ b/pulsar-client-cpp/lib/HandlerBase.h
@@ -48,7 +48,7 @@ class HandlerBase {
      * get method for derived class to access weak ptr to connection so that they
      * have to check if they can get a shared_ptr out of it or not
      */
-    ClientConnectionWeakPtr getCnx() { return connection_; }
+    ClientConnectionWeakPtr getCnx() const { return connection_; }
 
    protected:
     /*
@@ -88,7 +88,7 @@ class HandlerBase {
     const std::string topic_;
     ClientConnectionWeakPtr connection_;
     ExecutorServicePtr executor_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::mutex pendingReceiveMutex_;
     ptime creationTimestamp_;
 

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -735,3 +735,17 @@ void MultiTopicsConsumerImpl::setNegativeAcknowledgeEnabledForTesting(bool enabl
         c.second->setNegativeAcknowledgeEnabledForTesting(enabled);
     }
 }
+
+bool MultiTopicsConsumerImpl::isConnected() const {
+    Lock lock(mutex_);
+    if (state_ != Ready) {
+        return false;
+    }
+
+    for (const auto& topicAndConsumer : consumers_) {
+        if (!topicAndConsumer.second->isConnected()) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -51,39 +51,39 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     MultiTopicsConsumerImpl(ClientImplPtr client, const std::vector<std::string>& topics,
                             const std::string& subscriptionName, TopicNamePtr topicName,
                             const ConsumerConfiguration& conf, const LookupServicePtr lookupServicePtr_);
-    virtual ~MultiTopicsConsumerImpl();
-    virtual Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture();
-    virtual const std::string& getSubscriptionName() const;
-    virtual const std::string& getTopic() const;
-    virtual const std::string& getName() const;
-    virtual Result receive(Message& msg);
-    virtual Result receive(Message& msg, int timeout);
-    virtual void receiveAsync(ReceiveCallback& callback);
-    virtual void unsubscribeAsync(ResultCallback callback);
-    virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void closeAsync(ResultCallback callback);
-    virtual void start();
-    virtual void shutdown();
-    virtual bool isClosed();
-    virtual bool isOpen();
-    virtual Result pauseMessageListener();
-    virtual Result resumeMessageListener();
-    virtual void redeliverUnacknowledgedMessages();
-    virtual void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds);
-    virtual int getNumOfPrefetchedMessages() const;
-    virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
+    ~MultiTopicsConsumerImpl();
+    // overrided methods from ConsumerImplBase
+    Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture() override;
+    const std::string& getSubscriptionName() const override;
+    const std::string& getTopic() const override;
+    Result receive(Message& msg) override;
+    Result receive(Message& msg, int timeout) override;
+    void receiveAsync(ReceiveCallback& callback) override;
+    void unsubscribeAsync(ResultCallback callback) override;
+    void acknowledgeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void closeAsync(ResultCallback callback) override;
+    void start() override;
+    void shutdown() override;
+    bool isClosed() override;
+    bool isOpen() override;
+    Result pauseMessageListener() override;
+    Result resumeMessageListener() override;
+    void redeliverUnacknowledgedMessages() override;
+    void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds) override;
+    const std::string& getName() const override;
+    int getNumOfPrefetchedMessages() const override;
+    void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) override;
+    void seekAsync(const MessageId& msgId, ResultCallback callback) override;
+    void seekAsync(uint64_t timestamp, ResultCallback callback) override;
+    void negativeAcknowledge(const MessageId& msgId) override;
+    bool isConnected() const override;
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, MultiTopicsBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     // return first topic name when all topics name valid, or return null pointer
     static std::shared_ptr<TopicName> topicNamesValid(const std::vector<std::string>& topics);
     void unsubscribeOneTopicAsync(const std::string& topic, ResultCallback callback);
     Future<Result, Consumer> subscribeOneTopicAsync(const std::string& topic);
-    // not supported
-    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
-
-    virtual void negativeAcknowledge(const MessageId& msgId);
 
    protected:
     const ClientImplPtr client_;
@@ -94,7 +94,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     typedef std::map<std::string, ConsumerImplPtr> ConsumerMap;
     ConsumerMap consumers_;
     std::map<std::string, int> topicsPartitions_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::mutex pendingReceiveMutex_;
     MultiTopicsConsumerState state_;
     std::shared_ptr<std::atomic<int>> numberTopicPartitions_;
@@ -136,7 +136,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
                                          std::string& topicPartitionName, ResultCallback callback);
 
    private:
-    virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled);
+    void setNegativeAcknowledgeEnabledForTesting(bool enabled) override;
 
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
 };

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -617,4 +617,22 @@ void PartitionedConsumerImpl::setNegativeAcknowledgeEnabledForTesting(bool enabl
     }
 }
 
+bool PartitionedConsumerImpl::isConnected() const {
+    Lock stateLock(mutex_);
+    if (state_ != Ready) {
+        return false;
+    }
+    stateLock.unlock();
+
+    Lock consumersLock(consumersMutex_);
+    auto consumers = consumers_;
+    consumersLock.unlock();
+    for (const auto& consumer : consumers_) {
+        if (!consumer->isConnected()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -625,7 +625,7 @@ bool PartitionedConsumerImpl::isConnected() const {
     stateLock.unlock();
 
     Lock consumersLock(consumersMutex_);
-    auto consumers = consumers_;
+    const auto consumers = consumers_;
     consumersLock.unlock();
     for (const auto& consumer : consumers_) {
         if (!consumer->isConnected()) {

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -47,34 +47,36 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     PartitionedConsumerImpl(ClientImplPtr client, const std::string& subscriptionName,
                             const TopicNamePtr topicName, const unsigned int numPartitions,
                             const ConsumerConfiguration& conf);
-    virtual ~PartitionedConsumerImpl();
-    virtual Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture();
-    virtual const std::string& getSubscriptionName() const;
-    virtual const std::string& getTopic() const;
-    virtual Result receive(Message& msg);
-    virtual Result receive(Message& msg, int timeout);
-    virtual void receiveAsync(ReceiveCallback& callback);
-    virtual void unsubscribeAsync(ResultCallback callback);
-    virtual void acknowledgeAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void closeAsync(ResultCallback callback);
-    virtual void start();
-    virtual void shutdown();
-    virtual bool isClosed();
-    virtual bool isOpen();
-    virtual Result pauseMessageListener();
-    virtual Result resumeMessageListener();
-    virtual void redeliverUnacknowledgedMessages();
-    virtual void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds);
-    virtual const std::string& getName() const;
-    virtual int getNumOfPrefetchedMessages() const;
-    virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
+    ~PartitionedConsumerImpl();
+    // overrided methods from ConsumerImplBase
+    Future<Result, ConsumerImplBaseWeakPtr> getConsumerCreatedFuture() override;
+    const std::string& getSubscriptionName() const override;
+    const std::string& getTopic() const override;
+    Result receive(Message& msg) override;
+    Result receive(Message& msg, int timeout) override;
+    void receiveAsync(ReceiveCallback& callback) override;
+    void unsubscribeAsync(ResultCallback callback) override;
+    void acknowledgeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void acknowledgeCumulativeAsync(const MessageId& msgId, ResultCallback callback) override;
+    void closeAsync(ResultCallback callback) override;
+    void start() override;
+    void shutdown() override;
+    bool isClosed() override;
+    bool isOpen() override;
+    Result pauseMessageListener() override;
+    Result resumeMessageListener() override;
+    void redeliverUnacknowledgedMessages() override;
+    void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds) override;
+    const std::string& getName() const override;
+    int getNumOfPrefetchedMessages() const override;
+    void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) override;
+    void seekAsync(const MessageId& msgId, ResultCallback callback) override;
+    void seekAsync(uint64_t timestamp, ResultCallback callback) override;
+    void negativeAcknowledge(const MessageId& msgId) override;
+    bool isConnected() const override;
+
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, PartitionedBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
-    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
-    virtual void seekAsync(uint64_t timestamp, ResultCallback callback);
-
-    virtual void negativeAcknowledge(const MessageId& msgId);
 
    private:
     const ClientImplPtr client_;
@@ -87,7 +89,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     ConsumerList consumers_;
     // consumersMutex_ is used to share consumers_ and numPartitions_
     mutable std::mutex consumersMutex_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::mutex pendingReceiveMutex_;
     PartitionedConsumerState state_;
     unsigned int unsubscribedSoFar_;
@@ -117,7 +119,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     void internalListener(Consumer consumer);
     void receiveMessages();
     void failPendingReceiveCallback();
-    virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled);
+    void setNegativeAcknowledgeEnabledForTesting(bool enabled) override;
     Promise<Result, ConsumerImplBaseWeakPtr> partitionedConsumerCreatedPromise_;
     UnAckedMessageTrackerPtr unAckedMessageTrackerPtr_;
     std::queue<ReceiveCallback> pendingReceives_;

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -369,4 +369,22 @@ void PartitionedProducerImpl::handleGetPartitions(Result result,
     runPartitionUpdateTask();
 }
 
+bool PartitionedProducerImpl::isConnected() const {
+    Lock stateLock(mutex_);
+    if (state_ != Ready) {
+        return false;
+    }
+    stateLock.unlock();
+
+    Lock producersLock(producersMutex_);
+    auto producers = producers_;
+    producersLock.unlock();
+    for (const auto& producer : producers_) {
+        if (!producer->isConnected()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -377,7 +377,7 @@ bool PartitionedProducerImpl::isConnected() const {
     stateLock.unlock();
 
     Lock producersLock(producersMutex_);
-    auto producers = producers_;
+    const auto producers = producers_;
     producersLock.unlock();
     for (const auto& producer : producers_) {
         if (!producer->isConnected()) {

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -46,33 +46,24 @@ class PartitionedProducerImpl : public ProducerImplBase,
                             const ProducerConfiguration& config);
     virtual ~PartitionedProducerImpl();
 
-    virtual void sendAsync(const Message& msg, SendCallback callback);
-
+    // overrided methods from ProducerImplBase
+    const std::string& getProducerName() const override;
+    int64_t getLastSequenceId() const override;
+    const std::string& getSchemaVersion() const override;
+    void sendAsync(const Message& msg, SendCallback callback) override;
     /*
      * closes all active producers, it can be called explicitly from client as well as createProducer
      * when it fails to create one of the producers and we want to fail createProducer
      */
-    virtual void closeAsync(CloseCallback closeCallback);
-
-    virtual const std::string& getProducerName() const;
-
-    virtual int64_t getLastSequenceId() const;
-
-    virtual const std::string& getSchemaVersion() const;
-
-    virtual void start();
-
-    virtual void shutdown();
-
-    virtual bool isClosed();
-
-    virtual const std::string& getTopic() const;
-
-    virtual Future<Result, ProducerImplBaseWeakPtr> getProducerCreatedFuture();
-
-    virtual void triggerFlush();
-
-    virtual void flushAsync(FlushCallback callback);
+    void closeAsync(CloseCallback callback) override;
+    void start() override;
+    void shutdown() override;
+    bool isClosed() override;
+    const std::string& getTopic() const override;
+    Future<Result, ProducerImplBaseWeakPtr> getProducerCreatedFuture() override;
+    void triggerFlush() override;
+    void flushAsync(FlushCallback callback) override;
+    bool isConnected() const override;
 
     void handleSinglePartitionProducerCreated(Result result, ProducerImplBaseWeakPtr producerBaseWeakPtr,
                                               const unsigned int partitionIndex);
@@ -118,7 +109,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     MessageRoutingPolicyPtr routerPolicy_;
 
     // mutex_ is used to share state_, and numProducersCreated_
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
 
     PartitionedProducerState state_;
 

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -118,4 +118,6 @@ void Producer::producerFailMessages(Result result) {
     }
 }
 
+bool Producer::isConnected() const { return impl_ && impl_->isConnected(); }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -786,8 +786,6 @@ void ProducerImpl::disconnectProducer() {
     scheduleReconnection(shared_from_this());
 }
 
-const std::string& ProducerImpl::getName() const { return producerStr_; }
-
 void ProducerImpl::start() { HandlerBase::start(); }
 
 void ProducerImpl::shutdown() {
@@ -821,6 +819,11 @@ bool ProducerImplCmp::operator()(const ProducerImplPtr& a, const ProducerImplPtr
 bool ProducerImpl::isClosed() {
     Lock lock(mutex_);
     return state_ == Closed;
+}
+
+bool ProducerImpl::isConnected() const {
+    Lock lock(mutex_);
+    return getCnx().expired() && state_ == Ready;
 }
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -823,7 +823,7 @@ bool ProducerImpl::isClosed() {
 
 bool ProducerImpl::isConnected() const {
     Lock lock(mutex_);
-    return getCnx().expired() && state_ == Ready;
+    return !getCnx().expired() && state_ == Ready;
 }
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -56,13 +56,20 @@ class ProducerImpl : public HandlerBase,
                  const ProducerConfiguration& producerConfiguration, int32_t partition = -1);
     ~ProducerImpl();
 
-    virtual const std::string& getTopic() const;
-
-    virtual void sendAsync(const Message& msg, SendCallback callback);
-
-    virtual void closeAsync(CloseCallback callback);
-
-    virtual Future<Result, ProducerImplBaseWeakPtr> getProducerCreatedFuture();
+    // overrided methods from ProducerImplBase
+    const std::string& getProducerName() const override;
+    int64_t getLastSequenceId() const override;
+    const std::string& getSchemaVersion() const override;
+    void sendAsync(const Message& msg, SendCallback callback) override;
+    void closeAsync(CloseCallback callback) override;
+    void start() override;
+    void shutdown() override;
+    bool isClosed() override;
+    const std::string& getTopic() const override;
+    Future<Result, ProducerImplBaseWeakPtr> getProducerCreatedFuture() override;
+    void triggerFlush() override;
+    void flushAsync(FlushCallback callback) override;
+    bool isConnected() const override;
 
     bool removeCorruptMessage(uint64_t sequenceId);
 
@@ -70,25 +77,9 @@ class ProducerImpl : public HandlerBase,
 
     virtual void disconnectProducer();
 
-    const std::string& getProducerName() const;
-
-    int64_t getLastSequenceId() const;
-
-    const std::string& getSchemaVersion() const;
-
     uint64_t getProducerId() const;
 
     int32_t partition() const noexcept { return partition_; }
-
-    virtual void start();
-
-    virtual void shutdown();
-
-    virtual bool isClosed();
-
-    virtual void triggerFlush();
-
-    virtual void flushAsync(FlushCallback callback);
 
    protected:
     ProducerStatsBasePtr producerStatsBasePtr_;
@@ -108,12 +99,11 @@ class ProducerImpl : public HandlerBase,
     friend class BatchMessageContainerBase;
     friend class BatchMessageContainer;
 
-    virtual void connectionOpened(const ClientConnectionPtr& connection);
-    virtual void connectionFailed(Result result);
-
-    virtual HandlerBaseWeakPtr get_weak_from_this() { return shared_from_this(); }
-
-    const std::string& getName() const;
+    // overrided methods from HandlerBase
+    void connectionOpened(const ClientConnectionPtr& connection) override;
+    void connectionFailed(Result result) override;
+    HandlerBaseWeakPtr get_weak_from_this() override { return shared_from_this(); }
+    const std::string& getName() const override { return producerStr_; }
 
    private:
     void printStats();

--- a/pulsar-client-cpp/lib/ProducerImplBase.h
+++ b/pulsar-client-cpp/lib/ProducerImplBase.h
@@ -44,6 +44,7 @@ class ProducerImplBase {
     virtual Future<Result, ProducerImplBaseWeakPtr> getProducerCreatedFuture() = 0;
     virtual void triggerFlush() = 0;
     virtual void flushAsync(FlushCallback callback) = 0;
+    virtual bool isConnected() const = 0;
 };
 }  // namespace pulsar
 #endif  // PULSAR_PRODUCER_IMPL_BASE_HEADER

--- a/pulsar-client-cpp/lib/Reader.cc
+++ b/pulsar-client-cpp/lib/Reader.cc
@@ -115,4 +115,6 @@ Result Reader::seek(uint64_t timestamp) {
     return result;
 }
 
+bool Reader::isConnected() const { return impl_ && impl_->isConnected(); }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -140,4 +140,6 @@ void ReaderImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
 
 ReaderImplWeakPtr ReaderImpl::getReaderImplWeakPtr() { return readerImplWeakPtr_; }
 
+bool ReaderImpl::isConnected() const { return consumer_->isConnected(); }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -62,6 +62,8 @@ class PULSAR_PUBLIC ReaderImpl : public std::enable_shared_from_this<ReaderImpl>
 
     ReaderImplWeakPtr getReaderImplWeakPtr();
 
+    bool isConnected() const;
+
    private:
     void handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumer);
 

--- a/pulsar-client-cpp/tests/ConsumerTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerTest.cc
@@ -477,28 +477,29 @@ TEST(ConsumerTest, testIsConnected) {
     const std::string subName = "sub";
 
     Consumer consumer;
-    ASSERT_EQ(consumer.isConnected(), false);
+    ASSERT_FALSE(consumer.isConnected());
     // ConsumerImpl
     ASSERT_EQ(ResultOk, client.subscribe(nonPartitionedTopic1, subName, consumer));
-    ASSERT_EQ(consumer.isConnected(), true);
+    ASSERT_TRUE(consumer.isConnected());
     ASSERT_EQ(ResultOk, consumer.close());
-    ASSERT_EQ(consumer.isConnected(), false);
+    ASSERT_FALSE(consumer.isConnected());
 
     // MultiTopicsConsumerImpl
     ASSERT_EQ(ResultOk, client.subscribe(std::vector<std::string>{nonPartitionedTopic1, nonPartitionedTopic2},
                                          subName, consumer));
-    ASSERT_EQ(consumer.isConnected(), true);
+    ASSERT_TRUE(consumer.isConnected());
     ASSERT_EQ(ResultOk, consumer.close());
-    ASSERT_EQ(consumer.isConnected(), false);
+    ASSERT_FALSE(consumer.isConnected());
 
-    int res = makePutRequest(adminUrl + "admin/v2/persistent/" + partitionedTopic + "/partitions", "2");
+    int res = makePutRequest(
+        adminUrl + "admin/v2/persistent/public/default/" + partitionedTopic + "/partitions", "2");
     ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
 
     // PartitionedConsumerImpl
     ASSERT_EQ(ResultOk, client.subscribe(partitionedTopic, subName, consumer));
-    ASSERT_EQ(consumer.isConnected(), true);
+    ASSERT_TRUE(consumer.isConnected());
     ASSERT_EQ(ResultOk, consumer.close());
-    ASSERT_EQ(consumer.isConnected(), false);
+    ASSERT_FALSE(consumer.isConnected());
 }
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/tests/ProducerTest.cc
+++ b/pulsar-client-cpp/tests/ProducerTest.cc
@@ -101,11 +101,14 @@ TEST(ProducerTest, testSynchronouslySend) {
 
 TEST(ProducerTest, testIsConnected) {
     Client client(serviceUrl);
-    const std::string nonPartitionedTopic = "testIsConnectedNonPartitioned-" + std::to_string(time(nullptr));
-    const std::string partitionedTopic = "testIsConnectedPartitioned-" + std::to_string(time(nullptr));
+    const std::string nonPartitionedTopic =
+        "testProducerIsConnectedNonPartitioned-" + std::to_string(time(nullptr));
+    const std::string partitionedTopic =
+        "testProducerIsConnectedPartitioned-" + std::to_string(time(nullptr));
 
     Producer producer;
     ASSERT_EQ(producer.isConnected(), false);
+    // ProducerImpl
     ASSERT_EQ(ResultOk, client.createProducer(nonPartitionedTopic, producer));
     ASSERT_EQ(producer.isConnected(), true);
     ASSERT_EQ(ResultOk, producer.close());
@@ -114,6 +117,7 @@ TEST(ProducerTest, testIsConnected) {
     int res = makePutRequest(adminUrl + "admin/v2/persistent/" + partitionedTopic + "/partitions", "2");
     ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
 
+    // PartitionedProducerImpl
     ASSERT_EQ(ResultOk, client.createProducer(partitionedTopic, producer));
     ASSERT_EQ(producer.isConnected(), true);
     ASSERT_EQ(ResultOk, producer.close());

--- a/pulsar-client-cpp/tests/ProducerTest.cc
+++ b/pulsar-client-cpp/tests/ProducerTest.cc
@@ -107,21 +107,22 @@ TEST(ProducerTest, testIsConnected) {
         "testProducerIsConnectedPartitioned-" + std::to_string(time(nullptr));
 
     Producer producer;
-    ASSERT_EQ(producer.isConnected(), false);
+    ASSERT_FALSE(producer.isConnected());
     // ProducerImpl
     ASSERT_EQ(ResultOk, client.createProducer(nonPartitionedTopic, producer));
-    ASSERT_EQ(producer.isConnected(), true);
+    ASSERT_TRUE(producer.isConnected());
     ASSERT_EQ(ResultOk, producer.close());
-    ASSERT_EQ(producer.isConnected(), false);
+    ASSERT_FALSE(producer.isConnected());
 
-    int res = makePutRequest(adminUrl + "admin/v2/persistent/" + partitionedTopic + "/partitions", "2");
+    int res = makePutRequest(
+        adminUrl + "admin/v2/persistent/public/default/" + partitionedTopic + "/partitions", "2");
     ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
 
     // PartitionedProducerImpl
     ASSERT_EQ(ResultOk, client.createProducer(partitionedTopic, producer));
-    ASSERT_EQ(producer.isConnected(), true);
+    ASSERT_TRUE(producer.isConnected());
     ASSERT_EQ(ResultOk, producer.close());
-    ASSERT_EQ(producer.isConnected(), false);
+    ASSERT_FALSE(producer.isConnected());
 
     client.close();
 }

--- a/pulsar-client-cpp/tests/ReaderTest.cc
+++ b/pulsar-client-cpp/tests/ReaderTest.cc
@@ -563,3 +563,17 @@ TEST(ReaderTest, testMultiSameSubscriptionNameReaderShouldFail) {
     reader2.close();
     client.close();
 }
+
+TEST(ReaderTest, testIsConnected) {
+    const std::string topic = "testReaderIsConnected-" + std::to_string(time(nullptr));
+    Client client(serviceUrl);
+
+    Reader reader;
+    ASSERT_FALSE(reader.isConnected());
+
+    ASSERT_EQ(ResultOk, client.createReader(topic, MessageId::earliest(), {}, reader));
+    ASSERT_TRUE(reader.isConnected());
+
+    ASSERT_EQ(ResultOk, reader.close());
+    ASSERT_FALSE(reader.isConnected());
+}


### PR DESCRIPTION
### Motivation

Add `isConnected()` method to `Producer`, `Consumer` and `Reader` in C++ client.

### Modifications

- Implement `isConnected()` method that checks the network connection and state and add related tests.
- Unify the signature of overrided methods to avoid compile warnings like `overrides a member function but is not marked 'override' [-Winconsistent-missing-override]**`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- `ProducerTest.testIsConnected`
- `ConsumerTest.testIsConnected`
- `ReaderTest.testIsConnected`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (**yes**)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)
