### PR TITLE
[Issue 10445][pulsar-io] Exposed SubscriptionType in the SinkContext

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -20,6 +20,9 @@
 package org.apache.pulsar.functions.instance;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -668,17 +671,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     break;
             }
 
-            switch (sourceSpec.getSubscriptionType()) {
-                case FAILOVER:
-                    pulsarSourceConfig.setSubscriptionType(SubscriptionType.Failover);
-                    break;
-                case KEY_SHARED:
-                    pulsarSourceConfig.setSubscriptionType(SubscriptionType.Key_Shared);
-                    break;
-                default:
-                    pulsarSourceConfig.setSubscriptionType(SubscriptionType.Shared);
-                    break;
-            }
+            Preconditions.checkNotNull(contextImpl.getSubscriptionType());
+            pulsarSourceConfig.setSubscriptionType(contextImpl.getSubscriptionType());
 
             pulsarSourceConfig.setTypeClassName(sourceSpec.getTypeClassName());
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -21,8 +21,6 @@ package org.apache.pulsar.functions.instance;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -42,7 +40,6 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.impl.ProducerBase;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
@@ -53,7 +54,9 @@ import org.apache.pulsar.functions.instance.state.InstanceStateManager;
 import org.apache.pulsar.functions.instance.stats.FunctionCollectorRegistry;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.secretsprovider.EnvironmentBasedSecretsProvider;
+import org.apache.pulsar.io.core.SinkContext;
 import org.slf4j.Logger;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -137,6 +140,14 @@ public class ContextImplTest {
         context.getCounterAsync("test-key");
         verify(context.defaultStateStore, times(1)).getCounterAsync(eq("test-key"));
     }
+
+    @Test
+    public void testGetSubscriptionType()  {
+        SinkContext ctx = context;
+        // make sure SinkContext can get SubscriptionType.
+        Assert.assertEquals(ctx.getSubscriptionType(), SubscriptionType.Shared);
+    }
+
 
     @Test
     public void testPutStateStateEnabled() throws Exception {

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.core;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 import org.apache.pulsar.functions.api.StateStore;
@@ -68,7 +69,15 @@ public interface ConnectorContext {
      * @return the namespace this source belongs to
      */
     String getNamespace();
-    
+
+    /**
+     * Get subscription type
+     * @return subscription type
+     */
+    default SubscriptionType getSubscriptionType() {
+        return null;
+    }
+
     /**
      * The logger object that can be used to log in a sink
      * @return the logger object

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/ConnectorContext.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.io.core;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 import org.apache.pulsar.functions.api.StateStore;
@@ -69,14 +68,6 @@ public interface ConnectorContext {
      * @return the namespace this source belongs to
      */
     String getNamespace();
-
-    /**
-     * Get subscription type
-     * @return subscription type
-     */
-    default SubscriptionType getSubscriptionType() {
-        return null;
-    }
 
     /**
      * The logger object that can be used to log in a sink

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.io.core;
 
 import java.util.Collection;
+
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -42,4 +44,11 @@ public interface SinkContext extends ConnectorContext {
      */
     String getSinkName();
 
+    /**
+     * Get subscription type
+     * @return subscription type
+     */
+    default SubscriptionType getSubscriptionType() {
+        throw new UnsupportedOperationException("Context does not provide SubscriptionType");
+    }
 }

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
@@ -45,7 +45,7 @@ public interface SinkContext extends ConnectorContext {
     String getSinkName();
 
     /**
-     * Get subscription type
+     * Get subscription type used by the source providing data for the sink
      * @return subscription type
      */
     default SubscriptionType getSubscriptionType() {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #10445

### Motivation

SinkContext should expose Subscription type to the Sink
More context: https://github.com/apache/pulsar/pull/9927#discussion_r621441678

Needed for https://github.com/apache/pulsar/pull/9927

### Modifications

Added `getSubscriptionType()` to the `SinkContext` interface and `ContextImpl`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: yes
 
New method added to the interface that is a public API. Default method implementation is provided.

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
