### PR TITLE
Fix flaky test SimpleProducerConsumerTest.testActiveAndInActiveConsumerEntryCacheBehavior

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -1028,7 +1028,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         msg = subscriber1.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Verify: as active-subscriber2 has not consumed messages: EntryCache must have those entries in cache
-        assertTrue(entryCache.getSize() != 0);
+        Awaitility.await().untilAsserted(() -> assertNotEquals(entryCache.getSize(), 0));
 
         // 3.b Close subscriber2: which will trigger cache to clear the cache
         subscriber2.close();


### PR DESCRIPTION
Fixes #10555

### Motivation

See #10555 

### Modifications

* Use Awaitility for checking assertion