### PR TITLE
[broker] Adding logging to JavaInstanceRunnable to help debug issues like #10460

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -35,6 +35,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.CompressionType;
@@ -75,6 +77,7 @@ import static org.apache.pulsar.functions.instance.stats.FunctionStatsManager.US
 /**
  * This class implements the Context interface exposed to the user.
  */
+@ToString
 class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
     private InstanceConfig config;
     private Logger logger;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -797,8 +797,15 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
         try {
             if (sinkSpec.getConfigs().isEmpty()) {
+                if (log.isDebugEnabled()){
+                    log.debug("Opening Sink with empty hashmap with contextImpl: {} ", contextImpl.toString());
+                }
                 this.sink.open(new HashMap<>(), contextImpl);
             } else {
+                if (log.isDebugEnabled()){
+                    log.debug("Opening Sink with SinkSpec {} and contextImpl: {} ", sinkSpec.toString(),
+                            contextImpl.toString());
+                }
                 this.sink.open(new Gson().fromJson(sinkSpec.getConfigs(),
                         new TypeToken<Map<String, Object>>() {
                         }.getType()), contextImpl);


### PR DESCRIPTION
As reported in #10460 (and for other purposes), it's helpful to see the context when a function crashes when trying to open its sink. This PR adds a couple of debug lines to assist in troubleshooting those cases. 