### PR TITLE
Fix Apache RAT configuration for branch-2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1287,8 +1287,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/*.htpasswd</exclude>
             <exclude>src/test/resources/athenz.conf.test</exclude>
             <exclude>deployment/terraform-ansible/templates/myid</exclude>
-            <exclude>certificate-authority/index.txt</exclude>
-            <exclude>certificate-authority/README.md</exclude>
+            <exclude>**/certificate-authority/*</exclude>
 
             <!-- Exclude ZK test data file -->
             <exclude>**/zk-3.5-test-data/*</exclude>
@@ -1303,6 +1302,54 @@ flexible messaging model and an intuitive client API.</description>
             <!-- helm files -->
             <exclude>**/.helmignore</exclude>
             <exclude>**/_helpers.tpl</exclude>
+
+            <!-- project ignored files -->
+            <exclude>*.md</exclude>
+            <exclude>.github/**</exclude>
+            <exclude>**/*.nar</exclude>
+            <exclude>**/.terraform/**</exclude>
+            <exclude>**/.gitignore</exclude>
+            <exclude>**/.svn</exclude>
+            <exclude>**/*.iws</exclude>
+            <exclude>**/*.ipr</exclude>
+            <exclude>**/*.iml</exclude>
+            <exclude>**/*.cbp</exclude>
+            <exclude>**/*.pyc</exclude>
+            <exclude>**/.classpath</exclude>
+            <exclude>**/.project</exclude>
+            <exclude>**/.settings</exclude>
+            <exclude>**/target/**</exclude>
+            <exclude>**/CMakeFiles/**</exclude>
+            <exclude>**/CMakeCache.txt</exclude>
+            <exclude>**/cmake_install.cmake</exclude>
+            <exclude>pulsar-client-cpp/**/Makefile</exclude>
+            <exclude>pulsar-client-cpp/tests/main</exclude>
+            <exclude>pulsar-client-cpp/examples/SampleAsyncProducer</exclude>
+            <exclude>pulsar-client-cpp/examples/SampleConsumer</exclude>
+            <exclude>pulsar-client-cpp/examples/SampleConsumerListener</exclude>
+            <exclude>pulsar-client-cpp/examples/SampleProducer</exclude>
+            <exclude>pulsar-client-cpp/perf/perfProducer</exclude>
+            <exclude>pulsar-client-cpp/perf/perfConsumer</exclude>
+            <exclude>**/python/setup.py.template</exclude>
+            <exclude>**/python/dist/**</exclude>
+            <exclude>**/pulsar-client-cpp/pkg/rpm/RPMS/**</exclude>
+            <exclude>**/pulsar-client-cpp/pkg/rpm/SOURCES/**</exclude>
+            <exclude>**/pulsar-client-cpp/pkg/deb/BUILD/**</exclude>
+            <exclude>**/python/wheelhouse/**</exclude>
+            <exclude>**/python/MANIFEST</exclude>
+            <exclude>**/*.egg-info/**</exclude>
+            <exclude>**/*.log</exclude>
+            <exclude>**/build/**</exclude>
+            <exclude>**/file:/**</exclude>
+            <exclude>**/SecurityAuth.audit*</exclude>
+            <exclude>**/site2/**</exclude>
+            <exclude>**/.idea/**</exclude>
+            <exclude>**/*.a</exclude>
+            <exclude>**/*.so</exclude>
+            <exclude>**/*.so.*</exclude>
+            <exclude>**/*.dylib</exclude>
+            <exclude>src/test/resources/*.txt</exclude>
+            <exclude>node_modules/*</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Command `mvn apache-rat:check` does not pass on branch-2.7. This is a prerequisite for 2.7.2 release.

Contents of this patch:
- port most of the configuration from master branch
- add a few lines necessary for branch-2.7 (node_modules and certificate-authority)