### PR TITLE
Add metrics for non-contiguous deleted messages range

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
@@ -71,6 +71,8 @@ public class ManagedCursorMetrics extends AbstractMetrics {
                 dimensionMap.put("ledger_name", ledgerName);
                 dimensionMap.put("cursor_name", cursor.getName());
                 Metrics metrics = createMetrics(dimensionMap);
+                metrics.put("brk_ml_cursor_nonContiguousDeletedMessagesRange",
+                        (long) cursor.getTotalNonContiguousDeletedMessagesRange());
                 metrics.put("brk_ml_cursor_persistLedgerSucceed", cStats.getPersistLedgerSucceed());
                 metrics.put("brk_ml_cursor_persistLedgerErrors", cStats.getPersistLedgerErrors());
                 metrics.put("brk_ml_cursor_persistZookeeperSucceed", cStats.getPersistZookeeperSucceed());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedCursorMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedCursorMetricsTest.java
@@ -87,6 +87,7 @@ public class ManagedCursorMetricsTest extends MockedPulsarServiceBaseTest {
         Assert.assertNotEquals(metricsList.get(0).getMetrics().get("brk_ml_cursor_persistLedgerErrors"), 0L);
         Assert.assertNotEquals(metricsList.get(0).getMetrics().get("brk_ml_cursor_persistZookeeperSucceed"), 0L);
         Assert.assertEquals(metricsList.get(0).getMetrics().get("brk_ml_cursor_persistZookeeperErrors"), 0L);
+        Assert.assertEquals(metricsList.get(0).getMetrics().get("brk_ml_cursor_nonContiguousDeletedMessagesRange"), 0L);
     }
 
 }


### PR DESCRIPTION
### Motivation

Users want a metric for this value from the internal-stats call.

### Modifications

Add metrics for the ManagedCursor:

metrics.put("brk_ml_cursor_nonContiguousDeletedMessagesRange", 
(long) cursor.getTotalNonContiguousDeletedMessagesRange());

Modify test:

Assert.assertEquals(metricsList.get(0).getMetrics().get("brk_ml_cursor_nonContiguousDeletedMessagesRange"), 0L);
