### PR TITLE
[Broker] Fix race condition in invalidating ledger cache entries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -116,7 +116,7 @@ public class EntryCacheImpl implements EntryCache {
             return true;
         } else {
             // entry was not inserted into cache, we need to discard it
-            cacheEntry.release();
+            cacheEntry.invalidate();
             return false;
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -154,7 +154,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         }
         checkArgument(ledger.getId() == lh.getId(), "ledgerId %s doesn't match with acked ledgerId %s", ledger.getId(),
                 lh.getId());
-        
+
         if (!checkAndCompleteOp(ctx)) {
             // means callback might have been completed by different thread (timeout task thread).. so do nothing
             return;
@@ -189,7 +189,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
             // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling
             // insert
             ml.entryCache.insert(entry);
-            entry.release();
+            entry.invalidate();
         }
 
         PositionImpl lastEntry = PositionImpl.get(ledger.getId(), entryId);
@@ -248,7 +248,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
     /**
      * Checks if add-operation is completed
-     * 
+     *
      * @return true if task is not already completed else returns false.
      */
     private boolean checkAndCompleteOp(Object ctx) {
@@ -269,7 +269,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
     /**
      * It handles add failure on the given ledger. it can be triggered when add-entry fails or times out.
-     * 
+     *
      * @param ledger
      */
     void handleAddFailure(final LedgerHandle ledger) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/InvalidateableReferenceCounted.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/InvalidateableReferenceCounted.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.util;
+
+import io.netty.util.ReferenceCounted;
+
+public interface InvalidateableReferenceCounted extends ReferenceCounted {
+    /**
+     * Marks the entry to be removed. Internally {@link ReferenceCounted#release()} will be called unless
+     * the entry has already been invalidated before. No calls to {@link ReferenceCounted#release()} should be
+     * made separately to invalidate the entry.
+     *
+     * @return true if the value was marked to be invalidated, false if it was already invalidated before.
+     */
+    boolean invalidate();
+}


### PR DESCRIPTION
Fixes #10433

### Motivation

See #10433 . There's a rare race condition in invalidating ledger cache entries stored in RangeCache . 

### Modifications

- add separate `invalidate` method for invalidating `EntryImpl` ledger cache entries. This prevents race conditions in invalidation.