### PR TITLE
Remove residual info after forcibly deleting the namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -412,7 +412,7 @@ public abstract class NamespacesBase extends AdminResource {
             if (!topics.isEmpty()) {
                 for (String topic : topics) {
                     try {
-                        futures.add(pulsar().getAdminClient().topics().deleteAsync(topic, true));
+                        futures.add(pulsar().getAdminClient().topics().deleteAsync(topic, true, true));
                     } catch (Exception e) {
                         log.error("[{}] Failed to force delete topic {}", clientAppId(), topic, e);
                         asyncResponse.resume(new RestException(e));


### PR DESCRIPTION

### Motivation
Forcibly deleting the namespace will leave a large number of schemas. 
Topic and namespace are deleted, leaving the schema is meaningless.
If both Topic and namespace are deleted, we cannot find the schemas that need to be deleted based on other info

### Modifications
When the namespace is forcibly deleted, the schema is also deleted

### Verifying this change
