### PR TITLE
K8s Function Name Length Check Allows Invalid StatefulSet 

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -108,7 +108,7 @@ import static org.apache.pulsar.functions.utils.FunctionCommon.roundDecimal;
 public class KubernetesRuntime implements Runtime {
 
     private static final String ENV_SHARD_ID = "SHARD_ID";
-    private static final int maxJobNameSize = 55;
+    private static final int maxJobNameSize = 53;
     private static final int maxLabelSize = 63;
     public static final Pattern VALID_POD_NAME_REGEX =
             Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",


### PR DESCRIPTION
### Motivation

When using the Kubernetes runtime, there is a check that the function name to ensure that it will create valid Kubernetes objects. It is currently set to check for the length to be less than 55. If a function is submitted with this length, a StatefulSet is created that is unable to spawn pods. This is the error you will get:

``` 
Warning  FailedCreate  1s (x13 over 22s)  statefulset-controller  create Pod pf-1234-1234-123456789012345678901234567890123456789012-0 in StatefulSet pf-1234-1234-123456789012345678901234567890123456789012 failed error: Pod "pf-1234-1234-123456789012345678901234567890123456789012-0" is invalid: metadata.labels: Invalid value: "pf-1234-1234-123456789012345678901234567890123456789012-7476d599d9": must be no more than 63 characters

```
This is because one of the generated labels for the pod name will exceed the label length of 63 characters. I have reproduced in Kubernetes 1.16 and 1.18.

Reducing the function name by 2 characters avoids the problem.

Since the check is intended to prevent the user from making input changes that will not work in k8s, fixing this will make using functions in k8s less error-prone.

### Modifications

Changed the maximum function name size from 55 to 53 characters. When using k8s runtime, function names exceeding 52 characters will be rejected.

### Verifying this change

This change is already covered by existing tests, such as verifyCreateJobNameWithNameOverMaxCharLimit.

### Does this pull request potentially affect one of the following parts:

No

### Documentation

  - Does this pull request introduce a new feature? (no)

