### PR TITLE
[log] Add line number to the log to make it easier to locate the prob…

### DIFF
--- a/conf/functions_log4j2.xml
+++ b/conf/functions_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -54,7 +54,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n"
 
     # Rolling file appender configuration
     RollingFile:
@@ -63,7 +63,7 @@ Configuration:
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
       immediateFlush: false
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1
@@ -101,7 +101,7 @@ Configuration:
                       fileName : "${sys:pulsar.log.dir}/functions/${ctx:function}/${ctx:functionname}-${ctx:instance}.log"
                       filePattern : "${sys:pulsar.log.dir}/functions/${sys:pulsar.log.file}-${ctx:instance}-%d{MM-dd-yyyy}-%i.log.gz"
                       PatternLayout:
-                        Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1} - %msg%n"
+                        Pattern: "%d{ABSOLUTE} %level{length=5} [%thread] [instance: %X{instance}] %logger{1}#%L - %msg%n"
                       Policies:
                         TimeBasedTriggeringPolicy:
                           interval: 1

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -36,7 +36,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36}#%L - %msg%n</Pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,7 +33,7 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36}#%L - %msg%n"
     File:
       name: File
       fileName: ${filename}


### PR DESCRIPTION
### Motivation

No line number is recorded in the current log file with the pattern `%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n`, which is not conducive to locating the problem.

### Modifications

update the log4j2 pattern, %d{HH:mm:ss.SSS} [%t] %-5level %logger{36}**#%L** - %msg%n

