### PR TITLE
[Broker] Make Persistent*DispatcherMultipleConsumers.readMoreEntries synchronized

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -216,7 +216,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         readMoreEntries();
     }
 
-    public void readMoreEntries() {
+    public synchronized void readMoreEntries() {
         // totalAvailablePermits may be updated by other threads
         int currentTotalAvailablePermits = totalAvailablePermits;
         if (currentTotalAvailablePermits > 0 && isAtleastOneConsumerAvailable()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java
@@ -135,7 +135,7 @@ public class PersistentStreamingDispatcherMultipleConsumers extends PersistentDi
     }
 
     @Override
-    public void readMoreEntries() {
+    public synchronized void readMoreEntries() {
         // totalAvailablePermits may be updated by other threads
         int currentTotalAvailablePermits = totalAvailablePermits;
         if (currentTotalAvailablePermits > 0 && isAtleastOneConsumerAvailable()) {


### PR DESCRIPTION
### Motivation

There are concurrency issues in `PersistentDispatcherMultipleConsumers` and `PersistentStreamingDispatcherMultipleConsumers` classes. Some symptoms or previous fixes are #5311, #6054, #6255, #7266, #9789 .

Currently `PersistentStreamingDispatcherMultipleConsumers.readMoreEntries` method isn't synchronized:

https://github.com/apache/pulsar/blob/f2d72c9fc13a33df584ec1bd96a4c147774b858d/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherMultipleConsumers.java#L137-L140

In one location the method is called within a synchronized block like this:

https://github.com/apache/pulsar/blob/31f831574c3a65bae0e76801facaf2deb0b17fbb/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java#L191-L205

Another location where the `readEntries` call is explicitly wrapped in a synchronized block

https://github.com/apache/pulsar/blob/875262a0ae2fba82a6dd7d46dd2467d675b0d9c3/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L612-L621

Synchronization is missing in this location (and a few other locations):

https://github.com/apache/pulsar/blob/a1cebdb3e7cc3b8ee3ce567058182e7d31c762d2/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L2439-L2451

It seems that it would be more consistent to make the `readMoreEntries` method a `synchronized` method.


### Modifications

- make `readEntriesMethod` in `PersistentDispatcherMultipleConsumers` and `PersistentStreamingDispatcherMultipleConsumers` classes a `synchronized` method.