### PR TITLE
branch-2.7: Remove reference to ProducerSpec from Pulsar Functions GO

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -224,17 +224,6 @@ func (gi *goInstance) getProducer(topicName string) (pulsar.Producer, error) {
 		gi.context.instanceConf.funcDetails.Namespace,
 		gi.context.instanceConf.funcDetails.Name), gi.context.instanceConf.instanceID)
 
-	batchBuilderType := pulsar.DefaultBatchBuilder
-
-	if gi.context.instanceConf.funcDetails.Sink.ProducerSpec != nil {
-		batchBuilder := gi.context.instanceConf.funcDetails.Sink.ProducerSpec.BatchBuilder
-		if batchBuilder != "" {
-			if batchBuilder == "KEY_BASED" {
-				batchBuilderType = pulsar.KeyBasedBatchBuilder
-			}
-		}
-	}
-
 	producer, err := gi.client.CreateProducer(pulsar.ProducerOptions{
 		Topic:                   topicName,
 		Properties:              properties,


### PR DESCRIPTION
### Motivation
Integration tests on branch-2.7 do not work, because of a bunch of lines of code that were cherry-picked to branch-2.7.

Steps to reproduce
```
git checkout branch-2.7
mvn clean install -DskipTests
mvn package -Pdocker -f docker/pom.xml
mvn clean install -DintegrationTests -f tests/docker-images/pom.xml
```


This is the error:
```
[INFO] [91m# github.com/apache/pulsar/pulsar-function-go/pf
[INFO] pf/instance.go:227:22: undefined: pulsar.DefaultBatchBuilder
[INFO] pf/instance.go:229:45: gi.context.instanceConf.funcDetails.Sink.ProducerSpec undefined (type *api.SinkSpec has no field or method ProducerSpec)
[INFO] pf/instance.go:230:59: gi.context.instanceConf.funcDetails.Sink.ProducerSpec undefined (type *api.SinkSpec has no field or method ProducerSpec)
[INFO] pf/instance.go:233:24: undefined: pulsar.KeyBasedBatchBuilder
[INFO] [0m
```

### Modifications

Remove the lines that do not compile because of missing dependencies (ProducerSpec).

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
