### PR TITLE
Pulsar Admin: return a better error message

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -74,8 +74,8 @@ public class PulsarAdminException extends Exception {
         this.statusCode = e.getResponse().getStatus();
     }
 
-    public PulsarAdminException(ClientErrorException e, String message) {
-        super(message, e);
+    public PulsarAdminException(ServerErrorException e, String message) {
+        super(getReasonFromServer(e) + (message != null ? " " + message : ""), e);
         this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.admin;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
@@ -25,9 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Pulsar admin exceptions.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -74,8 +74,8 @@ public class PulsarAdminException extends Exception {
         this.statusCode = e.getResponse().getStatus();
     }
 
-    public PulsarAdminException(ServerErrorException e, String message) {
-        super(getReasonFromServer(e) + (message != null ? " " + message : ""), e);
+    public PulsarAdminException(ClientErrorException e, String message) {
+        super(message, e);
         this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }
@@ -87,7 +87,7 @@ public class PulsarAdminException extends Exception {
     }
 
     public PulsarAdminException(ServerErrorException e, String message) {
-        super(message, e);
+        super(getReasonFromServer(e) + (message != null ? " " + message : ""), e);
         this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }


### PR DESCRIPTION
### Motivation

sometimes, in case of Internal server error Pulsar Admin users see this kind of errors:
```

org.apache.pulsar.client.admin.PulsarAdminException$ServerSideErrorException: HTTP 500 Internal Server Errorjava.io.ByteArrayInputStream@56782aa4
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:208)
	at org.apache.pulsar.client.admin.internal.TopicsImpl$27.failed(TopicsImpl.java:1902)
	at org.glassfish.jersey.client.JerseyInvocation$1.failed(JerseyInvocation.java:839)
	at org.glassfish.jersey.client.JerseyInvocation$1.completed(JerseyInvocation.java:820)
```

### Modifications

Handle InputStream and try to extract properly the String

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
