### PR TITLE
[Broker] Fix issue in reusing EntryBatchIndexesAcks instances

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
@@ -24,8 +24,8 @@ import java.util.BitSet;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class EntryBatchIndexesAcks {
-    int maxSize = 100;
-    Pair<Integer, long[]>[] indexesAcks = new Pair[maxSize];
+    private int maxSize = 100;
+    private Pair<Integer, long[]>[] indexesAcks = new Pair[maxSize];
 
     public void setIndexesAcks(int entryIdx, Pair<Integer, long[]> indexesAcks) {
         this.indexesAcks[entryIdx] = indexesAcks;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
@@ -24,8 +24,8 @@ import java.util.BitSet;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class EntryBatchIndexesAcks {
-    private int maxSize = 100;
-    private Pair<Integer, long[]>[] indexesAcks = new Pair[maxSize];
+    private int size = 100;
+    private Pair<Integer, long[]>[] indexesAcks = new Pair[size];
 
     public void setIndexesAcks(int entryIdx, Pair<Integer, long[]> indexesAcks) {
         this.indexesAcks[entryIdx] = indexesAcks;
@@ -38,7 +38,7 @@ public class EntryBatchIndexesAcks {
 
     public int getTotalAckedIndexCount() {
         int count = 0;
-        for (int i = 0; i < maxSize; i++) {
+        for (int i = 0; i < size; i++) {
             Pair<Integer, long[]> pair = indexesAcks[i];
             if (pair != null) {
                 count += pair.getLeft() - BitSet.valueOf(pair.getRight()).cardinality();
@@ -52,12 +52,11 @@ public class EntryBatchIndexesAcks {
     }
 
     private void ensureCapacityAndReset(int entriesListSize) {
-        if (indexesAcks.length < entriesListSize) {
-            maxSize = entriesListSize;
-            indexesAcks = new Pair[maxSize];
+        size = entriesListSize;
+        if (indexesAcks.length < size) {
+            indexesAcks = new Pair[size];
         } else {
-            maxSize = entriesListSize;
-            for (int i = 0; i < maxSize; i++) {
+            for (int i = 0; i < size; i++) {
                 indexesAcks[i] = null;
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcks.java
@@ -48,23 +48,22 @@ public class EntryBatchIndexesAcks {
     }
 
     public void recycle() {
+        for (int i = 0; i < size; i++) {
+            indexesAcks[i] = null;
+        }
         handle.recycle(this);
     }
 
-    private void ensureCapacityAndReset(int entriesListSize) {
+    private void ensureCapacityAndSetSize(int entriesListSize) {
         size = entriesListSize;
         if (indexesAcks.length < size) {
             indexesAcks = new Pair[size];
-        } else {
-            for (int i = 0; i < size; i++) {
-                indexesAcks[i] = null;
-            }
         }
     }
 
     public static EntryBatchIndexesAcks get(int entriesListSize) {
         EntryBatchIndexesAcks ebi = RECYCLER.get();
-        ebi.ensureCapacityAndReset(entriesListSize);
+        ebi.ensureCapacityAndSetSize(entriesListSize);
         return ebi;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.testng.annotations.Test;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
@@ -27,24 +27,27 @@ public class EntryBatchIndexesAcksTest {
 
     @Test
     void shouldResetStateBeforeReusing() {
+        // given
+        // a bitset with 95 bits set
         BitSetRecyclable bitSet = BitSetRecyclable.create();
         bitSet.set(0, 95);
         long[] nintyFiveBitsSet = bitSet.toLongArray();
-
+        // and a EntryBatchIndexesAcks for the size of 10
         EntryBatchIndexesAcks acks = EntryBatchIndexesAcks.get(10);
+
+        // when setting 2 indexes with 95/100 bits set in each (5 "acked" in each)
         acks.setIndexesAcks(8, Pair.of(100, nintyFiveBitsSet));
         acks.setIndexesAcks(9, Pair.of(100, nintyFiveBitsSet));
 
+        // then the totalAckedIndexCount should be 10
         assertEquals(acks.getTotalAckedIndexCount(), 10);
 
+        // when recycled and used again
         acks.recycle();
-
         acks = EntryBatchIndexesAcks.get(2);
-        // there should be no previous state
-        assertEquals(acks.getTotalAckedIndexCount(), 0);
 
-        acks.setIndexesAcks(0, Pair.of(100, nintyFiveBitsSet));
-        assertEquals(acks.getTotalAckedIndexCount(), 5);
+        // then there should be no previous state and totalAckedIndexCount should be 0
+        assertEquals(acks.getTotalAckedIndexCount(), 0);
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBatchIndexesAcksTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.*;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.util.collections.BitSetRecyclable;
+import org.testng.annotations.Test;
+
+public class EntryBatchIndexesAcksTest {
+
+    @Test
+    void shouldResetStateBeforeReusing() {
+        BitSetRecyclable bitSet = BitSetRecyclable.create();
+        bitSet.set(0, 95);
+        long[] nintyFiveBitsSet = bitSet.toLongArray();
+
+        EntryBatchIndexesAcks acks = EntryBatchIndexesAcks.get(10);
+        acks.setIndexesAcks(8, Pair.of(100, nintyFiveBitsSet));
+        acks.setIndexesAcks(9, Pair.of(100, nintyFiveBitsSet));
+
+        assertEquals(acks.getTotalAckedIndexCount(), 10);
+
+        acks.recycle();
+
+        acks = EntryBatchIndexesAcks.get(2);
+        // there should be no previous state
+        assertEquals(acks.getTotalAckedIndexCount(), 0);
+
+        acks.setIndexesAcks(0, Pair.of(100, nintyFiveBitsSet));
+        assertEquals(acks.getTotalAckedIndexCount(), 5);
+    }
+
+}


### PR DESCRIPTION
### Motivation

The broker has a bug in calculating permits. Issues such as #5311, #6054 and #6255 are a sign of this.

https://github.com/apache/pulsar/blob/c4f154e79c03cff9055aa4e2ede7748c5952f2bc/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L227-L228

https://github.com/apache/pulsar/blob/875262a0ae2fba82a6dd7d46dd2467d675b0d9c3/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L527-L528

https://github.com/apache/pulsar/blob/8535dee5ca4d56a5944c068f116d9a32bb6d85f6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java#L255-L256

As it can be seen from the code locations for calculating permits, it is important that `batchIndexesAcks.getTotalAckedIndexCount()` returns the correct value. 
When reviewing the code, it was noticed that `EntryBatchIndexesAcks` instances are reused. The problem is, that state isn't properly cleared before reusing. `getTotalAckedIndexCount()` will include state from the previous usage in the calculation. This causes the permit calculations to get corrupted. There are bugs such as #5311, #6054 and #6255 which might be caused by corrupted permit calculations.

The only location where the previous state of the `EntryBatchIndexesAcks` instance is cleared is this line of code:
https://github.com/apache/pulsar/blob/4709f3aeaed1bc6a68a9a683c95e0398c940cd54/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L137

This doesn't take the case into account where the previous batch was larger than the next one. This is a unit test case that reproduces the issue:
```
        // given
        // a bitset with 95 bits set
        BitSetRecyclable bitSet = BitSetRecyclable.create();
        bitSet.set(0, 95);
        long[] nintyFiveBitsSet = bitSet.toLongArray();
        // and a EntryBatchIndexesAcks for the size of 10
        EntryBatchIndexesAcks acks = EntryBatchIndexesAcks.get(10);

        // when setting 2 indexes with 95/100 bits set in each (5 "acked" in each)
        acks.setIndexesAcks(8, Pair.of(100, nintyFiveBitsSet));
        acks.setIndexesAcks(9, Pair.of(100, nintyFiveBitsSet));

        // then the totalAckedIndexCount should be 10
        assertEquals(acks.getTotalAckedIndexCount(), 10);

        // when recycled and used again
        acks.recycle();
        acks = EntryBatchIndexesAcks.get(2);

        // then there should be no previous state and totalAckedIndexCount should be 0
        assertEquals(acks.getTotalAckedIndexCount(), 0);
```

### Modifications

- add a field to EntryBatchIndexesAcks for tracking the maximum size since as the result of reuse, the complete array might not be used
- properly reset state between usages
- add unit test that reproduced the issue