### PR TITLE
[Tests] Limit Pulsar Functions Java runtime to 128MB of RAM in int tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/utils/CommandGenerator.java
@@ -30,6 +30,9 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 @Setter
 @ToString
 public class CommandGenerator {
+    private static final long MB = 1048576L;
+    private static final long JAVA_RUNTIME_RAM_BYTES = 128 * MB;
+
     public enum Runtime {
         JAVA,
         PYTHON,
@@ -119,7 +122,6 @@ public class CommandGenerator {
                 }
                 break;
         }
-
         return commandBuilder.toString();
     }
 
@@ -192,6 +194,7 @@ public class CommandGenerator {
         switch (runtime){
             case JAVA:
                 commandBuilder.append(" --jar " + JAVAJAR);
+                commandBuilder.append(" --ram " + JAVA_RUNTIME_RAM_BYTES);
                 break;
             case PYTHON:
                 if (codeFile != null) {
@@ -281,6 +284,7 @@ public class CommandGenerator {
             switch (runtime) {
                 case JAVA:
                     commandBuilder.append(" --jar " + JAVAJAR);
+                    commandBuilder.append(" --ram " + JAVA_RUNTIME_RAM_BYTES);
                     break;
                 case PYTHON:
                     if (codeFile != null) {


### PR DESCRIPTION
### Motivation

- Pulsar Functions Java runtime uses maximum heap size of 1GB by default. 
- When running integration tests in CI, it would be better to limit the maximum heap size to 128 MB to reduce memory usage.

### Modifications

- pass parameter to creating and updating functions in integration tests to limit RAM to 128MB