### PR TITLE
[Issue 10522] support mock zookeeper with different session

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 
@@ -129,8 +130,9 @@ public class OwnerShipForCurrentServerTestBase {
         // Override default providers with mocked ones
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
+        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore();
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -53,10 +53,11 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
+import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.data.ACL;
 
 @Slf4j
 public abstract class TransactionTestBase extends TestRetrySupport {
@@ -144,8 +145,10 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         // Override default providers with mocked ones
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
+
+        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore();
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
 

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -219,6 +219,8 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public String toString() {
-        return "MockZookeeperSession";
+        return "MockZooKeeperSession{" +
+                "sessionId=" + sessionId +
+                '}';
     }
 }

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.zookeeper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+import org.apache.zookeeper.AsyncCallback.Children2Callback;
+import org.apache.zookeeper.AsyncCallback.ChildrenCallback;
+import org.apache.zookeeper.AsyncCallback.DataCallback;
+import org.apache.zookeeper.AsyncCallback.StatCallback;
+import org.apache.zookeeper.AsyncCallback.VoidCallback;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+import org.objenesis.instantiator.ObjectInstantiator;
+
+/**
+ * mock zookeeper with different session based on {@link MockZooKeeper}
+ */
+public class MockZooKeeperSession extends ZooKeeper {
+
+    private MockZooKeeper mockZooKeeper;
+
+    private long sessionId = 0L;
+
+    private static final Objenesis objenesis = new ObjenesisStd();
+
+    private static final AtomicInteger sessionIdGenerator = new AtomicInteger(0);
+
+    public static MockZooKeeperSession newInstance(MockZooKeeper mockZooKeeper) {
+        ObjectInstantiator<MockZooKeeperSession> instantiator = objenesis.getInstantiatorOf(MockZooKeeperSession.class);
+        MockZooKeeperSession mockZooKeeperSession = instantiator.newInstance();
+
+        mockZooKeeperSession.mockZooKeeper = mockZooKeeper;
+        mockZooKeeperSession.sessionId = sessionIdGenerator.getAndIncrement();
+        return mockZooKeeperSession;
+    }
+
+    private MockZooKeeperSession(String quorum) throws Exception {
+        // This constructor is never called
+        super(quorum, 1, event -> {
+        });
+        assert false;
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return mockZooKeeper.getSessionTimeout();
+    }
+
+    @Override
+    public States getState() {
+        return mockZooKeeper.getState();
+    }
+
+    @Override
+    public void register(Watcher watcher) {
+        mockZooKeeper.register(watcher);
+    }
+
+    @Override
+    public String create(String path, byte[] data, List<ACL> acl, CreateMode createMode)
+            throws KeeperException, InterruptedException {
+        return mockZooKeeper.create(path, data, acl, createMode);
+    }
+
+    @Override
+    public void create(final String path, final byte[] data, final List<ACL> acl, CreateMode createMode,
+                       final AsyncCallback.StringCallback cb, final Object ctx) {
+        mockZooKeeper.create(path, data, acl, createMode, cb, ctx);
+    }
+
+    @Override
+    public byte[] getData(String path, Watcher watcher, Stat stat) throws KeeperException {
+        return mockZooKeeper.getData(path, watcher, stat);
+    }
+
+    @Override
+    public void getData(final String path, boolean watch, final DataCallback cb, final Object ctx) {
+        mockZooKeeper.getData(path, watch, cb, ctx);
+    }
+
+    @Override
+    public void getData(final String path, final Watcher watcher, final DataCallback cb, final Object ctx) {
+        mockZooKeeper.getData(path, watcher, cb, ctx);
+    }
+
+    @Override
+    public void getChildren(final String path, final Watcher watcher, final ChildrenCallback cb, final Object ctx) {
+        mockZooKeeper.getChildren(path, watcher, cb, ctx);
+    }
+
+    @Override
+    public List<String> getChildren(String path, Watcher watcher) throws KeeperException {
+        return mockZooKeeper.getChildren(path, watcher);
+    }
+
+    @Override
+    public List<String> getChildren(String path, boolean watch) throws KeeperException, InterruptedException {
+        return mockZooKeeper.getChildren(path, watch);
+    }
+
+    @Override
+    public void getChildren(final String path, boolean watcher, final Children2Callback cb, final Object ctx) {
+        mockZooKeeper.getChildren(path, watcher, cb, ctx);
+    }
+
+    @Override
+    public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
+        return mockZooKeeper.exists(path, watch);
+    }
+
+    @Override
+    public Stat exists(String path, Watcher watcher) throws KeeperException, InterruptedException {
+        return mockZooKeeper.exists(path, watcher);
+    }
+
+    @Override
+    public void exists(String path, boolean watch, StatCallback cb, Object ctx) {
+        mockZooKeeper.exists(path, watch, cb, ctx);
+    }
+
+    @Override
+    public void exists(String path, Watcher watcher, StatCallback cb, Object ctx) {
+        mockZooKeeper.exists(path, watcher, cb, ctx);
+    }
+
+    @Override
+    public void sync(String path, VoidCallback cb, Object ctx) {
+        mockZooKeeper.sync(path, cb, ctx);
+    }
+
+    @Override
+    public Stat setData(final String path, byte[] data, int version) throws KeeperException, InterruptedException {
+        return mockZooKeeper.setData(path, data, version);
+    }
+
+    @Override
+    public void setData(final String path, final byte[] data, int version, final StatCallback cb, final Object ctx) {
+        mockZooKeeper.setData(path, data, version, cb, ctx);
+    }
+
+    @Override
+    public void delete(final String path, int version) throws InterruptedException, KeeperException {
+        mockZooKeeper.delete(path, version);
+    }
+
+    @Override
+    public void delete(final String path, int version, final VoidCallback cb, final Object ctx) {
+        mockZooKeeper.delete(path, version, cb, ctx);
+    }
+
+    @Override
+    public void multi(Iterable<org.apache.zookeeper.Op> ops, AsyncCallback.MultiCallback cb, Object ctx) {
+        mockZooKeeper.multi(ops, cb, ctx);
+    }
+
+    @Override
+    public List<OpResult> multi(Iterable<org.apache.zookeeper.Op> ops) throws InterruptedException, KeeperException {
+        return mockZooKeeper.multi(ops);
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+        mockZooKeeper.close();
+    }
+
+    public void shutdown() throws InterruptedException {
+        mockZooKeeper.shutdown();
+    }
+
+    Optional<KeeperException.Code> programmedFailure(MockZooKeeper.Op op, String path) {
+        return mockZooKeeper.programmedFailure(op, path);
+    }
+
+    void maybeThrowProgrammedFailure(MockZooKeeper.Op op, String path) throws KeeperException {
+        mockZooKeeper.maybeThrowProgrammedFailure(op, path);
+    }
+
+    public void failConditional(KeeperException.Code rc, BiPredicate<MockZooKeeper.Op, String> predicate) {
+        mockZooKeeper.failConditional(rc, predicate);
+    }
+
+    public void setAlwaysFail(KeeperException.Code rc) {
+        mockZooKeeper.setAlwaysFail(rc);
+    }
+
+    public void unsetAlwaysFail() {
+        mockZooKeeper.unsetAlwaysFail();
+    }
+
+    public void setSessionId(long id) {
+        sessionId = id;
+    }
+
+    @Override
+    public long getSessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public String toString() {
+        return "MockZookeeperSession";
+    }
+}


### PR DESCRIPTION
fixes #10522

**Motivation**
support mock zookeeper with different session

**Modification**
wrap `MockZookeeper` to support mock zookeeper with different session