### PR TITLE
[pulsar-broker] Handle NPE in unblock stuck subscrption task when dis…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1098,7 +1098,7 @@ public class PersistentSubscription implements Subscription {
     }
 
     public boolean checkAndUnblockIfStuck() {
-        return dispatcher.checkAndUnblockIfStuck();
+        return dispatcher != null ? dispatcher.checkAndUnblockIfStuck() : false;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentSubscription.class);


### PR DESCRIPTION
…patcher is not created

### Motivation
It fixes #10429 NPE when subscription has not created dispatcher yet.
```
2021-04-29T00:11:51,161 [pulsar-stats-updater-29-1] ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - Got exception when creating consumer stats for subscription __compaction: null
java.lang.NullPointerException: null
at org.apache.pulsar.broker.service.persistent.PersistentSubscription.checkAndUnblockIfStuck(PersistentSubscription.java:1101) ~[org.apache.pulsar-pulsar-broker-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$updateRates$45(PersistentTopic.java:1642) ~[org.apache.pulsar-pulsar-broker-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
```