### PR TITLE
Fix potential bug getting stats and remove unnecessary error log

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -395,7 +395,9 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
                 @Override
                 public void initializeFailed(ManagedLedgerException e) {
-                    log.error("[{}] Failed to initialize managed ledger: {}", name, e.getMessage());
+                    if (config.isCreateIfMissing()) {
+                        log.error("[{}] Failed to initialize managed ledger: {}", name, e.getMessage());
+                    }
 
                     // Clean the map if initialization fails
                     ledgers.remove(name, future);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1183,7 +1183,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             return;
         }
 
-        if (!checkMaxTopicsPerNamespace(topicName, 1, topicFuture)) {
+        if (createIfMissing && !checkMaxTopicsPerNamespace(topicName, 1, topicFuture)) {
             return;
         }
 


### PR DESCRIPTION
### Motivation

1. Fix potential bug when calling get stats and maximum number of topics per namespace is set.  
2. Remove unnecessary managed ledger error message when a topic does not exist when getting stats

