### PR TITLE
Fix publish callback's entry data is null during ledger rollover

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -207,8 +207,11 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
                 cb.addComplete(lastEntry, data.asReadOnly(), ctx);
                 ml.notifyCursors();
                 ml.notifyWaitingEntryCallBacks();
+                ReferenceCountUtil.release(data);
+                this.recycle();
+            } else {
+                ReferenceCountUtil.release(data);
             }
-            releaseAndRecycle();
         }
     }
 
@@ -231,8 +234,11 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
             cb.addComplete(PositionImpl.get(lh.getId(), entryId), data.asReadOnly(), ctx);
             ml.notifyCursors();
             ml.notifyWaitingEntryCallBacks();
+            ReferenceCountUtil.release(data);
+            this.recycle();
+        } else {
+            ReferenceCountUtil.release(data);
         }
-        releaseAndRecycle();
     }
 
     private void updateLatency() {
@@ -341,10 +347,5 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
                 ", startTime=" + startTime +
                 ", dataLength=" + dataLength +
                 '}';
-    }
-
-    private void releaseAndRecycle() {
-        ReferenceCountUtil.release(data);
-        recycle();
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -197,21 +197,18 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         ml.lastConfirmedEntry = lastEntry;
 
         if (closeWhenDone) {
-            ReferenceCountUtil.release(data);
             log.info("[{}] Closing ledger {} for being full", ml.getName(), ledger.getId());
+            // `data` will be released in `closeComplete`
             ledger.asyncClose(this, ctx);
         } else {
             updateLatency();
             AddEntryCallback cb = callbackUpdater.getAndSet(this, null);
             if (cb != null) {
                 cb.addComplete(lastEntry, data.asReadOnly(), ctx);
-                ReferenceCountUtil.release(data);
                 ml.notifyCursors();
                 ml.notifyWaitingEntryCallBacks();
-                this.recycle();
-            } else {
-                ReferenceCountUtil.release(data);
             }
+            releaseAndRecycle();
         }
     }
 
@@ -231,11 +228,11 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
         AddEntryCallback cb = callbackUpdater.getAndSet(this, null);
         if (cb != null) {
-            cb.addComplete(PositionImpl.get(lh.getId(), entryId), null, ctx);
+            cb.addComplete(PositionImpl.get(lh.getId(), entryId), data.asReadOnly(), ctx);
             ml.notifyCursors();
             ml.notifyWaitingEntryCallBacks();
-            this.recycle();
         }
+        releaseAndRecycle();
     }
 
     private void updateLatency() {
@@ -346,4 +343,8 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
                 '}';
     }
 
+    private void releaseAndRecycle() {
+        ReferenceCountUtil.release(data);
+        recycle();
+    }
 }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/9257 added an extra `ByteBuf` parameter to managed ledger's `AddEntryCallback#addComplete` so that broker can get a buffer view of the entry when it's persisted successfully. However, when a ledger is full and the rollover is triggered, the `addComplete` method will be triggered in `OpAddEntry#closeComplete` and the argument is null.

### Modifications

- Extend the lifetime of `data` when `ledger.asyncClose` is called in `OpAddEntry#safeRun`, and pass the `data` to `cb.addComplete`, after that, release the `data`.
- Make current test cover the ledger rollover case.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *ManagedLedgerTest#asyncAddEntryWithoutError*.