### PR TITLE
Synchronize OpAddEntry.safeRun() to prevent race on updating lastConfirmedEntry

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -176,7 +176,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
     // Called in executor hashed on managed ledger name, once the add operation is complete
     @Override
-    public void safeRun() {
+    public synchronized void safeRun() {
         // Remove this entry from the head of the pending queue
         OpAddEntry firstInQueue = ml.pendingAddEntries.poll();
         checkArgument(this == firstInQueue);


### PR DESCRIPTION
I noticed that OpAddEntry.safeRun() is modifying a volatile field (`ml.lastConfirmedEntry`) here: https://github.com/apache/pulsar/blob/55d6a77ec8e7d05f00f906111b7de63d6b52c74a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java#L197
Since we don't have a mutex while updating `lastConfirmedEntry`, it looks like that could create a concurrency issue if another thread races on the update. 
I found this while investigating #6054, though testing confirmed that this PR doesn't prevent the `lastConfirmedEntry` from getting stuck in that issue (as reported in this comment: https://github.com/apache/pulsar/issues/6054#issuecomment-840894974).