### PR TITLE
[Issue #10427] Add AvroSchema UUID support fix 

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -122,7 +122,6 @@ public class AvroSchema<T> extends AvroBaseStructSchema<T> {
             }
         }
         reflectData.addLogicalTypeConversion(new Conversions.UUIDConversion());
-        reflectData.addLogicalTypeConversion(new Conversions.DecimalConversion());
     }
 
     public static class TimestampConversion extends Conversion<DateTime> {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -121,6 +121,8 @@ public class AvroSchema<T> extends AvroBaseStructSchema<T> {
                 // Skip if have not provide joda-time dependency.
             }
         }
+        reflectData.addLogicalTypeConversion(new Conversions.UUIDConversion());
+        reflectData.addLogicalTypeConversion(new Conversions.DecimalConversion());
     }
 
     public static class TimestampConversion extends Conversion<DateTime> {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
@@ -91,8 +91,9 @@ public class SchemaUtil {
         try {
             return parseAvroSchema(pojo.getDeclaredField("SCHEMA$").get(null).toString());
         } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException ignored) {
-            ReflectData reflectData = schemaDefinition.getAlwaysAllowNull() ? ReflectData.AllowNull.get()
-                    : ReflectData.get();
+            ReflectData reflectData = schemaDefinition.getAlwaysAllowNull()
+                     ? new ReflectData.AllowNull()
+                     : new ReflectData();
             AvroSchema.addLogicalTypeConversions(reflectData, schemaDefinition.isJsr310ConversionEnabled());
             return reflectData.getSchema(pojo);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/util/SchemaUtil.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.client.impl.schema.util;
 
+import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.SchemaDefinitionBuilderImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -89,8 +91,10 @@ public class SchemaUtil {
         try {
             return parseAvroSchema(pojo.getDeclaredField("SCHEMA$").get(null).toString());
         } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException ignored) {
-            return schemaDefinition.getAlwaysAllowNull() ? ReflectData.AllowNull.get().getSchema(pojo)
-                    : ReflectData.get().getSchema(pojo);
+            ReflectData reflectData = schemaDefinition.getAlwaysAllowNull() ? ReflectData.AllowNull.get()
+                    : ReflectData.get();
+            AvroSchema.addLogicalTypeConversions(reflectData, schemaDefinition.isJsr310ConversionEnabled());
+            return reflectData.getSchema(pojo);
         }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -431,10 +431,11 @@ public class AvroSchemaTest {
 
     @Test
     public void testAvroUUID() {
-        org.apache.pulsar.client.api.Schema schema = org.apache.pulsar.client.api.Schema.AVRO(MyPojo.class);
-        MyPojo pojo = new MyPojo();
-        pojo.uid = UUID.randomUUID();
-        schema.encode(pojo);
+        org.apache.pulsar.client.api.Schema<MyPojo> schema = org.apache.pulsar.client.api.Schema.AVRO(MyPojo.class);
+        MyPojo pojo1 = new MyPojo();
+        pojo1.uid = UUID.randomUUID();
+        MyPojo pojo2 = schema.decode(schema.encode(pojo1));
+        assertEquals(pojo1.uid, pojo2.uid);
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -35,6 +35,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.UUID;
+
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
@@ -421,6 +423,18 @@ public class AvroSchemaTest {
         foo = schema.decode(schema.encode(foo));
         assertEquals(foo.getColor(), SchemaTestUtils.Color.RED);
         assertEquals(field1, foo.getField1());
+    }
+
+    static class MyPojo {
+        public UUID uid;
+    }
+
+    @Test
+    public void testAvroUUID() {
+        org.apache.pulsar.client.api.Schema schema = org.apache.pulsar.client.api.Schema.AVRO(MyPojo.class);
+        MyPojo pojo = new MyPojo();
+        pojo.uid = UUID.randomUUID();
+        schema.encode(pojo);
     }
 
 }


### PR DESCRIPTION
Fixes #10427

### Motivation

As AVRO support the UUID type (see [AVRO spec](https://avro.apache.org/docs/current/spec.html#UUID)),  add UUID support for the pulsar AvroSchema. 

It also adds the AVRO Decimal logical type (see [AVRO spec](https://avro.apache.org/docs/current/spec.html#Decimal)).

### Modifications

Add the logical type conversion to the ReflectData instance when parsing the provided POJO.

### Verifying this change

See the provided unit test in pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java

