### PR TITLE
Issue 10452: WebSocketHttpServletRequestWrapperTest is failing consistently on branch.2-7

### DIFF
--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -98,7 +98,16 @@
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
 
-		<!-- To write basic websockets against -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-zookeeper-utils</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+
+    <!-- To write basic websockets against -->
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>


### PR DESCRIPTION
- in branch-2.7 there is no "memory" MetadataStore
- we need to start a real ZKServer in order to make WebSocketHttpServletRequestWrapperTest pass