### PR TITLE
[Issue 10242] add authentication data for remote cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1026,7 +1026,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                         .enableTcpNoDelay(false)
                         .connectionsPerBroker(pulsar.getConfiguration().getReplicationConnectionsPerBroker())
                         .statsInterval(0, TimeUnit.SECONDS);
-                if (pulsar.getConfiguration().isAuthenticationEnabled()) {
+                if (data.getAuthenticationPlugin() != null && data.getAuthenticationParameters() != null) {
+                    clientBuilder.authentication(data.getAuthenticationPlugin(), data.getAuthenticationParameters());
+                } else if (pulsar.getConfiguration().isAuthenticationEnabled()) {
                     clientBuilder.authentication(pulsar.getConfiguration().getBrokerClientAuthenticationPlugin(),
                             pulsar.getConfiguration().getBrokerClientAuthenticationParameters());
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -394,6 +394,18 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
+
+        // Check authentication
+        try {
+            clusters.createCluster("auth", new ClusterData("http://dummy.web.example.com", "",
+                    "http://dummy.messaging.example.com", "",
+                    "authenticationPlugin", "authenticationParameters"));
+            ClusterData cluster = clusters.getCluster("auth");
+            assertEquals("authenticationPlugin", cluster.getAuthenticationPlugin());
+            assertEquals("authenticationParameters", cluster.getAuthenticationParameters());
+        } catch (RestException e) {
+            assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
+        }
     }
 
     Object asynRequests(Consumer<TestAsyncResponse> function) throws Exception {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -74,6 +74,12 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--proxy-url", description = "Proxy-service url when client would like to connect to broker via proxy.", required = false)
         private String proxyServiceUrl;
 
+        @Parameter(names = "--auth-plugin", description = "authentication plugin", required = false)
+        private String authenticationPlugin;
+
+        @Parameter(names = "--auth-parameters", description = "authentication parameters", required = false)
+        private String authenticationParameters;
+
         @Parameter(names = "--proxy-protocol", description = "protocol to decide type of proxy routing eg: SNI", required = false)
         private ProxyProtocol proxyProtocol;
 
@@ -81,7 +87,7 @@ public class CmdClusters extends CmdBase {
             String cluster = getOneArgument(params);
             getAdmin().clusters().createCluster(cluster,
                     new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls, proxyServiceUrl,
-                            proxyProtocol));
+                            authenticationPlugin, authenticationParameters, proxyProtocol));
         }
     }
 
@@ -105,13 +111,19 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--proxy-url", description = "Proxy-service url when client would like to connect to broker via proxy.", required = false)
         private String proxyServiceUrl;
 
+        @Parameter(names = "--auth-plugin", description = "authentication plugin", required = false)
+        private String authenticationPlugin;
+
+        @Parameter(names = "--auth-parameters", description = "authentication parameters", required = false)
+        private String authenticationParameters;
+
         @Parameter(names = "--proxy-protocol", description = "protocol to decide type of proxy routing eg: SNI", required = false)
         private ProxyProtocol proxyProtocol;
 
         void run() throws PulsarAdminException {
             String cluster = getOneArgument(params);
             getAdmin().clusters().updateCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl,
-                    brokerServiceUrlTls, proxyServiceUrl, proxyProtocol));
+                    brokerServiceUrlTls, proxyServiceUrl, authenticationPlugin, authenticationParameters, proxyProtocol));
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -66,6 +66,17 @@ public class ClusterData {
     )
     private String proxyServiceUrl;
     @ApiModelProperty(
+            name = "authenticationPlugin",
+            value = "Authentication plugin when client would like to connect to cluster.",
+            example = "org.apache.pulsar.client.impl.auth.AuthenticationToken"
+    )
+    private String authenticationPlugin;
+    @ApiModelProperty(
+            name = "authenticationParameters",
+            value = "Authentication parameters when client would like to connect to cluster."
+    )
+    private String authenticationParameters;
+    @ApiModelProperty(
         name = "proxyProtocol",
         value = "protocol to decide type of proxy routing eg: SNI-routing",
         example = "SNI"
@@ -100,14 +111,28 @@ public class ClusterData {
     }
 
     public ClusterData(String serviceUrl, String serviceUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
-            String proxyServiceUrl, ProxyProtocol proxyProtocol) {
+                       String authenticationPlugin, String authenticationParameters) {
         this.serviceUrl = serviceUrl;
         this.serviceUrlTls = serviceUrlTls;
         this.brokerServiceUrl = brokerServiceUrl;
         this.brokerServiceUrlTls = brokerServiceUrlTls;
+        this.authenticationPlugin = authenticationPlugin;
+        this.authenticationParameters = authenticationParameters;
+    }
+
+    public ClusterData(String serviceUrl, String serviceUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
+                       String proxyServiceUrl, String authenticationPlugin, String authenticationParameters,
+                       ProxyProtocol proxyProtocol) {
+        this.serviceUrl = serviceUrl;
+        this.serviceUrlTls = serviceUrlTls;
+        this.brokerServiceUrl = brokerServiceUrl;
+        this.brokerServiceUrlTls = brokerServiceUrlTls;
+        this.authenticationPlugin = authenticationPlugin;
+        this.authenticationParameters = authenticationParameters;
         this.proxyServiceUrl = proxyServiceUrl;
         this.proxyProtocol = proxyProtocol;
     }
+
 
     public void update(ClusterData other) {
         checkNotNull(other);
@@ -117,6 +142,8 @@ public class ClusterData {
         this.brokerServiceUrlTls = other.brokerServiceUrlTls;
         this.proxyServiceUrl = other.proxyServiceUrl;
         this.proxyProtocol = other.proxyProtocol;
+        this.authenticationPlugin = other.authenticationPlugin;
+        this.authenticationParameters = other.authenticationParameters;
     }
 
     public String getServiceUrl() {
@@ -171,6 +198,22 @@ public class ClusterData {
         return peerClusterNames;
     }
 
+    public String getAuthenticationPlugin() {
+        return authenticationPlugin;
+    }
+
+    public void setAuthenticationPlugin(String authenticationPlugin) {
+        this.authenticationPlugin = authenticationPlugin;
+    }
+
+    public String getAuthenticationParameters() {
+        return authenticationParameters;
+    }
+
+    public void setAuthenticationParameters(String authenticationParameters) {
+        this.authenticationParameters = authenticationParameters;
+    }
+
     public void setPeerClusterNames(LinkedHashSet<String> peerClusterNames) {
         this.peerClusterNames = peerClusterNames;
     }
@@ -183,7 +226,10 @@ public class ClusterData {
                     && Objects.equals(brokerServiceUrl, other.brokerServiceUrl)
                     && Objects.equals(brokerServiceUrlTls, other.brokerServiceUrlTls)
                     && Objects.equals(proxyServiceUrl, other.proxyServiceUrl)
-                    && Objects.equals(proxyProtocol, other.proxyProtocol);
+                    && Objects.equals(proxyProtocol, other.proxyProtocol)
+                    && Objects.equals(authenticationPlugin, other.authenticationPlugin)
+                    && Objects.equals(authenticationParameters, other.authenticationParameters);
+
         }
 
         return false;
@@ -203,7 +249,8 @@ public class ClusterData {
                 .add("brokerServiceUrlTls", brokerServiceUrlTls)
                 .add("proxyServiceUrl", proxyServiceUrl)
                 .add("proxyProtocol", proxyProtocol)
-                .add("peerClusterNames", peerClusterNames).toString();
+                .add("peerClusterNames", peerClusterNames).add("authenticationPlugin", authenticationPlugin)
+                .add("authenticationParameters", authenticationParameters).toString();
     }
 
 }


### PR DESCRIPTION
### Motivation
Fixes #10242

### Modifications
Add authentication plugin and parameters for each cluster to ClusterData.
When creating replicator producer for remote cluster, use the authentication data if exists.
Add admin cli command to set authentication data for cluster.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (**yes**)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (**yes**)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
