### PR TITLE
[Broker] Preventing extra dispatch when entries will make permits negative

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -480,7 +480,8 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         long totalMessagesSent = 0;
         long totalBytesSent = 0;
 
-        while (entriesToDispatch > 0 && (totalAvailablePermits - entriesToDispatch) > 0 && isAtleastOneConsumerAvailable()) {
+        while (entriesToDispatch > 0 && (totalAvailablePermits - entriesToDispatch) > 0
+                && isAtleastOneConsumerAvailable()) {
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -480,7 +480,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         long totalMessagesSent = 0;
         long totalBytesSent = 0;
 
-        while (entriesToDispatch > 0 && totalAvailablePermits > 0 && isAtleastOneConsumerAvailable()) {
+        while (entriesToDispatch > 0 && (totalAvailablePermits - entriesToDispatch) > 0 && isAtleastOneConsumerAvailable()) {
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection


### PR DESCRIPTION
I noticed that the broker currently does not consider the number of entries when determining if it should dispatch messages to the consumer. Due to the missing check, the broker can send more messages than available permits. 
This PR prevents that from happening for persistent topics. 

Related to #6054 