### PR TITLE
[CLIENT] fixed NPE in GenericJsonRecord

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/GenericRecord.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/GenericRecord.java
@@ -58,7 +58,7 @@ public interface GenericRecord extends GenericObject {
      * Retrieve the value of the provided <tt>fieldName</tt>.
      *
      * @param fieldName the field name
-     * @return the value object
+     * @return the value object, or null if field doesn't exist
      */
     Object getField(String fieldName);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -60,6 +60,9 @@ public class GenericJsonRecord extends VersionedGenericRecord {
     @Override
     public Object getField(String fieldName) {
         JsonNode fn = jn.get(fieldName);
+        if (fn == null) {
+            return null;
+        }
         if (fn.isContainerNode()) {
             AtomicInteger idx = new AtomicInteger(0);
             List<Field> fields = Lists.newArrayList(fn.fieldNames())

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
@@ -372,7 +372,7 @@ public class JSONSchemaTest {
     }
 
     @Test
-    public void testEncodeAndDecodeObject() {
+    public void testEncodeAndDecodeObject() throws JsonProcessingException {
         JSONSchema<PC> jsonSchema = JSONSchema.of(SchemaDefinition.<PC>builder().withPojo(PC.class).build());
         PC pc = new PC("dell", "alienware", 2021, GPU.AMD,
                 new Seller("WA", "street", 98004));
@@ -382,15 +382,16 @@ public class JSONSchemaTest {
     }
 
     @Test
-    public void testGetNativeSchema() throws IllegalAccessException {
+    public void testGetNativeSchema() throws SchemaValidationException {
         JSONSchema<PC> schema2 = JSONSchema.of(PC.class);
-        org.apache.avro.Schema avroSchema2 =
-                (Schema) schema2.getNativeSchema().orElseThrow(IllegalAccessException::new);
+        org.apache.avro.Schema avroSchema2 = (Schema) schema2.getNativeSchema().get();
         assertSame(schema2.schema, avroSchema2);
     }
 
     @Test
     public void testJsonGenericRecordBuilder() {
+        JSONSchema<Seller> sellerJsonSchema = JSONSchema.of(Seller.class);
+
         RecordSchemaBuilder sellerSchemaBuilder = SchemaBuilder.record("seller");
         sellerSchemaBuilder.field("state").type(SchemaType.STRING);
         sellerSchemaBuilder.field("street").type(SchemaType.STRING);


### PR DESCRIPTION
Fixes #10472

### Motivation
GenericJsonRecord should not error out if the non-existent field is queried.

### Modifications

Added a null check and returning null if the field does not exist.

### Verifying this change

Extended one of the tests for GenericJsonRecord.