### PR TITLE
[Bookie] Fallback to PULSAR_EXTRA_OPTS if BOOKIE_EXTRA_OPTS isn't defined

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -39,7 +39,7 @@ BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g
 BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"}}
 
 # Extra options to be passed to the jvm
-BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} ${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
+BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS:-"-Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS:-"-Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"}"} ${BOOKIE_MEM} ${BOOKIE_GC}"
 
 # Add extra paths to the bookkeeper classpath
 # BOOKIE_EXTRA_CLASSPATH=


### PR DESCRIPTION
### Motivation

- #9469 introduced a breaking change by changing the behavior . This change was part of 2.7.1 release.

### Modifications

- fallback to `PULSAR_EXTRA_OPTS` if `BOOKIE_EXTRA_OPTS` isn't defined

- don't pass `-Dio.netty.*` system properties if `PULSAR_EXTRA_OPTS` or
  `BOOKIE_EXTRA_OPTS` is set
  - this is to be consistent with `PULSAR_EXTRA_OPTS` behavior and
    to prevent duplicate properties
  - add `-Dio.netty.leakDetectionLevel=disabled` unless `BOOKIE_EXTRA_OPTS`
    is set since `PULSAR_EXTRA_OPTS` doesn't include that setting by default.
   (`simple` is the default if the property isn't set)

### Other context

- It is also necessary to cherry-pick #9621 to restore backwards compatibility in 2.7.x branch.