### PR TITLE
[Functions] Process async results in the same Java runnable thread

### DIFF
--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceTest.java
@@ -111,9 +111,13 @@ public class JavaInstanceTest {
                 function,
                 instanceConfig);
         String testString = "ABC123";
-        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
-        assertNotNull(result.getResult());
-        assertEquals(testString + "-lambda", result.getResult());
+        CompletableFuture<JavaExecutionResult> resultHolder = new CompletableFuture<>();
+        JavaExecutionResult result = instance.handleMessage(
+            mock(Record.class), testString,
+            (record, javaResult) -> resultHolder.complete(javaResult), cause -> {});
+        assertNull(result);
+        assertNotNull(resultHolder.get());
+        assertEquals(testString + "-lambda", resultHolder.get().getResult());
         instance.close();
     }
     
@@ -143,8 +147,11 @@ public class JavaInstanceTest {
                 function,
                 instanceConfig);
         String testString = "ABC123";
-        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
-        assertNull(result.getResult());
+        CompletableFuture<JavaExecutionResult> resultHolder = new CompletableFuture<>();
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString,
+            (record, javaResult) -> resultHolder.complete(javaResult), cause -> {});
+        assertNull(result);
+        assertNotNull(resultHolder.get());
         instance.close();
     }
 
@@ -170,8 +177,11 @@ public class JavaInstanceTest {
                 function,
                 instanceConfig);
         String testString = "ABC123";
-        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString);
-        assertSame(userException, result.getUserException().getCause());
+        CompletableFuture<JavaExecutionResult> resultHolder = new CompletableFuture<>();
+        JavaExecutionResult result = instance.handleMessage(mock(Record.class), testString,
+            (record, javaResult) -> resultHolder.complete(javaResult), cause -> {});
+        assertNull(result);
+        assertSame(userException, resultHolder.get().getUserException());
         instance.close();
     }
 

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.pulsar.client.impl.Backoff;
@@ -252,8 +253,13 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
                 LOG.error("[{}] Failed to published message for replicator of {}-{}: Attempts:{}", kinesisSink.streamName,
                         resultContext.getPartitionId(), resultContext.getRecordSequence(), stringBuffer.toString());
             } else {
-                LOG.error("[{}] Failed to published message for replicator of {}-{}, {} ", kinesisSink.streamName,
+                if (StringUtils.isEmpty(exception.getMessage())) {
+                    LOG.error("[{}] Failed to published message for replicator of {}-{}", kinesisSink.streamName,
+                        resultContext.getPartitionId(), resultContext.getRecordSequence(), exception);
+                } else {
+                    LOG.error("[{}] Failed to published message for replicator of {}-{}, {} ", kinesisSink.streamName,
                         resultContext.getPartitionId(), resultContext.getRecordSequence(), exception.getMessage());
+                }
             }
             kinesisSink.previousPublishFailed = TRUE;
             if (kinesisSink.sinkContext != null) {


### PR DESCRIPTION
*Motivation*

After introducing the support for async functions, the java function processing semantic is not enforced.
For example, if it fails to write a sink, it doesn't fail the java instance or fail the message. Hence it keeps
receiving messages but never ack or nack.

*Modification*

Change the way how aysnc function requests are processed to fix the issues we have seen in Kinesis connector.

