### PR TITLE
Support Pulsar Auth token for Debezium and Kafka connect adaptor

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
@@ -45,6 +45,12 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
     private static final String PULSAR_SERVICE_URL_CONFIG_DOC = "pulsar service url";
 
     /**
+     * <code>pulsar.auth.token</code>
+     */
+    public static final String PULSAR_AUTH_TOKEN_CONFIG = "pulsar.auth.token";
+    private static final String PULSAR_AUTH_TOKEN_CONFIG_DOC = "pulsar auth token";
+
+    /**
      * <code>topic.namespace</code>
      */
     public static final String TOPIC_NAMESPACE_CONFIG = "topic.namespace";
@@ -60,6 +66,10 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
                 Type.STRING,
                 Importance.HIGH,
                 PULSAR_SERVICE_URL_CONFIG_DOC)
+            .define(PULSAR_AUTH_TOKEN_CONFIG,
+                Type.STRING,
+                Importance.HIGH,
+                PULSAR_AUTH_TOKEN_CONFIG_DOC)
             .define(TOPIC_NAMESPACE_CONFIG,
                 Type.STRING,
                 "public/default",


### PR DESCRIPTION
Motivation:
Currently with the Debezium and with the Kafka Connect Adapter you cannot configure authentication in order to connect to a Pulsar cluster that requires "Token" authentication

Changes:
With this patch we are adding support in the Debezium and in the Kafka Connect Adaptor for connecting to a Pulsar instance that supports Token authentication.

Documentation:
Documentation will be provided as a follow up patch.