### PR TITLE
[Doc] Fix awsEndpoint format in Kinesis connector doc.

### DIFF
--- a/site2/docs/io-kinesis-sink.md
+++ b/site2/docs/io-kinesis-sink.md
@@ -50,7 +50,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -63,7 +63,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.5.0/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.6.0/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.6.1/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.6.2/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.6.3/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.6.3/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.7.0/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.7.1/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.7.1/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"

--- a/site2/website/versioned_docs/version-2.7.2/io-kinesis-sink.md
+++ b/site2/website/versioned_docs/version-2.7.2/io-kinesis-sink.md
@@ -51,7 +51,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
+        "awsEndpoint": "some.endpoint.aws",
         "awsRegion": "us-east-1",
         "awsKinesisStreamName": "my-stream",
         "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
@@ -64,7 +64,7 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```yaml
     configs:
-        awsEndpoint: "https://some.endpoint.aws"
+        awsEndpoint: "some.endpoint.aws"
         awsRegion: "us-east-1"
         awsKinesisStreamName: "my-stream"
         awsCredentialPluginParam: "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}"


### PR DESCRIPTION
### Motivation

Currently, in the kinesis connector doc, the example of the `awsEndpoint` is like the following: `https://some.endpoint.aws`.
But when the user follows this format, an exception will occur.
![image](https://user-images.githubusercontent.com/16974619/118906598-a3b4f600-b950-11eb-8061-fe346cc00a1c.png)
The correct example is like: `some.endpoint.aws`.

### Modifications

* Correct the `awsEndpoint` example in the kinesis connector doc.
