### PR TITLE
Fix C++ client cannot be built on Windows

### DIFF
--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -53,9 +53,6 @@ endif(MSVC)
 
 
 set(LIB_NAME_SHARED ${LIB_NAME})
-if (WIN32)
-    string(APPEND LIB_NAME_SHARED dll)
-endif()
 
 # this is the "object library" target: compiles the sources only once
 add_library(PULSAR_OBJECT_LIB OBJECT ${PULSAR_SOURCES})

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -31,9 +31,9 @@ typedef std::weak_ptr<ReaderImpl> ReaderImplWeakPtr;
 
 namespace test {
 
-extern std::mutex readerConfigTestMutex PULSAR_PUBLIC;
-extern std::atomic_bool readerConfigTestEnabled PULSAR_PUBLIC;
-extern ConsumerConfiguration consumerConfigOfReader PULSAR_PUBLIC;
+extern PULSAR_PUBLIC std::mutex readerConfigTestMutex;
+extern PULSAR_PUBLIC std::atomic_bool readerConfigTestEnabled;
+extern PULSAR_PUBLIC ConsumerConfiguration consumerConfigOfReader;
 
 }  // namespace test
 


### PR DESCRIPTION
### Motivation

C++ source code cannot be built on Windows. The build commands are:

```powershell
> cmake -B _builds -S . `
  -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF
> cmake --build .\_builds\
```

There're two errors. One is

> pulsar-client-cpp\lib\ReaderImpl.h(34): error C2144: syntax error: 'int' should be preceded by ';'
> ...

It's because `PULSAR_PUBLIC` is `__declspec(dllexport)` on Windows platform and it should be put before the variable type.

The other error is

> LINK : fatal error LNK1104: cannot open file 'pulsar.lib' pulsar\pulsar-client-cpp\_builds
\examples\SampleReaderCApi.vcxproj]
> ...

It looks like when files under `examples` and `perf` directories were compiled, it tried to link `pulsar.lib` and CMake target `pulsarShared`'s name has a `dll` suffix, like `pulsardll.lib` and `pulsardll.dll`. The suffix is redundant.

### Modifications

- Put `PULSAR_PUBLIC` before the variable type.
- Keep the `LIB_NAME` as the shared library's name, i.e. remove the `dll` suffix.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.