### PR TITLE
Update command descriptions from old 'property/cluster/namespace' format to current 'tenant/namespace' format

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -122,7 +122,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace")
     private class GetList extends CliCommand {
-        @Parameter(description = "tenant/namespaces", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -134,7 +134,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace bundle")
     private class GetListInBundle extends CliCommand {
-        @Parameter(description = "tenant/namespaces", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-b",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -53,7 +53,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -66,7 +66,7 @@ public class CmdNonPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -78,7 +78,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -92,7 +92,7 @@ public class CmdNonPersistentTopics extends CmdBase {
             + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -110,7 +110,7 @@ public class CmdNonPersistentTopics extends CmdBase {
             + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -122,7 +122,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace")
     private class GetList extends CliCommand {
-        @Parameter(description = "property/cluster/namespace", required = true)
+        @Parameter(description = "tenant/namespaces", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -134,7 +134,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace bundle")
     private class GetListInBundle extends CliCommand {
-        @Parameter(description = "property/cluster/namespace", required = true)
+        @Parameter(description = "tenant/namespaces", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-b",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -53,7 +53,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -66,7 +66,7 @@ public class CmdNonPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -78,7 +78,7 @@ public class CmdNonPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -92,7 +92,7 @@ public class CmdNonPersistentTopics extends CmdBase {
             + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -110,7 +110,7 @@ public class CmdNonPersistentTopics extends CmdBase {
             + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "non-persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "non-persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -119,7 +119,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Grant a new permission to a client role on a single topic.")
     private class GrantPermissions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
@@ -140,7 +140,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "was not set at the topic level, but rather at the namespace level, this "
             + "operation will return an error (HTTP status code 412).")
     private class RevokePermissions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--role", description = "Client role to which revoke permissions", required = true)
@@ -158,7 +158,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "by the permissions set at the namespace level combined (union) with any eventual "
             + "specific permission set on the topic.")
     private class Permissions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -170,7 +170,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -182,7 +182,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get Namespace bundle range of a topic")
     private class GetBundleRange extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -196,7 +196,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -214,7 +214,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "New updating number of partitions must be greater than existing number of partitions.")
     private class UpdatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -232,7 +232,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -246,7 +246,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "It will also delete all the partitions of the topic if it exists.")
     private class DeletePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -262,7 +262,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Delete a topic. "
             + "The topic cannot be deleted if there's any active subscription or producers connected to it.")
     private class DeleteCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -277,7 +277,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Unload a topic.")
     private class UnloadCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -302,7 +302,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of subscriptions on the topic")
     private class ListSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -315,7 +315,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Delete a durable subscriber from a topic. "
             + "The subscription cannot be deleted if there are any active consumers attached to it")
     private class DeleteSubscription extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
@@ -335,7 +335,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -347,7 +347,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-m",
@@ -363,7 +363,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal metadata info for the topic")
     private class GetInternalInfo extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -378,7 +378,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--per-partition", description = "Get per partition stats")
@@ -394,7 +394,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -406,7 +406,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Skip all the messages for the subscription")
     private class SkipAll extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s", "--subscription" }, description = "Subscription to be cleared", required = true)
@@ -421,7 +421,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Skip some messages for the subscription")
     private class Skip extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -440,7 +440,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for the subscription")
     private class ExpireMessages extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -459,7 +459,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for all subscriptions")
     private class ExpireMessagesForAllSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
@@ -474,7 +474,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Create a new subscription on a topic")
     private class CreateSubscription extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -503,7 +503,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Reset position for subscription to position closest to timestamp or messageId")
     private class ResetCursor extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -539,7 +539,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Terminate a topic and don't allow any more messages to be published")
     private class Terminate extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -557,7 +557,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Peek some messages for the subscription")
     private class PeekMessages extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -635,7 +635,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Compact a topic")
     private class Compact extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -649,7 +649,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Status of compaction on a topic")
     private class CompactionStatusCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-w", "--wait-complete" },

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -95,7 +95,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
     private class ListCmd extends CliCommand {
-        @Parameter(description = "tenant/namespaces", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -107,7 +107,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of partitioned topics under a namespace.")
     private class PartitionedTopicListCmd extends CliCommand {
-        @Parameter(description = "tenant/namespaces", required = true)
+        @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -95,7 +95,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of topics under a namespace.")
     private class ListCmd extends CliCommand {
-        @Parameter(description = "property/cluster/namespace", required = true)
+        @Parameter(description = "tenant/namespaces", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -107,7 +107,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of partitioned topics under a namespace.")
     private class PartitionedTopicListCmd extends CliCommand {
-        @Parameter(description = "property/cluster/namespace", required = true)
+        @Parameter(description = "tenant/namespaces", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -119,7 +119,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Grant a new permission to a client role on a single topic.")
     private class GrantPermissions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
@@ -140,7 +140,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "was not set at the topic level, but rather at the namespace level, this "
             + "operation will return an error (HTTP status code 412).")
     private class RevokePermissions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--role", description = "Client role to which revoke permissions", required = true)
@@ -158,7 +158,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "by the permissions set at the namespace level combined (union) with any eventual "
             + "specific permission set on the topic.")
     private class Permissions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -170,7 +170,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Lookup a topic from the current serving broker")
     private class Lookup extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -182,7 +182,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get Namespace bundle range of a topic")
     private class GetBundleRange extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -196,7 +196,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "The partitioned topic has to be created before creating a producer on it.")
     private class CreatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -214,7 +214,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "New updating number of partitions must be greater than existing number of partitions.")
     private class UpdatePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-p",
@@ -232,7 +232,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "If the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
     private class GetPartitionedTopicMetadataCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -246,7 +246,7 @@ public class CmdPersistentTopics extends CmdBase {
             + "It will also delete all the partitions of the topic if it exists.")
     private class DeletePartitionedCmd extends CliCommand {
 
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -262,7 +262,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Delete a topic. "
             + "The topic cannot be deleted if there's any active subscription or producers connected to it.")
     private class DeleteCmd extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--force", description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -277,7 +277,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Unload a topic.")
     private class UnloadCmd extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -302,7 +302,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the list of subscriptions on the topic")
     private class ListSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -315,7 +315,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Delete a durable subscriber from a topic. "
             + "The subscription cannot be deleted if there are any active consumers attached to it")
     private class DeleteSubscription extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-f",
@@ -335,7 +335,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -347,7 +347,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal stats for the topic")
     private class GetInternalStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-m",
@@ -363,7 +363,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Get the internal metadata info for the topic")
     private class GetInternalInfo extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -378,7 +378,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats for the partitioned topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStats extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = "--per-partition", description = "Get per partition stats")
@@ -394,7 +394,7 @@ public class CmdPersistentTopics extends CmdBase {
     @Parameters(commandDescription = "Get the stats-internal for the partitioned topic and its connected producers and consumers. "
             + "All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
     private class GetPartitionedStatsInternal extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -406,7 +406,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Skip all the messages for the subscription")
     private class SkipAll extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s", "--subscription" }, description = "Subscription to be cleared", required = true)
@@ -421,7 +421,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Skip some messages for the subscription")
     private class Skip extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -440,7 +440,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for the subscription")
     private class ExpireMessages extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -459,7 +459,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for all subscriptions")
     private class ExpireMessagesForAllSubscriptions extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
@@ -474,7 +474,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Create a new subscription on a topic")
     private class CreateSubscription extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -503,7 +503,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Reset position for subscription to position closest to timestamp or messageId")
     private class ResetCursor extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -539,7 +539,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Terminate a topic and don't allow any more messages to be published")
     private class Terminate extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -557,7 +557,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Peek some messages for the subscription")
     private class PeekMessages extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-s",
@@ -635,7 +635,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Compact a topic")
     private class Compact extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Override
@@ -649,7 +649,7 @@ public class CmdPersistentTopics extends CmdBase {
 
     @Parameters(commandDescription = "Status of compaction on a topic")
     private class CompactionStatusCmd extends CliCommand {
-        @Parameter(description = "persistent://property/cluster/namespace/topic", required = true)
+        @Parameter(description = "persistent://tenant/namespaces/topic", required = true)
         private java.util.List<String> params;
 
         @Parameter(names = { "-w", "--wait-complete" },

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
@@ -35,7 +35,7 @@ public class CmdResourceQuotas extends CmdBase {
     private class GetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "tenant/namespaces, must be specified together with '--bundle'")
+                "-n" }, description = "tenant/namespace, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
@@ -59,7 +59,7 @@ public class CmdResourceQuotas extends CmdBase {
     private class SetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "tenant/namespaces, must be specified together with '--bundle'")
+                "-n" }, description = "tenant/namespace, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
@@ -113,7 +113,7 @@ public class CmdResourceQuotas extends CmdBase {
     @Parameters(commandDescription = "Reset the specified namespace bundle's resource quota to default value.")
     private class ResetNamespaceBundleResourceQuota extends CliCommand {
 
-        @Parameter(names = { "--namespace", "-n" }, description = "tenant/namespaces", required = true)
+        @Parameter(names = { "--namespace", "-n" }, description = "tenant/namespace", required = true)
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}", required = true)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceQuotas.java
@@ -35,7 +35,7 @@ public class CmdResourceQuotas extends CmdBase {
     private class GetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'")
+                "-n" }, description = "tenant/namespaces, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
@@ -59,7 +59,7 @@ public class CmdResourceQuotas extends CmdBase {
     private class SetResourceQuota extends CliCommand {
 
         @Parameter(names = { "--namespace",
-                "-n" }, description = "property/cluster/namespace, must be specified together with '--bundle'")
+                "-n" }, description = "tenant/namespaces, must be specified together with '--bundle'")
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle",
@@ -113,7 +113,7 @@ public class CmdResourceQuotas extends CmdBase {
     @Parameters(commandDescription = "Reset the specified namespace bundle's resource quota to default value.")
     private class ResetNamespaceBundleResourceQuota extends CliCommand {
 
-        @Parameter(names = { "--namespace", "-n" }, description = "property/cluster/namespace", required = true)
+        @Parameter(names = { "--namespace", "-n" }, description = "tenant/namespaces", required = true)
         private java.util.List<String> names;
 
         @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}", required = true)


### PR DESCRIPTION
### Motivation

Some command use the old format "property/cluster/namespace", it is better that the help reflects current version style.

### Modifications

Fix the examples

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
