### PR TITLE
[fix #10235] fix deadlock on Monitoring thread blocked by `LeaderService.isLeader()`

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerStatsManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerStatsManager.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.functions.proto.Function;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class WorkerStatsManager {
 
@@ -65,6 +66,9 @@ public class WorkerStatsManager {
 
   @Setter
   private LeaderService leaderService;
+
+  @Setter
+  private Supplier<Boolean> isLeader;
 
   private CollectorRegistry collectorRegistry = new CollectorRegistry();
 
@@ -279,7 +283,7 @@ public class WorkerStatsManager {
   }
 
   private void generateLeaderMetrics(StringWriter stream) {
-    if (leaderService.isLeader()) {
+    if (isLeader.get()) {
 
       List<Function.FunctionMetaData> metadata = functionMetaDataManager.getAllFunctionMetaData();
       // get total number functions

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/ClusterServiceCoordinatorTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/ClusterServiceCoordinatorTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
 import org.apache.pulsar.functions.worker.executor.MockExecutorController;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -56,6 +58,7 @@ public class ClusterServiceCoordinatorTest {
     private ClusterServiceCoordinator coordinator;
     private ScheduledExecutorService mockExecutor;
     private MockExecutorController mockExecutorController;
+    private Supplier<Boolean> checkIsStillLeader;
 
     @BeforeMethod
     public void setup() throws Exception {
@@ -71,7 +74,8 @@ public class ClusterServiceCoordinatorTest {
         ).thenReturn(mockExecutor);
 
         this.leaderService = mock(LeaderService.class);
-        this.coordinator = new ClusterServiceCoordinator("test-coordinator", leaderService);
+        this.checkIsStillLeader = () -> leaderService.isLeader();
+        this.coordinator = new ClusterServiceCoordinator("test-coordinator", leaderService, checkIsStillLeader);
     }
 
 


### PR DESCRIPTION
Fixes #10235

### Motivation

According to #10235, when `LeaderService` is changing leadership status (like losing leadership, or becoming a leader), the `LeaderService` will be locked with `synchronized` block. Which will block other threads if calling `LeaderService.isLeader()`. This PR changes `ClusterServiceCoordinator` and `WorkerStatsManager` to check if is leader from `MembershipManager`, which will not block other threads if `LeaderService` is at `synchronized` block.

Also, this PR will not resolve the root cause of #10235, since there is lack of context about blocked reader for the `FunctionAssignmentTailer`. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
