### PR TITLE
fixed NPE in pulsar client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -721,9 +721,9 @@ public class PulsarClientImpl implements PulsarClient {
             }
             try {
                 closeCnxPool(cnxPool);
-            } catch (Throwable t) {
-                log.warn("Failed to shutdown cnxPool", t);
-                throwable = t;
+            } catch (PulsarClientException e) {
+                log.warn("Failed to shutdown cnxPool", e);
+                throwable = e;
             }
             if (timer != null && needStopTimer) {
                 try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -719,13 +719,11 @@ public class PulsarClientImpl implements PulsarClient {
                 log.warn("Failed to shutdown eventLoopGroup", t);
                 throwable = t;
             }
-            if (createdCnxPool) {
-                try {
-                    closeCnxPool(cnxPool);
-                } catch (Throwable t) {
-                    log.warn("Failed to shutdown cnxPool", t);
-                    throwable = t;
-                }
+            try {
+                closeCnxPool(cnxPool);
+            } catch (Throwable t) {
+                log.warn("Failed to shutdown cnxPool", t);
+                throwable = t;
             }
             if (timer != null && needStopTimer) {
                 try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -715,9 +715,9 @@ public class PulsarClientImpl implements PulsarClient {
                 // Shutting down eventLoopGroup separately because in some cases, cnxPool might be using different
                 // eventLoopGroup.
                 shutdownEventLoopGroup(eventLoopGroup);
-            } catch (Throwable t) {
-                log.warn("Failed to shutdown eventLoopGroup", t);
-                throwable = t;
+            } catch (PulsarClientException e) {
+                log.warn("Failed to shutdown eventLoopGroup", e);
+                throwable = e;
             }
             try {
                 closeCnxPool(cnxPool);
@@ -735,8 +735,8 @@ public class PulsarClientImpl implements PulsarClient {
             }
             try {
                 shutdownExecutors();
-            } catch (Throwable t) {
-                throwable = t;
+            } catch (PulsarClientException e) {
+                throwable = e;
             }
             if (conf != null && conf.getAuthentication() != null) {
                 try {


### PR DESCRIPTION
### Motivation

*PulsarClientImpl* throws NPE  if we attempt to close the resource when conf.getServiceUrl is blank.

### Modifications

Added a null check before accessing the resource.

This change is a trivial rework / code cleanup without any test coverage.