### PR TITLE
[Tests] Fix flakyness in TestDefaultMessageFormatter

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
@@ -101,10 +101,14 @@ public class DefaultMessageFormatter implements IMessageFormatter {
     }
 
     private String getIntValue(float size) {
-        if (size == 0) {
-            return String.valueOf(r.nextInt());
+        int i = 0;
+        if (size != 0) {
+            i = (int) _getFloatValue(size);
         }
-        return String.valueOf((int) _getFloatValue(size));
+        if (i == 0) {
+            i = r.nextInt() + 1;
+        }
+        return String.valueOf(i);
     }
     private String getLongValue(float size) {
         if (size == 0) {

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/TestDefaultMessageFormatter.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/TestDefaultMessageFormatter.java
@@ -66,7 +66,7 @@ public class TestDefaultMessageFormatter {
         Assert.assertTrue(l3 > 0);
         Assert.assertTrue(l3 <= 99999);
         Assert.assertTrue(i2 < 10);
-        Assert.assertTrue(0 < i2);
+        Assert.assertTrue(0 < i2, "i2 was " + i2);
         Assert.assertTrue(f2 < 100000);
         Assert.assertTrue( -100000 < f2);
 


### PR DESCRIPTION
Fixes #10378

### Motivation

The TestDefaultMessageFormatter test is flaky, see #10378 .

### Modifications

Since the test asserts that an int value must be greater than 0, make changes to the getIntValue method to fullfil this requirement.