### PR TITLE
[Java Client] Reset state before recycling OpSendMsg instance

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1239,6 +1239,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             totalChunks = 0;
             chunkId = -1;
             uncompressedSize = 0;
+            retryCount = 0;
+            batchSizeByte = 0;
+            numMessagesInBatch = 1;
             recyclerHandle.recycle(this);
         }
 


### PR DESCRIPTION
### Motivation

When reviewing the state management of some recycled instances, I came across an issue in Pulsar Java Client. OpSendMsg instances are recycled without clearing the state in a few fields. It is unclear what the impact of this inconsistency is.

### Modifications

- clear the `retryCount`, `batchSizeByte` and `numMessagesInBatch` fields in the `recycle` method.