### PR TITLE
[plusar-10479] Resolved Allow Java client to create consumer with rec…

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -22,10 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -69,6 +66,17 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         internalCleanup();
     }
 
+    public static void main(String[] args) {
+        try {
+            ZeroQueueSizeTest zeroQueueSizeTest = new ZeroQueueSizeTest();
+
+            zeroQueueSizeTest.setup();
+            zeroQueueSizeTest.zeroQueueSizeReceieveAsyncInCompatibility();
+        }catch (Exception ex){
+            ex.printStackTrace();
+        }
+    }
+
     @Test
     public void validQueueSizeConfig() {
         pulsarClient.newConsumer().receiverQueueSize(0);
@@ -79,15 +87,19 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         pulsarClient.newConsumer().receiverQueueSize(-1);
     }
 
+
     @Test(expectedExceptions = PulsarClientException.InvalidConfigurationException.class)
     public void zeroQueueSizeReceieveAsyncInCompatibility() throws PulsarClientException {
         String key = "zeroQueueSizeReceieveAsyncInCompatibility";
         final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+        Map<String, Object> config = new HashMap<>();
+        config.put("receiveInterval", 5000);
+        config.put("receiveThreads", 6);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().loadConf(config).topic(topicName).subscriptionName(subscriptionName)
                 .receiverQueueSize(0).subscribe();
-        consumer.receive(10, TimeUnit.SECONDS);
+        consumer.receiveAsync(10, TimeUnit.SECONDS);
     }
 
     @Test(expectedExceptions = PulsarClientException.class)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -88,8 +88,9 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
     }
 
 
-    @Test(expectedExceptions = PulsarClientException.InvalidConfigurationException.class)
-    public void zeroQueueSizeReceieveAsyncInCompatibility() throws PulsarClientException {
+    @Test(expectedExceptions = PulsarClientException.class)
+    public void zeroQueueSizeReceieveAsyncInCompatibility() throws PulsarClientException{
+
         String key = "zeroQueueSizeReceieveAsyncInCompatibility";
         final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
         final String subscriptionName = "my-ex-subscription-" + key;
@@ -99,7 +100,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         config.put("receiveThreads", 6);
         Consumer<byte[]> consumer = pulsarClient.newConsumer().loadConf(config).topic(topicName).subscriptionName(subscriptionName)
                 .receiverQueueSize(0).subscribe();
-        consumer.receiveAsync(10, TimeUnit.SECONDS);
+        consumer.receive(10, TimeUnit.SECONDS);
     }
 
     @Test(expectedExceptions = PulsarClientException.class)

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -119,6 +119,9 @@ public interface Consumer<T> extends Closeable {
      */
     Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException;
 
+
+    CompletableFuture<Message<T>> receiveAsync(int timeout,TimeUnit unit);
+
     /**
      * Batch receiving messages.
      *

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -119,9 +119,6 @@ public interface Consumer<T> extends Closeable {
      */
     Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException;
 
-
-    CompletableFuture<Message<T>> receiveAsync(int timeout,TimeUnit unit);
-
     /**
      * Batch receiving messages.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -172,8 +172,17 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     @Override
     public Message<T> receive(int timeout, TimeUnit unit) throws PulsarClientException {
         if (conf.getReceiverQueueSize() == 0) {
-            throw new PulsarClientException.InvalidConfigurationException(
-                    "Can't use receive with timeout, if the queue size is 0");
+
+            if(!(getState() == State.Connecting)){
+                throw new PulsarClientException.InvalidConfigurationException(
+                        "Can't use receive with timeout, if the queue size is 0");
+            }
+
+
+            if (batchReceivePolicy.getTimeoutMs() > 0){
+                // This abstract method A has a zero queue implementation
+                internalReceive();
+            }
         }
         if (listener != null) {
             throw new PulsarClientException.InvalidConfigurationException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -63,6 +63,12 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private SubscriptionMode subscriptionMode = SubscriptionMode.Durable;
 
+
+    /**This is time interval for receiving messages(Only while Zero queue) **/
+    private Integer receiveInterval;
+    /**his is receive threads for receiving messages(Only while Zero queue)  **/
+    private Integer receiveThreads;
+
     @JsonIgnore
     private MessageListener<T> messageListener;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -23,7 +23,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 /**
  * This class is aimed at simplifying work with {@code CompletableFuture}.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -21,7 +21,10 @@ package org.apache.pulsar.common.util;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 /**
  * This class is aimed at simplifying work with {@code CompletableFuture}.
  */
@@ -35,6 +38,36 @@ public class FutureUtil {
      */
     public static <T> CompletableFuture<Void> waitForAll(List<CompletableFuture<T>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Return a futrue, which can be scheduled regularly
+     * @param executor Periodic execution method
+     * @param command This is a functional interface and can therefore be used as the assignment
+     * target for a lambda expression or method reference.
+     * @param delay Delayable time
+     * @param unit Set time unit
+     * @return a new CompletableFuture that is completed when all of the given CompletableFutures complete
+     */
+    public static <T> CompletableFuture<T> schedule(
+            ScheduledExecutorService executor,
+            Supplier<T> command,
+            long delay,
+            TimeUnit unit
+    ) {
+        CompletableFuture<T> completableFuture = new CompletableFuture<>();
+        executor.schedule(
+                (() -> {
+                    try {
+                        return completableFuture.complete(command.get());
+                    } catch (Throwable t) {
+                        return completableFuture.completeExceptionally(t);
+                    }
+                }),
+                delay,
+                unit
+        );
+        return completableFuture;
     }
 
     public static <T> CompletableFuture<T> failedFuture(Throwable t) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation


This PR is aimed at the problem raised by [issues-10479](https://github.com/apache/pulsar/issues/10479), that is, when the parameter ```receiverQueueSize``` configured by ```PulsarClient``` is set to 0, the ```ZeroQueueConsumerImpl#receive``` method will be called to schedule the ```ZeroQueueConsumerImpl#fetchSingleMessageFromBroker``` task, but it does not consider the task timeout.

### Modifications

Modify ConsumerBase#receive to allow Java client to create consumer with receiverQueueSize(0) when receiving with timeout

### Verifying this change

Demo sample is here

[plusar-10479](https://github.com/apache/pulsar/issues/10479)

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - ZeroQueueSizeTest#zeroQueueSizeReceieveAsyncInCompatibility
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation


This abstract method A has a zero queue implementation