### PR TITLE
Branch 2.7: TopicPoliciesTest.testMaxSubscriptionsFailFast fails

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -696,7 +696,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }).exceptionally(ex -> {
             log.error("[{}] Failed to create subscription: {} error: {}", topic, subscriptionName, ex);
             USAGE_COUNT_UPDATER.decrementAndGet(PersistentTopic.this);
-            future.completeExceptionally(new PersistenceException(ex));
+
             if (ex.getCause() instanceof NotAllowedException) {
                 future.completeExceptionally(ex.getCause());
             } else {


### PR DESCRIPTION
In branch-2.7 we have this commit that introduces TopicPoliciesTest.testMaxSubscriptionsFailFast.
The test is failing, probably due to a merge problem during the cherry-pick.

```
Author: feynmanlin <feynmanlin@tencent.com>
Date:   Tue Mar 23 11:56:15 2021 +0800

    Fix the useless retry when the maximum number of subscriptions is reached (#9991)
    
    When the maximum number of subscriptions is reached, due to the long default value of operationTimeout, the client will keep retrying and get stuck for a long time.
    If a NotAllowedException is returned, the client will not continue to retry and will fail directly.
    
    Can the test fail in a short time
    
    (cherry picked from commit 31c5fb52bc841e40d678bd3787269160b7d14c12)
```