### PR TITLE
Refactored logic to allow Sink errors to be reported

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -351,10 +351,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     @SuppressWarnings("unchecked")
 	private void sendOutputMessage(Record srcRecord, Object output) throws Exception {
     	
-    	if (output == null) {
-    		return; // No point in sending null messages.
-    	}
-    	
         if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK) {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
         }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -21,10 +21,9 @@ package org.apache.pulsar.functions.instance;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -37,6 +36,13 @@ import org.testng.annotations.Test;
 
 @Slf4j
 public class JavaInstanceTest {
+	
+	@SuppressWarnings("serial")
+	private static class UserException extends Exception {
+    	public UserException(String msg) {
+    		super(msg);
+    	}
+    }
 
     /**
      * Verify that be able to run lambda functions.
@@ -53,6 +59,52 @@ public class JavaInstanceTest {
         assertNotNull(result.get().getResult());
         assertEquals(new String(testString + "-lambda"), result.get().getResult());
         instance.close();
+    }
+
+    @Test
+    public void testNullReturningFunction() throws Exception  {
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                (Function<String, String>) (input, context) -> null,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.get().getResult());
+    	instance.close();
+    }
+
+    @Test
+    public void testUserExceptionThrowingFunction() throws Exception  {
+    	Function<String, String> func = (input, context) -> {
+    		throw new UserException("Boom");
+    	};
+
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                func,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.get().getResult());
+    	assertNotNull(result.get().getUserException());
+    	instance.close();
+    }
+
+    @Test
+    public void testSystemExceptionThrowingFunction() throws Exception  {
+    	Function<String, String> func = (input, context) -> {
+    		throw new InterruptedException("Boom");
+    	};
+
+    	JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                func,
+                new InstanceConfig());
+    	String testString = "ABC123";
+    	CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+    	assertNull(result.get().getResult());
+    	assertNotNull(result.get().getUserException());
+    	instance.close();
     }
 
     @Test
@@ -84,6 +136,92 @@ public class JavaInstanceTest {
         CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
         assertNotNull(result.get().getResult());
         assertEquals(new String(testString + "-lambda"), result.get().getResult());
+        instance.close();
+    }
+    
+    @Test
+    public void testNullReturningAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+                try {
+                    Thread.sleep(500);
+                    result.complete(null);
+                } catch (Exception e) {
+                    result.completeExceptionally(e);
+                }
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+        assertNull(result.get().getResult());
+        instance.close();
+    }
+
+    @Test
+    public void testSystemExceptionThrowingAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+            	result.completeExceptionally(new InterruptedException(""));
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+        assertNull(result.get().getResult());
+        // TODO Change this
+        assertNotNull(result.get().getUserException());
+        instance.close();
+    }
+
+    @Test
+    public void testUserExceptionThrowingAsyncFunction() throws Exception {
+        InstanceConfig instanceConfig = new InstanceConfig();
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        Function<String, CompletableFuture<String>> function = (input, context) -> {
+            log.info("input string: {}", input);
+            CompletableFuture<String> result  = new CompletableFuture<>();
+            executor.submit(() -> {
+            	result.completeExceptionally(new UserException("Boom"));
+            });
+
+            return result;
+        };
+
+        JavaInstance instance = new JavaInstance(
+                mock(ContextImpl.class),
+                function,
+                instanceConfig);
+        String testString = "ABC123";
+        CompletableFuture<JavaExecutionResult> result = instance.handleMessage(mock(Record.class), testString);
+        assertNull(result.get().getResult());
+        assertNotNull(result.get().getUserException());
         instance.close();
     }
 


### PR DESCRIPTION

Fixes #10269 

### Motivation
When an exception is thrown inside the `sendOutputMessage` method of the `JavaInstanceRunnable` class, since it is inside a CompletableFuture, it gets "swallowed up" and not properly reported. This can result in a scenario in which the Pulsar Function is continuing to run and process messages, but no output is getting generated.

### Modifications

Move the call to `sendOutputMessage` method outside of the CompletableFuture stages, and into the normal execution flow, which allows us to catch any exceptions thrown by that method.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? This is a bug fix
