### PR TITLE
[Broker] Prevent carrying state of PositionImplRecyclable when recycled

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -163,6 +163,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         PositionImplRecyclable position = PositionImplRecyclable.create();
         position.ledgerId = key;
         position.entryId = value;
+        position.ackSet = null;
         return position;
     };
     private final LongPairRangeSet<PositionImpl> individualDeletedMessages;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclable.java
@@ -26,7 +26,7 @@ import io.netty.util.Recycler.Handle;
 public class PositionImplRecyclable extends PositionImpl implements Position {
 
     private final Handle<PositionImplRecyclable> recyclerHandle;
-    
+
     private static final Recycler<PositionImplRecyclable> RECYCLER = new Recycler<PositionImplRecyclable>() {
         @Override
         protected PositionImplRecyclable newObject(Recycler.Handle<PositionImplRecyclable> recyclerHandle) {
@@ -44,6 +44,7 @@ public class PositionImplRecyclable extends PositionImpl implements Position {
     }
 
     public void recycle() {
+        ackSet = null;
         recyclerHandle.recycle(this);
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclableTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclableTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertNull;
+import org.testng.annotations.Test;
+
+public class PositionImplRecyclableTest {
+
+    @Test
+    void shouldNotCarryStateInAckSetWhenRecycled() {
+        PositionImplRecyclable position = PositionImplRecyclable.create();
+        position.ackSet = new long[]{1L, 2L, 3L};
+        position.recycle();
+        PositionImplRecyclable position2 = PositionImplRecyclable.create();
+        assertNull(position2.ackSet);
+    }
+}


### PR DESCRIPTION
### Motivation

When reviewing the state management of some recycled instances, I came across an issue in PositionImplRecyclable where the ackSet field is not cleared when reused. It is unclear what the impact of this inconsistency is.
PositionImplRecyclable is used in [ManagedCursorImpl's recyclePositionRangeConverter](https://github.com/apache/pulsar/blob/bbd4e5d546397c982e4eff7d7ae3440c7c2a79fb/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L162-L167). 

### Modifications

- clear the ackSet field before and after reusing a PositionImplRecyclable instance.
- add a unit test that reproduced the issue before the fix