### PR TITLE
[Transaction] Fix transaction buffer delete marker problem.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -382,29 +382,32 @@ public class PersistentSubscription implements Subscription {
         if (position != null) {
             ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) cursor.getManagedLedger());
             PositionImpl nextPosition = managedLedger.getNextValidPosition(position);
-            managedLedger.asyncReadEntry(nextPosition, new ReadEntryCallback() {
-                @Override
-                public void readEntryComplete(Entry entry, Object ctx) {
-                    try {
-                        MessageMetadata messageMetadata = Commands.parseMessageMetadata(entry.getDataBuffer());
-                        isDeleteTransactionMarkerInProcess = false;
-                        if (Markers.isTxnCommitMarker(messageMetadata) || Markers.isTxnAbortMarker(messageMetadata)) {
-                            lastMarkDeleteForTransactionMarker = position;
-                            acknowledgeMessage(Collections.singletonList(nextPosition), ackType, properties);
+            if (nextPosition.compareTo((PositionImpl) managedLedger.getLastConfirmedEntry()) <= 0) {
+                managedLedger.asyncReadEntry(nextPosition, new ReadEntryCallback() {
+                    @Override
+                    public void readEntryComplete(Entry entry, Object ctx) {
+                        try {
+                            MessageMetadata messageMetadata = Commands.parseMessageMetadata(entry.getDataBuffer());
+                            isDeleteTransactionMarkerInProcess = false;
+                            if (Markers.isTxnCommitMarker(messageMetadata)
+                                    || Markers.isTxnAbortMarker(messageMetadata)) {
+                                lastMarkDeleteForTransactionMarker = position;
+                                acknowledgeMessage(Collections.singletonList(nextPosition), ackType, properties);
+                            }
+                        } finally {
+                            entry.release();
                         }
-                    } finally {
-                        entry.release();
                     }
-                }
 
-                @Override
-                public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                    isDeleteTransactionMarkerInProcess = false;
-                    if (log.isDebugEnabled()) {
-                        log.debug("Fail to read transaction marker! Position : {}", position, exception);
+                    @Override
+                    public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                        isDeleteTransactionMarkerInProcess = false;
+                        log.error("Fail to read transaction marker! Position : {}", position, exception);
                     }
-                }
-            }, null);
+                }, null);
+            } else {
+                isDeleteTransactionMarkerInProcess = false;
+            }
         } else {
             isDeleteTransactionMarkerInProcess = false;
         }


### PR DESCRIPTION
## Motivation
fix https://github.com/apache/pulsar/issues/9114
fix https://github.com/apache/pulsar/issues/10403
## implement
transaction buffer delete marker position may more than the LAC, add the judge logical to avoid delete the fail marker.

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

