### PR TITLE
Expose topic-level averageMsgSize to metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -118,6 +118,7 @@ public class NamespaceStatsAggregator {
         stats.bytesInCounter = tStatus.bytesInCounter;
         stats.msgOutCounter = tStatus.msgOutCounter;
         stats.bytesOutCounter = tStatus.bytesOutCounter;
+        stats.averageMsgSize = tStatus.averageMsgSize;
 
         stats.producersCount = 0;
         topic.getProducers().values().forEach(producer -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -37,6 +37,7 @@ class TopicStats {
     long bytesInCounter;
     long msgOutCounter;
     long bytesOutCounter;
+    double averageMsgSize;
 
     long storageSize;
     public long msgBacklog;
@@ -105,6 +106,7 @@ class TopicStats {
         metric(stream, cluster, namespace, topic, "pulsar_rate_out", stats.rateOut);
         metric(stream, cluster, namespace, topic, "pulsar_throughput_in", stats.throughputIn);
         metric(stream, cluster, namespace, topic, "pulsar_throughput_out", stats.throughputOut);
+        metric(stream, cluster, namespace, topic, "pulsar_average_msg_size", stats.averageMsgSize);
 
         metric(stream, cluster, namespace, topic, "pulsar_storage_size", stats.storageSize);
         metric(stream, cluster, namespace, topic, "pulsar_msg_backlog", stats.msgBacklog);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -50,6 +50,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.crypto.SecretKey;
 import javax.naming.AuthenticationException;
+import lombok.Cleanup;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
@@ -89,7 +90,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
     }
 
     @Test
-    public void testMetricsTopicCountAndAvgMsgSize() throws Exception {
+    public void testMetricsTopicCount() throws Exception {
         String ns1 = "prop/ns-abc1";
         String ns2 = "prop/ns-abc2";
         admin.namespaces().createNamespace(ns1);
@@ -103,12 +104,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             admin.topics().createNonPartitionedTopic(baseTopic2 + UUID.randomUUID());
         }
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
+        @Cleanup
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        assertTrue(metrics.containsKey("pulsar_average_msg_size"));
-        assertEquals(metrics.get("pulsar_average_msg_size").size(), 9);
         Collection<Metric> metric = metrics.get("pulsar_topics_count");
         metric.forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
@@ -118,6 +118,35 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 assertEquals(item.value, 3.0);
             }
         });
+    }
+
+    @Test
+    public void testMetricsAvgMsgSize2() throws Exception {
+        String ns1 = "prop/ns-abc1";
+        admin.namespaces().createNamespace(ns1, 1);
+        String baseTopic1 = "persistent://" + ns1 + "/testMetricsTopicCount";
+        String topicName = baseTopic1 + UUID.randomUUID();
+        Producer producer = pulsarClient.newProducer().producerName("my-pub")
+                .topic(topicName).create();
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topicName, false).get().get();
+        org.apache.pulsar.broker.service.Producer producerInServer = persistentTopic.getProducers().get("my-pub");
+        producerInServer.getStats().msgRateIn = 10;
+        producerInServer.getStats().msgThroughputIn = 100;
+        @Cleanup
+        ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
+        PrometheusMetricsGenerator.generate(pulsar, true, false, true, statsOut);
+        String metricsStr = statsOut.toString();
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        assertTrue(metrics.containsKey("pulsar_average_msg_size"));
+        assertEquals(metrics.get("pulsar_average_msg_size").size(), 1);
+        Collection<Metric> avgMsgSizes = metrics.get("pulsar_average_msg_size");
+        avgMsgSizes.forEach(item -> {
+            if (ns1.equals(item.tags.get("namespace"))) {
+                assertEquals(item.value, 10);
+            }
+        });
+        producer.close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
Now there is a record of average_msg_size in code, but it is not exposed.

### Modifications
Expose topic-level averageMsgSize to metrics

### Verifying this change
