### PR TITLE
In test logs, logger name is being printed twice

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36} - %msg%n" />
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level [%t{12}] %c{1.}@%L - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
### Motivation

In the test logs, we are printing the class name and the logger name (which are the same string). This makes up for a very long line and makes it more difficult to go through logs.