### PR TITLE
Fix hasMessageAvailable return true but can't read message

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -708,6 +708,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         log.info("[{}][{}] Subscribing to topic on cnx {}, consumerId {}", topic, subscription, cnx.ctx().channel(), consumerId);
 
         long requestId = client.newRequestId();
+        if (duringSeek.get()) {
+            acknowledgmentsGroupingTracker.flushAndClean();
+        }
 
         int currentSize;
         synchronized (this) {
@@ -1916,22 +1919,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }
 
             if (hasMoreMessages(lastMessageIdInBroker, startMessageId, resetIncludeHead)) {
-                //this situation will occur when :
-                // 1.We haven't read yet 2.The connection was reset multiple times
-                // 3.Broker has pushed messages to ReceiverQueue, but messages were cleaned due to connection reset
-                Backoff backoff = new BackoffBuilder()
-                        .setInitialTime(100, TimeUnit.MILLISECONDS)
-                        .setMax(2000, TimeUnit.MILLISECONDS)
-                        .setMandatoryStop(client.getConfiguration().getOperationTimeoutMs(), TimeUnit.MILLISECONDS)
-                        .create();
-                RetryUtil.retryAsynchronously(() -> {
-                    try {
-                        seek(startMessageId);
-                        return true;
-                    } catch (PulsarClientException e) {
-                        throw new RuntimeException(e);
-                    }
-                }, backoff, pinnedExecutor, booleanFuture);
+                booleanFuture.complete(true);
                 return booleanFuture;
             }
 


### PR DESCRIPTION
### Motivation

I temporarily fixed this problem in PR https://github.com/apache/pulsar/pull/10190.
Now we have found a better way, this way can avoid the seek, then avoid trigger another reconnection.
Thank you @codelipenghui  to troubleshoot this issue with me all night.

We have added a lot of log and found that this issue is caused by some race condition problems. Here is the first reason:
https://github.com/apache/pulsar/blob/f2d72c9fc13a33df584ec1bd96a4c147774b858d/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L1808-L1818
Now we have an acknowledgmentsGroupingTracker to filter duplicate messages, and this Tracker will be cleaned up after seek.

However, it is possible that the connection is ready and Broker has pushed message, but `acknowledgmentsGroupingTracker.flushAndClean(); ` has not been executed yet. 

Finally hasMessageAvailableAsync returns true, but the message cannot be read because it is filtered by the acknowledgmentsGroupingTracker


### Modifications
clean the tracker when connection was open

### Verifying this change

