### PR TITLE
Setup initial namespaces with MetadataStore

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarInitialNamespaceSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarInitialNamespaceSetup.java
@@ -63,7 +63,7 @@ public class PulsarInitialNamespaceSetup {
             }
         } catch (Exception e) {
             jcommander.usage();
-            throw e;
+            return 1;
         }
 
         if (arguments.configurationStore == null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarInitialNamespaceSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarInitialNamespaceSetup.java
@@ -51,7 +51,7 @@ public class PulsarInitialNamespaceSetup {
 
     }
 
-    public static void main(String[] args) throws Exception {
+    public static int doMain(String[] args) throws Exception {
         Arguments arguments = new Arguments();
         JCommander jcommander = new JCommander();
         try {
@@ -59,7 +59,7 @@ public class PulsarInitialNamespaceSetup {
             jcommander.parse(args);
             if (arguments.help) {
                 jcommander.usage();
-                return;
+                return 0;
             }
         } catch (Exception e) {
             jcommander.usage();
@@ -69,7 +69,7 @@ public class PulsarInitialNamespaceSetup {
         if (arguments.configurationStore == null) {
             System.err.println("Configuration store address argument is required (--configuration-store)");
             jcommander.usage();
-            System.exit(1);
+            return 1;
         }
 
         try (MetadataStore configStore = PulsarClusterMetadataSetup
@@ -80,7 +80,7 @@ public class PulsarInitialNamespaceSetup {
                     namespaceName = NamespaceName.get(namespace);
                 } catch (Exception e) {
                     System.out.println("Invalid namespace name.");
-                    System.exit(1);
+                    return 1;
                 }
 
                 // Create specified tenant
@@ -94,5 +94,10 @@ public class PulsarInitialNamespaceSetup {
         }
 
         System.out.println("Initial namespace setup success");
+        return 0;
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.exit(doMain(args));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -165,7 +165,7 @@ public class ClusterMetadataSetupTest {
                 "test/b",
                 "test/c",
         };
-        PulsarInitialNamespaceSetup.main(args);
+        assertEquals(PulsarInitialNamespaceSetup.doMain(args), 0);
         try (MetadataStoreExtended store = MetadataStoreExtended.create("127.0.0.1:" + localZkS.getZookeeperPort(),
                 MetadataStoreConfig.builder().build())) {
             TenantResources tenantResources = new TenantResources(store,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -158,6 +158,15 @@ public class ClusterMetadataSetupTest {
 
     @Test
     public void testInitialNamespaceSetup() throws Exception {
+        // missing arguments
+        assertEquals(PulsarInitialNamespaceSetup.doMain(new String[]{}), 1);
+        // invalid namespace
+        assertEquals(PulsarInitialNamespaceSetup.doMain(new String[]{
+                "--cluster", "testInitialNamespaceSetup-cluster",
+                "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "a/b/c/d"
+        }), 1);
+
         String[] args = {
                 "--cluster", "testInitialNamespaceSetup-cluster",
                 "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -21,11 +21,19 @@ package org.apache.pulsar.broker.zookeeper;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.pulsar.PulsarClusterMetadataSetup;
+import org.apache.pulsar.PulsarInitialNamespaceSetup;
+import org.apache.pulsar.broker.cache.ConfigurationCacheService;
+import org.apache.pulsar.broker.resources.PulsarResources;
+import org.apache.pulsar.broker.resources.TenantResources;
+import org.apache.pulsar.broker.web.PulsarWebResource;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
@@ -146,6 +154,26 @@ public class ClusterMetadataSetupTest {
 
         // expected exist
         assertNotNull(localZk.exists("/ledgers", false));
+    }
+
+    @Test
+    public void testInitialNamespaceSetup() throws Exception {
+        String[] args = {
+                "--cluster", "testInitialNamespaceSetup-cluster",
+                "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "test/a",
+                "test/b",
+                "test/c",
+        };
+        PulsarInitialNamespaceSetup.main(args);
+        try (MetadataStoreExtended store = MetadataStoreExtended.create("127.0.0.1:" + localZkS.getZookeeperPort(),
+                MetadataStoreConfig.builder().build())) {
+            TenantResources tenantResources = new TenantResources(store,
+                    PulsarResources.DEFAULT_OPERATION_TIMEOUT_SEC);
+            List<String> namespaces = tenantResources.getChildren(PulsarWebResource
+                    .path(ConfigurationCacheService.POLICIES, "test"));
+            assertEquals(new HashSet<>(namespaces), new HashSet<>(Arrays.asList("a", "b", "c")));
+        }
     }
 
     @BeforeMethod


### PR DESCRIPTION
### Motivation

Refactor the initial namespaces setup command to use the new `MetadataStore` API.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications
- Refactored `PulsarInitialNamespaceSetup` command to use the new `MetadataStore` API.

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *`ClusterMetadataSetupTest`*.

*(or)*

This change added tests and can be verified as follows:
  - *Added unit tests for the `PulsarInitialNamespaceSetup` command*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
