### PR TITLE
[Pulsar SQL] Fix Presto startup on JDK11

### DIFF
--- a/conf/presto/jvm.config
+++ b/conf/presto/jvm.config
@@ -26,3 +26,4 @@
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -Dpresto-temporarily-allow-java8=true
+-Djdk.attach.allowAttachSelf=true


### PR DESCRIPTION
### Motivation

When running Pulsar SQL on JDK11, there's a failure in startup (`log/server.log`):
```
2021-05-12T12:13:54.813Z        ERROR   main    io.prestosql.server.PrestoServer        Unable to create injector, see the following errors:

1) Error injecting constructor, java.io.IOException: java.io.IOException: Can not attach to current VM (try adding '-Djdk.attach.allowAttachSelf=true' to the JVM config)
  at io.airlift.jmx.JmxAgent9.<init>(JmxAgent9.java:47)
  at io.airlift.jmx.JmxModule.configure(JmxModule.java:55)
  while locating io.airlift.jmx.JmxAgent9
  while locating io.airlift.jmx.JmxAgent
    for the 1st parameter of io.airlift.jmx.JmxModule$JmxAnnouncementProvider.setJmxAgent(JmxModule.java:68)
  while locating io.airlift.jmx.JmxModule$JmxAnnouncementProvider
  while locating io.airlift.discovery.client.ServiceAnnouncement annotated with @com.google.inject.internal.Element(setName=,uniqueId=339, type=MULTIBINDER, keyType=)
  while locating java.util.Set<io.airlift.discovery.client.ServiceAnnouncement>
    for the 2nd parameter of io.airlift.discovery.client.Announcer.<init>(Announcer.java:68)
  at io.airlift.discovery.client.DiscoveryModule.configure(DiscoveryModule.java:64)
  while locating io.airlift.discovery.client.Announcer
    for the 2nd parameter of io.airlift.discovery.client.DiscoveryModule.createMergingServiceSelectorFactory(DiscoveryModule.java:122)
  at io.airlift.discovery.client.DiscoveryModule.createMergingServiceSelectorFactory(DiscoveryModule.java:122)
  while locating io.airlift.discovery.client.MergingServiceSelectorFactory
  at io.airlift.discovery.client.DiscoveryModule.configure(DiscoveryModule.java:73)
  while locating io.airlift.discovery.client.ServiceSelectorFactory
    for the 1st parameter of io.airlift.discovery.client.ServiceSelectorProvider.setServiceSelectorFactory(ServiceSelectorProvider.java:50)
  at io.prestosql.server.ServerMainModule.setup(ServerMainModule.java:218)
```

### Modifications

* Add `-Djdk.attach.allowAttachSelf=true` to `conf/presto/jvm.config`