### PR TITLE
Fix partitioned system topic check bug

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -168,7 +168,10 @@ public interface SystemTopicClient<T> {
     }
 
     static boolean isSystemTopic(TopicName topicName) {
-        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicName.getLocalName());
+        String localName = topicName.getLocalName();
+        int partitionIndex = localName.indexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+        String topicNameWithoutSuffix = partitionIndex == -1 ? localName : localName.substring(0, partitionIndex);
+        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicNameWithoutSuffix);
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -168,10 +168,12 @@ public interface SystemTopicClient<T> {
     }
 
     static boolean isSystemTopic(TopicName topicName) {
-        String localName = topicName.getLocalName();
-        int partitionIndex = localName.indexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
-        String topicNameWithoutSuffix = partitionIndex == -1 ? localName : localName.substring(0, partitionIndex);
-        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicNameWithoutSuffix);
+        if (topicName.isPartitioned()) {
+            return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME
+                    .equals(TopicName.get(topicName.getPartitionedTopicName()).getLocalName());
+        }
+
+        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicName.getLocalName());
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -24,9 +24,11 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.events.ActionType;
 import org.apache.pulsar.common.events.EventType;
+import org.apache.pulsar.common.events.EventsTopicNames;
 import org.apache.pulsar.common.events.PulsarEvent;
 import org.apache.pulsar.common.events.TopicPoliciesEvent;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
@@ -106,6 +108,18 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
         systemTopicClientForNamespace1.close();
         Assert.assertEquals(systemTopicClientForNamespace1.getWriters().size(), 0);
         Assert.assertEquals(systemTopicClientForNamespace1.getReaders().size(), 0);
+    }
+
+    @Test(timeOut = 30000)
+    public void checkSystemTopic() throws PulsarAdminException {
+        final String systemTopic = "persistent://" + NAMESPACE1 + "/" + EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
+        final String normalTopic = "persistent://" + NAMESPACE1 + "/normal_topic";
+        admin.topics().createPartitionedTopic(normalTopic, 3);
+        TopicName systemTopicName = TopicName.get(systemTopic);
+        TopicName normalTopicName = TopicName.get(normalTopic);
+
+        Assert.assertEquals(SystemTopicClient.isSystemTopic(systemTopicName), true);
+        Assert.assertEquals(SystemTopicClient.isSystemTopic(normalTopicName), false);
     }
 
     private void prepareData() throws PulsarAdminException {


### PR DESCRIPTION
### Motivation
When checking a partitioned topic whether a system topic, it will always be `false`. The check logic is.
```Java
static boolean isSystemTopic(TopicName topicName) {
        return EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME.equals(topicName.getLocalName());
    }
```
```Java
public static final String NAMESPACE_EVENTS_LOCAL_NAME = "__change_events";
```
The partitioned topic name is like `__change_events-partition-0`.

### Modification
1. Trim the partition suffix for the topic local name if exists.
2. Add a test to cover this case.
