### PR TITLE
[managed-ledger] Fix infinite loop timeout in asyncCreateLedger that deadlocks the client producer semaphore

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3529,6 +3529,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Ledger already created when timeout task is triggered", name);
+                    return;
                 }
             }
             cb.createComplete(BKException.Code.TimeoutException, null, ledgerCreated);


### PR DESCRIPTION
We currently have a producer deadlock where the producer semaphore is not getting released because the broker is not sending the ack. The mystery was why the broker was not sending the ack. 
During extensive log tracing, it was discovered that right when the subscription freezes, the log message `Ledger already created when timeout task is triggered` floods the broker log several thousand times, and after that, the broker stops processing messages. 