### PR TITLE
[Tests] Add workaround for failing PulsarFunctionsJavaProcessTest on JDK11

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -22,6 +22,7 @@ package org.apache.pulsar.functions.instance;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 
+import com.scurrilous.circe.checksum.Crc32cIntChecksum;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -564,6 +565,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     private void setupLogHandler() {
         if (instanceConfig.getFunctionDetails().getLogTopic() != null &&
                 !instanceConfig.getFunctionDetails().getLogTopic().isEmpty()) {
+            // make sure Crc32cIntChecksum class is loaded before logging starts
+            // to prevent "SSE4.2 CRC32C provider initialized" appearing in log topic
+            new Crc32cIntChecksum();
             logAppender = new LogAppender(client, instanceConfig.getFunctionDetails().getLogTopic(),
                     FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails()));
             logAppender.start();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -323,7 +323,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
 
         getFunctionInfoNotFound(functionName);
     }
-    
+
     protected void testFunctionNegAck(Runtime runtime) throws Exception {
         if (functionRuntimeType == FunctionRuntimeType.THREAD) {
             return;
@@ -1510,8 +1510,8 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         for (int i = 0; i < numMessages; i++) {
             Message<byte[]> msg = consumer.receive(30, TimeUnit.SECONDS);
             String logMsg = new String(msg.getValue(), UTF_8);
-            log.info("Received: {}", logMsg);
-            assertTrue(expectedMessages.contains(logMsg));
+            log.info("Received message: '{}'", logMsg);
+            assertTrue(expectedMessages.contains(logMsg), "Message '" + logMsg + "' not expected");
             expectedMessages.remove(logMsg);
         }
 


### PR DESCRIPTION
### Motivation

- `PulsarFunctionsJavaProcessTest.testJavaLoggingFunction` fails on JDK11 since `SSE4.2 CRC32C provider initialized`
  gets logged to the Pulsar Functions log topic. Classloading seems to be postponed when running on JDK11.

### Modifications

  - As a workaround, create a `Crc32cIntChecksum` class instance before starting the Pulsar Functions log appender.