### PR TITLE
[Bug] - Fixed Broken Links at Licensing & K8S Cluster Setup on AWS

### DIFF
--- a/site2/website/coding-guide.md
+++ b/site2/website/coding-guide.md
@@ -20,7 +20,7 @@ Apache Pulsar uses the following libraries a lot:
 
 Use these libraries whenever possible rather than introducing more dependencies. 
 
-Dependencies are bundled with our binary distributions, so we need to attach the relevant licenses. See [Third party dependencies and licensing](/community/licensing) for a guide on how to do it correctly.
+Dependencies are bundled with our binary distributions, so we need to attach the relevant licenses. See [Third party dependencies and licensing](https://pulsar.apache.org/docs/en/client-libraries/) for a guide on how to do it correctly.
 
 ## Future
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/deploy-kubernetes.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/deploy-kubernetes.md
@@ -75,7 +75,7 @@ or using [`helm`](#deploying-pulsar-components-helm).
 
 You can run Kubernetes on [Amazon Web Services](https://aws.amazon.com/) (AWS) in a variety of ways. A very simple way that was [recently introduced](https://aws.amazon.com/blogs/compute/kubernetes-clusters-aws-kops/) involves using the [Kubernetes Operations](https://github.com/kubernetes/kops) (kops) tool.
 
-You can find detailed instructions for setting up a Kubernetes cluster on AWS [here](https://github.com/kubernetes/kops/blob/master/docs/aws.md).
+You can find detailed instructions for setting up a Kubernetes cluster on AWS [here](https://github.com/kubernetes/kops/blob/master/docs/getting_started/aws.md).
 
 When you create a cluster using those instructions, your `kubectl` config in `~/.kube/config` (on MacOS and Linux) will be updated for you, so you probably won't need to change your configuration. Nonetheless, you can ensure that `kubectl` can interact with your cluster by listing the nodes in the cluster:
 


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <aadithya794@gmail.com>

Fixes #9730 


### Motivation
To ensure, the links are addressed to the write webpages.


### Modifications

*Describe the modifications you've done.*
Fixed the links,  https://pulsar.apache.org/en/coding-guide/ and another one linked to setting up Kubernetes cluster on AWS

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage: **Yes**

