### PR TITLE
[Issue-10611] consumer related topic stats only available while consumer or reader are connected

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -67,6 +68,9 @@ public class NonPersistentSubscription implements Subscription {
 
     // Timestamp of when this subscription was last seen active
     private volatile long lastActive;
+
+    private final LongAdder bytesOutFromRemovedConsumers = new LongAdder();
+    private final LongAdder msgOutFromRemovedConsumer = new LongAdder();
 
     public NonPersistentSubscription(NonPersistentTopic topic, String subscriptionName) {
         this.topic = topic;
@@ -192,6 +196,10 @@ public class NonPersistentSubscription implements Subscription {
         if (dispatcher != null) {
             dispatcher.removeConsumer(consumer);
         }
+        // preserve accumulative stats form removed consumer
+        ConsumerStats stats = consumer.getStats();
+        bytesOutFromRemovedConsumers.add(stats.bytesOutCounter);
+        msgOutFromRemovedConsumer.add(stats.msgOutCounter);
 
         // invalid consumer remove will throw an exception
         // decrement usage is triggered only for valid consumer close
@@ -446,6 +454,8 @@ public class NonPersistentSubscription implements Subscription {
 
     public NonPersistentSubscriptionStats getStats() {
         NonPersistentSubscriptionStats subStats = new NonPersistentSubscriptionStats();
+        subStats.bytesOutCounter = bytesOutFromRemovedConsumers.longValue();
+        subStats.msgOutCounter = msgOutFromRemovedConsumer.longValue();
 
         NonPersistentDispatcher dispatcher = this.dispatcher;
         if (dispatcher != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -75,6 +76,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublisherStats;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
@@ -95,6 +97,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     private static final AtomicLongFieldUpdater<NonPersistentTopic> ENTRIES_ADDED_COUNTER_UPDATER =
             AtomicLongFieldUpdater.newUpdater(NonPersistentTopic.class, "entriesAddedCounter");
     private volatile long entriesAddedCounter = 0;
+
+    private final LongAdder bytesOutFromRemovedSubscriptions = new LongAdder();
+    private final LongAdder msgOutFromRemovedSubscriptions = new LongAdder();
 
     private static final FastThreadLocal<TopicStats> threadLocalTopicStats = new FastThreadLocal<TopicStats>() {
         @Override
@@ -778,6 +783,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
         stats.msgInCounter = getMsgInCounter();
         stats.bytesInCounter = getBytesInCounter();
         stats.waitingPublishers = getWaitingProducersCount();
+        stats.bytesOutCounter = bytesOutFromRemovedSubscriptions.longValue();
+        stats.msgOutCounter = msgOutFromRemovedSubscriptions.longValue();
 
         subscriptions.forEach((name, subscription) -> {
             NonPersistentSubscriptionStats subStats = subscription.getStats();
@@ -974,7 +981,13 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
     public CompletableFuture<Void> unsubscribe(String subscriptionName) {
         // checkInactiveSubscriptions iterates over subscriptions map and removing from the map with the same thread.
         // That creates deadlock. so, execute remove it in different thread.
-        return CompletableFuture.runAsync(() -> subscriptions.remove(subscriptionName), brokerService.executor());
+        return CompletableFuture.runAsync(() -> {
+            NonPersistentSubscription sub = subscriptions.remove(subscriptionName);
+            // preserve accumulative stats form removed subscription
+            SubscriptionStats stats = sub.getStats();
+            bytesOutFromRemovedSubscriptions.add(stats.bytesOutCounter);
+            msgOutFromRemovedSubscriptions.add(stats.msgOutCounter);
+        }, brokerService.executor());
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
@@ -111,6 +112,9 @@ public class PersistentSubscription implements Subscription {
     private volatile Position lastMarkDeleteForTransactionMarker;
     private volatile boolean isDeleteTransactionMarkerInProcess = false;
     private final PendingAckHandle pendingAckHandle;
+
+    private final LongAdder bytesOutFromRemovedConsumers = new LongAdder();
+    private final LongAdder msgOutFromRemovedConsumer = new LongAdder();
 
     static {
         REPLICATED_SUBSCRIPTION_CURSOR_PROPERTIES.put(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
@@ -274,7 +278,13 @@ public class PersistentSubscription implements Subscription {
         if (dispatcher != null) {
             dispatcher.removeConsumer(consumer);
         }
-        if (dispatcher.getConsumers().isEmpty()) {
+
+        // preserve accumulative stats form removed consumer
+        ConsumerStats stats = consumer.getStats();
+        bytesOutFromRemovedConsumers.add(stats.bytesOutCounter);
+        msgOutFromRemovedConsumer.add(stats.msgOutCounter);
+
+        if (dispatcher != null && dispatcher.getConsumers().isEmpty()) {
             deactivateCursor();
 
             if (!cursor.isDurable()) {
@@ -957,6 +967,8 @@ public class PersistentSubscription implements Subscription {
         subStats.lastExpireTimestamp = lastExpireTimestamp;
         subStats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
         subStats.lastMarkDeleteAdvancedTimestamp = lastMarkDeleteAdvancedTimestamp;
+        subStats.bytesOutCounter = bytesOutFromRemovedConsumers.longValue();
+        subStats.msgOutCounter = msgOutFromRemovedConsumer.longValue();
         Dispatcher dispatcher = this.dispatcher;
         if (dispatcher != null) {
             Map<String, List<String>> consumerKeyHashRanges = getType() == SubType.Key_Shared

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.nonpersistent;
+
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.TopicStats;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Test(groups = "broker")
+public class NonPersistentTopicTest extends BrokerTestBase {
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testAccumulativeStats() throws Exception {
+        final String topicName = "non-persistent://prop/ns-abc/aTopic";
+        final String sharedSubName = "shared";
+        final String failoverSubName = "failOver";
+
+        Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .subscriptionType(SubscriptionType.Shared).subscriptionName(sharedSubName).subscribe();
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .subscriptionType(SubscriptionType.Failover).subscriptionName(failoverSubName).subscribe();
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+
+        NonPersistentTopic topic = (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+
+        // stats are at zero before any activity
+        TopicStats stats = topic.getStats(false, false);
+        assertEquals(stats.bytesInCounter, 0);
+        assertEquals(stats.msgInCounter, 0);
+        assertEquals(stats.bytesOutCounter, 0);
+        assertEquals(stats.msgOutCounter, 0);
+
+        producer.newMessage().value("test").eventTime(5).send();
+        producer.newMessage().value("test").eventTime(5).send();
+
+        Message<String> msg = consumer1.receive();
+        assertNotNull(msg);
+        msg = consumer2.receive();
+        assertNotNull(msg);
+
+        // send/receive result in non-zero stats
+        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false);
+        assertTrue(statsBeforeUnsubscribe.bytesInCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.msgInCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.bytesOutCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.msgOutCounter > 0);
+
+        consumer1.unsubscribe();
+        consumer2.unsubscribe();
+        producer.close();
+        topic.getProducers().values().forEach(topic::removeProducer);
+        assertEquals(topic.getProducers().size(), 0);
+
+        // consumer unsubscribe/producer removal does not result in stats loss
+        TopicStats statsAfterUnsubscribe = topic.getStats(false, false);
+        assertEquals(statsAfterUnsubscribe.bytesInCounter, statsBeforeUnsubscribe.bytesInCounter);
+        assertEquals(statsAfterUnsubscribe.msgInCounter, statsBeforeUnsubscribe.msgInCounter);
+        assertEquals(statsAfterUnsubscribe.bytesOutCounter, statsBeforeUnsubscribe.bytesOutCounter);
+        assertEquals(statsAfterUnsubscribe.msgOutCounter, statsBeforeUnsubscribe.msgOutCounter);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -26,11 +26,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +49,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -186,5 +189,55 @@ public class PersistentTopicTest extends BrokerTestBase {
         policies.deleted = false;
         persistentTopic.onPoliciesUpdate(policies);
         verify(persistentTopic, times(1)).checkReplicationAndRetryOnFailure();
+    }
+
+    @Test
+    public void testAccumulativeStats() throws Exception {
+        final String topicName = "persistent://prop/ns-abc/aTopic";
+        final String sharedSubName = "shared";
+        final String failoverSubName = "failOver";
+
+        Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .subscriptionType(SubscriptionType.Shared).subscriptionName(sharedSubName).subscribe();
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .subscriptionType(SubscriptionType.Failover).subscriptionName(failoverSubName).subscribe();
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+
+        // stats are at zero before any activity
+        TopicStats stats = topic.getStats(false, false);
+        assertEquals(stats.bytesInCounter, 0);
+        assertEquals(stats.msgInCounter, 0);
+        assertEquals(stats.bytesOutCounter, 0);
+        assertEquals(stats.msgOutCounter, 0);
+
+        producer.newMessage().value("test").eventTime(5).send();
+        producer.newMessage().value("test").eventTime(5).send();
+
+        Message<String> msg = consumer1.receive();
+        assertNotNull(msg);
+        msg = consumer2.receive();
+        assertNotNull(msg);
+
+        // send/receive result in non-zero stats
+        TopicStats statsBeforeUnsubscribe = topic.getStats(false, false);
+        assertTrue(statsBeforeUnsubscribe.bytesInCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.msgInCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.bytesOutCounter > 0);
+        assertTrue(statsBeforeUnsubscribe.msgOutCounter > 0);
+
+        consumer1.unsubscribe();
+        consumer2.unsubscribe();
+        producer.close();
+        topic.getProducers().values().forEach(topic::removeProducer);
+        assertEquals(topic.getProducers().size(), 0);
+
+        // consumer unsubscribe/producer removal does not result in stats loss
+        TopicStats statsAfterUnsubscribe = topic.getStats(false, false);
+        assertEquals(statsAfterUnsubscribe.bytesInCounter, statsBeforeUnsubscribe.bytesInCounter);
+        assertEquals(statsAfterUnsubscribe.msgInCounter, statsBeforeUnsubscribe.msgInCounter);
+        assertEquals(statsAfterUnsubscribe.bytesOutCounter, statsBeforeUnsubscribe.bytesOutCounter);
+        assertEquals(statsAfterUnsubscribe.msgOutCounter, statsBeforeUnsubscribe.msgOutCounter);
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #10611 

### Motivation

Stats report wrong values when consumers unsubscribe.
 
### Modifications

Preserved specific stats for the consumer on its removal.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - Added unit tests for persistent and non-persistent topics to check that specific counters preserved after consumers/producers removal. Tests failed before the fix.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (NO
  - The public API: NO
  - The schema: NO
  - The default values of configurations: NO
  - The wire protocol: NO
  - The rest endpoints: NO
  - The admin cli options: NO
  - Anything that affects deployment: NO

### Documentation

  - Does this pull request introduce a new feature? NO
