### PR TITLE
[PIP 79][common,broker,client] Change PartitionedTopicStats to support partial partitioned producer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -240,8 +240,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     protected volatile PublishRateLimiter brokerPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
 
     private DistributedIdGenerator producerNameGenerator;
+    private DistributedIdGenerator producerStatsKeyGenerator;
 
     public final static String PRODUCER_NAME_GENERATOR_PATH = "/counters/producer-name";
+    public final static String PRODUCER_STATS_KEY_GENERATOR_PATH = "/counters/producer-stats-key";
 
     private final BacklogQuotaManager backlogQuotaManager;
 
@@ -432,6 +434,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public void start() throws Exception {
         this.producerNameGenerator = new DistributedIdGenerator(pulsar.getCoordinationService(),
                 PRODUCER_NAME_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
+        this.producerStatsKeyGenerator = new DistributedIdGenerator(pulsar.getCoordinationService(),
+                PRODUCER_STATS_KEY_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
 
         ServerBootstrap bootstrap = defaultServerBootstrap.clone();
 
@@ -1839,6 +1843,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     public String generateUniqueProducerName() {
         return producerNameGenerator.getNextId();
+    }
+
+    public String generateUniqueProducerStatsKey() {
+        return producerStatsKeyGenerator.getNextId();
     }
 
     public Map<String, TopicStats> getTopicStats() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -85,6 +85,7 @@ public class Producer {
 
     private final ProducerAccessMode accessMode;
     private Optional<Long> topicEpoch;
+    private final Optional<String> producerStatsKey;
 
     private final Map<String, String> metadata;
 
@@ -94,7 +95,8 @@ public class Producer {
             boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
             boolean userProvidedProducerName,
             ProducerAccessMode accessMode,
-            Optional<Long> topicEpoch) {
+            Optional<Long> topicEpoch,
+            Optional<String> producerStatsKey) {
         this.topic = topic;
         this.cnx = cnx;
         this.producerId = producerId;
@@ -107,6 +109,7 @@ public class Producer {
         this.chunkedMessageRate = new Rate();
         this.isNonPersistentTopic = topic instanceof NonPersistentTopic;
         this.msgDrop = this.isNonPersistentTopic ? new Rate() : null;
+        this.producerStatsKey = producerStatsKey;
 
         this.metadata = metadata != null ? metadata : Collections.emptyMap();
 
@@ -122,6 +125,7 @@ public class Producer {
         stats.producerId = producerId;
         stats.metadata = this.metadata;
         stats.accessMode = Commands.convertProducerAccessMode(accessMode);
+        producerStatsKey.ifPresent(key -> stats.producerStatsKey = key);
 
         this.isRemote = producerName
                 .startsWith(cnx.getBrokerService().pulsar().getConfiguration().getReplicatorPrefix());
@@ -660,6 +664,10 @@ public class Producer {
 
     public Optional<Long> getTopicEpoch() {
         return topicEpoch;
+    }
+
+    public Optional<String> getProducerStatsKey() {
+        return producerStatsKey;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Producer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -38,11 +38,12 @@ public interface PulsarCommandSender {
 
     void sendErrorResponse(long requestId, ServerError error, String message);
 
-    void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion);
+    void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion,
+                                     Optional<String> producerStatsKey);
 
     void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
                                      SchemaVersion schemaVersion, Optional<Long> topicEpoch,
-                                     boolean isProducerReady);
+                                     boolean isProducerReady, Optional<String> producerStatsKey);
 
     void sendSendReceiptResponse(long producerId, long sequenceId, long highestId, long ledgerId,
                                  long entryId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -80,8 +80,10 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     }
 
     @Override
-    public void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion) {
-        BaseCommand command = Commands.newProducerSuccessCommand(requestId, producerName, schemaVersion);
+    public void sendProducerSuccessResponse(long requestId, String producerName, SchemaVersion schemaVersion,
+            Optional<String> producerStatsKey) {
+        BaseCommand command = Commands.newProducerSuccessCommand(requestId, producerName, schemaVersion,
+                producerStatsKey);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
         cnx.ctx().writeAndFlush(outBuf);
@@ -90,9 +92,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendProducerSuccessResponse(long requestId, String producerName, long lastSequenceId,
                                             SchemaVersion schemaVersion, Optional<Long> topicEpoch,
-                                            boolean isProducerReady) {
+                                            boolean isProducerReady, Optional<String> producerStatsKey) {
         BaseCommand command = Commands.newProducerSuccessCommand(requestId, producerName, lastSequenceId,
-                schemaVersion, topicEpoch, isProducerReady);
+                schemaVersion, topicEpoch, isProducerReady, producerStatsKey);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
         cnx.ctx().writeAndFlush(outBuf);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -61,7 +61,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
-import org.apache.pulsar.broker.ConfigHelper;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -20,6 +20,8 @@
 package org.apache.pulsar.broker.admin;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import java.util.List;
 import java.util.UUID;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -57,7 +59,16 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
 
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic)
+                .enableBatching(false)
                 .create();
+
+        for (int i = 0; i < 3; i++) {
+            try {
+                producer.newMessage().value("msg".getBytes()).send();
+            } catch (Throwable e) {
+                fail();
+            }
+        }
 
         List<String> partitionedTopics = admin.topics().getPartitionedTopicList(namespaceName);
         List<String> topics = admin.topics().getList(namespaceName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -47,8 +47,6 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 
-import org.apache.pulsar.broker.ConfigHelper;
-import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/GracefulExecutorServicesShutdownTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/GracefulExecutorServicesShutdownTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -148,6 +149,8 @@ public class GracefulExecutorServicesShutdownTest {
         // when
         shutdown.shutdown(executorService);
         CompletableFuture<Void> future = shutdown.handle();
+        // waiting to start awaitTermination
+        verify(executorService, timeout(100).atLeastOnce()).awaitTermination(anyLong(), any());
         future.cancel(false);
 
         // then

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -397,7 +397,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         // 1. simple add producer
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
-                ProducerAccessMode.Shared, Optional.empty());
+                ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 1);
 
@@ -414,7 +414,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         PersistentTopic failTopic = new PersistentTopic(failTopicName, ledgerMock, brokerService);
         Producer failProducer = new Producer(failTopic, serverCnx, 2 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest,0, false,
-                ProducerAccessMode.Shared, Optional.empty());
+                ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         try {
             topic.addProducer(failProducer, new CompletableFuture<>());
             fail("should have failed");
@@ -435,9 +435,9 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         String role = "appid1";
         Producer producer1 = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         try {
             topic.addProducer(producer1, new CompletableFuture<>()).join();
             topic.addProducer(producer2, new CompletableFuture<>()).join();
@@ -450,7 +450,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 1);
 
         Producer producer3 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
 
         try {
             topic.addProducer(producer3, new CompletableFuture<>()).join();
@@ -466,7 +466,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 0);
 
         Producer producer4 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
 
         topic.addProducer(producer3, new CompletableFuture<>());
         topic.addProducer(producer4, new CompletableFuture<>());
@@ -479,13 +479,13 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(topic.getProducers().size(), 0);
 
         Producer producer5 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 1, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
 
         topic.addProducer(producer5, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
 
         Producer producer6 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 2, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
 
         topic.addProducer(producer6, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
@@ -493,7 +493,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 2));
 
         Producer producer7 = new Producer(topic, serverCnx, 2 /* producer id */, "pulsar.repl.cluster1",
-                role, false, null, SchemaVersion.Latest, 3, true, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 3, true, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
 
         topic.addProducer(producer7, new CompletableFuture<>());
         Assert.assertEquals(topic.getProducers().size(), 1);
@@ -505,20 +505,20 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         String role = "appid1";
         // 1. add producer1
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role,
-                false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty());
+                false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 1);
 
         // 2. add producer2
         Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name2", role,
-                false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty());
+                false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         topic.addProducer(producer2, new CompletableFuture<>());
         assertEquals(topic.getProducers().size(), 2);
 
         // 3. add producer3 but reached maxProducersPerTopic
         try {
             Producer producer3 = new Producer(topic, serverCnx, 3 /* producer id */, "prod-name3", role,
-                    false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty());
+                    false, null, SchemaVersion.Latest,0, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
             topic.addProducer(producer3, new CompletableFuture<>()).join();
             fail("should have failed");
         } catch (Exception e) {
@@ -990,7 +990,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         // 3. delete topic with producer
         topic = (PersistentTopic) brokerService.getOrCreateTopic(successTopicName).get();
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
+                role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
         topic.addProducer(producer, new CompletableFuture<>()).join();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -1182,7 +1182,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             String role = "appid1";
             Thread.sleep(10); /* delay to ensure that the delete gets executed first */
             Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                    role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
+                    role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), Optional.empty());
             topic.addProducer(producer, new CompletableFuture<>()).join();
             fail("Should have failed");
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -417,7 +417,11 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         long resetTimeInMillis = TimeUnit.SECONDS
                 .toMillis(RelativeTimeUtil.parseRelativeTimeInSeconds(resetTimeStr));
         admin.topics().createPartitionedTopic(topicName, partitions);
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(false).create();
+        for (int i = 0; i < 2; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
         // Disable pre-fetch in consumer to track the messages received
         org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
                 .subscriptionName("my-subscription").subscribe();
@@ -463,7 +467,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         for (PersistentSubscription sub : subs) {
             backlogs += sub.getNumberOfEntriesInBacklog(false);
         }
-        assertEquals(backlogs, 10);
+        assertEquals(backlogs, 12);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.fail;
 
 import io.netty.channel.ChannelHandlerContext;
 
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -140,7 +141,8 @@ public class ClientErrorsTest {
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
             if (counter.incrementAndGet() == 2) {
-                ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+                ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty,
+                        Optional.of("stats-key")));
                 return;
             }
             ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.ServiceNotReady, "msg"));
@@ -214,7 +216,8 @@ public class ClientErrorsTest {
                 ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.AuthorizationError, "msg"));
                 return;
             }
-            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
 
         });
 
@@ -253,7 +256,8 @@ public class ClientErrorsTest {
             int i = counter.incrementAndGet();
             if (i == 1 || i == 5) {
                 // succeed on 1st and 5th attempts
-                ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+                ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                        , Optional.of("stats-key")));
                 return;
             }
             ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.PersistenceError, "msg"));
@@ -475,7 +479,8 @@ public class ClientErrorsTest {
                 ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.AuthorizationError, "msg"));
                 return;
             }
-            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
         });
 
         try {
@@ -504,7 +509,8 @@ public class ClientErrorsTest {
                 ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.AuthorizationError, "msg"));
                 return;
             }
-            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
         });
 
         mockBrokerService.setHandleSend((ctx, send, headersAndPayload) ->
@@ -559,7 +565,8 @@ public class ClientErrorsTest {
                 ctx.writeAndFlush(Commands.newError(producer.getRequestId(), ServerError.AuthorizationError, "msg"));
                 return;
             }
-            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
         });
 
         mockBrokerService.setHandleCloseProducer((ctx, closeProducer) -> {
@@ -674,7 +681,8 @@ public class ClientErrorsTest {
         });
 
         mockBrokerService.setHandleProducer((ctx, produce) -> {
-            ctx.writeAndFlush(Commands.newProducerSuccess(produce.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(produce.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
         });
 
         mockBrokerService.setHandleSend((ctx, sendCmd, headersAndPayload) -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
 
@@ -183,7 +184,8 @@ public class MockBrokerService {
                 return;
             }
             // default
-            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty));
+            ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer", SchemaVersion.Empty
+                    , Optional.of("stats-key")));
         }
 
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -41,7 +40,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.Cleanup;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PartialPartitionedProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PartialPartitionedProducerTest.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.TopicMetadata;
+import org.apache.pulsar.client.impl.customroute.PartialRoundRobinMessageRouterImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Slf4j
+@Test(groups = "broker-impl")
+public class PartialPartitionedProducerTest extends ProducerConsumerBase {
+    @Override
+    @BeforeClass
+    public void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testPtWithSinglePartition() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-with-single-routing");
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        final PartitionedProducerImpl<byte[]> producerImpl = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+
+        for (int i = 0; i < 10; i++) {
+            producerImpl.newMessage().value("msg".getBytes()).send();
+        }
+        assertEquals(producerImpl.getProducers().size(), 1);
+    }
+
+    @Test
+    public void testPtWithPartialPartition() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-with-partial-routing");
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        final PartitionedProducerImpl<byte[]> producerImpl = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.CustomPartition)
+                .messageRouter(new PartialRoundRobinMessageRouterImpl(3))
+                .create();
+
+        for (int i = 0; i < 10; i++) {
+            producerImpl.newMessage().value("msg".getBytes()).send();
+        }
+        assertEquals(producerImpl.getProducers().size(), 3);
+    }
+
+    // AddPartitionTest
+    @Test
+    public void testPtLazyLoading() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-lazily");
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        final PartitionedProducerImpl<byte[]> producerImpl = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .create();
+
+        final Supplier<Boolean> send = () -> {
+            for (int i = 0; i < 10; i++) {
+                try {
+                    producerImpl.newMessage().value("msg".getBytes()).send();
+                } catch (Throwable e) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        // create first producer at initialization step
+        assertEquals(producerImpl.getProducers().size(), 1);
+
+        assertTrue(send.get());
+        assertEquals(producerImpl.getProducers().size(), 10);
+    }
+
+    @Test
+    public void testPtLoadingNotSharedMode() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-not-shared-mode");
+        admin.topics().createPartitionedTopic(topic, 10);
+
+        final PartitionedProducerImpl<byte[]> producerImplExclusive = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .accessMode(ProducerAccessMode.Exclusive)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .create();
+
+        // create first producer at initialization step
+        assertEquals(producerImplExclusive.getProducers().size(), 10);
+
+        producerImplExclusive.close();
+
+        final PartitionedProducerImpl<byte[]> producerImplWaitForExclusive = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .accessMode(ProducerAccessMode.WaitForExclusive)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .create();
+
+        assertEquals(producerImplWaitForExclusive.getProducers().size(), 10);
+    }
+
+    // AddPartitionAndLimitTest
+    @Test
+    public void testPtUpdateWithPartialPartition() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-update-with-partial-routing");
+        admin.topics().createPartitionedTopic(topic, 2);
+
+        final Field field = PartitionedProducerImpl.class.getDeclaredField("topicMetadata");
+        field.setAccessible(true);
+        final PartitionedProducerImpl<byte[]> producerImpl = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.CustomPartition)
+                .messageRouter(new PartialRoundRobinMessageRouterImpl(3))
+                .accessMode(ProducerAccessMode.Shared)
+                .autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .create();
+
+        final Supplier<Boolean> send = ()-> {
+            for (int i = 0; i < 10; i++) {
+                try {
+                    producerImpl.newMessage().value("msg".getBytes()).send();
+                } catch (Throwable e) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        // create first producer at initialization step
+        assertEquals(producerImpl.getProducers().size(), 1);
+
+        assertTrue(send.get());
+        assertEquals(producerImpl.getProducers().size(), 2);
+
+        admin.topics().updatePartitionedTopic(topic, 3);
+        Thread.sleep(1000);
+        assertEquals(((TopicMetadata) field.get(producerImpl)).numPartitions(), 3);
+        assertEquals(producerImpl.getProducers().size(), 2);
+
+        assertTrue(send.get());
+        assertEquals(producerImpl.getProducers().size(), 3);
+
+        admin.topics().updatePartitionedTopic(topic, 4);
+        Thread.sleep(1000);
+        assertEquals(((TopicMetadata) field.get(producerImpl)).numPartitions(), 4);
+        assertTrue(send.get());
+        assertEquals(producerImpl.getProducers().size(), 3);
+    }
+
+    @Test
+    public void testPtUpdateNotSharedMode() throws Throwable {
+        final String topic = BrokerTestUtil.newUniqueName("pt-update-not-shared");
+        admin.topics().createPartitionedTopic(topic, 2);
+
+        final Field field = PartitionedProducerImpl.class.getDeclaredField("topicMetadata");
+        field.setAccessible(true);
+        final PartitionedProducerImpl<byte[]> producerImplExclusive = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .accessMode(ProducerAccessMode.Exclusive)
+                .autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .create();
+
+        assertEquals(producerImplExclusive.getProducers().size(), 2);
+
+        admin.topics().updatePartitionedTopic(topic, 3);
+        Thread.sleep(1000);
+        assertEquals(((TopicMetadata) field.get(producerImplExclusive)).numPartitions(), 3);
+        assertEquals(producerImplExclusive.getProducers().size(), 3);
+
+        producerImplExclusive.close();
+
+        final PartitionedProducerImpl<byte[]> producerImplWaitForExclusive = (PartitionedProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .accessMode(ProducerAccessMode.WaitForExclusive)
+                .autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .create();
+
+        assertEquals(producerImplWaitForExclusive.getProducers().size(), 3);
+
+        admin.topics().updatePartitionedTopic(topic, 4);
+        Thread.sleep(1000);
+        assertEquals(((TopicMetadata) field.get(producerImplWaitForExclusive)).numPartitions(), 4);
+        assertEquals(producerImplWaitForExclusive.getProducers().size(), 4);
+
+        producerImplWaitForExclusive.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -134,9 +135,9 @@ public class PulsarTestClient extends PulsarClientImpl {
     @Override
     protected <T> ProducerImpl<T> newProducerImpl(String topic, int partitionIndex, ProducerConfigurationData conf,
                                                   Schema<T> schema, ProducerInterceptors interceptors,
-                                                  CompletableFuture<Producer<T>> producerCreatedFuture) {
+                                                  CompletableFuture<Producer<T>> producerCreatedFuture, Optional<String> producerStatsKey) {
         return new ProducerImpl<T>(this, topic, conf, producerCreatedFuture, partitionIndex, schema,
-                interceptors) {
+                interceptors, producerStatsKey) {
             @Override
             protected BlockingQueue<OpSendMsg> createPendingMessagesQueue() {
                 return new ArrayBlockingQueue<OpSendMsg>(conf.getMaxPendingMessages()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -862,7 +862,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
                 .messageRouter(new MessageRouter() {
                     @Override
                     public int choosePartition(Message<?> msg, TopicMetadata metadata) {
-                        return Integer.parseInt(msg.getKey()) % metadata.numPartitions();
+                        return msg.hasKey() ? Integer.parseInt(msg.getKey()) % metadata.numPartitions() : 0;
                     }
                 })
                 .create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -50,7 +50,6 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
-import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.policies.data.FunctionStats;
 import org.apache.pulsar.common.policies.data.FunctionStatus;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -520,7 +520,8 @@ public class ClientCnx extends PulsarHandler {
             ProducerResponse pr = new ProducerResponse(success.getProducerName(),
                     success.getLastSequenceId(),
                     success.getSchemaVersion(),
-                    success.hasTopicEpoch() ? Optional.of(success.getTopicEpoch()) : Optional.empty());
+                    success.hasTopicEpoch() ? Optional.of(success.getTopicEpoch()) : Optional.empty(),
+                    success.hasProducerStatsKey() ? success.getProducerStatsKey() : null);
             requestFuture.complete(pr);
         } else {
             log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -22,10 +22,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
+
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -35,11 +36,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.NotSupportedException;
 import org.apache.pulsar.client.api.Schema;
@@ -48,6 +52,7 @@ import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +60,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
     private static final Logger log = LoggerFactory.getLogger(PartitionedProducerImpl.class);
 
-    private List<ProducerImpl<T>> producers;
+    private ConcurrentOpenHashMap<Integer, ProducerImpl<T>> producers;
     private MessageRouter routerPolicy;
     private final ProducerStatsRecorderImpl stats;
     private TopicMetadata topicMetadata;
@@ -68,11 +73,12 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     public PartitionedProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf, int numPartitions,
             CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema, ProducerInterceptors interceptors) {
         super(client, topic, conf, producerCreatedFuture, schema, interceptors);
-        this.producers = Lists.newArrayListWithCapacity(numPartitions);
+        this.producers = new ConcurrentOpenHashMap<>();
         this.topicMetadata = new TopicMetadataImpl(numPartitions);
         this.routerPolicy = getMessageRouter();
         stats = client.getConfiguration().getStatsIntervalSeconds() > 0 ? new ProducerStatsRecorderImpl() : null;
 
+        // MaxPendingMessagesAcrossPartitions doesn't support partial partition such as SinglePartition correctly
         int maxPendingMessages = Math.min(conf.getMaxPendingMessages(),
                 conf.getMaxPendingMessagesAcrossPartitions() / numPartitions);
         conf.setMaxPendingMessages(maxPendingMessages);
@@ -113,25 +119,29 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
     @Override
     public String getProducerName() {
-        return producers.get(0).getProducerName();
+        return producers.values().get(0).getProducerName();
     }
 
     @Override
     public long getLastSequenceId() {
         // Return the highest sequence id across all partitions. This will be correct,
         // since there is a single id generator across all partitions for the same producer
-        return producers.stream().map(Producer::getLastSequenceId).mapToLong(Long::longValue).max().orElse(-1);
+        return producers.values().stream().map(Producer::getLastSequenceId).mapToLong(Long::longValue).max().orElse(-1);
     }
 
     private void start() {
+        final List<Integer> indexList = conf.getAccessMode() == ProducerAccessMode.Shared ?
+                // try to create producer at least one partition
+                Collections.singletonList(routerPolicy
+                        .choosePartition(((TypedMessageBuilderImpl<T>) newMessage()).getMessage(), topicMetadata)) :
+                // try to create producer for all partitions
+                IntStream.range(0, topicMetadata.numPartitions()).boxed().collect(Collectors.toList());
+
         AtomicReference<Throwable> createFail = new AtomicReference<Throwable>();
         AtomicInteger completed = new AtomicInteger();
-        for (int partitionIndex = 0; partitionIndex < topicMetadata.numPartitions(); partitionIndex++) {
-            String partitionName = TopicName.get(topic).getPartition(partitionIndex).toString();
-            ProducerImpl<T> producer = client.newProducerImpl(partitionName, partitionIndex,
-                    conf, schema, interceptors, new CompletableFuture<>());
-            producers.add(producer);
-            producer.producerCreatedFuture().handle((prod, createException) -> {
+
+        for (int partitionIndex : indexList) {
+            createProducer(partitionIndex).handle((prod, createException) -> {
                 if (createException != null) {
                     setState(State.Failed);
                     createFail.compareAndSet(null, createException);
@@ -141,7 +151,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 // due to any
                 // failure in one of the partitions and close the successfully
                 // created partitions
-                if (completed.incrementAndGet() == topicMetadata.numPartitions()) {
+                if (completed.incrementAndGet() == indexList.size()) {
                     if (createFail.get() == null) {
                         setState(State.Ready);
                         log.info("[{}] Created partitioned producer", topic);
@@ -159,7 +169,14 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 return null;
             });
         }
+    }
 
+    private CompletableFuture<Producer<T>> createProducer(final int partitionIndex) {
+        String partitionName = TopicName.get(topic).getPartition(partitionIndex).toString();
+        ProducerImpl<T> producer = client.newProducerImpl(partitionName, partitionIndex,
+                conf, schema, interceptors, new CompletableFuture<>());
+        producers.put(partitionIndex, producer);
+        return producer.producerCreatedFuture();
     }
 
     @Override
@@ -169,6 +186,30 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
     @Override
     CompletableFuture<MessageId> internalSendWithTxnAsync(Message<?> message, Transaction txn) {
+        int partition = routerPolicy.choosePartition(message, topicMetadata);
+        checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
+                "Illegal partition index chosen by the message routing policy: " + partition);
+
+        if (!producers.containsKey(partition)) {
+            final State createState = createProducer(partition).handle((prod, createException) -> {
+                if (createException != null) {
+                    log.error("[{}] Could not create internal producer. partitionIndex: {}", topic, partition,
+                            createException);
+                    try {
+                        producers.remove(partition).close();
+                    } catch (PulsarClientException e) {
+                        log.error("[{}] Could not close internal producer. partitionIndex: {}", topic, partition, e);
+                    }
+                    return State.Failed;
+                }
+                log.debug("[{}] Created internal producer. partitionIndex: {}", topic, partition);
+                return State.Ready;
+            }).join();
+            if (createState == State.Failed) {
+                return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
+            }
+        }
+
         switch (getState()) {
             case Ready:
             case Connecting:
@@ -185,34 +226,30 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
         }
 
-        int partition = routerPolicy.choosePartition(message, topicMetadata);
-        checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
-                "Illegal partition index chosen by the message routing policy: " + partition);
         return producers.get(partition).internalSendWithTxnAsync(message, txn);
     }
 
     @Override
     public CompletableFuture<Void> flushAsync() {
-        List<CompletableFuture<Void>> flushFutures =
-            producers.stream().map(ProducerImpl::flushAsync).collect(Collectors.toList());
-        return CompletableFuture.allOf(flushFutures.toArray(new CompletableFuture[flushFutures.size()]));
+        return CompletableFuture.allOf(
+                producers.values().stream().map(ProducerImpl::flushAsync).toArray(CompletableFuture[]::new));
     }
 
     @Override
     void triggerFlush() {
-        producers.forEach(ProducerImpl::triggerFlush);
+        producers.values().forEach(ProducerImpl::triggerFlush);
     }
 
     @Override
     public boolean isConnected() {
         // returns false if any of the partition is not connected
-        return producers.stream().allMatch(ProducerImpl::isConnected);
+        return producers.values().stream().allMatch(ProducerImpl::isConnected);
     }
 
     @Override
     public long getLastDisconnectedTimestamp() {
         long lastDisconnectedTimestamp = 0;
-        Optional<ProducerImpl<T>> p = producers.stream().max(Comparator.comparingLong(ProducerImpl::getLastDisconnectedTimestamp));
+        Optional<ProducerImpl<T>> p = producers.values().stream().max(Comparator.comparingLong(ProducerImpl::getLastDisconnectedTimestamp));
         if (p.isPresent()) {
             lastDisconnectedTimestamp = p.get().getLastDisconnectedTimestamp();
         }
@@ -232,9 +269,9 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         }
 
         AtomicReference<Throwable> closeFail = new AtomicReference<Throwable>();
-        AtomicInteger completed = new AtomicInteger(topicMetadata.numPartitions());
+        AtomicInteger completed = new AtomicInteger((int) producers.size());
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-        for (Producer<T> producer : producers) {
+        for (Producer<T> producer : producers.values()) {
             if (producer != null) {
                 producer.closeAsync().handle((closed, ex) -> {
                     if (ex != null) {
@@ -268,14 +305,14 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             return null;
         }
         stats.reset();
-        for (int i = 0; i < topicMetadata.numPartitions(); i++) {
-            stats.updateCumulativeStats(producers.get(i).getStats());
-        }
+        producers.values().forEach(p -> stats.updateCumulativeStats(p.getStats()));
         return stats;
     }
 
     public List<ProducerImpl<T>> getProducers() {
-        return producers.stream().collect(Collectors.toList());
+        return producers.values().stream()
+                .sorted(Comparator.comparingInt(e -> TopicName.getPartitionIndex(e.getTopic())))
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -308,39 +345,44 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                     future.complete(null);
                     return future;
                 } else if (oldPartitionNumber < currentPartitionNumber) {
-                    List<CompletableFuture<Producer<T>>> futureList = list
-                        .subList(oldPartitionNumber, currentPartitionNumber)
-                        .stream()
-                        .map(partitionName -> {
-                            int partitionIndex = TopicName.getPartitionIndex(partitionName);
-                            ProducerImpl<T> producer =
-                                new ProducerImpl<>(client,
-                                    partitionName, conf, new CompletableFuture<>(),
-                                    partitionIndex, schema, interceptors);
-                            producers.add(producer);
-                            return producer.producerCreatedFuture();
-                        }).collect(Collectors.toList());
+                    if (conf.getAccessMode() == ProducerAccessMode.Shared) {
+                        topicMetadata = new TopicMetadataImpl(currentPartitionNumber);
+                        future.complete(null);
+                        return future;
+                    } else {
+                        List<CompletableFuture<Producer<T>>> futureList = list
+                                .subList(oldPartitionNumber, currentPartitionNumber)
+                                .stream()
+                                .map(partitionName -> {
+                                    int partitionIndex = TopicName.getPartitionIndex(partitionName);
+                                    ProducerImpl<T> producer =
+                                            new ProducerImpl<>(client,
+                                                    partitionName, conf, new CompletableFuture<>(),
+                                                    partitionIndex, schema, interceptors);
+                                    producers.put(partitionIndex, producer);
+                                    return producer.producerCreatedFuture();
+                                }).collect(Collectors.toList());
 
-                    FutureUtil.waitForAll(futureList)
-                        .thenAccept(finalFuture -> {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] success create producers for extended partitions. old: {}, new: {}",
-                                    topic, oldPartitionNumber, currentPartitionNumber);
-                            }
-                            topicMetadata = new TopicMetadataImpl(currentPartitionNumber);
-                            future.complete(null);
-                        })
-                        .exceptionally(ex -> {
-                            // error happened, remove
-                            log.warn("[{}] fail create producers for extended partitions. old: {}, new: {}",
-                                topic, oldPartitionNumber, currentPartitionNumber);
-                            List<ProducerImpl<T>> sublist = producers.subList(oldPartitionNumber, producers.size());
-                            sublist.forEach(newProducer -> newProducer.closeAsync());
-                            sublist.clear();
-                            future.completeExceptionally(ex);
-                            return null;
-                        });
-                    return null;
+                        FutureUtil.waitForAll(futureList)
+                                .thenAccept(finalFuture -> {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("[{}] success create producers for extended partitions. old: {}, new: {}",
+                                                topic, oldPartitionNumber, currentPartitionNumber);
+                                    }
+                                    topicMetadata = new TopicMetadataImpl(currentPartitionNumber);
+                                    future.complete(null);
+                                })
+                                .exceptionally(ex -> {
+                                    // error happened, remove
+                                    log.warn("[{}] fail create producers for extended partitions. old: {}, new: {}",
+                                            topic, oldPartitionNumber, currentPartitionNumber);
+                                    IntStream.range(oldPartitionNumber, (int) producers.size())
+                                            .forEach(i -> producers.remove(i).closeAsync());
+                                    future.completeExceptionally(ex);
+                                    return null;
+                                });
+                        return null;
+                    }
                 } else {
                     log.error("[{}] not support shrink topic partitions. old: {}, new: {}",
                         topic, oldPartitionNumber, currentPartitionNumber);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerResponse.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerResponse.java
@@ -31,4 +31,5 @@ public class ProducerResponse {
     private byte[] schemaVersion;
 
     private Optional<Long> topicEpoch;
+    private String producerStatsKey;
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -325,7 +325,7 @@ public class PulsarClientImpl implements PulsarClient {
                 producer = newPartitionedProducerImpl(topic, conf, schema, interceptors, producerCreatedFuture,
                         metadata);
             } else {
-                producer = newProducerImpl(topic, -1, conf, schema, interceptors, producerCreatedFuture);
+                producer = newProducerImpl(topic, -1, conf, schema, interceptors, producerCreatedFuture, Optional.empty());
             }
 
             producers.add(producer);
@@ -381,9 +381,10 @@ public class PulsarClientImpl implements PulsarClient {
                                                   ProducerConfigurationData conf,
                                                   Schema<T> schema,
                                                   ProducerInterceptors interceptors,
-                                                  CompletableFuture<Producer<T>> producerCreatedFuture) {
+                                                  CompletableFuture<Producer<T>> producerCreatedFuture,
+                                                  Optional<String> producerStatsKey) {
         return new ProducerImpl<>(PulsarClientImpl.this, topic, conf, producerCreatedFuture, partitionIndex, schema,
-                interceptors);
+                interceptors, producerStatsKey);
     }
 
     public CompletableFuture<Consumer<byte[]>> subscribeAsync(ConsumerConfigurationData<byte[]> conf) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/customroute/PartialRoundRobinMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/customroute/PartialRoundRobinMessageRouterImpl.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.customroute;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRouter;
+import org.apache.pulsar.client.api.TopicMetadata;
+
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
+
+public class PartialRoundRobinMessageRouterImpl implements MessageRouter {
+    private final int numPartitionsLimit;
+    private final List<Integer> partialList = new CopyOnWriteArrayList<>();
+    private static final AtomicIntegerFieldUpdater<PartialRoundRobinMessageRouterImpl> PARTITION_INDEX_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(PartialRoundRobinMessageRouterImpl.class, "partitionIndex");
+    @SuppressWarnings("unused")
+    private volatile int partitionIndex = 0;
+
+    public PartialRoundRobinMessageRouterImpl(final int numPartitionsLimit) {
+        this.numPartitionsLimit = numPartitionsLimit;
+    }
+
+    /**
+     * Choose a partition based on the topic metadata.
+     * Key hash routing isn't supported.
+     *
+     * @param msg message
+     * @param metadata topic metadata
+     * @return the partition to route the message.
+     */
+    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
+        return getOrCreatePartialList(metadata)
+                .get(signSafeMod(PARTITION_INDEX_UPDATER.getAndIncrement(this), partialList.size()));
+    }
+
+    private List<Integer> getOrCreatePartialList(TopicMetadata metadata) {
+        if (partialList.isEmpty()) {
+            partialList.addAll(IntStream.range(0, metadata.numPartitions())
+                    .boxed()
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.shuffle(list);
+                        return list.stream();
+                    }))
+                    .limit(numPartitionsLimit)
+                    .collect(Collectors.toList()));
+        }
+        if (partialList.size() < numPartitionsLimit && partialList.size() < metadata.numPartitions()) {
+            partialList.addAll(IntStream.range(0, metadata.numPartitions())
+                    .boxed()
+                    .filter(e -> !partialList.contains(e))
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.shuffle(list);
+                        return list.stream();
+                    }))
+                    .limit(numPartitionsLimit - partialList.size())
+                    .collect(Collectors.toList()));
+        }
+        return partialList;
+    }
+
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -81,12 +81,12 @@ public class PartitionedProducerImplTest {
         when(client.getConfiguration()).thenReturn(clientConfigurationData);
         when(client.timer()).thenReturn(timer);
         when(client.newProducer()).thenReturn(producerBuilderImpl);
-        when(client.newProducerImpl(anyString(), anyInt(), any(), any(), any(), any()))
+        when(client.newProducerImpl(anyString(), anyInt(), any(), any(), any(), any(), any()))
                 .thenAnswer(invocationOnMock -> {
             return new ProducerImpl<>(client, invocationOnMock.getArgument(0),
                     invocationOnMock.getArgument(2), invocationOnMock.getArgument(5),
                     invocationOnMock.getArgument(1), invocationOnMock.getArgument(3),
-                    invocationOnMock.getArgument(4));
+                    invocationOnMock.getArgument(4), invocationOnMock.getArgument(6));
         });
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import com.google.common.collect.Maps;
 import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Map;
 import org.apache.pulsar.client.api.ProducerAccessMode;
@@ -25,7 +26,7 @@ import org.apache.pulsar.client.api.ProducerAccessMode;
 /**
  * Statistics about a publisher.
  */
-public class PublisherStats {
+public class PublisherStats implements Cloneable {
     private int count;
 
     public ProducerAccessMode accessMode;
@@ -44,6 +45,8 @@ public class PublisherStats {
 
     /** Id of this publisher. */
     public long producerId;
+
+    public String producerStatsKey;
 
     /** Producer name. */
     private int producerNameOffset = -1;
@@ -77,6 +80,9 @@ public class PublisherStats {
         this.msgThroughputIn += stats.msgThroughputIn;
         double newAverageMsgSize = (this.averageMsgSize * (this.count - 1) + stats.averageMsgSize) / this.count;
         this.averageMsgSize = newAverageMsgSize;
+        if (this.producerStatsKey == null) {
+            this.producerStatsKey = stats.producerStatsKey;
+        }
         return this;
     }
 
@@ -137,5 +143,18 @@ public class PublisherStats {
         this.clientVersionOffset = this.stringBuffer.length();
         this.clientVersionLength = clientVersion.length();
         this.stringBuffer.append(clientVersion);
+    }
+
+    @Override
+    public PublisherStats clone() {
+        try {
+            final PublisherStats newStats = (PublisherStats) super.clone();
+            newStats.stringBuffer = new StringBuilder(this.stringBuffer);
+            newStats.metadata = Maps.newHashMap(this.metadata);
+            return newStats;
+        }
+        catch (CloneNotSupportedException e) {
+            throw new RuntimeException("Failed to clone " + this.getClass().getName(), e);
+        }
     }
 }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -256,6 +256,7 @@ enum ProtocolVersion {
     v15 = 15; // Add CommandGetOrCreateSchema and CommandGetOrCreateSchemaResponse
     v16 = 16; // Add support for raw message metadata
     v17 = 17; // Added support ack receipt
+    v18 = 18; // Added ProducerStatsKey
 }
 
 message CommandConnect {
@@ -481,6 +482,8 @@ message CommandProducer {
     // leave it empty and then it will always carry the same epoch number on
     // the subsequent reconnections.
     optional uint64 topic_epoch = 11;
+
+    optional string producer_stats_key = 12;
 }
 
 message CommandSend {
@@ -629,6 +632,8 @@ message CommandProducerSuccess {
     // for creating the producer. Instead it will wait indefinitely until it gets
     // a subsequent  `CommandProducerSuccess` with `producer_ready==true`.
     optional bool producer_ready = 6 [default = true];
+
+    optional string producer_stats_key = 7;
 }
 
 message CommandError {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
@@ -81,11 +81,13 @@ public class PublisherStatsTest {
         stats1.msgRateIn = 1;
         stats1.msgThroughputIn = 1;
         stats1.averageMsgSize = 1;
+        stats1.producerStatsKey = "key1";
 
         PublisherStats stats2 = new PublisherStats();
         stats2.msgRateIn = 1;
         stats2.msgThroughputIn = 2;
         stats2.averageMsgSize = 3;
+        stats2.producerStatsKey = "key1";
 
         PublisherStats target = new PublisherStats();
         target.add(stats1);
@@ -94,6 +96,7 @@ public class PublisherStatsTest {
         assertEquals(target.msgRateIn, 2.0);
         assertEquals(target.msgThroughputIn, 3.0);
         assertEquals(target.averageMsgSize, 2.0);
+        assertEquals(target.producerStatsKey, "key1");
     }
 
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/compaction/TestCompaction.java
@@ -182,7 +182,7 @@ public class TestCompaction extends PulsarTestSuite {
                 .messageRouter(new MessageRouter() {
                     @Override
                     public int choosePartition(Message<?> msg, TopicMetadata metadata) {
-                        return Integer.parseInt(msg.getKey()) % metadata.numPartitions();
+                        return msg.hasKey() ? Integer.parseInt(msg.getKey()) % metadata.numPartitions() : 0;
                     }
                 })
                 .create()


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/wiki/PIP-79%3A-Reduce-redundant-producers-from-partitioned-producer

### Motivation

Please see the PIP document.
This is a part of implementations. **Before review it, please check https://github.com/apache/pulsar/pull/10279. After https://github.com/apache/pulsar/pull/10279 is merged, I will rebase to top of master branch.**

### Modifications

* Change PartitionedTopicStats to support partial partitioned producer like [this(#10279)](https://github.com/equanz/pulsar/blob/a04a7bec47ed78258ef9bdc1b0120f987762f2f6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/customroute/PartialRoundRobinMessageRouterImpl.java)

For backward compatibility reason, I introduce new producer property `producerStatsKey`. If this property is same, then associate publisher stats as same producer at partitioned producer stats.

I think about using `producerName` instead of introducing `producerStatsKey`, but I think we should not use it. Because currently `producerName` is configured by the system(different for each partition) or yourself(same between all partitions). Therefore, if we use `producerName` as association key, we should change system behavior (I think this is breaking changes) or request to user that "you should set `producerName` yourself if you want to associate publisher stats per partitioned producer".

If any suggestions, please comment to this PR.

### Verifying this change

* [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Added test for partitioned producer stats

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (yes)
    - https://github.com/apache/pulsar/blob/c0a48454bf4199943c1ca7cf821e6351843a55ee/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java#L49
  - The default values of configurations: (no)
  - The wire protocol: (yes)
    - https://github.com/apache/pulsar/blob/c0a48454bf4199943c1ca7cf821e6351843a55ee/pulsar-common/src/main/proto/PulsarApi.proto#L259
    - https://github.com/apache/pulsar/blob/c0a48454bf4199943c1ca7cf821e6351843a55ee/pulsar-common/src/main/proto/PulsarApi.proto#L486
    - https://github.com/apache/pulsar/blob/c0a48454bf4199943c1ca7cf821e6351843a55ee/pulsar-common/src/main/proto/PulsarApi.proto#L636
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

* Does this pull request introduce a new feature? (no)
