### PR TITLE
Implemented AtomicBoolean of havePendingRead in readMoreEntries()

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1861,7 +1861,7 @@ public class PersistentTopic extends AbstractTopic
                 if (sub.getDispatcher() instanceof PersistentDispatcherMultipleConsumers) {
                     PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers) sub
                             .getDispatcher();
-                    cs.subscriptionHavePendingRead = dispatcher.havePendingRead;
+                    cs.subscriptionHavePendingRead = dispatcher.havePendingRead.get();
                     cs.subscriptionHavePendingReplayRead = dispatcher.havePendingReplayRead;
                 } else if (sub.getDispatcher() instanceof PersistentDispatcherSingleActiveConsumer) {
                     PersistentDispatcherSingleActiveConsumer dispatcher = (PersistentDispatcherSingleActiveConsumer) sub

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -130,7 +130,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         consumer2.close();
 
         // block sub to read messages
-        sharedDispatcher.havePendingRead = true;
+        sharedDispatcher.havePendingRead.set(true);
         failOverDispatcher.havePendingRead = true;
 
         producer.newMessage().value("test").eventTime(5).send();
@@ -146,7 +146,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertNull(msg);
 
         // allow reads but dispatchers are still blocked
-        sharedDispatcher.havePendingRead = false;
+        sharedDispatcher.havePendingRead.set(false);
         failOverDispatcher.havePendingRead = false;
 
         // run task to unblock stuck dispatcher: first iteration sets the lastReadPosition and next iteration will


### PR DESCRIPTION
I noticed that we're performing a compareAndSet type of operation in `readMoreEntries()` in the persistent dispatchers on the field `havePendingRead`, but the way we're doing it isn't thread-safe since `readMoreEntries()` isn't synchronized. 
As @rdhabalia mentioned in #9789 that there are no pending reads despite backlog and available permits, it seems like there may be a concurrency issue with the pending read status. 

I need someone with more experience with concurrency primitives in Java to review this PR to indicate if it actually improves anything because I only found one place where there was a clear "compareAndSet" type of operation, so I don't see clearly competing accesses, and it's not clear to me if access on this field occurs from multiple threads in this location.
