### PR TITLE
[C++] Avoid sending flow requests with zero permits

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -204,7 +204,7 @@ void ConsumerImpl::connectionFailed(Result result) {
 }
 
 void ConsumerImpl::sendFlowPermitsToBroker(const ClientConnectionPtr& cnx, int numMessages) {
-    if (cnx) {
+    if (cnx && numMessages > 0) {
         LOG_DEBUG(getName() << "Send more permits: " << numMessages);
         SharedBuffer cmd = Commands::newFlow(consumerId_, static_cast<unsigned int>(numMessages));
         cnx->sendCommand(cmd);

--- a/pulsar-client-cpp/tests/ZeroQueueSizeTest.cc
+++ b/pulsar-client-cpp/tests/ZeroQueueSizeTest.cc
@@ -223,3 +223,64 @@ TEST(ZeroQueueSizeTest, testPauseResume) {
 
     client.close();
 }
+
+TEST(ZeroQueueSizeTest, testPauseResumeNoReconnection) {
+    Client client(lookupUrl);
+    const auto topic = "ZeroQueueSizeTestPauseListener-" + std::to_string(time(nullptr));
+
+    std::mutex mtx;
+    std::condition_variable cond;
+    bool running = true;
+
+    auto notify = [&mtx, &cond, &running] {
+        std::unique_lock<std::mutex> lock(mtx);
+        running = false;
+        cond.notify_all();
+    };
+    auto wait = [&mtx, &cond, &running] {
+        std::unique_lock<std::mutex> lock(mtx);
+        running = true;
+        while (running) {
+            cond.wait(lock);
+        }
+    };
+
+    std::mutex mtxForMessages;
+    std::vector<std::string> receivedMessages;
+
+    ConsumerConfiguration consumerConf;
+    consumerConf.setReceiverQueueSize(0);
+    consumerConf.setMessageListener(
+        [&mtxForMessages, &receivedMessages, &notify](Consumer consumer, const Message& msg) {
+            std::unique_lock<std::mutex> lock(mtxForMessages);
+            receivedMessages.emplace_back(msg.getDataAsString());
+            lock.unlock();
+            consumer.acknowledge(msg);
+            notify();  // notify the consumer that a new message arrived
+        });
+
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "my-sub", consumerConf, consumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk,
+              client.createProducer(topic, ProducerConfiguration().setBatchingEnabled(false), producer));
+
+    constexpr int numMessages = 300;
+    for (int i = 0; i < numMessages; i++) {
+        const auto message = MessageBuilder().setContent(std::to_string(i)).build();
+        consumer.resumeMessageListener();
+        producer.sendAsync(message, {});
+        wait();  // wait until a new message is received
+        consumer.pauseMessageListener();
+    }
+
+    std::unique_lock<std::mutex> lock(mtxForMessages);
+    ASSERT_EQ(receivedMessages.size(), numMessages);
+    for (int i = 0; i < numMessages; i++) {
+        ASSERT_EQ(i, std::stoi(receivedMessages[i]));
+    }
+    lock.unlock();
+
+    client.close();
+}

--- a/pulsar-client-cpp/tests/ZeroQueueSizeTest.cc
+++ b/pulsar-client-cpp/tests/ZeroQueueSizeTest.cc
@@ -226,7 +226,7 @@ TEST(ZeroQueueSizeTest, testPauseResume) {
 
 TEST(ZeroQueueSizeTest, testPauseResumeNoReconnection) {
     Client client(lookupUrl);
-    const auto topic = "ZeroQueueSizeTestPauseListener-" + std::to_string(time(nullptr));
+    const auto topic = "ZeroQueueSizeTestPauseResumeNoReconnection-" + std::to_string(time(nullptr));
 
     std::mutex mtx;
     std::condition_variable cond;


### PR DESCRIPTION
### Motivation

When broker receives a FLOW request with zero permit, an `IllegalArgumentException` will be thrown in `ServerCnx#handleFlow` and then the connection will be closed so that the consumer will reconnect to the broker. If `resumeMessageListener()` was called for a zero queue consumer, the permits may be zero and trigger a reconnection. The frequent reconnections may cause messages repeated or out of order.

### Modifications

- Validate the permits of a FLOW command before sending it.
- Add a test that a zero queue consumer resumes and pauses for each message periodically. Before this PR, there's a great chance that the received messages are repeated or out of order, even a ACK was sent.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests `ZeroQueueSizeTest#testPauseResumeNoReconnection`.