### PR TITLE
[CI] Run pulsar-broker tests that don't belong to any TestNG group

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -42,7 +42,7 @@ function broker_group_1() {
 }
 
 function broker_group_2() {
-  $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming'
+  $MVN_TEST_COMMAND -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,other'
 }
 
 function broker_client_api() {

--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -23,12 +23,15 @@ import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
 import org.testng.IAnnotationTransformer;
+import org.testng.annotations.IConfigurationAnnotation;
 import org.testng.annotations.ITestAnnotation;
+import org.testng.annotations.ITestOrConfiguration;
 import org.testng.internal.annotations.DisabledRetryAnalyzer;
 
 public class AnnotationListener implements IAnnotationTransformer {
 
     private static final long DEFAULT_TEST_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
+    private static final String OTHER_GROUP = "other";
 
     public AnnotationListener() {
         System.out.println("Created annotation listener");
@@ -48,5 +51,22 @@ public class AnnotationListener implements IAnnotationTransformer {
         if (annotation.getTimeOut() == 0) {
             annotation.setTimeOut(DEFAULT_TEST_TIMEOUT_MILLIS);
         }
+
+        addToOtherGroupIfNoGroupsSpecified(annotation);
+    }
+
+    private void addToOtherGroupIfNoGroupsSpecified(ITestOrConfiguration annotation) {
+        // Add test to "other" group if there's no specified group
+        if (annotation.getGroups() == null || annotation.getGroups().length == 0) {
+            annotation.setGroups(new String[]{OTHER_GROUP});
+        }
+    }
+
+    @Override
+    public void transform(IConfigurationAnnotation annotation, Class testClass, Constructor testConstructor,
+                          Method testMethod) {
+        // configuration methods such as BeforeMethod / BeforeClass methods should also be added to the "other" group
+        // since BeforeMethod/BeforeClass methods get run only when the group matches or when there's "alwaysRun=true"
+        addToOtherGroupIfNoGroupsSpecified(annotation);
     }
 }


### PR DESCRIPTION
Fixes #10589 

### Motivation

See #10589 . Tests that don't belong to any TestNG group aren't run at all in pulsar-broker module.

### Modifications

* Add logic to Pulsar's TestNG listener to add a test method to "other" group when no group has been specified.
* Run the "other" group as part of broker_group_2