### PR TITLE
MetadataCache: readModifyUpdate should return the new value in the future

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -98,7 +98,7 @@ public class BaseResources<T> {
     }
 
     public CompletableFuture<Void> setAsync(String path, Function<T, T> modifyFunction) {
-        return cache.readModifyUpdate(path, modifyFunction);
+        return cache.readModifyUpdate(path, modifyFunction).thenApply(__ -> null);
     }
 
     public void setWithCreate(String path, Function<Optional<T>, T> createFunction) throws MetadataStoreException {
@@ -113,7 +113,7 @@ public class BaseResources<T> {
     }
 
     public CompletableFuture<Void> setWithCreateAsync(String path, Function<Optional<T>, T> createFunction) {
-        return cache.readModifyUpdateOrCreate(path, createFunction);
+        return cache.readModifyUpdateOrCreate(path, createFunction).thenApply(__ -> null);
     }
 
     public void create(String path, T data) throws MetadataStoreException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -989,7 +989,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, Consumer<Noti
         for (Map.Entry<String, BundleData> entry : loadData.getBundleData().entrySet()) {
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
-            futures.add(bundlesCache.readModifyUpdateOrCreate(getBundleDataPath(bundle), __ -> data));
+            futures.add(bundlesCache.readModifyUpdateOrCreate(getBundleDataPath(bundle), __ -> data)
+                    .thenApply(__ -> null));
         }
 
         // Write the time average broker data to metadata store.
@@ -997,7 +998,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, Consumer<Noti
             final String broker = entry.getKey();
             final TimeAverageBrokerData data = entry.getValue().getTimeAverageData();
             futures.add(timeAverageBrokerDataCache.readModifyUpdateOrCreate(
-                    TIME_AVERAGE_BROKER_ZPATH + "/" + broker, __ -> data));
+                    TIME_AVERAGE_BROKER_ZPATH + "/" + broker, __ -> data)
+                    .thenApply(__ -> null));
         }
 
         try {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -88,7 +88,7 @@ public interface MetadataCache<T> {
      *            a function that will be passed the current value and returns a modified value to be stored
      * @return a future to track the completion of the operation
      */
-    CompletableFuture<Void> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction);
+    CompletableFuture<T> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction);
 
     /**
      * Perform an atomic read-modify-update of the value.
@@ -101,7 +101,7 @@ public interface MetadataCache<T> {
      *            a function that will be passed the current value and returns a modified value to be stored
      * @return a future to track the completion of the operation
      */
-    CompletableFuture<Void> readModifyUpdate(String path, Function<T, T> modifyFunction);
+    CompletableFuture<T> readModifyUpdate(String path, Function<T, T> modifyFunction);
 
     /**
      * Create a new object in the metadata store.

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -136,7 +136,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         assertEquals(objCache.getIfCached(key1), Optional.of(value1));
         assertEquals(objCache.get(key1).join(), Optional.of(value1));
 
-        objCache.readModifyUpdateOrCreate(key1, __ -> value2).join();
+        assertEquals(objCache.readModifyUpdateOrCreate(key1, __ -> value2).join(), value2);
         assertEquals(objCache.getIfCached(key1), Optional.of(value2));
         assertEquals(objCache.get(key1).join(), Optional.of(value2));
 
@@ -288,9 +288,8 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         MyClass value1 = new MyClass("a", 1);
         objCache.create(key1, value1).join();
 
-        objCache.readModifyUpdate(key1, v -> {
-            return new MyClass(v.a, v.b + 1);
-        }).join();
+        assertEquals(objCache.readModifyUpdate(key1, v -> new MyClass(v.a, v.b + 1)).join(),
+                new MyClass("a", 2));
 
         Optional<MyClass> newValue1 = objCache.get(key1).join();
         assertTrue(newValue1.isPresent());


### PR DESCRIPTION
### Motivation

The atomic read-modify-update method in the `MetadataCache` should return a `CompletableFuture<T>` with the newly applied value instead of `CompletableFuture<Void>`. This will allow to piggyback more async calls on the completion of the update.

