### PR TITLE
[Schema] Support consume multiple schema types messages by AutoConsumeSchema

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -903,7 +903,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Object nativeObject = message.getValue().getNativeObject();
         String baseTopic = message.getProperty("baseTopic");
         JsonNode jsonNode;
-        KeyValue kv;
+        KeyValue<?, ?> kv;
         switch (baseTopic) {
             case "bytes_schema":
                 Assert.assertEquals(new String((byte[]) nativeObject), "bytes value");
@@ -935,7 +935,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 Assert.assertEquals(genericRecord.get("id"), 10);
                 break;
             case "k_one_v_three_schema_separate":
-                kv = (KeyValue<?, ?>) nativeObject;
+                kv = (KeyValue<GenericRecord, GenericRecord>) nativeObject;
                 jsonNode = ((GenericJsonRecord) kv.getKey()).getJsonNode();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 1);
                 jsonNode = ((GenericJsonRecord) kv.getValue()).getJsonNode();
@@ -943,8 +943,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 Assert.assertEquals(jsonNode.get("name").textValue(), "kv-separate");
                 break;
             case "k_one_v_four_schema_inline":
-                kv = (KeyValue<?, ?>) nativeObject;
-                jsonNode = ((GenericJsonRecord) kv.getKey()).getJsonNode();
+                kv = (KeyValue<GenericRecord, GenericRecord>) nativeObject;
+                jsonNode = (JsonNode) ((GenericJsonRecord) kv.getKey()).getNativeObject();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 10);
                 jsonNode = ((GenericJsonRecord) kv.getValue()).getJsonNode();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 30);
@@ -952,8 +952,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 Assert.assertEquals(jsonNode.get("age").intValue(), 20);
                 break;
             case "k_int_v_three_schema_separate":
-                kv = (KeyValue<?, ?>) nativeObject;
-                Assert.assertEquals(kv.getKey(), new Integer(100));
+                kv = (KeyValue<Integer, GenericRecord>) nativeObject;
+                Assert.assertEquals(kv.getKey(), 100);
                 jsonNode = ((GenericJsonRecord) kv.getValue()).getJsonNode();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 40);
                 Assert.assertEquals(jsonNode.get("name").textValue(), "kv-separate");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -752,7 +752,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-<<<<<<< HEAD
     public void testNullKey() throws Exception {
         final String tenant = PUBLIC_TENANT;
         final String namespace = "test-namespace-" + randomName(16);
@@ -785,7 +784,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Message<String> message = consumer.receive();
         assertNull(message.getKey());
         assertEquals("foo", message.getValue());
-=======
+    }
+
     public void testConsumeMultipleSchemaMessages() throws Exception {
         final String namespace = "test-namespace-" + randomName(16);
         String ns = PUBLIC_TENANT + "/" + namespace;
@@ -961,7 +961,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             default:
                 // nothing to do
         }
->>>>>>> 9ae9522001f... support consume multiple schema type message data by auto consume schema AutoConsumeSchema
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -944,7 +944,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 break;
             case "k_one_v_four_schema_inline":
                 kv = (KeyValue<GenericRecord, GenericRecord>) nativeObject;
-                jsonNode = (JsonNode) ((GenericJsonRecord) kv.getKey()).getNativeObject();
+                jsonNode = ((GenericJsonRecord) kv.getKey()).getJsonNode();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 10);
                 jsonNode = ((GenericJsonRecord) kv.getValue()).getJsonNode();
                 Assert.assertEquals(jsonNode.get("id").intValue(), 30);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -841,7 +841,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
             }
             log.info("auto consumer get native object class: {}, value: {}",
                     message.getValue().getNativeObject().getClass(), message.getValue().getNativeObject());
-            checkSchemaForAutoSchema(i, message);
+            checkSchemaForAutoSchema(message);
         }
     }
 
@@ -896,7 +896,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         consumer.close();
     }
 
-    private void checkSchemaForAutoSchema(int index, Message<GenericRecord> message) {
+    private void checkSchemaForAutoSchema(Message<GenericRecord> message) {
         if (!message.getReaderSchema().isPresent()) {
             Assert.fail("Failed to get reader schema for auto consume multiple schema topic.");
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -481,7 +480,7 @@ public class MessageImpl<T> implements Message<T> {
                     (org.apache.pulsar.common.schema.KeyValue) kvSchema.decode(getKeyBytes(), getData(), schemaVersion);
             if (schema instanceof AutoConsumeSchema) {
                 return (T) AutoConsumeSchema.wrapPrimitiveObject(keyValue,
-                        schema.getSchemaInfo().getType(), schemaVersion);
+                        ((AutoConsumeSchema) schema).getSchemaInfo(schemaVersion).getType(), schemaVersion);
             } else {
                 return (T) keyValue;
             }
@@ -497,7 +496,7 @@ public class MessageImpl<T> implements Message<T> {
                     (org.apache.pulsar.common.schema.KeyValue) kvSchema.decode(getKeyBytes(), getData(), null);
             if (schema instanceof AutoConsumeSchema) {
                 return (T) AutoConsumeSchema.wrapPrimitiveObject(keyValue,
-                        schema.getSchemaInfo().getType(), null);
+                        ((AutoConsumeSchema) schema).getSchemaInfo(getSchemaVersion()).getType(), null);
             } else {
                 return (T) keyValue;
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -426,6 +426,9 @@ public class MessageImpl<T> implements Message<T> {
 
     private SchemaInfo getSchemaInfo() {
         ensureSchemaIsLoaded();
+        if (schema instanceof AutoConsumeSchema) {
+            return ((AutoConsumeSchema) schema).getSchemaInfo(getSchemaVersion());
+        }
         return schema.getSchemaInfo();
     }
 
@@ -451,7 +454,7 @@ public class MessageImpl<T> implements Message<T> {
 
     private KeyValueSchema getKeyValueSchema() {
         if (schema instanceof AutoConsumeSchema) {
-            return (KeyValueSchema) ((AutoConsumeSchema) schema).getInternalSchema();
+            return (KeyValueSchema) ((AutoConsumeSchema) schema).getInternalSchema(getSchemaVersion());
         } else {
             return (KeyValueSchema) schema;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -52,7 +52,7 @@ import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
-import org.apache.pulsar.common.protocol.schema.SchemaVersion;
+import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -420,7 +420,7 @@ public class MessageImpl<T> implements Message<T> {
 
     private void ensureSchemaIsLoaded() {
         if (schema instanceof AutoConsumeSchema) {
-            ((AutoConsumeSchema) schema).fetchSchemaIfNeeded(SchemaVersion.Latest);
+            ((AutoConsumeSchema) schema).fetchSchemaIfNeeded(BytesSchemaVersion.of(getSchemaVersion()));
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -52,6 +52,7 @@ import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -401,7 +402,7 @@ public class MessageImpl<T> implements Message<T> {
                     .atSchemaVersion(schemaVersion));
         } else if (schema instanceof AbstractSchema) {
             byte[] schemaVersion = getSchemaVersion();
-            return Optional.of(((AbstractSchema) schema)
+            return Optional.of(((AbstractSchema<?>) schema)
                     .atSchemaVersion(schemaVersion));
         } else {
             return Optional.of(schema);
@@ -419,9 +420,10 @@ public class MessageImpl<T> implements Message<T> {
 
     private void ensureSchemaIsLoaded() {
         if (schema instanceof AutoConsumeSchema) {
-            ((AutoConsumeSchema) schema).fetchSchemaIfNeeded();
+            ((AutoConsumeSchema) schema).fetchSchemaIfNeeded(SchemaVersion.Latest);
         }
     }
+
     private SchemaInfo getSchemaInfo() {
         ensureSchemaIsLoaded();
         return schema.getSchemaInfo();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -987,7 +987,7 @@ public class PulsarClientImpl implements PulsarClient {
         return new MultiVersionSchemaInfoProvider(TopicName.get(topicName), this);
     }
 
-    private LoadingCache<String, SchemaInfoProvider> getSchemaProviderLoadingCache() {
+    protected LoadingCache<String, SchemaInfoProvider> getSchemaProviderLoadingCache() {
         return schemaProviderLoadingCache;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -123,7 +123,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     @Override
     public TypedMessageBuilder<T> keyBytes(byte[] key) {
-        if (schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
+        if (schema instanceof KeyValueSchema && schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
             KeyValueSchema kvSchema = (KeyValueSchema) schema;
             checkArgument(!(kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED),
                     "This method is not allowed to set keys when in encoding type is SEPARATED");
@@ -149,7 +149,8 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             msgMetadata.setNullValue(true);
             return this;
         }
-        if (schema.getSchemaInfo() != null && schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
+        if (value instanceof org.apache.pulsar.common.schema.KeyValue
+                && schema.getSchemaInfo() != null && schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
             KeyValueSchema kvSchema = (KeyValueSchema) schema;
             org.apache.pulsar.common.schema.KeyValue kv = (org.apache.pulsar.common.schema.KeyValue) value;
             if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -108,7 +108,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
         fetchSchemaIfNeeded(sv);
         ensureSchemaInitialized(sv);
-        return adapt(schemaMap.get(sv).decode(bytes, schemaVersion), schemaVersion);
+        return adapt(schemaMap.get(sv).decode(bytes), schemaVersion);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -127,6 +127,17 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         return schemaMap.get(SchemaVersion.Latest).getSchemaInfo();
     }
 
+    public SchemaInfo getSchemaInfo(byte[] schemaVersion) {
+        if (schemaVersion == null) {
+            return Schema.BYTES.getSchemaInfo();
+        }
+        SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
+        if (schemaMap.containsKey(sv)) {
+            return schemaMap.get(sv).getSchemaInfo();
+        }
+        return null;
+    }
+
     @Override
     public void configureSchemaInfo(String topicName,
                                     String componentName,
@@ -253,6 +264,10 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
 
     public Schema<?> getInternalSchema() {
         return schemaMap.get(SchemaVersion.Latest);
+    }
+
+    public Schema<?> getInternalSchema(byte[] schemaVersion) {
+        return schemaMap.get(BytesSchemaVersion.of(schemaVersion));
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -261,6 +261,9 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
      * places and we will introduce lots of deadlocks.
      */
     public void fetchSchemaIfNeeded(SchemaVersion schemaVersion) throws SchemaSerializationException {
+        if (schemaVersion == null) {
+            schemaVersion = BytesSchemaVersion.of(new byte[0]);
+        }
         if (!schemaMap.containsKey(schemaVersion)) {
             if (schemaInfoProvider == null) {
                 throw new SchemaSerializationException("Can't get accurate schema information for topic " + topicName +

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -21,8 +21,11 @@ package org.apache.pulsar.client.impl.schema;
 import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Optional;
 
 /**
  * Auto detect schema.
@@ -71,7 +74,12 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
 
         if (requireSchemaValidation) {
             // verify if the message can be decoded by the underlying schema
-            schema.validate(message);
+            if (schema instanceof KeyValueSchema
+                    && ((KeyValueSchema) schema).getKeyValueEncodingType().equals(KeyValueEncodingType.SEPARATED)) {
+                ((KeyValueSchema) schema).getValueSchema().validate(message);
+            } else {
+                schema.validate(message);
+            }
         }
 
         return message;
@@ -94,6 +102,11 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
         ensureSchemaInitialized();
 
         return schema.getSchemaInfo();
+    }
+
+    @Override
+    public Optional<Object> getNativeSchema() {
+        return Optional.ofNullable(schema);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
@@ -93,13 +93,9 @@ public class MultiVersionSchemaInfoProvider implements SchemaInfoProvider {
     }
 
     private CompletableFuture<SchemaInfo> loadSchema(byte[] schemaVersion) {
-         if (schemaVersion.length == 0) {
-             return getLatestSchema();
-         } else {
-             return pulsarClient.getLookup()
-                     .getSchema(topicName, schemaVersion)
-                     .thenApply(o -> o.orElse(null));
-         }
+        return pulsarClient.getLookup()
+                .getSchema(topicName, schemaVersion)
+                .thenApply(o -> o.orElse(null));
     }
 
     public PulsarClientImpl getPulsarClient() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
@@ -93,9 +93,13 @@ public class MultiVersionSchemaInfoProvider implements SchemaInfoProvider {
     }
 
     private CompletableFuture<SchemaInfo> loadSchema(byte[] schemaVersion) {
-         return pulsarClient.getLookup()
-                .getSchema(topicName, schemaVersion)
-                .thenApply(o -> o.orElse(null));
+         if (schemaVersion.length == 0) {
+             return getLatestSchema();
+         } else {
+             return pulsarClient.getLookup()
+                     .getSchema(topicName, schemaVersion)
+                     .thenApply(o -> o.orElse(null));
+         }
     }
 
     public PulsarClientImpl getPulsarClient() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/AbstractGenericSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/AbstractGenericSchemaTest.java
@@ -23,6 +23,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +75,7 @@ public class AbstractGenericSchemaTest {
 
             GenericRecord record;
             if (decodeSchema instanceof AutoConsumeSchema) {
-                record = decodeSchema.decode(data, new byte[0]);
+                record = decodeSchema.decode(data, new LongSchemaVersion(0L).bytes());
             } else {
                 record = decodeSchema.decode(data);
             }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProviderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProviderTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -61,7 +62,7 @@ public class MultiVersionSchemaInfoProviderTest {
                         any(TopicName.class),
                         any(byte[].class)))
                 .thenReturn(completableFuture);
-        SchemaInfo schemaInfoByVersion = schemaProvider.getSchemaByVersion(new byte[0]).get();
+        SchemaInfo schemaInfoByVersion = schemaProvider.getSchemaByVersion(new LongSchemaVersion(0).bytes()).get();
         assertEquals(schemaInfoByVersion, schemaInfo);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProviderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProviderTest.java
@@ -32,7 +32,6 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -62,7 +61,7 @@ public class MultiVersionSchemaInfoProviderTest {
                         any(TopicName.class),
                         any(byte[].class)))
                 .thenReturn(completableFuture);
-        SchemaInfo schemaInfoByVersion = schemaProvider.getSchemaByVersion(new LongSchemaVersion(0).bytes()).get();
+        SchemaInfo schemaInfoByVersion = schemaProvider.getSchemaByVersion(new byte[0]).get();
         assertEquals(schemaInfoByVersion, schemaInfo);
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -358,11 +358,12 @@ public class LookupProxyHandler {
         final long clientRequestId = commandGetSchema.getRequestId();
         String serviceUrl = getBrokerServiceUrl(clientRequestId);
         String topic = commandGetSchema.getTopic();
-        Optional<SchemaVersion> tempVersion = Optional.empty();
+        Optional<SchemaVersion> schemaVersion;
         if (commandGetSchema.hasSchemaVersion()) {
-            tempVersion = Optional.of(commandGetSchema.getSchemaVersion()).map(BytesSchemaVersion::of);
+            schemaVersion = Optional.of(commandGetSchema.getSchemaVersion()).map(BytesSchemaVersion::of);
+        } else {
+            schemaVersion = Optional.empty();
         }
-        final Optional<SchemaVersion> schemaVersion = tempVersion;
 
         if(!StringUtils.isNotBlank(serviceUrl)) {
             return;

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -357,6 +358,11 @@ public class LookupProxyHandler {
         final long clientRequestId = commandGetSchema.getRequestId();
         String serviceUrl = getBrokerServiceUrl(clientRequestId);
         String topic = commandGetSchema.getTopic();
+        Optional<SchemaVersion> tempVersion = Optional.empty();
+        if (commandGetSchema.hasSchemaVersion()) {
+            tempVersion = Optional.of(commandGetSchema.getSchemaVersion()).map(BytesSchemaVersion::of);
+        }
+        final Optional<SchemaVersion> schemaVersion = tempVersion;
 
         if(!StringUtils.isNotBlank(serviceUrl)) {
             return;
@@ -375,12 +381,7 @@ public class LookupProxyHandler {
             // Connected to backend broker
             long requestId = proxyConnection.newRequestId();
             ByteBuf command;
-            byte[] schemaVersion = null;
-            if (commandGetSchema.hasSchemaVersion()) {
-                schemaVersion = commandGetSchema.getSchemaVersion();
-            }
-            command = Commands.newGetSchema(requestId, topic,
-                    Optional.ofNullable(schemaVersion).map(BytesSchemaVersion::of));
+            command = Commands.newGetSchema(requestId, topic, schemaVersion);
             clientCnx.sendGetRawSchema(command, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     log.warn("[{}] Failed to get schema {}: {}", clientAddress, topic, t);


### PR DESCRIPTION
Based on the PR https://github.com/apache/pulsar/pull/10573

### Motivation

Support consuming multiple schema types messages by AutoConsumeSchema.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

Add a new unit test to verify consuming multiple schema type messages by AutoConsumeSchema.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
