### PR TITLE
Fixed accessing potentially empty Optional field

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -644,7 +644,7 @@ public class NamespaceService implements AutoCloseable {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Broker not found for SLA Monitoring Namespace {}",
-                    candidateBroker + ":" + config.getWebServicePort().get());
+                    candidateBroker + ":" + config.getWebServicePort());
         }
         return false;
     }


### PR DESCRIPTION
### Motivation

If the root logger level is set to debug the the HTTP port is disabled, there are exceptions thrown during the bundle lookup phase, because a debug statement is trying to `get()` an empty optional.

### Modification

Just print the optional instead of forcing to get the value.