### PR TITLE
Update vcpkg.json package list

### DIFF
--- a/pulsar-client-cpp/vcpkg.json
+++ b/pulsar-client-cpp/vcpkg.json
@@ -16,11 +16,16 @@
     "boost-serialization",
     "boost-xpressive",
     "curl",
-    "dlfcn-win32",
     "openssl",
     "protobuf",
     "snappy",
     "zlib",
-    "zstd"
+    "zstd",
+    "python3",
+    "log4cxx",
+    {
+      "name": "dlfcn-win32",
+      "platform": "windows"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation

* vcpkg does not restrict dlfcn-win32 to windows env.

### Modifications

* Restrict dlfcn-win32 to windows env
* Add additional components
