### PR TITLE
[broker] Setup pulsar cluster with MetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreLifecycle.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreLifecycle.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.api;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Extension of the {@link MetadataStore} interface that supports lifecycle operation methods which might not
+ * be supported by all implementations.
+ */
+public interface MetadataStoreLifecycle {
+    /**
+     * Initialize the metadata store cluster if needed.
+     *
+     * For example, if the backend metadata store is a zookeeper cluster and the pulsar cluster is configured to
+     * access the zookeeper cluster in the chroot mode, then this method could be used to initialize the root node
+     * during pulsar cluster metadata setup.
+     *
+     * @return a future to track the async request.
+     */
+    CompletableFuture<Void> initializeCluster();
+}


### PR DESCRIPTION
### Motivation

Refactor the pulsar cluster setup command to use the new `MetadataStore` API.

### Modifications

- Refactored `PulsarClusterMetadataSetup` command to use the new `MetadataStore` API.
- Added a new `MetadataStoreLifecycle` interface for the `MetadataStore` implementations to do initialization as needed.
  - For zookeeper, it creates the root node in chroot mode

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
This change is already covered by existing tests, such as *`ClusterMetadataSetupTest`*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)