### PR TITLE
MessageCrypto interface should not expose Netty ByteBuf class in the API

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -42,6 +42,7 @@ import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Clock;
@@ -3069,9 +3070,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         String encAlgo = encryptionCtx.getAlgorithm();
         int batchSize = encryptionCtx.getBatchSize().orElse(0);
 
-        ByteBuf payloadBuf = Unpooled.wrappedBuffer(msg.getData());
+        ByteBuffer payloadBuf = ByteBuffer.wrap(msg.getData());
         // try to decrypt use default MessageCryptoBc
-        @SuppressWarnings("rawtypes") MessageCrypto crypto = new MessageCryptoBc("test", false);
+        MessageCrypto<MessageMetadata, MessageMetadata> crypto =
+                new MessageCryptoBc("test", false);
 
         MessageMetadata messageMetadata = new MessageMetadata()
                 .setEncryptionParam(encrParam)
@@ -3087,11 +3089,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             messageMetadata.setEncryptionAlgo(encAlgo);
         }
 
-        ByteBuf decryptedPayload = crypto.decrypt(() -> messageMetadata, payloadBuf, reader);
+        ByteBuffer decryptedPayload = ByteBuffer.allocate(crypto.getMaxOutputSize(payloadBuf.remaining()));
+        crypto.decrypt(() -> messageMetadata, payloadBuf, decryptedPayload, reader);
 
         // try to uncompress
         CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(compressionType);
-        ByteBuf uncompressedPayload = codec.decode(decryptedPayload, uncompressedSize);
+        ByteBuf uncompressedPayload = codec.decode(Unpooled.wrappedBuffer(decryptedPayload), uncompressedSize);
 
         if (batchSize > 0) {
             SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -33,14 +33,17 @@
     <name>Pulsar Client :: API</name>
 
     <dependencies>
+        <!--
+            This module is meant to be free of any dependencies, because we don't want to have external symbols
+            exposed directly in our API.
+
+            The exception here is Protobuf, in order to support Protobuf schema. The library is marked as provided
+            so it's the user responsibility to add it to the classpath.
+        -->
+
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -22,8 +22,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
-import io.netty.buffer.ByteBuf;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -64,7 +62,6 @@ import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.MessageCrypto;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.CryptoException;
-import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.EncryptionKeys;
 import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -532,7 +529,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
     @Override
     public int getMaxOutputSize(int inputLen) {
-        return cipher.getOutputSize(inputLen);
+        return inputLen + Math.max(inputLen, 512);
     }
 
     private boolean getKeyAndDecryptData(MessageMetadata msgMetadata, ByteBuffer payload, ByteBuffer targetBuffer) {

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -380,13 +380,16 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      * @return encryptedData if success
      */
     @Override
-    public synchronized ByteBuf encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
-                                        Supplier<MessageMetadata> messageMetadataBuilderSupplier, ByteBuf payload) throws PulsarClientException {
+    public synchronized void encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
+                                        Supplier<MessageMetadata> messageMetadataBuilderSupplier,
+                                     ByteBuffer payload, ByteBuffer outBuffer) throws PulsarClientException {
 
         MessageMetadata msgMetadata = messageMetadataBuilderSupplier.get();
 
         if (encKeys.isEmpty()) {
-            return payload;
+            outBuffer.put(payload);
+            outBuffer.flip();
+            return;
         }
 
         // Update message metadata with encrypted data key
@@ -427,31 +430,23 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         // Update message metadata with encryption param
         msgMetadata.setEncryptionParam(iv);
 
-        ByteBuf targetBuf = null;
         try {
             // Encrypt the data
             cipher.init(Cipher.ENCRYPT_MODE, dataKey, gcmParam);
 
-            ByteBuffer sourceNioBuf = payload.nioBuffer(payload.readerIndex(), payload.readableBytes());
+            int maxLength = cipher.getOutputSize(payload.remaining());
+            if (outBuffer.remaining() < maxLength) {
+                throw new IllegalArgumentException("Outbuffer has not enough space available");
+            }
 
-            int maxLength = cipher.getOutputSize(payload.readableBytes());
-            targetBuf = PulsarByteBufAllocator.DEFAULT.buffer(maxLength, maxLength);
-            ByteBuffer targetNioBuf = targetBuf.nioBuffer(0, maxLength);
-
-            int bytesStored = cipher.doFinal(sourceNioBuf, targetNioBuf);
-            targetBuf.writerIndex(bytesStored);
-
+            int bytesStored = cipher.doFinal(payload, outBuffer);
+            outBuffer.flip();
+            outBuffer.limit(bytesStored);
         } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeyException
                 | InvalidAlgorithmParameterException | ShortBufferException e) {
-
-            targetBuf.release();
             log.error("{} Failed to encrypt message. {}", logCtx, e);
             throw new PulsarClientException.CryptoException(e.getMessage());
-
         }
-
-        payload.release();
-        return targetBuf;
     }
 
     private boolean decryptDataKey(String keyName, byte[] encryptedDataKey, List<KeyValue> encKeyMeta,
@@ -465,7 +460,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         // Read the private key info using callback
         EncryptionKeyInfo keyInfo = keyReader.getPrivateKey(keyName, keyMeta);
 
-        // Convert key from byte to PivateKey
+        // Convert key from byte to PrivateKey
         PrivateKey privateKey;
         try {
             privateKey = loadPrivateKey(keyInfo.getKey());
@@ -509,41 +504,38 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         return true;
     }
 
-    private ByteBuf decryptData(SecretKey dataKeySecret, MessageMetadata msgMetadata, ByteBuf payload) {
+    private boolean decryptData(SecretKey dataKeySecret, MessageMetadata msgMetadata,
+                                ByteBuffer payload, ByteBuffer targetBuffer) {
 
         // unpack iv and encrypted data
         iv =  msgMetadata.getEncryptionParam();
 
         GCMParameterSpec gcmParams = new GCMParameterSpec(tagLen, iv);
-        ByteBuf targetBuf = null;
         try {
             cipher.init(Cipher.DECRYPT_MODE, dataKeySecret, gcmParams);
 
-            ByteBuffer sourceNioBuf = payload.nioBuffer(payload.readerIndex(), payload.readableBytes());
-
-            int maxLength = cipher.getOutputSize(payload.readableBytes());
-            targetBuf = PulsarByteBufAllocator.DEFAULT.buffer(maxLength, maxLength);
-            ByteBuffer targetNioBuf = targetBuf.nioBuffer(0, maxLength);
-
-            int decryptedSize = cipher.doFinal(sourceNioBuf, targetNioBuf);
-            targetBuf.writerIndex(decryptedSize);
+            int maxLength = cipher.getOutputSize(payload.remaining());
+            if (targetBuffer.remaining() < maxLength) {
+                throw new IllegalArgumentException("Target buffer size is too small");
+            }
+            int decryptedSize = cipher.doFinal(payload, targetBuffer);
+            targetBuffer.flip();
+            targetBuffer.limit(decryptedSize);
+            return true;
 
         } catch (InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException
                 | BadPaddingException | ShortBufferException e) {
             log.error("{} Failed to decrypt message {}", logCtx, e.getMessage());
-            if (targetBuf != null) {
-                targetBuf.release();
-                targetBuf = null;
-            }
+            return false;
         }
-
-        return targetBuf;
     }
 
-    private ByteBuf getKeyAndDecryptData(MessageMetadata msgMetadata, ByteBuf payload) {
+    @Override
+    public int getMaxOutputSize(int inputLen) {
+        return cipher.getOutputSize(inputLen);
+    }
 
-        ByteBuf decryptedData = null;
-
+    private boolean getKeyAndDecryptData(MessageMetadata msgMetadata, ByteBuffer payload, ByteBuffer targetBuffer) {
         List<EncryptionKeys> encKeys = msgMetadata.getEncryptionKeysList();
 
         // Go through all keys to retrieve data key from cache
@@ -557,10 +549,9 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 // Taking a small performance hit here if the hash collides. When it
                 // retruns a different key, decryption fails. At this point, we would
                 // call decryptDataKey to refresh the cache and come here again to decrypt.
-                decryptedData = decryptData(storedSecretKey, msgMetadata, payload);
-                // If decryption succeeded, data is non null
-                if (decryptedData != null) {
-                    break;
+                if (decryptData(storedSecretKey, msgMetadata, payload, targetBuffer)) {
+                    // If decryption succeeded, we can already return
+                    return true;
                 }
             } else {
                 // First time, entry won't be present in cache
@@ -568,8 +559,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             }
 
         }
-        return decryptedData;
 
+        return false;
     }
 
     /*
@@ -581,18 +572,17 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      *
      * @param keyReader KeyReader implementation to retrieve key value
      *
-     * @return decryptedData if success, null otherwise
+     * @return true if success, false otherwise
      */
     @Override
-    public ByteBuf decrypt(Supplier<MessageMetadata> messageMetadataSupplier, ByteBuf payload, CryptoKeyReader keyReader) {
+    public boolean decrypt(Supplier<MessageMetadata> messageMetadataSupplier,
+                        ByteBuffer payload, ByteBuffer outBuffer, CryptoKeyReader keyReader) {
 
         MessageMetadata msgMetadata = messageMetadataSupplier.get();
         // If dataKey is present, attempt to decrypt using the existing key
         if (dataKey != null) {
-            ByteBuf decryptedData = getKeyAndDecryptData(msgMetadata, payload);
-            // If decryption succeeded, data is non null
-            if (decryptedData != null) {
-                return decryptedData;
+            if (getKeyAndDecryptData(msgMetadata, payload, outBuffer)) {
+                return true;
             }
         }
 
@@ -608,10 +598,10 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         if (encKeyInfo == null || dataKey == null) {
             // Unable to decrypt data key
-            return null;
+            return false;
         }
 
-        return getKeyAndDecryptData(msgMetadata, payload);
+        return getKeyAndDecryptData(msgMetadata, payload, outBuffer);
 
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -33,6 +33,7 @@ import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,6 +82,7 @@ import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.apache.pulsar.client.util.RetryUtil;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.EncryptionContext.EncryptionKey;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
@@ -1454,10 +1456,16 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }
         }
 
-        ByteBuf decryptedData = this.msgCrypto.decrypt(() -> msgMetadata, payload, conf.getCryptoKeyReader());
-        if (decryptedData != null) {
+
+        int maxDecryptedSize = msgCrypto.getMaxOutputSize(payload.readableBytes());
+        ByteBuf decryptedData = PulsarByteBufAllocator.DEFAULT.buffer(maxDecryptedSize);
+        ByteBuffer nioDecryptedData = decryptedData.nioBuffer(0, maxDecryptedSize);
+        if (msgCrypto.decrypt(() -> msgMetadata, payload.nioBuffer(), nioDecryptedData, conf.getCryptoKeyReader())) {
+            decryptedData.writerIndex();
             return decryptedData;
         }
+
+        decryptedData.release();
 
         switch (conf.getCryptoFailureAction()) {
             case CONSUME:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1461,7 +1461,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         ByteBuf decryptedData = PulsarByteBufAllocator.DEFAULT.buffer(maxDecryptedSize);
         ByteBuffer nioDecryptedData = decryptedData.nioBuffer(0, maxDecryptedSize);
         if (msgCrypto.decrypt(() -> msgMetadata, payload.nioBuffer(), nioDecryptedData, conf.getCryptoKeyReader())) {
-            decryptedData.writerIndex();
+            decryptedData.writerIndex(nioDecryptedData.limit());
             return decryptedData;
         }
 

--- a/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
+++ b/tests/pulsar-client-shade-test/src/test/java/org/apache/pulsar/tests/integration/SimpleProducerConsumerTest.java
@@ -45,6 +45,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Security;
@@ -550,7 +551,7 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
         String encAlgo = encryptionCtx.getAlgorithm();
         int batchSize = encryptionCtx.getBatchSize().orElse(0);
 
-        ByteBuf payloadBuf = Unpooled.wrappedBuffer(msg.getData());
+        ByteBuffer payloadBuf = ByteBuffer.wrap(msg.getData());
         // try to decrypt use default MessageCryptoBc
         MessageCrypto crypto = new MessageCryptoBc("test", false);
         MessageMetadata msgMetadata = new MessageMetadata()
@@ -569,11 +570,12 @@ public class SimpleProducerConsumerTest extends TestRetrySupport {
             .setKey(encryptionKeyName)
             .setValue(dataKey);
 
-        ByteBuf decryptedPayload = crypto.decrypt(() -> msgMetadata, payloadBuf, reader);
+        ByteBuffer decryptedPayload = ByteBuffer.allocate(crypto.getMaxOutputSize(payloadBuf.remaining()));
+        crypto.decrypt(() -> msgMetadata, payloadBuf, decryptedPayload, reader);
 
         // try to uncompress
         CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(compressionType);
-        ByteBuf uncompressedPayload = codec.decode(decryptedPayload, uncompressedSize);
+        ByteBuf uncompressedPayload = codec.decode(Unpooled.wrappedBuffer(decryptedPayload), uncompressedSize);
 
         if (batchSize > 0) {
             SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();


### PR DESCRIPTION
### Motivation

`MessageCrypto` is included in `pulsar-client-api` and it's exposing Netty `ByteBuf` in its API. 

The problem is that we are shading Netty and the classes are renamed. We must not have external libraries symbols as part of our API. 

The result is that Netty symbols are exposed as `org.apache.pulsar.shade.io.netty...` and therefore are not going to be interoperable with other libraries.

Because of this, `pulsar-client-api` was also included into the shaded Jars and that brings in other issues (like missing the sources/javadocs of the PulsarClient APIs).

### Modifications

 * Removed Netty dependency on `pulsar-client-api`
 * Made breaking change in the MessageCrypto to use `java.nio.ByteBuffer` in API

