### PR TITLE
[Tests] Fix test retries for Pulsar Functions integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
@@ -80,7 +80,7 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
             { FunctionRuntimeType.THREAD }
         };
     }
-    
+
     @DataProvider(name = "FunctionRuntimes")
     public static Object[][] functionRuntimes() {
         return new Object[][] {
@@ -100,8 +100,22 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
         this.functionRuntimeType = functionRuntimeType;
     }
 
-    @BeforeClass(alwaysRun = true)
-    public void setupFunctionWorkers() {
+    @Override
+    public void setupCluster() throws Exception {
+        super.setupCluster();
+        setupFunctionWorkers();
+    }
+
+    @Override
+    public void tearDownCluster() throws Exception {
+        try {
+            teardownFunctionWorkers();
+        } finally {
+            super.tearDownCluster();
+        }
+    }
+
+    protected void setupFunctionWorkers() {
         final int numFunctionWorkers = 2;
         log.info("Setting up {} function workers : function runtime type = {}",
             numFunctionWorkers, functionRuntimeType);
@@ -109,8 +123,7 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
         log.info("{} function workers has started", numFunctionWorkers);
     }
 
-    @AfterClass(alwaysRun = true)
-    public void teardownFunctionWorkers() {
+    protected void teardownFunctionWorkers() {
         log.info("Tearing down function workers ...");
         pulsarCluster.stopWorkers();
         log.info("All functions workers are stopped.");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/java/PulsarFunctionsJavaTest.java
@@ -62,11 +62,6 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
            return;
        }
 
-       if (pulsarCluster == null) {
-           super.setupCluster();
-           super.setupFunctionWorkers();
-       }
-
        String inputTopicName = "persistent://public/default/test-serde-java-input-" + randomName(8);
        String outputTopicName = "test-publish-serde-output-" + randomName(8);
        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarCluster.getHttpServiceUrl()).build()) {
@@ -98,7 +93,7 @@ public class PulsarFunctionsJavaTest extends PulsarFunctionsTest {
        assertEquals(functionStatus.getNumInstances(), 1);
        assertEquals(functionStatus.getInstances().get(0).getStatus().isRunning(), true);
    }
-   
+
 
    @Test(groups = {"java_function", "function"})
    public void testJavaExclamationFunction() throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarIOTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarIOTestBase.java
@@ -29,10 +29,6 @@ public abstract class PulsarIOTestBase extends PulsarFunctionsTestBase {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected void testSink(SinkTester tester, boolean builtin) throws Exception {
-        if (pulsarCluster == null) {
-            super.setupCluster();
-            super.setupFunctionWorkers();
-        }
         tester.startServiceContainer(pulsarCluster);
         try {
         	PulsarIOSinkRunner runner = new PulsarIOSinkRunner(pulsarCluster, functionRuntimeType.toString());
@@ -41,16 +37,11 @@ public abstract class PulsarIOTestBase extends PulsarFunctionsTestBase {
             tester.stopServiceContainer(pulsarCluster);
         }
     }
-	
+
 	@SuppressWarnings("rawtypes")
 	protected <ServiceContainerT extends GenericContainer>  void testSink(SinkTester<ServiceContainerT> sinkTester,
 			boolean builtinSink,
 			SourceTester<ServiceContainerT> sourceTester) throws Exception {
-
-		if (pulsarCluster == null) {
-			super.setupCluster();
-			super.setupFunctionWorkers();
-		}
 
 		ServiceContainerT serviceContainer = sinkTester.startServiceContainer(pulsarCluster);
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
@@ -39,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
 
 	protected final AtomicInteger testId = new AtomicInteger(0);
-	
+
     @Test(groups = "source")
     public void testDebeziumMySqlSourceJson() throws Exception {
         testDebeziumMySqlConnect("org.apache.kafka.connect.json.JsonConverter", true);
@@ -76,11 +76,6 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         // This is the binlog count that contained in mysql container.
         final int numMessages = 47;
 
-        if (pulsarCluster == null) {
-            super.setupCluster();
-            super.setupFunctionWorkers();
-        }
-
         @Cleanup
         PulsarClient client = PulsarClient.builder()
             .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
@@ -108,10 +103,10 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         DebeziumMySQLContainer mySQLContainer = new DebeziumMySQLContainer(pulsarCluster.getClusterName());
         sourceTester.setServiceContainer(mySQLContainer);
 
-        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(), 
-        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope, 
+        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(),
+        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope,
         		consumeTopicName, client);
-        
+
         runner.testSource(sourceTester);
     }
 
@@ -126,11 +121,6 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
 
         // This is the binlog count that contained in postgresql container.
         final int numMessages = 26;
-
-        if (pulsarCluster == null) {
-            super.setupCluster();
-            super.setupFunctionWorkers();
-        }
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()
@@ -152,10 +142,10 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         DebeziumPostgreSqlContainer postgreSqlContainer = new DebeziumPostgreSqlContainer(pulsarCluster.getClusterName());
         sourceTester.setServiceContainer(postgreSqlContainer);
 
-        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(), 
-        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope, 
+        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(),
+        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope,
         		consumeTopicName, client);
-        
+
         runner.testSource(sourceTester);
     }
 
@@ -170,12 +160,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
 
         // This is the binlog count that contained in mongodb container.
         final int numMessages = 17;
-
-        if (pulsarCluster == null) {
-            super.setupCluster();
-            super.setupFunctionWorkers();
-        }
-
+        
         @Cleanup
         PulsarClient client = PulsarClient.builder()
                 .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
@@ -195,11 +180,11 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         // setup debezium mongodb server
         DebeziumMongoDbContainer mongoDbContainer = new DebeziumMongoDbContainer(pulsarCluster.getClusterName());
         sourceTester.setServiceContainer(mongoDbContainer);
-        
-        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(), 
-        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope, 
+
+        PulsarIODebeziumSourceRunner runner = new PulsarIODebeziumSourceRunner(pulsarCluster, functionRuntimeType.toString(),
+        		converterClassName, tenant, namespace, sourceName, outputTopicName, numMessages, jsonWithEnvelope,
         		consumeTopicName, client);
-        
+
         runner.testSource(sourceTester);
     }
 


### PR DESCRIPTION
### Motivation

- `TestRetrySupport` will call the cleanup & setup methods between test retries to enable test retries.
- Test retries for Pulsar Functions integration tests were broken since Functions Worker setup/teardown wasn't part of these calls.

- The change also ensures correct startup order so that the Pulsar cluster is started before the Functions worker. 

- When running tests on JDK11 there were odd test failures that indicated an incorrect startup order.
  The problems went away with these changes. **These changes are necessary for running integration tests on JDK11.**

### Modifications

- remove `@BeforeClass` annotation from `setupFunctionWorkers` method and call it in an overridden `setupCluster` method.
- remove `@AfterClass` annotation from `teardownFunctionWorkers` method and call it in an overridden `tearDownCluster` method. 
- remove unnecessary initialization calls from some integration test classes.