### PR TITLE
[Schema] Add schemaType field in SchemaHash

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -300,7 +300,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
             Schema newSchema = parser.parse(new String(schemaData.getData(), UTF_8));
 
             for (SchemaAndMetadata schemaAndMetadata : schemaAndMetadataList) {
-                if (isUsingAvroSchemaParser(schemaData.getType())) {
+                if (isUsingAvroSchemaParser(schemaAndMetadata.schema.getType())) {
                     Schema.Parser existParser = new Schema.Parser();
                     Schema existSchema = existParser.parse(new String(schemaAndMetadata.schema.getData(), UTF_8));
                     if (newSchema.equals(existSchema) && schemaAndMetadata.schema.getType() == schemaData.getType()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -58,12 +58,14 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -556,4 +558,39 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             }
         }
     }
+
+    @Test
+    public void testProducerMultipleSchemaMessages() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicName = "auto_schema_test";
+
+        String ns = tenant + "/" + namespace;
+        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
+        admin.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+
+        final String topic = TopicName.get(TopicDomain.persistent.value(), tenant, namespace, topicName).toString();
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES())
+                .topic(topic)
+                .create();
+
+        producer.newMessage(Schema.STRING).value("test").send();
+        producer.newMessage(Schema.JSON(Schemas.PersonThree.class)).value(new Schemas.PersonThree(0, "ran")).send();
+        producer.newMessage(Schema.AVRO(Schemas.PersonThree.class)).value(new Schemas.PersonThree(0, "ran")).send();
+        producer.newMessage(Schema.AVRO(Schemas.PersonOne.class)).value(new Schemas.PersonOne(0)).send();
+        producer.newMessage(Schema.JSON(Schemas.PersonThree.class)).value(new Schemas.PersonThree(1, "tang")).send();
+        producer.newMessage(Schema.BYTES).value("test".getBytes(StandardCharsets.UTF_8)).send();
+        producer.newMessage(Schema.BYTES).value("test".getBytes(StandardCharsets.UTF_8)).send();
+        producer.newMessage(Schema.BOOL).value(true).send();
+
+        List<SchemaInfo> allSchemas = admin.schemas().getAllSchemas(topic);
+        Assert.assertEquals(allSchemas.size(), 5);
+        Assert.assertEquals(allSchemas.get(0), Schema.STRING.getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(1), Schema.JSON(Schemas.PersonThree.class).getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(2), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(3), Schema.AVRO(Schemas.PersonOne.class).getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(4), Schema.BOOL.getSchemaInfo());
+    }
+
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 
 /**
  * Schema hash wrapper with a HashCode inner type.
@@ -36,22 +37,25 @@ public class SchemaHash {
 
     private final HashCode hash;
 
-    private SchemaHash(HashCode hash) {
+    private final SchemaType schemaType;
+
+    private SchemaHash(HashCode hash, SchemaType schemaType) {
         this.hash = hash;
+        this.schemaType = schemaType;
     }
 
     public static SchemaHash of(Schema schema) {
         return of(Optional.ofNullable(schema)
                           .map(Schema::getSchemaInfo)
-                          .map(SchemaInfo::getSchema).orElse(new byte[0]));
+                          .map(SchemaInfo::getSchema).orElse(new byte[0]), schema.getSchemaInfo().getType());
     }
 
     public static SchemaHash of(SchemaData schemaData) {
-        return of(schemaData.getData());
+        return of(schemaData.getData(), schemaData.getType());
     }
 
-    private static SchemaHash of(byte[] schemaBytes) {
-        return new SchemaHash(hashFunction.hashBytes(schemaBytes));
+    private static SchemaHash of(byte[] schemaBytes, SchemaType schemaType) {
+        return new SchemaHash(hashFunction.hashBytes(schemaBytes), schemaType);
     }
 
     public byte[] asBytes() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -45,9 +45,9 @@ public class SchemaHash {
     }
 
     public static SchemaHash of(Schema schema) {
-        return of(Optional.ofNullable(schema)
-                          .map(Schema::getSchemaInfo)
-                          .map(SchemaInfo::getSchema).orElse(new byte[0]), schema.getSchemaInfo().getType());
+        Optional<SchemaInfo> schemaInfo = Optional.ofNullable(schema).map(Schema::getSchemaInfo);
+        return of(schemaInfo.map(SchemaInfo::getSchema).orElse(new byte[0]),
+                schemaInfo.map(SchemaInfo::getType).orElse(null));
     }
 
     public static SchemaHash of(SchemaData schemaData) {


### PR DESCRIPTION
### Motivation

Currently, the schemaHash only uses the schema data to distinguish different schemas, it's not enough due to the primitive schemas all have empty schema data, and the JSON, AVRO schema will maintain the same schema data if they based on the same POJO.

### Modifications

Add a new field `schemaType` in SchemaHash.

### Verifying this change

Add a new unit test to produce multiple schemas messages by AutoProduceBytesSchema in ALWAYS_COMPATIBLE mode.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

