### PR TITLE
Fix the AlreadyClosedException used in leader election

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
@@ -34,9 +34,9 @@ import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyClosedException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;


### PR DESCRIPTION
### Motivation

From the context, it looks to me that the exception thrown in the line https://github.com/apache/pulsar/blob/2a522c85c0add3f1f647befb0a560689324114bd/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java#L163 should be an `org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyClosedException` rather than an `org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException`.

### Modifications

Change the `AlreadyClosedException` that imported.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

**This change is a trivial rework / code cleanup without any test coverage.**


