### PR TITLE
Don't return non-persistent topic when list tables by Pulsar SQL

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -162,7 +162,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         }
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 60000)
     public void testDurableSubscribe() throws Exception {
 
         Properties properties = new Properties();

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -176,7 +177,8 @@ public class PulsarMetadata implements ConnectorMetadata {
                 List<String> pulsarTopicList = null;
                 try {
                     pulsarTopicList = this.pulsarAdmin.topics()
-                        .getList(restoreNamespaceDelimiterIfNeeded(schemaNameOrNull, pulsarConnectorConfig));
+                        .getList(restoreNamespaceDelimiterIfNeeded(schemaNameOrNull, pulsarConnectorConfig),
+                                TopicDomain.persistent);
                 } catch (PulsarAdminException e) {
                     if (e.getStatusCode() == 404) {
                         log.warn("Schema " + schemaNameOrNull + " does not exsit");
@@ -378,7 +380,7 @@ public class PulsarMetadata implements ConnectorMetadata {
 
         Set<String> topicsSetWithoutPartition;
         try {
-            List<String> allTopics = this.pulsarAdmin.topics().getList(namespace);
+            List<String> allTopics = this.pulsarAdmin.topics().getList(namespace, TopicDomain.persistent);
             topicsSetWithoutPartition = allTopics.stream()
                     .map(t -> t.split(TopicName.PARTITIONED_TOPIC_SUFFIX)[0])
                     .collect(Collectors.toSet());

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -462,7 +462,7 @@ public abstract class TestPulsarConnector {
         });
 
         Topics topics = mock(Topics.class);
-        when(topics.getList(anyString())).thenAnswer(new Answer<List<String>>() {
+        when(topics.getList(anyString(), any())).thenAnswer(new Answer<List<String>>() {
             @Override
             public List<String> answer(InvocationOnMock invocationOnMock) throws Throwable {
                 Object[] args = invocationOnMock.getArguments();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.presto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
@@ -37,6 +38,7 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.tests.integration.docker.ContainerExecException;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -145,6 +147,19 @@ public class TestBasicPresto extends TestPulsarSQLBase {
             assertTrue(e.getResult().getStderr().contains(topic2));
             assertTrue(e.getResult().getStderr().contains("matched the table name public/default/" + tableName));
         }
+    }
+
+    @Test
+    public void testListTopicShouldNotShowNonPersistentTopics() throws Exception {
+        String tableName = "non_persistent" + randomName(5);
+
+        String topic1 = "public/default/" + tableName.toUpperCase();
+        TopicName topicName1 = TopicName.get(topic1);
+        prepareData(topicName1, false, false, JSONSchema.of(Stock.class));
+
+        String query = "show tables from pulsar.\"public/default\"";
+        ContainerExecResult result = execQuery(query);
+        assertFalse(result.getStdout().contains("non_persistent"));
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestBasicPresto.java
@@ -153,7 +153,7 @@ public class TestBasicPresto extends TestPulsarSQLBase {
     public void testListTopicShouldNotShowNonPersistentTopics() throws Exception {
         String tableName = "non_persistent" + randomName(5);
 
-        String topic1 = "public/default/" + tableName.toUpperCase();
+        String topic1 = "non-persistent://public/default/" + tableName.toUpperCase();
         TopicName topicName1 = TopicName.get(topic1);
         prepareData(topicName1, false, false, JSONSchema.of(Stock.class));
 


### PR DESCRIPTION
### Motivation

Don't return non-persistent topic when list tables by Pulsar SQL

### Verifying this change

New integration test added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
