### PR TITLE
[Java Client] Avoid sending flow requests with zero permits

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -855,7 +855,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
      * send the flow command to have the broker start pushing messages
      */
     private void sendFlowPermitsToBroker(ClientCnx cnx, int numMessages) {
-        if (cnx != null) {
+        if (cnx != null && numMessages > 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Adding {} additional permits", topic, subscription, numMessages);
             }


### PR DESCRIPTION
### Motivation

It's the Java client side fix for https://github.com/apache/pulsar/pull/10506.

When broker receives a FLOW request with zero permit, an IllegalArgumentException will be thrown in `ServerCnx#handleFlow` and then the connection will be closed so that the consumer will reconnect to the broker. If `resume()` was called for a zero queue consumer, the permits may be zero and trigger a reconnection. The frequent reconnections may cause messages repeated or out of order.

### Modifications

- Validate the permits of a FLOW command before sending it.
- Add a test that a zero queue consumer resumes and pauses for each message periodically. Before this PR, there's a great chance that the received messages are repeated or out of order, even a ACK was sent.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests `ZeroQueueSizeTest#testPauseAndResumeNoReconnection`.