### PR TITLE
fix lock manager npe when broker shutting down

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,7 @@ import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
 @Slf4j
 class LockManagerImpl<T> implements LockManager<T> {
 
-    private final Set<ResourceLockImpl<T>> locks = new HashSet<>();
+    private final Set<ResourceLockImpl<T>> locks = new CopyOnWriteArraySet<>();
     private final MetadataStoreExtended store;
     private final MetadataCache<T> cache;
     private final MetadataSerde<T> serde;
@@ -115,10 +116,9 @@ class LockManagerImpl<T> implements LockManager<T> {
 
     private void handleDataNotification(Notification n) {
         if (n.getType() == NotificationType.Deleted) {
-            List<ResourceLockImpl<T>> invalidedLocks = locks.stream()
+            locks.stream()
                     .filter(l -> l.getPath().equals(n.getPath()))
-                    .collect(Collectors.toList());
-            invalidedLocks.forEach(ResourceLockImpl::lockWasInvalidated);
+                    .forEach(ResourceLockImpl::lockWasInvalidated);
         }
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata.coordination.impl;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -114,7 +113,6 @@ class LockManagerImpl<T> implements LockManager<T> {
         }
     }
 
-    @VisibleForTesting
     private void handleDataNotification(Notification n) {
         if (n.getType() == NotificationType.Deleted) {
             for (ResourceLockImpl<T> lock : locks) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -115,11 +115,10 @@ class LockManagerImpl<T> implements LockManager<T> {
 
     private void handleDataNotification(Notification n) {
         if (n.getType() == NotificationType.Deleted) {
-            for (ResourceLockImpl<T> lock : locks) {
-                if (lock.getPath().equals(n.getPath())) {
-                    lock.lockWasInvalidated();
-                }
-            }
+            List<ResourceLockImpl<T>> invalidedLocks = locks.stream()
+                    .filter(l -> l.getPath().equals(n.getPath()))
+                    .collect(Collectors.toList());
+            invalidedLocks.forEach(ResourceLockImpl::lockWasInvalidated);
         }
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.metadata.coordination.impl;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -113,11 +114,14 @@ class LockManagerImpl<T> implements LockManager<T> {
         }
     }
 
+    @VisibleForTesting
     private void handleDataNotification(Notification n) {
         if (n.getType() == NotificationType.Deleted) {
-            locks.stream()
-                    .filter(l -> l.getPath().equals(n.getPath()))
-                    .forEach(l -> l.lockWasInvalidated());
+            for (ResourceLockImpl<T> lock : locks) {
+                if (lock.getPath().equals(n.getPath())) {
+                    lock.lockWasInvalidated();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
In broker shutting down stage, it throw the following exception.
```
11:31:55.887 [metadata-store-5-1] ERROR org.apache.pulsar.metadata.impl.AbstractMetadataStore - Failed to process metadata store notification
java.util.ConcurrentModificationException: null
        at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1553) ~[?:1.8.0_131]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_131]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_131]
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[?:1.8.0_131]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[?:1.8.0_131]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_131]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418) ~[?:1.8.0_131]
        at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl.handleDataNotification(LockManagerImpl.java:120) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.apache.pulsar.metadata.impl.AbstractMetadataStore.lambda$null$0(AbstractMetadataStore.java:141) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:890) ~[?:1.8.0_131]
        at org.apache.pulsar.metadata.impl.AbstractMetadataStore.lambda$receivedNotification$1(AbstractMetadataStore.java:139) ~[pulsar-metadata-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT
]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_131]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```

When using `locks.stream.filter()`, it get a set contains the result. Then use foreach to traverse the elements. 
However, when the elements remove by another thread, the foreach will throw exception.

### Modification
1. use for loop instead of stream to traverse the locks set.