### PR TITLE
[#10503] allow user to set custom configs to plugin worker service

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -534,6 +534,12 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_WORKER,
+            doc = "The additional configs for the function worker service if functionsWorkerServiceNarPackage provided"
+    )
+    private Map<String, Object> functionsWorkerServiceCustomConfigs = Collections.emptyMap();
+
+    @FieldContext(
+            category = CATEGORY_WORKER,
             doc = "Enable to expose Pulsar Admin Client from Function Context, default is disabled"
     )
     private boolean exposeAdminClientEnabled = false;


### PR DESCRIPTION
Fixes #10503

### Motivation

#8560 provide an interface for functions worker service and allows user to implement their own functions worker as a plugin functions worker. It would be great if the user can pass some custom settings to plugin functions worker service through `WorkerConfig`.

### Modifications

- add `functionsWorkerServiceCustomConfigs` to `WorkerConfig`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
