### PR TITLE
[Transaction] Fix transaction timeout tracker expired problem.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -70,10 +70,13 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
                 currentTimeout = timer.newTimeout(this, timeout, TimeUnit.MILLISECONDS);
                 nowTaskTimeoutTime = transactionTimeoutTime;
             } else if (nowTaskTimeoutTime > transactionTimeoutTime) {
-                if (currentTimeout.cancel()) {
+                if (currentTimeout.cancel() || currentTimeout.isExpired()) {
                     currentTimeout = timer.newTimeout(this, timeout, TimeUnit.MILLISECONDS);
                     nowTaskTimeoutTime = transactionTimeoutTime;
                 }
+            } else if (currentTimeout.isExpired()) {
+                currentTimeout = timer.newTimeout(this, timeout, TimeUnit.MILLISECONDS);
+                nowTaskTimeoutTime = transactionTimeoutTime;
             }
         }
         return CompletableFuture.completedFuture(false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -182,6 +182,36 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     }
 
     @Test
+    public void testTimeoutTrackerExpired() throws Exception {
+        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
+                .until(() -> pulsar.getTransactionMetadataStoreService()
+                        .getStores().get(TransactionCoordinatorID.get(0)) != null);
+        MLTransactionMetadataStore transactionMetadataStore =
+                (MLTransactionMetadataStore) pulsar.getTransactionMetadataStoreService()
+                        .getStores().get(TransactionCoordinatorID.get(0));
+        checkTransactionMetadataStoreReady(transactionMetadataStore);
+        Field field = MLTransactionMetadataStore.class.getDeclaredField("txnMetaMap");
+        field.setAccessible(true);
+        ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>> txnMap =
+                (ConcurrentMap<TxnID, Pair<TxnMeta, List<Position>>>) field.get(transactionMetadataStore);
+
+        transactionMetadataStore.newTransaction(2000).get();
+
+        txnMap.forEach((txnID, txnMetaListPair) ->
+                Assert.assertEquals(txnMetaListPair.getLeft().status(), TxnStatus.OPEN));
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(3000, TimeUnit.MILLISECONDS)
+                .until(() -> txnMap.size() == 0);
+
+        transactionMetadataStore.newTransaction(2000).get();
+
+        txnMap.forEach((txnID, txnMetaListPair) ->
+                Assert.assertEquals(txnMetaListPair.getLeft().status(), TxnStatus.OPEN));
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(3000, TimeUnit.MILLISECONDS)
+                .until(() -> txnMap.size() == 0);
+    }
+
+    @Test
     public void testTimeoutTrackerMultiThreading() throws Exception {
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
         Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -184,8 +184,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void testTimeoutTrackerExpired() throws Exception {
         pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS)
-                .until(() -> pulsar.getTransactionMetadataStoreService()
+        Awaitility.await().until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
                 (MLTransactionMetadataStore) pulsar.getTransactionMetadataStoreService()
@@ -198,17 +197,18 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
         transactionMetadataStore.newTransaction(2000).get();
 
+        assertEquals(txnMap.size(), 1);
+
         txnMap.forEach((txnID, txnMetaListPair) ->
                 Assert.assertEquals(txnMetaListPair.getLeft().status(), TxnStatus.OPEN));
-        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(3000, TimeUnit.MILLISECONDS)
-                .until(() -> txnMap.size() == 0);
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).until(() -> txnMap.size() == 0);
 
         transactionMetadataStore.newTransaction(2000).get();
+        assertEquals(txnMap.size(), 1);
 
         txnMap.forEach((txnID, txnMetaListPair) ->
                 Assert.assertEquals(txnMetaListPair.getLeft().status(), TxnStatus.OPEN));
-        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).atMost(3000, TimeUnit.MILLISECONDS)
-                .until(() -> txnMap.size() == 0);
+        Awaitility.await().atLeast(1000, TimeUnit.MICROSECONDS).until(() -> txnMap.size() == 0);
     }
 
     @Test


### PR DESCRIPTION
## Motivation
now transaction timeout tracker in expired state, it will not cancel successfully. so should add the timeout expired check

## implement
add the timeout expired check
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

