### PR TITLE
[pulsar-io] Using ObjectMapper instead of Gson to parse Source/SInk configuration

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -197,6 +197,7 @@ public class PulsarClientImpl implements PulsarClient {
         } catch (Throwable t) {
             shutdown();
             shutdownEventLoopGroup(eventLoopGroup);
+            closeConnectionPool(cnxPool);
             throw t;
         }
     }
@@ -718,13 +719,11 @@ public class PulsarClientImpl implements PulsarClient {
                 log.warn("Failed to shutdown eventLoopGroup", t);
                 throwable = t;
             }
-            if (createdCnxPool) {
-                try {
-                    cnxPool.close();
-                } catch (Throwable t) {
-                    log.warn("Failed to shutdown cnxPool", t);
-                    throwable = t;
-                }
+            try {
+                closeConnectionPool(cnxPool);
+            } catch (Throwable t) {
+                log.warn("Failed to shutdown cnxPool", t);
+                throwable = t;
             }
             if (timer != null && needStopTimer) {
                 try {
@@ -764,8 +763,18 @@ public class PulsarClientImpl implements PulsarClient {
         }
     }
 
+    private void closeConnectionPool(ConnectionPool cnxPool) throws PulsarClientException {
+        if (createdCnxPool && cnxPool != null) {
+            try {
+                cnxPool.close();
+            } catch (Throwable t) {
+                throw PulsarClientException.unwrap(t);
+            }
+        }
+    }
+
     private void shutdownEventLoopGroup(EventLoopGroup eventLoopGroup) throws PulsarClientException {
-        if (createdEventLoopGroup && !eventLoopGroup.isShutdown()) {
+        if (createdEventLoopGroup && eventLoopGroup != null && !eventLoopGroup.isShutdown()) {
             try {
                 eventLoopGroup.shutdownGracefully().get();
             } catch (Throwable t) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.ProducerConfig;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.Record;
@@ -129,8 +130,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
     // a read write lock for stats operations
     private ReadWriteLock statsLock = new ReentrantReadWriteLock();
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public JavaInstanceRunnable(InstanceConfig instanceConfig,
                                 PulsarClient pulsarClient,
@@ -733,7 +732,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (sourceSpec.getConfigs().isEmpty()) {
                 this.source.open(new HashMap<>(), contextImpl);
             } else {
-                this.source.open(objectMapper.readValue(sourceSpec.getConfigs(),
+                this.source.open(ObjectMapperFactory.getThreadLocal().readValue(sourceSpec.getConfigs(),
                         new TypeReference<Map<String, Object>>() {}), contextImpl);
             }
         } catch (Exception e) {
@@ -800,7 +799,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (sinkSpec.getConfigs().isEmpty()) {
                 this.sink.open(new HashMap<>(), contextImpl);
             } else {
-                this.sink.open(objectMapper.readValue(sinkSpec.getConfigs(),
+                this.sink.open(ObjectMapperFactory.getThreadLocal().readValue(sinkSpec.getConfigs(),
                         new TypeReference<Map<String, Object>>() {}), contextImpl);
             }
         } catch (Exception e) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -19,6 +19,8 @@
 
 package org.apache.pulsar.functions.instance;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -129,6 +131,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
     // a read write lock for stats operations
     private ReadWriteLock statsLock = new ReentrantReadWriteLock();
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public JavaInstanceRunnable(InstanceConfig instanceConfig,
                                 PulsarClient pulsarClient,
@@ -799,9 +803,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (sinkSpec.getConfigs().isEmpty()) {
                 this.sink.open(new HashMap<>(), contextImpl);
             } else {
-                this.sink.open(new Gson().fromJson(sinkSpec.getConfigs(),
-                        new TypeToken<Map<String, Object>>() {
-                        }.getType()), contextImpl);
+                this.sink.open(objectMapper.readValue(sinkSpec.getConfigs(),
+                        new TypeReference<Map<String, Object>>() {}), contextImpl);
             }
         } catch (Exception e) {
             log.error("Sink open produced uncaught exception: ", e);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -21,8 +21,6 @@ package org.apache.pulsar.functions.instance;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -735,9 +733,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (sourceSpec.getConfigs().isEmpty()) {
                 this.source.open(new HashMap<>(), contextImpl);
             } else {
-                this.source.open(new Gson().fromJson(sourceSpec.getConfigs(),
-                        new TypeToken<Map<String, Object>>() {
-                        }.getType()), contextImpl);
+                this.source.open(objectMapper.readValue(sourceSpec.getConfigs(),
+                        new TypeReference<Map<String, Object>>() {}), contextImpl);
             }
         } catch (Exception e) {
             log.error("Source open produced uncaught exception: ", e);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -20,7 +20,6 @@
 package org.apache.pulsar.functions.instance;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.proto.Function.SinkSpecOrBuilder;
+import org.apache.pulsar.functions.proto.Function.SourceSpecOrBuilder;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -129,6 +130,16 @@ public class JavaInstanceRunnableTest {
         Mockito.when(sinkSpec.getConfigs()).thenReturn("{\"ttl\": 9223372036854775807}");
         Map<String, Object> parsedConfig =
                 new ObjectMapper().readValue(sinkSpec.getConfigs(), new TypeReference<Map<String, Object>>() {});
+        Assert.assertEquals(parsedConfig.get("ttl").getClass(), Long.class);
+        Assert.assertEquals(parsedConfig.get("ttl"), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testSourceConfigParsingPreservesOriginalType() throws Exception {
+        SourceSpecOrBuilder sourceSpec = Mockito.mock(SourceSpecOrBuilder.class);
+        Mockito.when(sourceSpec.getConfigs()).thenReturn("{\"ttl\": 9223372036854775807}");
+        Map<String, Object> parsedConfig =
+                new ObjectMapper().readValue(sourceSpec.getConfigs(), new TypeReference<Map<String, Object>>() {});
         Assert.assertEquals(parsedConfig.get("ttl").getClass(), Long.class);
         Assert.assertEquals(parsedConfig.get("ttl"), Long.MAX_VALUE);
     }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.functions.instance;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.pulsar.functions.api.Context;
@@ -25,11 +27,14 @@ import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.Function.SinkSpec;
+import org.apache.pulsar.functions.proto.Function.SinkSpecOrBuilder;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 public class JavaInstanceRunnableTest {
 
@@ -116,5 +121,15 @@ public class JavaInstanceRunnableTest {
         Assert.assertEquals(javaInstanceRunnable.getFunctionStatus().build(), InstanceCommunication.FunctionStatus.newBuilder().build());
 
         Assert.assertEquals(javaInstanceRunnable.getMetrics(), InstanceCommunication.MetricsData.newBuilder().build());
+    }
+
+    @Test
+    public void testSinkConfigParsingPreservesOriginalType() throws Exception {
+        SinkSpecOrBuilder sinkSpec = Mockito.mock(SinkSpecOrBuilder.class);
+        Mockito.when(sinkSpec.getConfigs()).thenReturn("{\"ttl\": 9223372036854775807}");
+        Map<String, Object> parsedConfig =
+                new ObjectMapper().readValue(sinkSpec.getConfigs(), new TypeReference<Map<String, Object>>() {});
+        Assert.assertEquals(parsedConfig.get("ttl").getClass(), Long.class);
+        Assert.assertEquals(parsedConfig.get("ttl"), Long.MAX_VALUE);
     }
 }


### PR DESCRIPTION
Fixes #10440

### Motivation

Data types should be preserved after deserializing the sink/source config.

### Modifications

Using ObjectMapper instead of Gson to parse the config.

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit tests*

  - The schema: don't know