### PR TITLE
PIP-45: Initialize ManagedLedgerFactory with MetadataStore

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorMXBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorMXBeanImpl.java
@@ -18,10 +18,9 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
-
-import java.util.concurrent.atomic.LongAdder;
 
 public class ManagedCursorMXBeanImpl implements ManagedCursorMXBean {
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -40,7 +40,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -73,13 +72,10 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
-import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Stat;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,10 +83,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final MetaStore store;
     private final BookkeeperFactoryForCustomEnsemblePlacementPolicy bookkeeperFactory;
     private final boolean isBookkeeperManaged;
-    private final ZooKeeper zookeeper;
     private final ManagedLedgerFactoryConfig config;
     protected final OrderedScheduler scheduledExecutor;
-    private final OrderedExecutor orderedExecutor;
 
     private final ExecutorService cacheEvictionExecutor;
 
@@ -122,57 +116,49 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
     }
 
-    public ManagedLedgerFactoryImpl(ClientConfiguration bkClientConfiguration, String zkConnection) throws Exception {
-        this(bkClientConfiguration, zkConnection, new ManagedLedgerFactoryConfig());
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore, ClientConfiguration bkClientConfiguration)
+            throws Exception {
+        this(metadataStore, bkClientConfiguration, new ManagedLedgerFactoryConfig());
     }
 
     @SuppressWarnings("deprecation")
-    public ManagedLedgerFactoryImpl(ClientConfiguration bkClientConfiguration, ManagedLedgerFactoryConfig config)
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore, ClientConfiguration bkClientConfiguration,
+                                    ManagedLedgerFactoryConfig config)
             throws Exception {
-        this(ZooKeeperClient.newBuilder()
-                .connectString(bkClientConfiguration.getZkServers())
-                .sessionTimeoutMs(bkClientConfiguration.getZkTimeout())
-                .build(), bkClientConfiguration, config);
+        this(metadataStore, new DefaultBkFactory(bkClientConfiguration),
+                true /* isBookkeeperManaged */, config, NullStatsLogger.INSTANCE);
     }
 
-    private ManagedLedgerFactoryImpl(ZooKeeper zkc, ClientConfiguration bkClientConfiguration,
-            ManagedLedgerFactoryConfig config) throws Exception {
-        this(new DefaultBkFactory(bkClientConfiguration, zkc), true /* isBookkeeperManaged */,
-                zkc, config, NullStatsLogger.INSTANCE);
-    }
-
-    public ManagedLedgerFactoryImpl(ClientConfiguration clientConfiguration, String zkConnection, ManagedLedgerFactoryConfig config) throws Exception {
-        this(new DefaultBkFactory(clientConfiguration),
-            true,
-            ZooKeeperClient.newBuilder()
-                .connectString(zkConnection)
-                .sessionTimeoutMs(clientConfiguration.getZkTimeout()).build(), config, NullStatsLogger.INSTANCE);
-    }
-
-    public ManagedLedgerFactoryImpl(BookKeeper bookKeeper, ZooKeeper zooKeeper) throws Exception {
-        this((policyConfig) -> bookKeeper, zooKeeper, new ManagedLedgerFactoryConfig());
-    }
-
-    public ManagedLedgerFactoryImpl(BookKeeper bookKeeper, ZooKeeper zooKeeper, ManagedLedgerFactoryConfig config)
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore, BookKeeper bookKeeper)
             throws Exception {
-        this((policyConfig) -> bookKeeper, false /* isBookkeeperManaged */,
-                zooKeeper, config, NullStatsLogger.INSTANCE);
+        this(metadataStore, bookKeeper, new ManagedLedgerFactoryConfig());
     }
 
-    public ManagedLedgerFactoryImpl(BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
-                                    ZooKeeper zooKeeper, ManagedLedgerFactoryConfig config)
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore, BookKeeper bookKeeper,
+                                    ManagedLedgerFactoryConfig config)
             throws Exception {
-        this(bookKeeperGroupFactory, false /* isBookkeeperManaged */, zooKeeper, config, NullStatsLogger.INSTANCE);
+        this(metadataStore, (policyConfig) -> bookKeeper, config);
     }
 
-    public ManagedLedgerFactoryImpl(BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
-                                    ZooKeeper zooKeeper, ManagedLedgerFactoryConfig config, StatsLogger statsLogger)
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore,
+                                    BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
+                                    ManagedLedgerFactoryConfig config)
             throws Exception {
-        this(bookKeeperGroupFactory, false /* isBookkeeperManaged */, zooKeeper, config, statsLogger);
+        this(metadataStore, bookKeeperGroupFactory, false /* isBookkeeperManaged */,
+                config, NullStatsLogger.INSTANCE);
     }
 
-    private ManagedLedgerFactoryImpl(BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
-                                     boolean isBookkeeperManaged, ZooKeeper zooKeeper,
+    public ManagedLedgerFactoryImpl(MetadataStore metadataStore,
+                                    BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
+                                    ManagedLedgerFactoryConfig config, StatsLogger statsLogger)
+            throws Exception {
+        this(metadataStore, bookKeeperGroupFactory, false /* isBookkeeperManaged */,
+                config, statsLogger);
+    }
+
+    private ManagedLedgerFactoryImpl(MetadataStore metadataStore,
+                                     BookkeeperFactoryForCustomEnsemblePlacementPolicy bookKeeperGroupFactory,
+                                     boolean isBookkeeperManaged,
                                      ManagedLedgerFactoryConfig config, StatsLogger statsLogger) throws Exception {
         scheduledExecutor = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(config.getNumManagedLedgerSchedulerThreads())
@@ -180,24 +166,18 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 .traceTaskExecution(config.isTraceTaskExecution())
                 .name("bookkeeper-ml-scheduler")
                 .build();
-        orderedExecutor = OrderedExecutor.newBuilder()
-                .numThreads(config.getNumManagedLedgerWorkerThreads())
-                .statsLogger(statsLogger)
-                .traceTaskExecution(config.isTraceTaskExecution())
-                .name("bookkeeper-ml-workers")
-                .build();
         cacheEvictionExecutor = Executors
                 .newSingleThreadExecutor(new DefaultThreadFactory("bookkeeper-ml-cache-eviction"));
 
         this.bookkeeperFactory = bookKeeperGroupFactory;
         this.isBookkeeperManaged = isBookkeeperManaged;
-        this.zookeeper = isBookkeeperManaged ? zooKeeper : null;
-        this.metadataStore = new ZKMetadataStore(zooKeeper);
-        this.store = new MetaStoreImpl(metadataStore, orderedExecutor);
+        this.metadataStore = metadataStore;
+        this.store = new MetaStoreImpl(metadataStore, scheduledExecutor);
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
         this.entryCacheManager = new EntryCacheManager(this);
-        this.statsTask = scheduledExecutor.scheduleAtFixedRate(this::refreshStats, 0, StatsPeriodSeconds, TimeUnit.SECONDS);
+        this.statsTask = scheduledExecutor.scheduleAtFixedRate(this::refreshStats,
+                0, StatsPeriodSeconds, TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(this::flushCursors,
                 config.getCursorPositionFlushSeconds(), config.getCursorPositionFlushSeconds(), TimeUnit.SECONDS);
 
@@ -213,12 +193,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
         private final BookKeeper bkClient;
 
-        public DefaultBkFactory(ClientConfiguration bkClientConfiguration, ZooKeeper zkc)
-                throws BKException, IOException, InterruptedException {
-            bkClient = new BookKeeper(bkClientConfiguration, zkc);
-        }
-
-        public DefaultBkFactory(ClientConfiguration bkClientConfiguration) throws InterruptedException, BKException, IOException {
+        public DefaultBkFactory(ClientConfiguration bkClientConfiguration)
+                throws InterruptedException, BKException, IOException {
             bkClient = new BookKeeper(bkClientConfiguration);
         }
 
@@ -350,8 +326,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                     ManagedLedgerImpl l = existingFuture.get();
                     if (l.getState().equals(State.Fenced.toString()) || l.getState().equals(State.Closed.toString())) {
                         // Managed ledger is in unusable state. Recreate it.
-                        log.warn("[{}] Attempted to open ledger in {} state. Removing from the map to recreate it", name,
-                            l.getState());
+                        log.warn("[{}] Attempted to open ledger in {} state. Removing from the map to recreate it",
+                                name, l.getState());
                         ledgers.remove(name, existingFuture);
                     }
                 } catch (Exception e) {
@@ -381,8 +357,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                     bookkeeperFactory.get(
                             new EnsemblePlacementPolicyConfig(config.getBookKeeperEnsemblePlacementPolicyClassName(),
                                     config.getBookKeeperEnsemblePlacementPolicyProperties())),
-                    store, config, scheduledExecutor,
-                    orderedExecutor, name, mlOwnershipChecker);
+                    store, config, scheduledExecutor, name, mlOwnershipChecker);
             PendingInitializeManagedLedger pendingLedger = new PendingInitializeManagedLedger(newledger);
             pendingInitializeLedgers.put(name, pendingLedger);
             newledger.initialize(new ManagedLedgerInitializeLedgerCallback() {
@@ -429,7 +404,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
 
     @Override
-    public ReadOnlyCursor openReadOnlyCursor(String managedLedgerName, Position startPosition, ManagedLedgerConfig config)
+    public ReadOnlyCursor openReadOnlyCursor(String managedLedgerName, Position startPosition,
+                                             ManagedLedgerConfig config)
             throws InterruptedException, ManagedLedgerException {
         class Result {
             ReadOnlyCursor c = null;
@@ -467,9 +443,11 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 bookkeeperFactory
                         .get(new EnsemblePlacementPolicyConfig(config.getBookKeeperEnsemblePlacementPolicyClassName(),
                                 config.getBookKeeperEnsemblePlacementPolicyProperties())),
-                store, config, scheduledExecutor, orderedExecutor, managedLedgerName);
+                store, config, scheduledExecutor, managedLedgerName);
 
-        roManagedLedger.initializeAndCreateCursor((PositionImpl) startPosition).thenAccept(roCursor -> callback.openReadOnlyCursorComplete(roCursor, ctx)).exceptionally(ex -> {
+        roManagedLedger.initializeAndCreateCursor((PositionImpl) startPosition)
+                .thenAccept(roCursor -> callback.openReadOnlyCursorComplete(roCursor, ctx))
+                .exceptionally(ex -> {
             Throwable t = ex;
             if (t instanceof CompletionException) {
                 t = ex.getCause();
@@ -526,10 +504,6 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         latch.await();
         log.info("{} ledgers closed", numLedgers);
 
-        if (zookeeper != null) {
-            zookeeper.close();
-        }
-
         if (isBookkeeperManaged) {
             try {
                 BookKeeper bookkeeper = bookkeeperFactory.get();
@@ -542,15 +516,9 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         }
 
         scheduledExecutor.shutdownNow();
-        orderedExecutor.shutdownNow();
         cacheEvictionExecutor.shutdownNow();
 
         entryCacheManager.clear();
-        try {
-            metadataStore.close();
-        } catch (Exception e) {
-            throw new ManagedLedgerException(e);
-        }
     }
 
     @Override
@@ -748,7 +716,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     /**
-     * Delete all managed ledger resources and metadata
+     * Delete all managed ledger resources and metadata.
      */
     void deleteManagedLedger(String managedLedgerName, DeleteLedgerCallback callback, Object ctx) {
         // Read the managed ledger metadata from store
@@ -801,7 +769,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 });
     }
 
-    private CompletableFuture<Void> deleteCursor(BookKeeper bkc, String managedLedgerName, String cursorName, CursorInfo cursor) {
+    private CompletableFuture<Void> deleteCursor(BookKeeper bkc, String managedLedgerName, String cursorName,
+                                                 CursorInfo cursor) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         CompletableFuture<Void> cursorLedgerDeleteFuture;
 
@@ -852,7 +821,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     /**
-     * Factory to create Bookkeeper-client for a given ensemblePlacementPolicy
+     * Factory to create Bookkeeper-client for a given ensemblePlacementPolicy.
      *
      */
     public interface BookkeeperFactoryForCustomEnsemblePlacementPolicy {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.min;
 import static org.apache.bookkeeper.mledger.util.Errors.isNoSuchLedgerExistsException;
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableMap;
@@ -275,12 +274,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     Map<String, byte[]> createdLedgerCustomMetadata;
 
     public ManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
-            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor, OrderedExecutor orderedExecutor,
+            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
             final String name) {
-        this(factory, bookKeeper, store, config, scheduledExecutor, orderedExecutor, name, null);
+        this(factory, bookKeeper, store, config, scheduledExecutor, name, null);
     }
     public ManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
-            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor, OrderedExecutor orderedExecutor,
+            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
             final String name, final Supplier<Boolean> mlOwnershipChecker) {
         this.factory = factory;
         this.bookKeeper = bookKeeper;
@@ -290,7 +289,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.ledgerMetadata = LedgerMetadataUtils.buildBaseManagedLedgerMetadata(name);
         this.digestType = BookKeeper.DigestType.fromApiDigestType(config.getDigestType());
         this.scheduledExecutor = scheduledExecutor;
-        this.executor = orderedExecutor;
+        this.executor = bookKeeper.getMainWorkerPool();
         TOTAL_SIZE_UPDATER.set(this, 0);
         NUMBER_OF_ENTRIES_UPDATER.set(this, 0);
         ENTRIES_ADDED_COUNTER_UPDATER.set(this, 0);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -42,9 +42,9 @@ import org.apache.pulsar.metadata.api.Stat;
 public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
 
     public ReadOnlyManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
-            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor, OrderedExecutor orderedExecutor,
+            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
             String name) {
-        super(factory, bookKeeper, store, config, scheduledExecutor, orderedExecutor, name);
+        super(factory, bookKeeper, store, config, scheduledExecutor, name);
     }
 
     CompletableFuture<ReadOnlyCursor> initializeAndCreateCursor(PositionImpl startPosition) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -69,9 +70,10 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setMaxCacheSize(10);
         config.setCacheEvictionWatermark(0.8);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
         EntryCache cache1 = cacheManager.getEntryCache(ml1);
         EntryCache cache2 = cacheManager.getEntryCache(ml2);
 
@@ -131,9 +133,10 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setMaxCacheSize(10);
         config.setCacheEvictionWatermark(0.8);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
         EntryCache cache1 = cacheManager.getEntryCache(ml1);
 
         assertTrue(cache1.insert(EntryImpl.create(1, 1, new byte[4])));
@@ -154,9 +157,10 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setMaxCacheSize(200);
         config.setCacheEvictionWatermark(0.8);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
         EntryCache cache1 = cacheManager.getEntryCache(ml1);
         List<EntryImpl> entries = new ArrayList<>();
 
@@ -186,9 +190,10 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setMaxCacheSize(0);
         config.setCacheEvictionWatermark(0.8);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
         EntryCache cache1 = cacheManager.getEntryCache(ml1);
         EntryCache cache2 = cacheManager.getEntryCache(ml2);
 
@@ -223,10 +228,11 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setMaxCacheSize(7 * 10);
         config.setCacheEvictionWatermark(0.8);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("ledger");
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory2.open("ledger");
         EntryCache cache1 = ledger.entryCache;
 
         for (int i = 0; i < 10; i++) {
@@ -252,10 +258,11 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setCacheEvictionWatermark(0.8);
         config.setCacheEvictionFrequency(1);
 
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
-        EntryCacheManager cacheManager = factory.getEntryCacheManager();
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("ledger");
+        EntryCacheManager cacheManager = factory2.getEntryCacheManager();
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory2.open("ledger");
 
         ManagedCursorImpl c1 = (ManagedCursorImpl) ledger.openCursor("c1");
         ManagedCursorImpl c2 = (ManagedCursorImpl) ledger.openCursor("c2");
@@ -321,7 +328,8 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         config.setCacheEvictionFrequency(100);
         config.setCacheEvictionTimeThresholdMillis(100);
 
-        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("test");
         ManagedCursor c1 = ledger.openCursor("c1");
@@ -346,8 +354,6 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
 
         assertEquals(cacheManager.getSize(), 0);
         assertEquals(cache.getSize(), 0);
-
-        factory.shutdown();
     }
 
     @Test(timeOut = 5000)
@@ -356,7 +362,9 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerFactoryConfig config = new ManagedLedgerFactoryConfig();
         config.setMaxCacheSize(0);
-        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
         EntryCacheManager cacheManager = factory.getEntryCacheManager();
         EntryCache entryCache = cacheManager.getEntryCache(ml1);
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorPropertiesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorPropertiesTest.java
@@ -27,7 +27,6 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
@@ -90,8 +89,7 @@ public class ManagedCursorPropertiesTest extends MockedBookKeeperTestCase {
         c1.markDelete(p3, properties);
 
         // Create a new factory to force a managed ledger close and recovery
-        ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
 
         // Reopen the managed ledger
         ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -85,10 +85,10 @@ import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.common.api.proto.IntRange;
-import org.apache.zookeeper.KeeperException.Code;
-import org.apache.zookeeper.MockZooKeeper;
 import org.awaitility.Awaitility;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -161,8 +161,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     void readWithCacheDisabled() throws Exception {
         ManagedLedgerFactoryConfig config = new ManagedLedgerFactoryConfig();
         config.setMaxCacheSize(0);
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), config);
-        ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
+        ManagedLedger ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
 
         ManagedCursor c1 = ledger.openCursor("c1");
         ManagedCursor c2 = ledger.openCursor("c2");
@@ -341,7 +343,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ledger.addEntry("dummy-entry-2".getBytes(Encoding));
         ManagedCursor c3 = ledger.openCursor("c3");
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
 
         c1 = ledger.openCursor("c1");
@@ -356,8 +359,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         assertEquals(c3.getNumberOfEntries(), 0);
         assertFalse(c3.hasMoreEntries());
-
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -527,7 +528,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(entries.size(), 1);
 
         stopBookKeeper();
-        stopZooKeeper();
+        metadataStore.setAlwaysFail(new MetadataStoreException("error"));
 
         try {
             cursor.markDelete(entries.get(0).getPosition());
@@ -972,14 +973,14 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Reopen
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger");
         c1 = ledger.openCursor("c1");
         c2 = ledger.openCursor("c2");
 
         assertEquals(c1.getMarkDeletedPosition(), p1);
         assertEquals(c2.getMarkDeletedPosition(), p2);
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1008,8 +1009,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Reopen
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
-        ledger = factory.open("my_test_ledger");
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ledger = factory2.open("my_test_ledger");
         c1 = ledger.openCursor("c1");
         c2 = ledger.openCursor("c2");
         c3 = ledger.openCursor("c3");
@@ -1019,10 +1021,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c2.getMarkDeletedPosition(), p1);
         assertEquals(c3.getMarkDeletedPosition(), p0);
         assertEquals(c4.getMarkDeletedPosition(), p1);
-        factory2.shutdown();
     }
 
-    @Test(timeOut = 20000)
+    @Test
     public void asyncMarkDeleteBlocking() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(10);
@@ -1061,12 +1062,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getNumberOfEntries(), 0);
 
         // Reopen
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger");
         ManagedCursor c2 = ledger.openCursor("c1");
 
         assertEquals(c2.getMarkDeletedPosition(), lastPosition.get());
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1103,12 +1104,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         latch.await();
 
         // Reopen
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger");
         ManagedCursor c2 = ledger.openCursor("c1");
 
         assertEquals(c2.getMarkDeletedPosition(), lastPosition);
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1214,10 +1215,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedger ledger = factory.open("my_test_ledger");
 
         bkc.failAfter(1, BKException.Code.NotEnoughBookiesException);
-        zkc.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
-                return path.equals("/managed-ledgers/my_test_ledger/c1")
-                    && op == MockZooKeeper.Op.CREATE;
-            });
+        metadataStore.failConditional(new MetadataStoreException("error"), (op, path) ->
+                path.equals("/managed-ledgers/my_test_ledger/c1")
+                        && op == FaultInjectionMetadataStore.OperationType.PUT
+        );
 
         try {
             ledger.openCursor("c1");
@@ -1248,14 +1249,14 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // Force-reopen so the recovery will be forced to read from ledger
         bkc.returnEmptyLedgerAfter(1);
         ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, conf);
         ledger = factory2.open("my_test_ledger");
         cursor = ledger.openCursor("cursor");
 
         // Cursor was rolled back to p2 because of the ledger recovery failure
         assertEquals(cursor.getMarkDeletedPosition(), p2);
-
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1268,7 +1269,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         assertEquals(c1.getReadPosition(), p3);
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
 
         bkc.failAfter(3, BKException.Code.LedgerRecoveryException);
 
@@ -1277,7 +1279,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Verify the ManagedCursor was rewind back to the snapshotted position
         assertEquals(c1.getReadPosition(), p3);
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1285,7 +1286,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedger ledger = factory.open("my_test_ledger");
         ledger.openCursor("c1");
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
 
         bkc.failAfter(4, BKException.Code.MetadataVersionException);
 
@@ -1295,8 +1297,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         } catch (ManagedLedgerException e) {
             // ok
         }
-
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1309,7 +1309,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         assertEquals(c1.getReadPosition(), p3);
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
 
         bkc.failAfter(4, BKException.Code.ReadException);
 
@@ -1318,7 +1319,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Verify the ManagedCursor was rewind back to the snapshotted position
         assertEquals(c1.getReadPosition(), p3);
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000)
@@ -1573,7 +1573,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c3.getNumberOfEntries(), 0);
         assertFalse(c3.hasMoreEntries());
 
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
 
         c1 = ledger.openCursor("c1");
@@ -1591,7 +1592,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c3.getNumberOfEntriesInBacklog(false), 0);
         assertEquals(c3.getNumberOfEntries(), 0);
         assertFalse(c3.hasMoreEntries());
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")
@@ -1613,14 +1613,14 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getNumberOfEntriesInBacklog(false), 0);
 
         // Re-open to recover from storage
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig());
 
         c1 = ledger.openCursor("c1");
 
         // Only the 1st mark-delete was persisted
         assertEquals(c1.getNumberOfEntriesInBacklog(false), 2);
-        factory2.shutdown();
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")
@@ -2666,7 +2666,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         factory.shutdown();
 
         // Re-Open
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory.open("my_test_ledger", new ManagedLedgerConfig());
         c1 = ledger.openCursor("c1");
         assertEquals(c1.getNumberOfEntriesInBacklog(false), 20 - 5);
@@ -2708,7 +2708,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getNumberOfEntriesInBacklog(false), 20 - 5);
 
         // Re-Open
-        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig());
         c1 = ledger.openCursor("c1");
         assertEquals(c1.getNumberOfEntriesInBacklog(false), 20 - 5);
@@ -2727,7 +2728,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(entriesStr.get(4), "dummy-entry-6");
 
         assertFalse(c1.hasMoreEntries());
-        factory2.shutdown();
     }
 
     /**
@@ -2758,13 +2758,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         });
 
         // update cursor-info with data which makes bad-version for existing managed-cursor
-        CountDownLatch latch1 = new CountDownLatch(1);
         String path = "/managed-ledgers/my_test_ledger/c1";
-        zkc.setData(path, "".getBytes(), -1, (rc, path1, ctx, stat) -> {
-            // updated path
-            latch1.countDown();
-        }, null);
-        latch1.await();
+        metadataStore.put(path, "".getBytes(), Optional.empty()).join();
 
         // try to create ledger again which will fail because managedCursorInfo znode is already updated with different
         // version so, this call will fail with BadVersionException
@@ -2872,8 +2867,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(individualDeletedMessagesCount.get(), totalAddEntries / 2 - 1);
 
         // Re-Open
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
-        ledger = (ManagedLedgerImpl) factory.open(ledgerName, managedLedgerConfig);
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ledger = (ManagedLedgerImpl) factory2.open(ledgerName, managedLedgerConfig);
         c1 = (ManagedCursorImpl) ledger.openCursor("c1");
         // verify cursor has been recovered
         assertEquals(c1.getNumberOfEntriesInBacklog(false), totalAddEntries / 2);
@@ -2932,8 +2928,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(individualDeletedMessagesCount.get(), totalAddEntries / 2 - 1);
 
         // Re-Open
-        factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
-        ledger = (ManagedLedgerImpl) factory.open(ledgerName, managedLedgerConfig);
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ledger = (ManagedLedgerImpl) factory2.open(ledgerName, managedLedgerConfig);
         c1 = (ManagedCursorImpl) ledger.openCursor(cursorName);
         // verify cursor has been recovered
         assertEquals(c1.getNumberOfEntriesInBacklog(false), totalAddEntries / 2);
@@ -3364,7 +3361,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerFactoryConfig factoryConfig = new ManagedLedgerFactoryConfig();
         factoryConfig.setCursorPositionFlushSeconds(1);
-        ManagedLedgerFactory factory1 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), factoryConfig);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory1 = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConfig);
         ManagedLedger ledger1 = factory1.open("testFlushCursorAfterInactivity", config);
         ManagedCursor c1 = ledger1.openCursor("c");
         List<Position> positions = new ArrayList<Position>();
@@ -3397,19 +3396,13 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 .pollDelay(Duration.ofMillis(2000))
                 .untilAsserted(() -> {
                     // Abruptly re-open the managed ledger without graceful close
-                    ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
-                    try {
-                        ManagedLedger ledger2 = factory2.open("testFlushCursorAfterInactivity", config);
-                        ManagedCursor c2 = ledger2.openCursor("c");
+                    @Cleanup("shutdown")
+                    ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+                    ManagedLedger ledger2 = factory2.open("testFlushCursorAfterInactivity", config);
+                    ManagedCursor c2 = ledger2.openCursor("c");
 
-                        assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
-
-                    } finally {
-                        factory2.shutdown();
-                    }
+                    assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
                 });
-
-        factory1.shutdown();
     }
 
     @Test
@@ -3419,7 +3412,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerFactoryConfig factoryConfig = new ManagedLedgerFactoryConfig();
         factoryConfig.setCursorPositionFlushSeconds(1);
-        ManagedLedgerFactory factory1 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle(), factoryConfig);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory1 = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConfig);
         ManagedLedger ledger1 = factory1.open("testFlushCursorAfterIndDelInactivity", config);
         ManagedCursor c1 = ledger1.openCursor("c");
         List<Position> positions = new ArrayList<Position>();
@@ -3447,7 +3442,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getMarkDeletedPosition(), positions.get(positions.size() - 1));
 
         // reopen the cursor and we should see entries not be flushed
-        ManagedLedgerFactory dirtyFactory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactory dirtyFactory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ManagedLedger ledgerDirty = dirtyFactory.open("testFlushCursorAfterIndDelInactivity", config);
         ManagedCursor dirtyCursor = ledgerDirty.openCursor("c");
 
@@ -3459,16 +3455,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 .pollDelay(Duration.ofMillis(2000))
                 .untilAsserted(() -> {
                     // Abruptly re-open the managed ledger without graceful close
-                    ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
-                    try {
-                        ManagedLedger ledger2 = factory2.open("testFlushCursorAfterIndDelInactivity", config);
-                        ManagedCursor c2 = ledger2.openCursor("c");
+                    @Cleanup("shutdown")
+                    ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+                    ManagedLedger ledger2 = factory2.open("testFlushCursorAfterIndDelInactivity", config);
+                    ManagedCursor c2 = ledger2.openCursor("c");
 
-                        assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
-
-                    } finally {
-                        factory2.shutdown();
-                    }
+                    assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
                 });
 
         factory1.shutdown();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryChangeLedgerPathTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryChangeLedgerPathTest.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.List;
+import lombok.Cleanup;
 import org.apache.bookkeeper.common.allocator.PoolingPolicy;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.Entry;
@@ -51,7 +52,8 @@ public class ManagedLedgerFactoryChangeLedgerPathTest extends BookKeeperClusterT
         configuration.setEnableDigestTypeAutodetection(true);
         configuration.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
 
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(configuration, zkConnectString);
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, configuration);
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setEnsembleSize(1)
@@ -74,7 +76,6 @@ public class ManagedLedgerFactoryChangeLedgerPathTest extends BookKeeperClusterT
             Entry entry = entryList.get(i);
             Assert.assertEquals(("entry" + i).getBytes("UTF8"), entry.getData());
         }
-        factory.shutdown();
     }
     @Test()
     public void testChangeZKPath2() throws Exception {
@@ -86,7 +87,10 @@ public class ManagedLedgerFactoryChangeLedgerPathTest extends BookKeeperClusterT
         configuration.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
 
         ManagedLedgerFactoryConfig managedLedgerFactoryConfig = new ManagedLedgerFactoryConfig();
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(configuration, zkConnectString,managedLedgerFactoryConfig);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, configuration,
+                managedLedgerFactoryConfig);
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setEnsembleSize(1)
@@ -109,6 +113,5 @@ public class ManagedLedgerFactoryChangeLedgerPathTest extends BookKeeperClusterT
             Entry entry = entryList.get(i);
             Assert.assertEquals(("entry" + i).getBytes("UTF8"), entry.getData());
         }
-        factory.shutdown();
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanTest.java
@@ -44,7 +44,7 @@ public class ManagedLedgerMBeanTest extends MockedBookKeeperTestCase {
     public void simple() throws Exception {
         ManagedLedgerFactoryConfig config = new ManagedLedgerFactoryConfig();
         config.setMaxCacheSize(0);
-        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(bkc, zkc, config);
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, config);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger");
         ManagedCursor cursor = ledger.openCursor("c1");
         ManagedLedgerMBeanImpl mbean = ledger.mbean;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -49,7 +49,6 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.Ledge
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
-import org.apache.zookeeper.MockZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -1075,7 +1074,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
         offloader.inject = () -> {
             try {
-                stopZooKeeper();
+                stopMetadataStore();
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -1090,7 +1089,6 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         final MLDataFormats.OffloadContext offloadContext = ledgerInfo.getOffloadContext();
         //should not set complete when
         assertEquals(offloadContext.getComplete(), false);
-        zkc = MockZooKeeper.newInstance();
     }
 
     static class ErroringMockLedgerOffloader extends MockLedgerOffloader {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/offload/OffloadUtilsTest.java
@@ -39,7 +39,7 @@ public class OffloadUtilsTest {
         map.put("key1", "value1");
         map.put("key2", "value2");
 
-        //only one copy of the offload metadata information is stored in zookeeper,
+        //only one copy of the offload metadata information is stored in metadata store,
         // and the original properties need to be cleared during offload
         OffloadUtils.setOffloadDriverMetadata(builder, "offload", map);
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -53,10 +53,11 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.commons.io.FileUtils;
-import org.apache.zookeeper.CreateMode;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -71,7 +72,7 @@ public abstract class BookKeeperClusterTestCase {
 
     // ZooKeeper related variables
     protected ZooKeeperUtil zkUtil = new ZooKeeperUtil();
-    protected ZooKeeper zkc;
+    protected FaultInjectionMetadataStore metadataStore;
 
     // BookKeeper related variables
     protected List<File> tmpDirs = new LinkedList<File>();
@@ -108,8 +109,6 @@ public abstract class BookKeeperClusterTestCase {
             startZKCluster(zkPath);
             // start bookkeeper service
             startBKCluster(zkPath);
-
-            zkc.create(zkPath + "/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         } catch (Exception e) {
             LOG.error("Error setting up", e);
             throw e;
@@ -140,7 +139,9 @@ public abstract class BookKeeperClusterTestCase {
 
     protected void startZKCluster(String path) throws Exception {
         zkUtil.startServer(path);
-        zkc = zkUtil.getZooKeeperClient();
+        metadataStore = new FaultInjectionMetadataStore(
+                MetadataStoreFactory.create(zkUtil.getZooKeeperConnectString(),
+                MetadataStoreConfig.builder().build()));
     }
 
     /**
@@ -375,10 +376,7 @@ public abstract class BookKeeperClusterTestCase {
     /**
      * Restart bookie servers. Also restarts all the respective auto recovery process, if isAutoRecoveryEnabled is true.
      *
-     * @throws InterruptedException
-     * @throws IOException
-     * @throws KeeperException
-     * @throws BookieException
+     * @throws Exception
      */
     public void restartBookies() throws Exception {
         restartBookies(null);
@@ -390,10 +388,7 @@ public abstract class BookKeeperClusterTestCase {
      *
      * @param newConf
      *            New Configuration Settings
-     * @throws InterruptedException
-     * @throws IOException
-     * @throws KeeperException
-     * @throws BookieException
+     * @throws Exception
      */
     public void restartBookies(ServerConfiguration newConf) throws Exception {
         // shut down bookie server
@@ -448,11 +443,12 @@ public abstract class BookKeeperClusterTestCase {
         }
 
         int port = conf.getBookiePort();
-        while (bkc.getZkHandle()
-            .exists(ledgerRootPath + "/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port,
-                false) == null) {
-            Thread.sleep(500);
-        }
+
+        Awaitility.await().until(() ->
+                metadataStore.exists(
+                        ledgerRootPath + "/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port)
+                        .join()
+        );
 
         bkc.readBookiesBlocking();
         LOG.info("New bookie on port " + port + " has been created.");
@@ -479,10 +475,10 @@ public abstract class BookKeeperClusterTestCase {
         server.start();
 
         int port = conf.getBookiePort();
-        while (bkc.getZkHandle().exists(
-                "/ledgers/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port, false) == null) {
-            Thread.sleep(500);
-        }
+        Awaitility.await().until(() ->
+                metadataStore.exists(
+                        "/ledgers/available/" + InetAddress.getLocalHost().getHostAddress() + ":" + port).join()
+        );
 
         bkc.readBookiesBlocking();
         LOG.info("New bookie on port " + port + " has been created.");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -19,17 +19,17 @@
 package org.apache.bookkeeper.test;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.MockZooKeeper;
-import org.apache.zookeeper.ZooDefs;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -44,9 +44,6 @@ public abstract class MockedBookKeeperTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(MockedBookKeeperTestCase.class);
 
-    // ZooKeeper related variables
-    protected MockZooKeeper zkc;
-
     // BookKeeper related variables
     protected PulsarMockBookKeeper bkc;
     protected int numBookies;
@@ -55,6 +52,8 @@ public abstract class MockedBookKeeperTestCase {
 
     protected OrderedScheduler executor;
     protected ExecutorService cachedExecutor;
+
+    protected FaultInjectionMetadataStore metadataStore;
 
     public MockedBookKeeperTestCase() {
         // By default start a 3 bookies cluster
@@ -68,6 +67,9 @@ public abstract class MockedBookKeeperTestCase {
     @BeforeMethod(alwaysRun = true)
     public final void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
+        metadataStore = new FaultInjectionMetadataStore(
+                MetadataStoreFactory.create("memory://local", MetadataStoreConfig.builder().build()));
+
         try {
             // start bookkeeper service
             startBookKeeper();
@@ -76,10 +78,8 @@ public abstract class MockedBookKeeperTestCase {
             throw e;
         }
 
-        ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
-        factory = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
+        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
 
-        zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         setUpTestCase();
     }
 
@@ -99,7 +99,6 @@ public abstract class MockedBookKeeperTestCase {
             factory.shutdown();
             factory = null;
             stopBookKeeper();
-            stopZooKeeper();
             LOG.info("--------- stopped {}", method);
         } catch (Exception e) {
             LOG.error("tearDown Error", e);
@@ -132,23 +131,20 @@ public abstract class MockedBookKeeperTestCase {
      * @throws Exception
      */
     protected void startBookKeeper() throws Exception {
-        zkc = MockZooKeeper.newInstance();
         for (int i = 0; i < numBookies; i++) {
-            ZkUtils.createFullPathOptimistic(zkc, "/ledgers/available/192.168.1.1:" + (5000 + i), "".getBytes(), null,
-                    null);
+            metadataStore.put( "/ledgers/available/192.168.1.1:" + (5000 + i), new byte[0], Optional.empty()).join();
         }
 
-        zkc.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(), null, null);
+        metadataStore.put("/ledgers/LAYOUT", "1\nflat:1".getBytes(), Optional.empty()).join();
 
-        bkc = new PulsarMockBookKeeper(zkc, executor.chooseThread(this));
+        bkc = new PulsarMockBookKeeper(executor);
     }
 
     protected void stopBookKeeper() {
         bkc.shutdown();
     }
 
-    protected void stopZooKeeper() throws Exception {
-        zkc.shutdown();
+    protected void stopMetadataStore() {
+        metadataStore.setAlwaysFail(new MetadataStoreException("failed"));
     }
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -106,7 +106,7 @@ public class PulsarClusterMetadataTeardown {
         if (arguments.configurationStore != null && arguments.cluster != null) {
             // Should it be done by REST API before broker is down?
             @Cleanup
-            MetadataStore configMetadataStore = MetadataStoreFactory.create(arguments.zookeeper,
+            MetadataStore configMetadataStore = MetadataStoreFactory.create(arguments.configurationStore,
                     MetadataStoreConfig.builder().sessionTimeoutMillis(arguments.zkSessionTimeoutMillis).build());
             deleteRecursively(configMetadataStore, "/admin/clusters/" + arguments.cluster);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -21,9 +21,8 @@ package org.apache.pulsar;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.protobuf.InvalidProtocolBufferException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.Optional;
+import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -32,11 +31,9 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.pulsar.broker.service.schema.SchemaStorageFormat.SchemaLocator;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
-import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.ZKUtil;
-import org.apache.zookeeper.ZooKeeper;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,73 +83,43 @@ public class PulsarClusterMetadataTeardown {
             throw e;
         }
 
+        @Cleanup
+        MetadataStore metadataStore = MetadataStoreFactory.create(arguments.zookeeper,
+                MetadataStoreConfig.builder().sessionTimeoutMillis(arguments.zkSessionTimeoutMillis).build());
+
         if (arguments.bkMetadataServiceUri != null) {
+            @Cleanup
             BookKeeper bookKeeper =
                     new BookKeeper(new ClientConfiguration().setMetadataServiceUri(arguments.bkMetadataServiceUri));
-            ZooKeeper localZk = initZk(arguments.zookeeper, arguments.zkSessionTimeoutMillis);
-            ManagedLedgerFactory managedLedgerFactory = new ManagedLedgerFactoryImpl(bookKeeper, localZk);
 
-            deleteManagedLedgers(localZk, managedLedgerFactory);
-            deleteSchemaLedgers(localZk, bookKeeper);
+            @Cleanup("shutdown")
+            ManagedLedgerFactory managedLedgerFactory = new ManagedLedgerFactoryImpl(metadataStore, bookKeeper);
 
-            managedLedgerFactory.shutdown();  // `localZk` would be closed here
-            bookKeeper.close();
+            deleteManagedLedgers(metadataStore, managedLedgerFactory);
+            deleteSchemaLedgers(metadataStore, bookKeeper);
         }
 
-        ZooKeeper localZk = initZk(arguments.zookeeper, arguments.zkSessionTimeoutMillis);
-
         for (String localZkNode : localZkNodes) {
-            deleteZkNodeRecursively(localZk, "/" + localZkNode);
+            deleteRecursively(metadataStore, "/" + localZkNode);
         }
 
         if (arguments.configurationStore != null && arguments.cluster != null) {
             // Should it be done by REST API before broker is down?
-            ZooKeeper configStoreZk = initZk(arguments.configurationStore, arguments.zkSessionTimeoutMillis);
-            deleteZkNodeRecursively(configStoreZk, "/admin/clusters/" + arguments.cluster);
-            configStoreZk.close();
+            @Cleanup
+            MetadataStore configMetadataStore = MetadataStoreFactory.create(arguments.zookeeper,
+                    MetadataStoreConfig.builder().sessionTimeoutMillis(arguments.zkSessionTimeoutMillis).build());
+            deleteRecursively(configMetadataStore, "/admin/clusters/" + arguments.cluster);
         }
 
-        localZk.close();
         log.info("Cluster metadata for '{}' teardown.", arguments.cluster);
     }
 
-    public static ZooKeeper initZk(String connection, int sessionTimeout) throws InterruptedException {
-        ZooKeeperClientFactory zkFactory = new ZookeeperClientFactoryImpl();
-        try {
-            return zkFactory.create(connection, ZooKeeperClientFactory.SessionType.ReadWrite, sessionTimeout).get();
-        } catch (ExecutionException e) {
-            log.error("Failed to connect to '{}': {}", connection, e.getMessage());
-            throw new RuntimeException(e);
-        }
-    }
+    private static void deleteRecursively(MetadataStore metadataStore, String path){
+        metadataStore.getChildren(path).join().forEach(child -> {
+            deleteRecursively(metadataStore, path + "/" + child);
+        });
 
-    public static void deleteZkNodeRecursively(ZooKeeper zooKeeper, String path) throws InterruptedException {
-        try {
-            ZKUtil.deleteRecursive(zooKeeper, path);
-        } catch (KeeperException e) {
-            log.warn("Failed to delete node {} from ZK [{}]: {}", path, zooKeeper, e);
-        }
-    }
-
-    private static List<String> getChildren(ZooKeeper zooKeeper, String path) {
-        try {
-            return zooKeeper.getChildren(path, null);
-        } catch (InterruptedException | KeeperException e) {
-            if (e instanceof KeeperException.NoNodeException) {
-                return new ArrayList<>();
-            }
-            log.error("Failed to get children of {}: {}", path, e);
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static byte[] getData(ZooKeeper zooKeeper, String path) {
-        try {
-            return zooKeeper.getData(path, null, null);
-        } catch (KeeperException | InterruptedException e) {
-            log.error("Failed to get data from {}: {}", path, e);
-            throw new RuntimeException(e);
-        }
+        metadataStore.delete(path, Optional.empty()).join();
     }
 
     private static void deleteLedger(BookKeeper bookKeeper, long ledgerId) {
@@ -167,13 +134,13 @@ public class PulsarClusterMetadataTeardown {
         }
     }
 
-    private static void deleteManagedLedgers(ZooKeeper zooKeeper, ManagedLedgerFactory managedLedgerFactory) {
+    private static void deleteManagedLedgers(MetadataStore metadataStore, ManagedLedgerFactory managedLedgerFactory) {
         final String managedLedgersRoot = "/managed-ledgers";
-        getChildren(zooKeeper, managedLedgersRoot).forEach(tenant -> {
+        metadataStore.getChildren(managedLedgersRoot).join().forEach(tenant -> {
             final String tenantRoot = managedLedgersRoot + "/" + tenant;
-            getChildren(zooKeeper, tenantRoot).forEach(namespace -> {
+            metadataStore.getChildren(tenantRoot).join().forEach(namespace -> {
                 final String namespaceRoot = String.join("/", tenantRoot, namespace, "persistent");
-                getChildren(zooKeeper, namespaceRoot).forEach(topic -> {
+                metadataStore.getChildren(namespaceRoot).join().forEach(topic -> {
                     final TopicName topicName = TopicName.get(String.join("/", tenant, namespace, topic));
                     try {
                         managedLedgerFactory.delete(topicName.getPersistenceNamingEncoding());
@@ -186,16 +153,17 @@ public class PulsarClusterMetadataTeardown {
         });
     }
 
-    private static void deleteSchemaLedgers(ZooKeeper zooKeeper, BookKeeper bookKeeper) {
+    private static void deleteSchemaLedgers(MetadataStore metadataStore, BookKeeper bookKeeper) {
         final String schemaLedgersRoot = "/schemas";
-        getChildren(zooKeeper, schemaLedgersRoot).forEach(tenant -> {
+        metadataStore.getChildren(schemaLedgersRoot).join().forEach(tenant -> {
             final String tenantRoot = schemaLedgersRoot + "/" + tenant;
-            getChildren(zooKeeper, tenantRoot).forEach(namespace -> {
+            metadataStore.getChildren(tenantRoot).join().forEach(namespace -> {
                 final String namespaceRoot = tenantRoot + "/" + namespace;
-                getChildren(zooKeeper, namespaceRoot).forEach(topic -> {
+                metadataStore.getChildren(namespaceRoot).join().forEach(topic -> {
                     final String topicRoot = namespaceRoot + "/" + topic;
                     try {
-                        SchemaLocator.parseFrom(getData(zooKeeper, topicRoot)).getIndexList().stream()
+                        SchemaLocator.parseFrom(metadataStore.get(topicRoot).join().get().getValue())
+                                .getIndexList().stream()
                                 .map(indexEntry -> indexEntry.getPosition().getLedgerId())
                                 .forEach(ledgerId -> deleteLedger(bookKeeper, ledgerId));
                     } catch (InvalidProtocolBufferException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -118,6 +118,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setStickyReadsEnabled(conf.isBookkeeperEnableStickyReads());
         bkConf.setNettyMaxFrameSizeBytes(conf.getMaxMessageSize() + Commands.MESSAGE_SIZE_FRAME_PADDING);
         bkConf.setDiskWeightBasedPlacementEnabled(conf.isBookkeeperDiskWeightBasedPlacementEnabled());
+        bkConf.setNumWorkerThreads(1);
 
         if (StringUtils.isNotBlank(conf.getBookkeeperMetadataServiceUri())) {
             bkConf.setMetadataServiceUri(conf.getBookkeeperMetadataServiceUri());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -37,6 +37,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
+import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +52,12 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
             bkEnsemblePolicyToBkClientMap = Maps.newConcurrentMap();
     private StatsProvider statsProvider = new NullStatsProvider();
 
-    public void initialize(ServiceConfiguration conf, ZooKeeper zkClient,
+    public void initialize(ServiceConfiguration conf, MetadataStore metadataStore,
+                           ZooKeeper zkClient,
                            BookKeeperClientFactory bookkeeperProvider) throws Exception {
         ManagedLedgerFactoryConfig managedLedgerFactoryConfig = new ManagedLedgerFactoryConfig();
         managedLedgerFactoryConfig.setMaxCacheSize(conf.getManagedLedgerCacheSizeMB() * 1024L * 1024L);
         managedLedgerFactoryConfig.setCacheEvictionWatermark(conf.getManagedLedgerCacheEvictionWatermark());
-        managedLedgerFactoryConfig.setNumManagedLedgerWorkerThreads(conf.getManagedLedgerNumWorkerThreads());
         managedLedgerFactoryConfig.setNumManagedLedgerSchedulerThreads(conf.getManagedLedgerNumSchedulerThreads());
         managedLedgerFactoryConfig.setCacheEvictionFrequency(conf.getManagedLedgerCacheEvictionFrequency());
         managedLedgerFactoryConfig.setCacheEvictionTimeThresholdMillis(
@@ -102,7 +103,7 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         };
 
         this.managedLedgerFactory =
-                new ManagedLedgerFactoryImpl(bkFactory, zkClient, managedLedgerFactoryConfig, statsLogger);
+                new ManagedLedgerFactoryImpl(metadataStore, bkFactory, managedLedgerFactoryConfig, statsLogger);
     }
 
     public ManagedLedgerFactory getManagedLedgerFactory() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -616,7 +616,7 @@ public class PulsarService implements AutoCloseable {
 
             this.bkClientFactory = newBookKeeperClientFactory();
             managedLedgerClientFactory = ManagedLedgerStorage.create(
-                config, getZkClient(), bkClientFactory
+                config, localMetadataStore, getZkClient(), bkClientFactory
             );
 
             this.brokerService = new BrokerService(this);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.classification.InterfaceAudience.Private;
 import org.apache.pulsar.common.classification.InterfaceStability.Unstable;
+import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.zookeeper.ZooKeeper;
 
 /**
@@ -44,6 +45,7 @@ public interface ManagedLedgerStorage extends AutoCloseable {
      * @throws Exception
      */
     void initialize(ServiceConfiguration conf,
+                    MetadataStore metadataStore,
                     ZooKeeper zkClient,
                     BookKeeperClientFactory bookkeperProvider) throws Exception;
 
@@ -84,11 +86,12 @@ public interface ManagedLedgerStorage extends AutoCloseable {
      * @return the initialized managed ledger storage.
      */
     static ManagedLedgerStorage create(ServiceConfiguration conf,
+                                       MetadataStore metadataStore,
                                        ZooKeeper zkClient,
                                        BookKeeperClientFactory bkProvider) throws Exception {
         final Class<?> storageClass = Class.forName(conf.getManagedLedgerStorageClassName());
         final ManagedLedgerStorage storage = (ManagedLedgerStorage) storageClass.newInstance();
-        storage.initialize(conf, zkClient, bkProvider);
+        storage.initialize(conf, metadataStore, zkClient, bkProvider);
         return storage;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
@@ -40,15 +41,15 @@ public class MockedBookKeeperClientFactory implements BookKeeperClientFactory {
     private static final Logger log = LoggerFactory.getLogger(MockedBookKeeperClientFactory.class);
 
     private final BookKeeper mockedBk;
-    private final ExecutorService executor;
+    private final OrderedExecutor executor;
 
     public MockedBookKeeperClientFactory() {
         try {
-            executor = Executors.newSingleThreadExecutor(
-                    new ThreadFactoryBuilder().setNameFormat("mock-bk-client-factory")
-                    .setUncaughtExceptionHandler((thread, ex) -> log.info("Uncaught exception", ex))
-                    .build());
-            mockedBk = new PulsarMockBookKeeper(null, executor);
+            executor = OrderedExecutor.newBuilder()
+                    .numThreads(1)
+                    .name("mock-bk-client-factory")
+                    .build();
+            mockedBk = new PulsarMockBookKeeper(executor);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -41,6 +41,7 @@ import java.util.function.Supplier;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
@@ -93,7 +94,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected static final String configClusterName = "test";
 
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
-    private ExecutorService bkExecutor;
+    private OrderedExecutor bkExecutor;
 
     public MockedPulsarServiceBaseTest() {
         resetConfig();
@@ -169,14 +170,11 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected final void init() throws Exception {
         doInitConf();
         sameThreadOrderedSafeExecutor = new SameThreadOrderedSafeExecutor();
-        bkExecutor = Executors.newSingleThreadExecutor(
-                new ThreadFactoryBuilder().setNameFormat("mock-pulsar-bk")
-                    .setUncaughtExceptionHandler((thread, ex) -> log.info("Uncaught exception", ex))
-                    .build());
+        bkExecutor = OrderedExecutor.newBuilder().numThreads(1).name("mock-pulsar-bk").build();
 
         mockZooKeeper = createMockZooKeeper();
         mockZooKeeperGlobal = createMockZooKeeperGlobal();
-        mockBookKeeper = createMockBookKeeper(mockZooKeeper, bkExecutor);
+        mockBookKeeper = createMockBookKeeper(bkExecutor);
 
         startBroker();
     }
@@ -339,16 +337,15 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         return  MockZooKeeper.newInstanceForGlobalZK(MoreExecutors.newDirectExecutorService());
     }
 
-    public static NonClosableMockBookKeeper createMockBookKeeper(ZooKeeper zookeeper,
-                                                                 ExecutorService executor) throws Exception {
-        return spy(new NonClosableMockBookKeeper(zookeeper, executor));
+    public static NonClosableMockBookKeeper createMockBookKeeper(OrderedExecutor executor) throws Exception {
+        return spy(new NonClosableMockBookKeeper(executor));
     }
 
     // Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
     public static class NonClosableMockBookKeeper extends PulsarMockBookKeeper {
 
-        public NonClosableMockBookKeeper(ZooKeeper zk, ExecutorService executor) throws Exception {
-            super(zk, executor);
+        public NonClosableMockBookKeeper(OrderedExecutor executor) throws Exception {
+            super(executor);
         }
 
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -104,7 +105,8 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         log.info("Closing ledger and reopening");
 
         // / Reopen the same managed-ledger
-        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_recovery_index_test_ledger", config);
 
         cursor = ledger.openCursor("c1");
@@ -119,7 +121,6 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
 
         cursor.close();
         ledger.close();
-        factory2.shutdown();
     }
 
     @Test
@@ -167,7 +168,8 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         // reopen ledger
         ledger.close();
         // / Reopen the same managed-ledger
-        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ledger = factory2.open("my_ml_broker_entry_metadata_test_ledger", managedLedgerConfig);
 
         long thirdLedgerId = -1;
@@ -183,7 +185,6 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         }
         cursor.close();
         ledger.close();
-        factory2.shutdown();
     }
 
     public static Set<BrokerEntryMetadataInterceptor> getBrokerEntryMetadataInterceptors() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
@@ -74,7 +75,7 @@ public class OwnerShipForCurrentServerTestBase {
     protected PulsarClient pulsarClient;
 
     private MockZooKeeper mockZooKeeper;
-    private ExecutorService bkExecutor;
+    private OrderedExecutor bkExecutor;
     private NonClosableMockBookKeeper mockBookKeeper;
 
     public void internalSetup() throws Exception {
@@ -88,11 +89,11 @@ public class OwnerShipForCurrentServerTestBase {
     private void init() throws Exception {
         mockZooKeeper = createMockZooKeeper();
 
-        bkExecutor = Executors.newSingleThreadExecutor(
-                new ThreadFactoryBuilder().setNameFormat("mock-pulsar-bk")
-                        .setUncaughtExceptionHandler((thread, ex) -> log.info("Uncaught exception", ex))
-                        .build());
-        mockBookKeeper = createMockBookKeeper(mockZooKeeper, bkExecutor);
+        bkExecutor = OrderedExecutor.newBuilder()
+                .numThreads(1)
+                .name("mock-pulsar-bk")
+                .build();
+        mockBookKeeper = createMockBookKeeper(bkExecutor);
         startBroker();
     }
 
@@ -156,16 +157,15 @@ public class OwnerShipForCurrentServerTestBase {
         return zk;
     }
 
-    public static NonClosableMockBookKeeper createMockBookKeeper(ZooKeeper zookeeper,
-                                                                                             ExecutorService executor) throws Exception {
-        return spy(new NonClosableMockBookKeeper(zookeeper, executor));
+    public static NonClosableMockBookKeeper createMockBookKeeper(OrderedExecutor executor) throws Exception {
+        return spy(new NonClosableMockBookKeeper(executor));
     }
 
     // Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
     public static class NonClosableMockBookKeeper extends PulsarMockBookKeeper {
 
-        public NonClosableMockBookKeeper(ZooKeeper zk, ExecutorService executor) throws Exception {
-            super(zk, executor);
+        public NonClosableMockBookKeeper(OrderedExecutor executor) throws Exception {
+            super(executor);
         }
 
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockBookKeeper;
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.ArgumentMatchers.same;
@@ -47,10 +45,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -72,6 +70,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleC
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandActiveConsumerChange;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
@@ -109,8 +108,11 @@ public class PersistentDispatcherFailoverConsumerTest {
     final String successTopicName = "persistent://part-perf/global/perf.t1/ptopic";
     final String failTopicName = "persistent://part-perf/global/perf.t1/pfailTopic";
 
+    private OrderedExecutor executor;
+
     @BeforeMethod
     public void setup() throws Exception {
+        executor = OrderedExecutor.newBuilder().numThreads(1).name("persistent-dispatcher-failover-test").build();
         ServiceConfiguration svcConfig = spy(new ServiceConfiguration());
         svcConfig.setBrokerShutdownTimeoutMs(0L);
         pulsar = spy(new PulsarService(svcConfig));
@@ -119,9 +121,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         mlFactoryMock = mock(ManagedLedgerFactory.class);
         doReturn(mlFactoryMock).when(pulsar).getManagedLedgerFactory();
 
-        mockZk = createMockZooKeeper();
-        doReturn(mockZk).when(pulsar).getZkClient();
-        doReturn(createMockBookKeeper(mockZk, ForkJoinPool.commonPool()))
+        doReturn(TransactionTestBase.createMockBookKeeper(executor))
             .when(pulsar).getBookKeeperClient();
 
         ZooKeeperCache cache = mock(ZooKeeperCache.class);
@@ -204,9 +204,8 @@ public class PersistentDispatcherFailoverConsumerTest {
             pulsar.close();
             pulsar = null;
         }
-        if (mockZk != null) {
-            mockZk.close();
-        }
+
+        executor.shutdown();
     }
 
     void setupMLAsyncCallbackMocks() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -47,6 +46,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.naming.TopicName;
@@ -86,14 +86,14 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
         doReturn(svcConfig).when(pulsar).getConfiguration();
 
         mlFactoryMock = mock(ManagedLedgerFactory.class);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(2));
         cursorMock = ledger.openCursor("c1");
         ledgerMock = ledger;
         mlFactoryMock = factory;
         doReturn(mlFactoryMock).when(pulsar).getManagedLedgerFactory();
 
-        ZooKeeper mockZk = createMockZooKeeper();
+        ZooKeeper mockZk = TransactionTestBase.createMockZooKeeper();
         doReturn(mockZk).when(pulsar).getZkClient();
 
         brokerService = spy(new BrokerService(pulsar));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -174,7 +174,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
         ZooKeeper mockZk = createMockZooKeeper();
         doReturn(mockZk).when(pulsar).getZkClient();
-        doReturn(createMockBookKeeper(mockZk, ForkJoinPool.commonPool()))
+        doReturn(createMockBookKeeper(executor))
             .when(pulsar).getBookKeeperClient();
 
         ZooKeeperCache cache = mock(ZooKeeperCache.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -170,7 +170,7 @@ public class ServerCnxTest {
 
         ZooKeeper mockZk = createMockZooKeeper();
         doReturn(mockZk).when(pulsar).getZkClient();
-        doReturn(createMockBookKeeper(mockZk, ForkJoinPool.commonPool()))
+        doReturn(createMockBookKeeper(executor))
             .when(pulsar).getBookKeeperClient();
 
         configCacheService = mock(ConfigurationCacheService.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -39,10 +39,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
@@ -109,11 +107,11 @@ public class PersistentSubscriptionTest {
 
     private static final Logger log = LoggerFactory.getLogger(PersistentTopicTest.class);
 
-    private ExecutorService executor;
+    private OrderedExecutor executor;
 
     @BeforeMethod
     public void setup() throws Exception {
-        executor = Executors.newSingleThreadExecutor();
+        executor = OrderedExecutor.newBuilder().numThreads(1).name("persistent-subscription-test").build();
 
         ServiceConfiguration svcConfig = spy(new ServiceConfiguration());
         svcConfig.setBrokerShutdownTimeoutMs(0L);
@@ -170,7 +168,7 @@ public class PersistentSubscriptionTest {
 
         ZooKeeper zkMock = createMockZooKeeper();
         doReturn(zkMock).when(pulsarMock).getZkClient();
-        doReturn(createMockBookKeeper(zkMock, executor))
+        doReturn(createMockBookKeeper(executor))
                 .when(pulsarMock).getBookKeeperClient();
 
         ZooKeeperCache cache = mock(ZooKeeperCache.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -773,7 +773,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         p4.close();
     }
 
-    @Test(invocationCount = 100, skipFailedInvocations = true)
+    @Test
     public void testManagedLedgerBookieClientStats() throws Exception {
         @Cleanup
         Producer<byte[]> p1 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -773,9 +773,12 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         p4.close();
     }
 
-    @Test
+    @Test(invocationCount = 100, skipFailedInvocations = true)
     public void testManagedLedgerBookieClientStats() throws Exception {
+        @Cleanup
         Producer<byte[]> p1 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();
+
+        @Cleanup
         Producer<byte[]> p2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2").create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
@@ -806,15 +809,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
         cm = (List<Metric>) metrics.get("pulsar_managedLedger_client_bookkeeper_ml_workers_completed_tasks_0");
-        assertEquals(cm.size(), 1);
-        assertEquals(cm.get(0).tags.get("cluster"), "test");
+        assertEquals(cm.size(), 0);
 
         cm = (List<Metric>) metrics.get("pulsar_managedLedger_client_bookkeeper_ml_workers_task_execution_count");
-        assertEquals(cm.size(), 2);
-        assertEquals(cm.get(0).tags.get("cluster"), "test");
-
-        p1.close();
-        p2.close();
+        assertEquals(cm.size(), 0);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -56,7 +56,8 @@ public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
         // Fence the topic by opening the ManagedLedger for the topic outside the Pulsar broker. This will cause the
         // broker to fail subsequent send operation and it will trigger a recover
         ManagedLedgerClientFactory clientFactory = new ManagedLedgerClientFactory();
-        clientFactory.initialize(pulsar.getConfiguration(), pulsar.getZkClient(), pulsar.getBookKeeperClientFactory());
+        clientFactory.initialize(pulsar.getConfiguration(), pulsar.getLocalMetadataStore(),
+                pulsar.getZkClient(), pulsar.getBookKeeperClientFactory());
         ManagedLedgerFactory mlFactory = clientFactory.getManagedLedgerFactory();
         ManagedLedger ml = mlFactory.open(TopicName.get(topicName).getPersistenceNamingEncoding());
         ml.close();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import lombok.Data;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.Stat;
+
+/**
+ * Add possibility to inject failures during tests that interact with MetadataStore.
+ */
+public class FaultInjectionMetadataStore implements MetadataStore {
+
+    private final MetadataStore store;
+    private final AtomicReference<MetadataStoreException> alwaysFail;
+    private final CopyOnWriteArrayList<Failure> failures;
+
+    public enum OperationType {
+        GET,
+        GET_CHILDREN,
+        EXISTS,
+        PUT,
+        DELETE,
+    }
+
+    @Data
+    private static class Failure {
+        private final MetadataStoreException exception;
+        private final BiPredicate<OperationType, String> predicate;
+    }
+
+    public FaultInjectionMetadataStore(MetadataStore store) {
+        this.store = store;
+        this.failures = new CopyOnWriteArrayList<>();
+        this.alwaysFail = new AtomicReference<>();
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> get(String path) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.GET, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.get(path);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getChildren(String path) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.GET_CHILDREN, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.getChildren(path);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(String path) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.EXISTS, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.exists(path);
+    }
+
+    @Override
+    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.PUT, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.put(path, value, expectedVersion);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String path, Optional<Long> expectedVersion) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.DELETE, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.delete(path, expectedVersion);
+    }
+
+    @Override
+    public void registerListener(Consumer<Notification> listener) {
+        store.registerListener(listener);
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(Class<T> clazz) {
+        return store.getMetadataCache(clazz);
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef) {
+        return store.getMetadataCache(typeRef);
+    }
+
+    @Override
+    public <T> MetadataCache<T> getMetadataCache(MetadataSerde<T> serde) {
+        return store.getMetadataCache(serde);
+    }
+
+    @Override
+    public void close() throws Exception {
+        store.close();
+    }
+
+    public void failConditional(MetadataStoreException ex, BiPredicate<OperationType, String> predicate) {
+        failures.add(new Failure(ex, predicate));
+    }
+
+    public void setAlwaysFail(MetadataStoreException ex) {
+        this.alwaysFail.set(ex);
+    }
+
+    public void unsetAlwaysFail() {
+        this.alwaysFail.set(null);
+    }
+
+    private Optional<MetadataStoreException> programmedFailure(OperationType op, String path) {
+        MetadataStoreException ex = this.alwaysFail.get();
+        if (ex != null) {
+            return Optional.of(ex);
+        }
+        Optional<Failure> failure = failures.stream()
+                .filter(f -> f.predicate.test(op, path))
+                .findFirst();
+        if (failure.isPresent()) {
+            failures.remove(failure.get());
+        }
+
+        return failure.map(Failure::getException);
+    }
+}

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -98,8 +98,6 @@ public abstract class BookKeeperClusterTestCase {
 
     @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
-        metadataStore = new FaultInjectionMetadataStore(MetadataStoreFactory.create("memory://local",
-                MetadataStoreConfig.builder().build()));
         executor = Executors.newCachedThreadPool();
         InMemoryMetaStore.reset();
         setMetastoreImplClass(baseConf);
@@ -108,6 +106,11 @@ public abstract class BookKeeperClusterTestCase {
         try {
             // start zookeeper service
             startZKCluster();
+
+            metadataStore = new FaultInjectionMetadataStore(MetadataStoreFactory.create(
+                    zkUtil.getZooKeeperConnectString(),
+                    MetadataStoreConfig.builder().build()));
+
             // start bookkeeper service
             startBKCluster();
         } catch (Exception e) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
+import lombok.Cleanup;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -57,6 +58,9 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.testclient.utils.PaddingDecimalFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,7 +170,11 @@ public class ManagedLedgerWriter {
 
         ManagedLedgerFactoryConfig mlFactoryConf = new ManagedLedgerFactoryConfig();
         mlFactoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkConf, mlFactoryConf);
+
+        @Cleanup
+        MetadataStore metadataStore = MetadataStoreFactory.create(arguments.zookeeperServers,
+                MetadataStoreConfig.builder().build());
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkConf, mlFactoryConf);
 
         ManagedLedgerConfig mlConf = new ManagedLedgerConfig();
         mlConf.setEnsembleSize(arguments.ensembleSize);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.transaction.coordinator;
 
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
@@ -56,7 +57,9 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public void testTransactionOperation() throws Exception {
         ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
         factoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
         TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
                 new ManagedLedgerConfig());
@@ -123,7 +126,9 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public void testRecoverSequenceId(boolean isUseManagedLedger) throws Exception {
         ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
         factoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
         TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         managedLedgerConfig.setMaxEntriesPerLedger(3);
@@ -164,7 +169,9 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public void testInitTransactionReader() throws Exception {
         ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
         factoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
         TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         managedLedgerConfig.setMaxEntriesPerLedger(2);
@@ -268,7 +275,9 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public void testDeleteLog() throws Exception {
         ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
         factoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
         TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
                 new ManagedLedgerConfig());
@@ -328,7 +337,9 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public void testRecoverWhenDeleteFromCursor() throws Exception {
         ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
         factoryConf.setMaxCacheSize(0);
-        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, zkc, factoryConf);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
         TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
                 new ManagedLedgerConfig());

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/test/MockedBookKeeperTestCase.java
@@ -24,6 +24,11 @@ import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.ZooDefs;
@@ -35,6 +40,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -45,8 +51,7 @@ public abstract class MockedBookKeeperTestCase {
 
     static final Logger LOG = LoggerFactory.getLogger(MockedBookKeeperTestCase.class);
 
-    // ZooKeeper related variables
-    protected MockZooKeeper zkc;
+    protected FaultInjectionMetadataStore metadataStore;
 
     // BookKeeper related variables
     protected PulsarMockBookKeeper bkc;
@@ -71,6 +76,8 @@ public abstract class MockedBookKeeperTestCase {
     @BeforeMethod(alwaysRun = true)
     public void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
+        metadataStore = new FaultInjectionMetadataStore(MetadataStoreFactory.create("memory://local",
+                MetadataStoreConfig.builder().build()));
         try {
             // start bookkeeper service
             startBookKeeper();
@@ -80,9 +87,7 @@ public abstract class MockedBookKeeperTestCase {
         }
 
         ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
-        factory = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
-
-        zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, conf);
     }
 
     @AfterMethod(alwaysRun = true)
@@ -92,7 +97,8 @@ public abstract class MockedBookKeeperTestCase {
             factory.shutdown();
             factory = null;
             stopBookKeeper();
-            stopZooKeeper();
+            stopMetadataStore();
+            metadataStore.close();
             LOG.info("--------- stopped {}", method);
         } catch (Exception e) {
             LOG.error("tearDown Error", e);
@@ -117,23 +123,21 @@ public abstract class MockedBookKeeperTestCase {
      * @throws Exception
      */
     protected void startBookKeeper() throws Exception {
-        zkc = MockZooKeeper.newInstance();
         for (int i = 0; i < numBookies; i++) {
-            ZkUtils.createFullPathOptimistic(zkc, "/ledgers/available/192.168.1.1:" + (5000 + i), "".getBytes(), null,
-                    null);
+            metadataStore.put("/ledgers/available/192.168.1.1:" + (5000 + i), "".getBytes(), Optional.empty());
         }
 
-        zkc.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(), null, null);
+        metadataStore.put("/ledgers/LAYOUT", "1\nflat:1".getBytes(), Optional.empty());
 
-        bkc = new PulsarMockBookKeeper(zkc, executor.chooseThread(this));
+        bkc = new PulsarMockBookKeeper(executor);
     }
 
     protected void stopBookKeeper() throws Exception {
         bkc.shutdown();
     }
 
-    protected void stopZooKeeper() throws Exception {
-        zkc.shutdown();
+    protected void stopMetadataStore() {
+        metadataStore.setAlwaysFail(new MetadataStoreException("error"));
     }
 
 }

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
@@ -61,21 +61,9 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
     private  Map<String, String> map = new HashMap<>();
 
     public FileSystemManagedLedgerOffloaderTest() throws Exception {
-        this.bk = new PulsarMockBookKeeper(createMockZooKeeper(), scheduler.chooseThread(this));
+        this.bk = new PulsarMockBookKeeper(scheduler);
         this.toWrite = buildReadHandle();
         map.put("ManagedLedgerName", topic);
-    }
-
-    private static MockZooKeeper createMockZooKeeper() throws Exception {
-        MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
-        List<ACL> dummyAclList = new ArrayList<ACL>(0);
-
-        ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                "".getBytes(UTF_8), dummyAclList, CreateMode.PERSISTENT);
-
-        zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(UTF_8), dummyAclList,
-                CreateMode.PERSISTENT);
-        return zk;
     }
 
     private ReadHandle buildReadHandle() throws Exception {

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderBase.java
@@ -56,20 +56,8 @@ public abstract class BlobStoreManagedLedgerOffloaderBase {
 
     protected BlobStoreManagedLedgerOffloaderBase() throws Exception {
         scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(5).name("offloader").build();
-        bk = new PulsarMockBookKeeper(createMockZooKeeper(), scheduler.chooseThread(this));
+        bk = new PulsarMockBookKeeper(scheduler);
         provider = getBlobStoreProvider();
-    }
-
-    protected static MockZooKeeper createMockZooKeeper() throws Exception {
-        MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
-        List<ACL> dummyAclList = new ArrayList<ACL>(0);
-
-        ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                "".getBytes(UTF_8), dummyAclList, CreateMode.PERSISTENT);
-
-        zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(UTF_8), dummyAclList,
-                CreateMode.PERSISTENT);
-        return zk;
     }
 
     protected static MockManagedLedger createMockManagedLedger() {


### PR DESCRIPTION
### Motivation

Pass the MetadataStore instance from PulsarService directly to `ManagedLedgerFactory`. There are not anymore interactions of ManagedLedger with Zookeeper.