### PR TITLE
[Documentation] Document the configuration of Project JDK and Maven JDK in IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,35 +146,35 @@ required plugins.
     
     From the JDK version drop-down list, select **Download JDK...** or choose an existing recent Java 8 (1.8) JDK version.
 
-3. In the download dialog, select version `1.8`. You can pick a version from many vendors. Unless you have a specific preference, choose `AdoptOpenJDK (Hotspot)`.
+3. In the download dialog, select version **1.8**. You can pick a version from many vendors. Unless you have a specific preference, choose **AdoptOpenJDK (Hotspot)**.
  
 
 #### Configure Java version for Maven in IntelliJ
 
 1. Open Maven Importing Settings dialog by going to 
-   `Settings -> Build, Execution, Deployment -> Build Tools -> Maven -> Importing`.
+   **Settings** -> **Build, Execution, Deployment** -> **Build Tools** -> **Maven** -> **Importing**.
 
-2. Choose "Use Project JDK" for "JDK for Importer" setting. This uses the Java 8 (1.8) JDK for running Maven 
+2. Choose **Use Project JDK** for **JDK for Importer** setting. This uses the Java 8 (1.8) JDK for running Maven 
    when importing the project to IntelliJ. Some of the configuration in the Maven build is conditional based on 
    the JDK version. Incorrect configuration gets chosen when the "JDK for Importer" isn't the same as the "Project JDK".
 
-3. Validate that the JRE setting in "Maven -> Runner" dialog is set to "Use Project JDK".
+3. Validate that the JRE setting in **Maven** -> **Runner** dialog is set to **Use Project JDK**.
 
 #### Configure annotation processing in IntelliJ
 
 1. Open Annotation Processors Settings dialog box by going to
-   `Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors`.
+   **Settings** -> **Build, Execution, Deployment** -> **Compiler** -> **Annotation Processors**.
 
 2. Select the following buttons:
-   1. "Enable annotation processing"
-   2. "Obtain processors from project classpath"
-   3. "Store generated sources relative to: Module content root"
+   1. **Enable annotation processing**
+   2. **Obtain processors from project classpath**
+   3. Store generated sources relative to: **Module content root**
 
 3. Set the generated source directories to be equal to the Maven directories:
    1. Set "Production sources directory:" to "target/generated-sources/annotations".
    2. Set "Test sources directory:" to "target/generated-test-sources/test-annotations".
 
-4. Click "OK".
+4. Click **OK**.
 
 5. Install the lombok plugin in intellij.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ required plugins.
 
     Click **File** -> **Project Structure** -> **Project Settings** -> **Project**.
    
-2. Click on the JDK version drop down and select `Download JDK...` or choose an existing recent Java 8 (1.8) JDK version.
+2. Select the JDK version.
+    
+    From the JDK version drop-down list, select **Download JDK...** or choose an existing recent Java 8 (1.8) JDK version.
 
 3. In the download dialog, select version `1.8`. You can pick from many vendors. Unless you have a specific preference, choose  `AdoptOpenJDK (Hotspot)`.
  

--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ required plugins.
 
 ### Intellij
 
+#### Configure Project JDK to Java 8 (1.8) JDK
+
+1. Open Project Settings dialog by going to  
+   `File -> Project Structure -> Project Settings -> Project`.
+   
+2. Click on the JDK version drop down and select `Download JDK...` or choose an existing recent Java 8 (1.8) JDK version.
+
+3. In the download dialog, select version `1.8` and vendor `AdoptOpenJDK (Hotspot)` for the JDK to download.
+ 
+
+#### Configure Java version for Maven in IntelliJ
+
+1. Open Maven Importing Settings dialog by going to 
+   `Settings -> Build, Execution, Deployment -> Build Tools -> Maven -> Importing`.
+
+2. Choose "Use Project JDK" for "JDK for Importer" setting. This uses the Java 8 (1.8) JDK for running Maven 
+   when importing the project to IntelliJ. Some of the configuration in the Maven build is conditional based on 
+   the JDK version. Incorrect configuration gets chosen when the "JDK for Importer" isn't the same as the "Project JDK".
+
+3. Validate that the JRE setting in "Maven -> Runner" dialog is set to "Use Project JDK".
+
 #### Configure annotation processing in IntelliJ
 
 1. Open Annotation Processors Settings dialog box by going to

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ required plugins.
 
 #### Configure Project JDK to Java 8 (1.8) JDK
 
-1. Open Project Settings dialog by going to  
-   `File -> Project Structure -> Project Settings -> Project`.
+1. Open **Project Settings**. 
+
+    Click **File** -> **Project Structure** -> **Project Settings** -> **Project**.
    
 2. Click on the JDK version drop down and select `Download JDK...` or choose an existing recent Java 8 (1.8) JDK version.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ required plugins.
    
 2. Click on the JDK version drop down and select `Download JDK...` or choose an existing recent Java 8 (1.8) JDK version.
 
-3. In the download dialog, select version `1.8` and vendor `AdoptOpenJDK (Hotspot)` for the JDK to download.
+3. In the download dialog, select version `1.8`. You can pick from many vendors. Unless you have a specific preference, choose  `AdoptOpenJDK (Hotspot)`.
  
 
 #### Configure Java version for Maven in IntelliJ

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ required plugins.
     
     From the JDK version drop-down list, select **Download JDK...** or choose an existing recent Java 8 (1.8) JDK version.
 
-3. In the download dialog, select version `1.8`. You can pick from many vendors. Unless you have a specific preference, choose  `AdoptOpenJDK (Hotspot)`.
+3. In the download dialog, select version `1.8`. You can pick a version from many vendors. Unless you have a specific preference, choose `AdoptOpenJDK (Hotspot)`.
  
 
 #### Configure Java version for Maven in IntelliJ

--- a/site2/website/contributing.md
+++ b/site2/website/contributing.md
@@ -120,7 +120,7 @@ You are now ready to start developing!
 
 #### IDE Setup
 
-Please find the [instructions for IDE Setup in the README.md](https://github.com/apache/pulsar/#setting-up-your-ide) file. 
+For how to set up IDE, see [here](https://github.com/apache/pulsar/blob/master/README.md#setting-up-your-ide). 
 
 
 ### Create a branch in your fork

--- a/site2/website/contributing.md
+++ b/site2/website/contributing.md
@@ -118,43 +118,10 @@ these two remotes for pushing changes).
 
 You are now ready to start developing!
 
-#### [Optional] IDE Setup
+#### IDE Setup
 
-Depending on your preferred development environment, you may need to prepare it to develop Pulsar code.
+Please find the [instructions for IDE Setup in the README.md](https://github.com/apache/pulsar/#setting-up-your-ide) file. 
 
-##### IntelliJ
-
-###### Enable Annotation Processing
-
-To configure annotation processing in IntelliJ:
-
-1. Open Annotation Processors Settings dialog box by going to Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors.
-1. Select the following buttons:
-    1. "Enable annotation processing"
-    1. "Obtain processors from project classpath"
-    1. "Store generated sources relative to: Module content root"
-1. Set the generated source directories to be equal to the Maven directories:
-    1. Set "Production sources directory:" to "target/generated-sources/annotations".
-    1. Set "Test sources directory:" to "target/generated-test-sources/test-annotations".
-1. Click "OK".
-
-##### Eclipse
-
-Use a recent Eclipse version that includes m2e. Start Eclipse with a fresh workspace in a
-separate directory from your checkout.
-
-###### Initial setup
-
-1. Import the Pulsar projects
-
-	File
-	-> Import...
-	-> Existing Maven Projects
-	-> Browse to the directory you cloned into and select "pulsar"
-	-> make sure all pulsar projects are selected
-	-> Finalize
-
-You now should have all the Pulsar projects imported into eclipse and should see no compile errors.
 
 ### Create a branch in your fork
 


### PR DESCRIPTION
### Motivation

Currently Java 8 is recommended for Pulsar development. The IntelliJ setup instructions don't currently include the configuration of the Project JDK. It would be helpful to document this.

Java 11 support for building Pulsar in currently being improved. The side effect of this is that some of the configuration is dynamically chosen based on the JDK version. If the JDK version used for importing in IntelliJ is Java 11, and development is done on Java 8, this will lead to inconsistencies and errors about invalid parameters `--add-opens java.base/jdk.internal.loader=ALL-UNNAMED` in tests since the parameters were chosen at import time when running on Java 11.

### Modifications

- update IntelliJ IDE setup instructions in README.md
- remove duplicated IDE setup instructions in `site2/website/contributing.md`