### PR TITLE
Resource locks should automatically revalidate after a metadata session is re-established

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2773,7 +2773,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         CountDownLatch l2 = new CountDownLatch(1);
         store.asyncUpdateLedgerIds(mLName, builder.build(),
-                new Stat(mLName, 1, 0, 0),
+                new Stat(mLName, 1, 0, 0, false, true),
                 new MetaStoreCallback<Void>() {
             @Override
             public void operationComplete(Void result, Stat version) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
@@ -45,4 +45,14 @@ public class Stat {
      * When the value was last modified.
      */
     final long modificationTimestamp;
+
+    /**
+     * Whether the key-value pair is ephemeral or persistent
+     */
+    final boolean ephemeral;
+
+    /**
+     * Whether the key-value pair had been created within the current "session"
+     */
+    final boolean createdBySelf;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -20,13 +20,13 @@ package org.apache.pulsar.metadata.coordination.impl;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -36,17 +36,19 @@ import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
-import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
 import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
 
 @Slf4j
 class LockManagerImpl<T> implements LockManager<T> {
 
-    private final Set<ResourceLock<T>> locks = new HashSet<>();
+    private final Set<ResourceLockImpl<T>> locks = new HashSet<>();
     private final MetadataStoreExtended store;
     private final MetadataCache<T> cache;
     private final MetadataSerde<T> serde;
@@ -61,6 +63,8 @@ class LockManagerImpl<T> implements LockManager<T> {
         this.store = store;
         this.cache = store.getMetadataCache(clazz);
         this.serde = new JSONMetadataSerdeSimpleType<>(TypeFactory.defaultInstance().constructSimpleType(clazz, null));
+        store.registerSessionListener(this::handleSessionEvent);
+        store.registerListener(this::handleDataNotification);
     }
 
     @Override
@@ -70,45 +74,51 @@ class LockManagerImpl<T> implements LockManager<T> {
 
     @Override
     public CompletableFuture<ResourceLock<T>> acquireLock(String path, T value) {
-        byte[] payload;
-        try {
-            payload = serde.serialize(value);
-        } catch (Throwable t) {
-            return FutureUtils.exception(t);
-        }
+        ResourceLockImpl<T> lock = new ResourceLockImpl<>(store, serde, path, value);
 
         CompletableFuture<ResourceLock<T>> result = new CompletableFuture<>();
-        store.put(path, payload, Optional.of(-1L), EnumSet.of(CreateOption.Ephemeral))
-                .thenAccept(stat -> {
-                    ResourceLock<T> lock = new ResourceLockImpl<>(store, serde, path, value,
-                            stat.getVersion());
-                    synchronized (LockManagerImpl.this) {
-                        if (state == State.Ready) {
-                            log.info("Acquired resource lock on {}", path);
-                            locks.add(lock);
-                            lock.getLockExpiredFuture().thenRun(() -> {
-                                log.info("Released resource lock on {}", path);
-                                synchronized (LockManagerImpl.this) {
-                                    locks.remove(lock);
-                                }
-                            });
-                        } else {
-                            // LockManager was closed in between. Release the lock asynchronously
-                            lock.release();
+        lock.acquire().thenRun(() -> {
+            synchronized (LockManagerImpl.this) {
+                if (state == State.Ready) {
+                    locks.add(lock);
+                    lock.getLockExpiredFuture().thenRun(() -> {
+                        log.info("Released resource lock on {}", path);
+                        synchronized (LockManagerImpl.this) {
+                            locks.remove(lock);
                         }
-                    }
-                    result.complete(lock);
-                }).exceptionally(ex -> {
-                    if (ex.getCause() instanceof BadVersionException) {
-                        result.completeExceptionally(
-                                new LockBusyException("Resource at " + path + " is already locked"));
-                    } else {
-                        result.completeExceptionally(ex.getCause());
-                    }
-                    return null;
-                });
+                    });
+                } else {
+                    // LockManager was closed in between. Release the lock asynchronously
+                    lock.release();
+                }
+            }
+      result.complete(lock);
+        }).exceptionally(ex -> {
+            if (ex.getCause() instanceof BadVersionException) {
+                result.completeExceptionally(
+                        new LockBusyException("Resource at " + path + " is already locked"));
+            } else {
+                result.completeExceptionally(ex.getCause());
+            }
+            return null;
+        });
 
         return result;
+    }
+
+    private void handleSessionEvent(SessionEvent se) {
+        if (se == SessionEvent.SessionReestablished) {
+            log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
+            locks.forEach(ResourceLockImpl::revalidate);
+        }
+    }
+
+    private void handleDataNotification(Notification n) {
+        if (n.getType() == NotificationType.Deleted) {
+            locks.stream()
+                    .filter(l -> l.getPath().equals(n.getPath()))
+                    .forEach(l -> l.lockWasInvalidated());
+        }
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -18,17 +18,25 @@
  */
 package org.apache.pulsar.metadata.coordination.impl;
 
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
 
+@Slf4j
 public class ResourceLockImpl<T> implements ResourceLock<T> {
 
-    private final MetadataStore store;
+    private final MetadataStoreExtended store;
     private final MetadataSerde<T> serde;
     private final String path;
 
@@ -36,20 +44,23 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     private long version;
     private final CompletableFuture<Void> expiredFuture;
 
-    private static enum State {
-        Valid, Released
+    private enum State {
+        Init,
+        Valid,
+        Releasing,
+        Released,
     }
 
     private State state;
 
-    public ResourceLockImpl(MetadataStore store, MetadataSerde<T> serde, String path, T value, long version) {
+    public ResourceLockImpl(MetadataStoreExtended store, MetadataSerde<T> serde, String path, T value) {
         this.store = store;
         this.serde = serde;
         this.path = path;
         this.value = value;
-        this.version = version;
+        this.version = -1;
         this.expiredFuture = new CompletableFuture<>();
-        this.state = State.Valid;
+        this.state = State.Init;
     }
 
     @Override
@@ -81,13 +92,31 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
             return CompletableFuture.completedFuture(null);
         }
 
-        return store.delete(path, Optional.of(version))
+        state = State.Releasing;
+        CompletableFuture<Void> result = new CompletableFuture<>();
+
+        store.delete(path, Optional.of(version))
                 .thenRun(() -> {
                     synchronized (ResourceLockImpl.this) {
                         state = State.Released;
                     }
                     expiredFuture.complete(null);
+                    result.complete(null);
+                }).exceptionally(ex -> {
+                    if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
+                        // The lock is not there on release. We can anyway proceed
+                        synchronized (ResourceLockImpl.this) {
+                            state = State.Released;
+                        }
+                        expiredFuture.complete(null);
+                        result.complete(null);
+                    } else {
+                        result.completeExceptionally(ex);
+                    }
+                    return null;
                 });
+
+        return result;
     }
 
     @Override
@@ -103,5 +132,134 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     @Override
     public int hashCode() {
         return path.hashCode();
+    }
+
+    synchronized CompletableFuture<Void> acquire() {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        acquireWithNoRevalidation()
+                .thenRun(() -> result.complete(null))
+                .exceptionally(ex -> {
+                    if (ex.getCause() instanceof LockBusyException) {
+                        revalidate()
+                                .thenAccept(__ -> result.complete(null))
+                                .exceptionally(ex1 -> {
+                                   result.completeExceptionally(ex1);
+                                   return null;
+                                });
+                    } else {
+                        result.completeExceptionally(ex.getCause());
+                    }
+                    return null;
+                });
+
+        return result;
+    }
+
+    // Simple operation of acquiring the lock with no retries, or checking for the lock content
+    private CompletableFuture<Void> acquireWithNoRevalidation() {
+        byte[] payload;
+        try {
+            payload = serde.serialize(value);
+        } catch (Throwable t) {
+            return FutureUtils.exception(t);
+        }
+
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        store.put(path, payload, Optional.of(-1L), EnumSet.of(CreateOption.Ephemeral))
+                .thenAccept(stat -> {
+                    synchronized (ResourceLockImpl.this) {
+                        state = State.Valid;
+                        version = stat.getVersion();
+                    }
+                    log.info("Acquired resource lock on {}", path);
+                    result.complete(null);
+                }).exceptionally(ex -> {
+            if (ex.getCause() instanceof BadVersionException) {
+                result.completeExceptionally(
+                        new LockBusyException("Resource at " + path + " is already locked"));
+            } else {
+                result.completeExceptionally(ex.getCause());
+            }
+            return null;
+        });
+
+        return result;
+    }
+
+    synchronized  void lockWasInvalidated() {
+        if (state != State.Valid) {
+            // Ignore notifications while we're releasing the lock ourselves
+            return;
+        }
+
+        log.info("Lock on resource {} was invalidated", path);
+        revalidate()
+                .thenRun(() -> log.info("Successfully revalidated the lock on {}", path))
+                .exceptionally(ex -> {
+                    synchronized (ResourceLockImpl.this) {
+                        log.warn("Failed to revalidate the lock at {}. Marked as expired", path);
+                        state = State.Released;
+                        expiredFuture.complete(null);
+                    }
+                    return null;
+                });
+    }
+
+    synchronized CompletableFuture<Void> revalidate() {
+        return store.get(path)
+                .thenCompose(optGetResult -> {
+                    if (!optGetResult.isPresent()) {
+                        // The lock just disappeared, try to acquire it again
+                        return acquireWithNoRevalidation()
+                                .thenRun(() -> log.info("Successfully re-acquired missing lock at {}", path));
+                    }
+
+                    GetResult res = optGetResult.get();
+                    if (!res.getStat().isEphemeral()) {
+                        return FutureUtils.exception(
+                                new LockBusyException(
+                                        "Path " + path + " is already created as non-ephemeral"));
+                    }
+
+                    T existingValue;
+                    try {
+                        existingValue = serde.deserialize(optGetResult.get().getValue());
+                    } catch (Throwable t) {
+                        return FutureUtils.exception(t);
+                    }
+
+                    synchronized (ResourceLockImpl.this) {
+                        if (value.equals(existingValue)) {
+                            // The lock value is still the same, that means that we're the
+                            // logical "owners" of the lock.
+
+                            if (res.getStat().isCreatedBySelf()) {
+                                // If the new lock belongs to the same session, there's no
+                                // need to recreate it.
+                                version = res.getStat().getVersion();
+                            } else {
+                                // The lock needs to get recreated since it belong to an earlier
+                                // session which maybe expiring soon
+                                log.info("Deleting stale lock at {}", path);
+                                return store.delete(path, Optional.of(res.getStat().getVersion()))
+                                        .thenCompose(__ -> acquireWithNoRevalidation())
+                                        .thenRun(() -> log.info("Successfully re-acquired stale lock at {}", path));
+                            }
+                        }
+
+                        // At this point we have an existing lock with a value different to what we
+                        // expect. If our session is the owner, we can recreate, otherwise the
+                        // lock has been acquired by someone else and we give up.
+
+                        if (!res.getStat().isCreatedBySelf()) {
+                            return FutureUtils.exception(
+                                    new LockBusyException("Resource at " + path + " is already locked"));
+                        }
+
+                        return store.delete(path, Optional.of(res.getStat().getVersion()))
+                                .thenCompose(__ -> acquireWithNoRevalidation())
+                                .thenRun(() -> log.info("Successfully re-acquired lock at {}", path));
+                    }
+                });
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -117,6 +117,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
 
     @Override
     public synchronized void process(WatchedEvent event) {
+        log.info("Got ZK session watch event: {}", event);
         checkState(event.getState());
     }
 
@@ -156,7 +157,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
         default:
             if (currentStatus != SessionEvent.SessionReestablished) {
                 // since it reconnected to zoo keeper, we reset the disconnected time
-                log.info("ZooKeeper client reconnection with server quorum");
+                log.info("ZooKeeper client reconnection with server quorum. Current status: {}", currentStatus);
                 disconnectedAt = 0;
 
                 sessionListener.accept(SessionEvent.Reconnected);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -33,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.SessionTracker;
+import org.apache.zookeeper.server.SessionTrackerImpl;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.assertj.core.util.Files;
 
@@ -79,6 +81,24 @@ public class TestZKServer implements AutoCloseable {
         log.info("Stopped test ZK server");
     }
 
+    public void expireSession(long sessionId) {
+        zks.expire(new SessionTracker.Session() {
+            @Override
+            public long getSessionId() {
+                return sessionId;
+            }
+
+            @Override
+            public int getTimeout() {
+                return 10_000;
+            }
+
+            @Override
+            public boolean isClosing() {
+                return false;
+            }
+        });
+    }
 
     @Override
     public void close() throws Exception {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -19,7 +19,9 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -28,8 +30,13 @@ import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
+import org.apache.pulsar.metadata.api.coordination.LockManager;
+import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
+import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.testng.annotations.Test;
 
 public class ZKSessionTest extends BaseMetadataStoreTest {
@@ -85,5 +92,45 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
 
         e = sessionEvents.poll(1, TimeUnit.SECONDS);
         assertNull(e);
+    }
+
+    @Test
+    public void testReacquireLocksAfterSessionLost() throws Exception {
+        @Cleanup
+        MetadataStoreExtended store = MetadataStoreExtended.create(zks.getConnectionString(),
+                MetadataStoreConfig.builder()
+                        .sessionTimeoutMillis(2_000)
+                        .build());
+
+        BlockingQueue<SessionEvent> sessionEvents = new LinkedBlockingQueue<>();
+        store.registerSessionListener(sessionEvents::add);
+
+        @Cleanup
+        CoordinationService coordinationService = new CoordinationServiceImpl(store);
+        @Cleanup
+        LockManager<String> lm1 = coordinationService.getLockManager(String.class);
+
+        String path = newKey();
+
+        ResourceLock<String> lock = lm1.acquireLock(path, "value-1").join();
+
+        zks.expireSession(((ZKMetadataStore) store).getZkSessionId());
+
+        SessionEvent e = sessionEvents.poll(5, TimeUnit.SECONDS);
+        assertEquals(e, SessionEvent.ConnectionLost);
+
+        e = sessionEvents.poll(10, TimeUnit.SECONDS);
+        assertEquals(e, SessionEvent.SessionLost);
+
+        e = sessionEvents.poll(10, TimeUnit.SECONDS);
+        assertEquals(e, SessionEvent.Reconnected);
+        e = sessionEvents.poll(10, TimeUnit.SECONDS);
+        assertEquals(e, SessionEvent.SessionReestablished);
+
+        Thread.sleep(2_000);
+
+        assertFalse(lock.getLockExpiredFuture().isDone());
+
+        assertTrue(store.get(path).join().isPresent());
     }
 }


### PR DESCRIPTION
### Motivation

This change is to enhance the `ResourceLock` to automatically revalidate the lock with the metadata store once a session is lost and then re-established. 
There are multiple state in which a lock can be left after the session is recovered, with either stale value that is going to get cleaned up or some other instance took over the lock.

This single implementation will be then used in all the places where we're taking ownerships in the code-base.

