### PR TITLE
Fix NPE when ACK grouping tracker checks duplicated message id

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -200,6 +200,9 @@ public class MessageIdImpl implements MessageId {
 
     @Override
     public int compareTo(MessageId o) {
+        if (o == null) {
+            throw new UnsupportedOperationException("MessageId is null");
+        }
         if (o instanceof MessageIdImpl) {
             MessageIdImpl other = (MessageIdImpl) o;
             int batchIndex = (o instanceof BatchMessageIdImpl) ? ((BatchMessageIdImpl) o).getBatchIndex() : NO_BATCH;
@@ -210,8 +213,7 @@ public class MessageIdImpl implements MessageId {
         } else if (o instanceof TopicMessageIdImpl) {
             return compareTo(((TopicMessageIdImpl) o).getInnerMessageId());
         } else {
-            final String typeName = (o != null) ? o.getClass().getName() : "null";
-            throw new UnsupportedOperationException("Unknown MessageId type: " + typeName);
+            throw new UnsupportedOperationException("Unknown MessageId type: " + o.getClass().getName());
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -210,7 +210,8 @@ public class MessageIdImpl implements MessageId {
         } else if (o instanceof TopicMessageIdImpl) {
             return compareTo(((TopicMessageIdImpl) o).getInnerMessageId());
         } else {
-            throw new UnsupportedOperationException("Unknown MessageId type: " + o.getClass().getName());
+            final String typeName = (o != null) ? o.getClass().getName() : "null";
+            throw new UnsupportedOperationException("Unknown MessageId type: " + typeName);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import io.netty.util.Recycler;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.MessageId;
@@ -113,7 +114,10 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
      * resent after a disconnection and for which the user has already sent an acknowledgement.
      */
     @Override
-    public boolean isDuplicate(MessageId messageId) {
+    public boolean isDuplicate(@NonNull MessageId messageId) {
+        if (lastCumulativeAck.messageId == null) {
+            return false;
+        }
         if (messageId.compareTo(lastCumulativeAck.messageId) <= 0) {
             // Already included in a cumulative ack
             return true;


### PR DESCRIPTION
### Motivation

Recently I encountered the following NPE but it's hard to reproduce.

```
01:40:14.630 [pulsar-client-io-54-1] WARN  org.apache.pulsar.client.impl.ClientCnx - [10.0.0.44/10.0.0.44:6650] Got exception java.lang.NullPointerException
    at org.apache.pulsar.client.impl.MessageIdImpl.compareTo(MessageIdImpl.java:213)
    at org.apache.pulsar.client.impl.MessageIdImpl.compareTo(MessageIdImpl.java:37)
    at org.apache.pulsar.client.impl.PersistentAcknowledgmentsGroupingTracker.isDuplicate(PersistentAcknowledgmentsGroupingTracker.java:117)
    at org.apache.pulsar.client.impl.ConsumerImpl.messageReceived(ConsumerImpl.java:1013)
```

From the stack we can see NPE was thrown when an ACK grouping tracker checks duplicated message id. The tracker maintains a `LastCumulativeAck` field that has a `MessageIdImpl` type field `messageId`. However, `messageId` could be null after `recycle()` or just was created with a null `MessageIdImpl`. We should check null here. Anyway, it may be introduced from https://github.com/apache/pulsar/pull/8996

### Modifications

- Check null in `PersistentAcknowledgmentsGroupingTracker#isDuplicate` and returns false if it's null, then the tracker will do nothing in `ConsumerImpl#messageReceived`.
- Check null in `MessageIdImpl#compareTo` and throw `UnsupportedOperationException` if the compared object is null.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.