### PR TITLE
Use Message.getReaderSchema() in Pulsar IO Sinks when possible

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -616,6 +616,11 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertEquals(data.getKey().getField("i"), i * 100);
                 assertEquals(data.getValue().getField("i"), i * 1000);
                 c0.acknowledge(wrapper);
+                Schema<?> schema = wrapper.getReaderSchema().get();
+                KeyValueSchema keyValueSchema = (KeyValueSchema) schema;
+                assertEquals(SchemaType.AVRO, keyValueSchema.getKeySchema().getSchemaInfo().getType());
+                assertEquals(SchemaType.AVRO, keyValueSchema.getValueSchema().getSchemaInfo().getType());
+                assertNotNull(schema.getSchemaInfo());
             }
             // verify c1
             for (int i = 0; i < numMessages; i++) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
@@ -158,6 +158,14 @@ public abstract class AbstractStructSchema<T> extends AbstractSchema<T> {
                 return Optional.empty();
             }
         }
+
+        @Override
+        public String toString() {
+            return "VersionedSchema(type=" + schemaInfo.getType() +
+                    ",schemaVersion="+BytesSchemaVersion.of(schemaVersion) +
+                    ",name="+schemaInfo.getName()
+                    + ")";
+        }
     }
 
     private AbstractStructSchema<T> getAbstractStructSchemaAtVersion(byte[] schemaVersion, SchemaInfo schemaInfo) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
@@ -122,6 +122,8 @@ public class KeyValueSchema<K, V> extends AbstractSchema<KeyValue<K, V>> {
         // defer configuring the key/value schema info until `configureSchemaInfo` is called.
         if (!requireFetchingSchemaInfo()) {
             configureKeyValueSchemaInfo();
+        } else {
+            buildKeyValueSchemaInfo();
         }
     }
 
@@ -224,10 +226,14 @@ public class KeyValueSchema<K, V> extends AbstractSchema<KeyValue<K, V>> {
         return KeyValueSchema.of(keySchema.clone(), valueSchema.clone(), keyValueEncodingType);
     }
 
-    private void configureKeyValueSchemaInfo() {
+    private void buildKeyValueSchemaInfo() {
         this.schemaInfo = KeyValueSchemaInfo.encodeKeyValueSchemaInfo(
-            keySchema, valueSchema, keyValueEncodingType
+                keySchema, valueSchema, keyValueEncodingType
         );
+    }
+
+    private void configureKeyValueSchemaInfo() {
+        buildKeyValueSchemaInfo();
         this.keySchema.setSchemaInfoProvider(new SchemaInfoProvider() {
             @Override
             public CompletableFuture<SchemaInfo> getSchemaByVersion(byte[] schemaVersion) {

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
@@ -41,8 +41,11 @@ public class TestGenericObjectSink implements Sink<GenericObject> {
         log.info("received record {} {}", record, record.getClass());
         log.info("schema {}", record.getSchema());
         log.info("native schema {}", record.getSchema().getNativeSchema().orElse(null));
+        log.info("schemaInfo {}", record.getSchema().getSchemaInfo());
+        log.info("schemaInfo.type {}", record.getSchema().getSchemaInfo().getType());
 
         String expectedRecordType = record.getProperties().getOrDefault("expectedType", "MISSING");
+        log.info("expectedRecordType {}", expectedRecordType);
         if (!expectedRecordType.equals(record.getSchema().getSchemaInfo().getType().name())) {
             throw new RuntimeException("Unexpected record type " + record.getSchema().getSchemaInfo().getType().name() + " is not " + expectedRecordType);
         }

--- a/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
+++ b/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java
@@ -44,7 +44,7 @@ public class TestGenericObjectSink implements Sink<GenericObject> {
 
         String expectedRecordType = record.getProperties().getOrDefault("expectedType", "MISSING");
         if (!expectedRecordType.equals(record.getSchema().getSchemaInfo().getType().name())) {
-            throw new RuntimeException("Unexpected record type "+record.getSchema().getSchemaInfo().getType().name() +" is not "+expectedRecordType);
+            throw new RuntimeException("Unexpected record type " + record.getSchema().getSchemaInfo().getType().name() + " is not " + expectedRecordType);
         }
 
         log.info("value {}", record.getValue());
@@ -65,6 +65,16 @@ public class TestGenericObjectSink implements Sink<GenericObject> {
         log.info("value {}", record.getValue());
         log.info("value schema type {}", record.getValue().getSchemaType());
         log.info("value native object {}", record.getValue().getNativeObject());
+
+        String expectedSchemaDefinition = record.getProperties().getOrDefault("expectedSchemaDefinition", "");
+        log.info("schemaDefinition {}", record.getSchema().getSchemaInfo().getSchemaDefinition());
+        log.info("expectedSchemaDefinition {}", expectedSchemaDefinition);
+        if (!expectedSchemaDefinition.isEmpty()) {
+            String schemaDefinition = record.getSchema().getSchemaInfo().getSchemaDefinition();
+            if (!expectedSchemaDefinition.equals(schemaDefinition)) {
+                throw new RuntimeException("Unexpected schema definition " + schemaDefinition + " is not " + expectedSchemaDefinition);
+            }
+        }
 
         record.ack();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
@@ -84,7 +84,7 @@ public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
     public static class PojoV2 {
         private String field1;
         private int field2;
-        private double field3;
+        private Double field3;
     }
 
     @Data

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarGenericObjectSinkTest.java
@@ -74,9 +74,17 @@ public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
 
     @Data
     @Builder
-    public static final class Pojo {
+    public static class Pojo {
         private String field1;
         private int field2;
+    }
+
+    @Data
+    @Builder
+    public static class PojoV2 {
+        private String field1;
+        private int field2;
+        private double field3;
     }
 
     @Data
@@ -159,6 +167,82 @@ public class PulsarGenericObjectSinkTest extends PulsarStandaloneTestSuite {
             log.info("sink {} status {}", sinkName, status);
             assertEquals(status.getInstances().size(), 1);
             assertTrue(status.getInstances().get(0).getStatus().numWrittenToSink >= numRecordsPerTopic * specs.size());
+            assertTrue(status.getInstances().get(0).getStatus().numSinkExceptions == 0);
+            assertTrue(status.getInstances().get(0).getStatus().numSystemExceptions == 0);
+            log.info("sink {} is okay", sinkName);
+        } finally {
+            dumpFunctionLogs(sinkName);
+        }
+
+        deleteSink(sinkName);
+        getSinkInfoNotFound(sinkName);
+    }
+
+    @Test(groups = {"sink"})
+    public void testGenericObjectSinkWithSchemaChange() throws Exception {
+
+        @Cleanup PulsarClient client = PulsarClient.builder()
+                .serviceUrl(container.getPlainTextServiceUrl())
+                .build();
+
+        @Cleanup
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(container.getHttpServiceUrl()).build();
+
+
+        final int numRecords = 2;
+
+        String sinkName = "genericobject-sink";
+        String topicName = "test-genericobject-sink-schema-change";
+
+        submitSinkConnector(sinkName, topicName, "org.apache.pulsar.tests.integration.io.TestGenericObjectSink", JAVAJAR);
+        // get sink info
+        getSinkInfoSuccess(sinkName);
+        getSinkStatus(sinkName);
+
+        @Cleanup Producer<byte[]> producer = client.newProducer()
+                    .topic(topicName)
+                    .create();
+        Schema<Pojo> schemav1 = Schema.AVRO(Pojo.class);
+        Pojo record1 = Pojo.builder().field1("foo").field2(23).build();
+        producer.newMessage(schemav1)
+                .value(record1)
+                .property("expectedType", schemav1.getSchemaInfo().getType().toString())
+                .property("expectedSchemaDefinition", schemav1.getSchemaInfo().getSchemaDefinition())
+                .property("recordNumber", "1")
+                .send();
+
+        Schema<PojoV2> schemav2 = Schema.AVRO(PojoV2.class);
+        PojoV2 record2 = PojoV2.builder().field1("foo").field2(23).field3(42.5).build();
+        producer.newMessage(schemav2)
+                .value(record2)
+                .property("expectedType", schemav2.getSchemaInfo().getType().toString())
+                .property("expectedSchemaDefinition", schemav2.getSchemaInfo().getSchemaDefinition())
+                .property("recordNumber", "2")
+                .send();
+
+        // wait that sink processed all records without errors
+
+        try {
+            log.info("waiting for sink {}", sinkName);
+
+            for (int i = 0; i < 120; i++) {
+                SinkStatus status = admin.sinks().getSinkStatus("public", "default", sinkName);
+                log.info("sink {} status {}", sinkName, status);
+                assertEquals(status.getInstances().size(), 1);
+                SinkStatus.SinkInstanceStatus instance = status.getInstances().get(0);
+                if (instance.getStatus().numWrittenToSink >= numRecords
+                        || instance.getStatus().numSinkExceptions > 0
+                        || instance.getStatus().numSystemExceptions > 0
+                        || instance.getStatus().numRestarts > 0) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+
+            SinkStatus status = admin.sinks().getSinkStatus("public", "default", sinkName);
+            log.info("sink {} status {}", sinkName, status);
+            assertEquals(status.getInstances().size(), 1);
+            assertTrue(status.getInstances().get(0).getStatus().numWrittenToSink >= numRecords);
             assertTrue(status.getInstances().get(0).getStatus().numSinkExceptions == 0);
             assertTrue(status.getInstances().get(0).getStatus().numSystemExceptions == 0);
             log.info("sink {} is okay", sinkName);


### PR DESCRIPTION
### Motivation

When you run a Sink<GenericObject> and you call record.getSchema(), it does not return an accurate representation of the schema in case of a schema update.

For instance:
- the topic starts with AVRO Schema schema1
- the AutoConsumeSchema starts by populating the internal SchemaInfo with the definition of schema1
- the topic advances to AVRO Schema schema2
- the AutoConsumeSchema still reports SchemaInfo for schema1
- record.getSchema().getNativeSchema() reports the wrong schema definition

### Modifications

With this change we leverage PIP-85 Message.getReaderSchema() API that returns the exact schema used for the Message, that is the schema that these pieces for information updated to the same "schemaVersion" of the Message represented by the Record:
- reports the correct getSchemaInfo() 
- reports the correct getNativeSchema() 

I also fixing a problem in KeyValueSchema for atSchemaVersion(), the constructor of KeyValueSchema did not fill in the SchemaInfo data structure, resulting in NPEs.
 
### Verifying this change
This change adds a new integration test and a unit test

### Does this pull request potentially affect one of the following parts:
It affects Pulsar Sinks that implement Sink<GenericRecord>, in fact now Record.getSchema() will return accurate schema information. 

### Documentation
No need for docs, previous behaviour was unexpected, the new behaviour is what you expect.