### PR TITLE
Fix ConcurrentOpenLongPairRangeSet remove all ranges

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -343,7 +343,7 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
 
         // remove all the keys between two endpoint keys
         rangeBitSetMap.forEach((key, set) -> {
-            if (lowerEndpoint.getKey() == upperEndpoint.getKey()) {
+            if (lowerEndpoint.getKey() == upperEndpoint.getKey() && key == upperEndpoint.getKey()) {
                 set.clear((int) lower, (int) upper + 1);
             } else {
                 // eg: remove-range: [(3,5) - (5,5)] -> Delete all items from 3,6->3,N,4.*,5,0->5,5

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -170,6 +170,30 @@ public class ConcurrentOpenLongPairRangeSetTest {
     }
 
     @Test
+    public void testRemoveRangeInSameKey() {
+        ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
+        set.addOpenClosed(0, 1, 0, 50);
+        set.addOpenClosed(0, 97, 0, 99);
+        set.addOpenClosed(0, 99, 1, 5);
+        set.addOpenClosed(1, 9, 1, 15);
+        set.addOpenClosed(1, 19, 2, 10);
+        set.addOpenClosed(2, 24, 2, 28);
+        set.addOpenClosed(3, 11, 3, 20);
+        set.addOpenClosed(4, 11, 4, 20);
+        // range is [(0:1..0:50],(0:97..0:99],(1:-1..1:5],(1:9..1:15],(2:-1..2:10],(2:24..2:28],(3:11..3:20],(4:11..4:20]]
+        set.remove(Range.closed(new LongPair(0, 0), new LongPair(0, Integer.MAX_VALUE - 1)));
+        // after remove is [(1:-1..1:5],(1:9..1:15],(2:-1..2:10],(2:24..2:28],(3:11..3:20],(4:11..4:20]]
+        int count = 0;
+        List<Range<LongPair>> ranges = set.asRanges();
+        assertEquals(ranges.get(count++), Range.openClosed(new LongPair(1, -1), new LongPair(1, 5)));
+        assertEquals(ranges.get(count++), Range.openClosed(new LongPair(1, 9), new LongPair(1, 15)));
+        assertEquals(ranges.get(count++), Range.openClosed(new LongPair(2, -1), new LongPair(2, 10)));
+        assertEquals(ranges.get(count++), Range.openClosed(new LongPair(2, 24), new LongPair(2, 28)));
+        assertEquals(ranges.get(count++), Range.openClosed(new LongPair(3, 11), new LongPair(3, 20)));
+        assertEquals(ranges.get(count), Range.openClosed(new LongPair(4, 11), new LongPair(4, 20)));
+    }
+
+    @Test
     public void testSpanWithGuava() {
         ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
         com.google.common.collect.RangeSet<LongPair> gSet = TreeRangeSet.create();


### PR DESCRIPTION

### Motivation
Expected result: only the data in the current range is removed
Actual result: removed data for all ranges


