### PR TITLE
Fix distribution build errors due to permission denied

### DIFF
--- a/pulsar-client-cpp/pkg/deb/build-deb.sh
+++ b/pulsar-client-cpp/pkg/deb/build-deb.sh
@@ -37,6 +37,7 @@ cd BUILD
 tar xfz $SRC_ROOT_DIR/target/apache-pulsar-$POM_VERSION-src.tar.gz
 pushd $CPP_DIR
 
+chmod +x $(find . -name "*.sh")
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON
 make pulsarShared pulsarSharedNossl pulsarStatic pulsarStaticWithDeps  -j 3
 popd

--- a/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pulsar-client-cpp/pkg/rpm/SPECS/pulsar-client.spec
@@ -53,6 +53,7 @@ static library.
 
 %build
 cd pulsar-client-cpp
+chmod +x $(find . -name "*.sh")
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON -DBUILD_PYTHON_WRAPPER=OFF
 make pulsarShared pulsarSharedNossl pulsarStatic pulsarStaticWithDeps -j 3
 


### PR DESCRIPTION
Fixes #10582


### Motivation

Currently, the `sourceReleaseAssemblyDescriptor` from apache parent pom makes the scripts in `pulsar-client-cpp` lost their execution permissions, which leads to the build error in #10582 

### Modifications

This PR enables the needed permissions. 

