### PR TITLE
Allow to create MetadataCache with custom serde

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/CacheGetResult.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/CacheGetResult.java
@@ -16,28 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.cache.impl;
+package org.apache.pulsar.metadata.api;
 
-import com.fasterxml.jackson.databind.JavaType;
-import java.io.IOException;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.apache.pulsar.metadata.api.MetadataSerde;
+import lombok.Data;
 
-public class JSONMetadataSerdeSimpleType<T> implements MetadataSerde<T> {
+/**
+ * Represent a result for a {@link MetadataCache#getWithStats(String)} operation.
+ */
+@Data
+public class CacheGetResult<T> {
+    /**
+     * The value of the key stored.
+     */
+    private final T value;
 
-    private final JavaType typeRef;
-
-    public JSONMetadataSerdeSimpleType(JavaType typeRef) {
-        this.typeRef = typeRef;
-    }
-
-    @Override
-    public byte[] serialize(T value) throws IOException {
-        return ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value);
-    }
-
-    @Override
-    public T deserialize(byte[] content) throws IOException {
-        return ObjectMapperFactory.getThreadLocal().readValue(content, typeRef);
-    }
+    /**
+     * The {@link Stat} object associated with the value.
+     */
+    private final Stat stat;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -43,6 +43,17 @@ public interface MetadataCache<T> {
     CompletableFuture<Optional<T>> get(String path);
 
     /**
+     * Tries to fetch one item from the cache or fallback to the store if not present.
+     * <p>
+     * If the key is not found, the {@link Optional} will be empty.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Optional<CacheGetResult<T>>> getWithStats(String path);
+
+    /**
      * Check if an object is present in cache without triggering a load from the metadata store.
      *
      * @param path

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataSerde.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.cache.impl;
+package org.apache.pulsar.metadata.api;
 
 import java.io.IOException;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -139,4 +139,14 @@ public interface MetadataStore extends AutoCloseable {
      * @return the metadata cache object
      */
     <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef);
+
+    /**
+     * Create a metadata cache that uses a particular serde object.
+     *
+     * @param <T>
+     * @param serde
+     *            the custom serialization/deserialization object
+     * @return the metadata cache object
+     */
+    <T> MetadataCache<T> getMetadataCache(MetadataSerde<T> serde);
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 
 public class JSONMetadataSerdeTypeRef<T> implements MetadataSerde<T> {
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -39,7 +39,9 @@ import java.util.function.Supplier;
 
 import lombok.Getter;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.pulsar.metadata.api.CacheGetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
@@ -56,7 +58,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
     private final MetadataStore store;
     private final MetadataSerde<T> serde;
 
-    private final AsyncLoadingCache<String, Optional<Entry<T, Stat>>> objCache;
+    private final AsyncLoadingCache<String, Optional<CacheGetResult<T>>> objCache;
 
     public MetadataCacheImpl(MetadataStore store, TypeReference<T> typeRef) {
         this(store, new JSONMetadataSerdeTypeRef<>(typeRef));
@@ -66,27 +68,27 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         this(store, new JSONMetadataSerdeSimpleType<>(type));
     }
 
-    private MetadataCacheImpl(MetadataStore store, MetadataSerde<T> serde) {
+    public MetadataCacheImpl(MetadataStore store, MetadataSerde<T> serde) {
         this.store = store;
         this.serde = serde;
 
         this.objCache = Caffeine.newBuilder()
                 .refreshAfterWrite(CACHE_REFRESH_TIME_MILLIS, TimeUnit.MILLISECONDS)
-                .buildAsync(new AsyncCacheLoader<String, Optional<Entry<T, Stat>>>() {
+                .buildAsync(new AsyncCacheLoader<String, Optional<CacheGetResult<T>>>() {
                     @Override
-                    public CompletableFuture<Optional<Entry<T, Stat>>> asyncLoad(String key, Executor executor) {
+                    public CompletableFuture<Optional<CacheGetResult<T>>> asyncLoad(String key, Executor executor) {
                         return readValueFromStore(key);
                     }
 
                     @Override
-                    public CompletableFuture<Optional<Entry<T, Stat>>> asyncReload(String key,
-                            Optional<Entry<T, Stat>> oldValue, Executor executor) {
+                    public CompletableFuture<Optional<CacheGetResult<T>>> asyncReload(String key,
+                            Optional<CacheGetResult<T>> oldValue, Executor executor) {
                         return readValueFromStore(key);
                     }
                 });
     }
 
-    private CompletableFuture<Optional<Entry<T, Stat>>> readValueFromStore(String path) {
+    private CompletableFuture<Optional<CacheGetResult<T>>> readValueFromStore(String path) {
         return store.get(path)
                 .thenCompose(optRes -> {
                     if (!optRes.isPresent()) {
@@ -96,7 +98,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     try {
                         T obj = serde.deserialize(optRes.get().getValue());
                         return FutureUtils
-                                .value(Optional.of(new SimpleImmutableEntry<T, Stat>(obj, optRes.get().getStat())));
+                                .value(Optional.of(new CacheGetResult<>(obj, optRes.get().getStat())));
                     } catch (Throwable t) {
                         return FutureUtils.exception(new ContentDeserializationException(t));
                     }
@@ -106,14 +108,19 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
     @Override
     public CompletableFuture<Optional<T>> get(String path) {
         return objCache.get(path)
-                .thenApply(optRes -> optRes.map(Entry::getKey));
+                .thenApply(optRes -> optRes.map(CacheGetResult::getValue));
+    }
+
+    @Override
+    public CompletableFuture<Optional<CacheGetResult<T>>> getWithStats(String path) {
+        return objCache.get(path);
     }
 
     @Override
     public Optional<T> getIfCached(String path) {
-        CompletableFuture<Optional<Map.Entry<T, Stat>>> future = objCache.getIfPresent(path);
+        CompletableFuture<Optional<CacheGetResult<T>>> future = objCache.getIfPresent(path);
         if (future != null && future.isDone() && !future.isCompletedExceptionally()) {
-            return future.join().map(Entry::getKey);
+            return future.join().map(CacheGetResult::getValue);
         } else {
             return Optional.empty();
         }
@@ -130,12 +137,12 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                         T clone;
                         try {
                             // Use clone and CAS zk to ensure thread safety
-                            clone = serde.deserialize(serde.serialize(optEntry.get().getKey()));
+                            clone = serde.deserialize(serde.serialize(optEntry.get().getValue()));
                         } catch (IOException e) {
                             return FutureUtils.exception(e);
                         }
                         currentValue = Optional.of(clone);
-                        expectedVersion = optEntry.get().getValue().getVersion();
+                        expectedVersion = optEntry.get().getStat().getVersion();
                     } else {
                         currentValue = Optional.empty();
                         expectedVersion = -1;
@@ -153,7 +160,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
                         // Make sure we have the value cached before the operation is completed
                         objCache.put(path,
-                                FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(newValueObj, stat))));
+                                FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
                     }).thenApply(__ -> newValueObj);
                 }), path);
     }
@@ -166,9 +173,9 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                         return FutureUtils.exception(new NotFoundException(""));
                     }
 
-                    Map.Entry<T, Stat> entry = optEntry.get();
-                    T currentValue = entry.getKey();
-                    long expectedVersion = optEntry.get().getValue().getVersion();
+                    CacheGetResult<T> entry = optEntry.get();
+                    T currentValue = entry.getValue();
+                    long expectedVersion = optEntry.get().getStat().getVersion();
 
                     T newValueObj;
                     byte[] newValue;
@@ -184,7 +191,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
                         // Make sure we have the value cached before the operation is completed
                         objCache.put(path,
-                                FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(newValueObj, stat))));
+                                FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
                     }).thenApply(__ -> newValueObj);
                 }), path);
     }
@@ -202,7 +209,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         store.put(path, content, Optional.of(-1L))
                 .thenAccept(stat -> {
                     // Make sure we have the value cached before the operation is completed
-                    objCache.put(path, FutureUtils.value(Optional.of(new SimpleImmutableEntry<T, Stat>(value, stat))));
+                    objCache.put(path, FutureUtils.value(Optional.of(new CacheGetResult<>(value, stat))));
                     future.complete(null);
                 }).exceptionally(ex -> {
                     if (ex.getCause() instanceof BadVersionException) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
@@ -47,7 +47,7 @@ import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
-import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 class LeaderElectionImpl<T> implements LeaderElection<T> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +42,7 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
-import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 class LockManagerImpl<T> implements LockManager<T> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -31,7 +31,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.apache.pulsar.metadata.cache.impl.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 public class ResourceLockImpl<T> implements ResourceLock<T> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
@@ -114,6 +115,13 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     @Override
     public <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef) {
         MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this, typeRef);
+        metadataCaches.add(metadataCache);
+        return metadataCache;
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(MetadataSerde<T> serde) {
+        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<>(this, serde);
         metadataCaches.add(metadataCache);
         return metadataCache;
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -26,6 +26,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -38,13 +40,16 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.metadata.api.CacheGetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.api.Stat;
 import org.testng.annotations.Test;
 
 public class MetadataCacheTest extends BaseMetadataStoreTest {
@@ -335,5 +340,46 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         objCache1.readModifyUpdate(key1, v -> {
             return new MyClass(v.a, v.b + 1);
         }).join();
+    }
+
+    @Test(dataProvider = "impl")
+    public void getWithStats(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataCache<MyClass> objCache = store.getMetadataCache(MyClass.class);
+
+        String key1 = newKey();
+
+        MyClass value1 = new MyClass("a", 1);
+        Stat stat1 = store.put(key1, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value1), Optional.of(-1L)).join();
+
+        CacheGetResult<MyClass> res = objCache.getWithStats(key1).join().get();
+        assertEquals(res.getValue(), value1);
+        assertEquals(res.getStat().getVersion(), stat1.getVersion());
+    }
+
+    @Test(dataProvider = "impl")
+    public void cacheWithCustomSerde(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        // Simple serde that convert numbers to ascii
+        MetadataCache<Integer> objCache = store.getMetadataCache(new MetadataSerde<Integer>() {
+            @Override
+            public byte[] serialize(Integer value) throws IOException {
+                return value.toString().getBytes(StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public Integer deserialize(byte[] content) throws IOException {
+                return Integer.parseInt(new String(content, StandardCharsets.UTF_8));
+            }
+        });
+
+        String key1 = newKey();
+
+        objCache.create(key1, 1).join();
+
+        assertEquals(objCache.get(key1).join().get(), (Integer) 1);
     }
 }


### PR DESCRIPTION
### Motivation

While the majority of `MetadataCache` usages are with JSON, there is the need to allow for custom serde for cases in which we need to cache Protobuf metadata.

Also, added `MetadatCache.getWithStat()` so that a user can still use the cache (and the serde) while accessing the underlying version of the data.