### PR TITLE
Force printing of system.out.printf message

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -212,7 +212,7 @@ The following is an example.
 
 ```java
 producer.sendAsync("my-async-message".getBytes()).thenAccept(msgId -> {
-    System.out.printf("Message with ID %s successfully sent%n", msgId);
+    System.out.println("Message with ID " + msgId + " successfully sent");
 });
 ```
 
@@ -255,7 +255,7 @@ while (true) {
 
   try {
       // Do something with the message
-      System.out.printf("Message received: %s%n", new String(msg.getData()));
+      System.out.println("Message received: " + new String(msg.getData()));
 
       // Acknowledge the message so that it can be deleted by the message broker
       consumer.acknowledge(msg);

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -255,7 +255,7 @@ while (true) {
 
   try {
       // Do something with the message
-      System.out.printf("Message received: %s$n", new String(msg.getData()));
+      System.out.printf("Message received: %s%n", new String(msg.getData()));
 
       // Acknowledge the message so that it can be deleted by the message broker
       consumer.acknowledge(msg);

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -212,7 +212,7 @@ The following is an example.
 
 ```java
 producer.sendAsync("my-async-message".getBytes()).thenAccept(msgId -> {
-    System.out.printf("Message with ID %s successfully sent", msgId);
+    System.out.printf("Message with ID %s successfully sent%n", msgId);
 });
 ```
 
@@ -255,7 +255,7 @@ while (true) {
 
   try {
       // Do something with the message
-      System.out.printf("Message received: %s", new String(msg.getData()));
+      System.out.printf("Message received: %s$n", new String(msg.getData()));
 
       // Acknowledge the message so that it can be deleted by the message broker
       consumer.acknowledge(msg);


### PR DESCRIPTION
### Motivation

`printf` writes into a buffer that will not print instantly. Even worse IDE terminals will ignore `System.out.flush()` calls.

See https://stackoverflow.com/questions/9852705/java-printf-not-printing#comment12559175_9852740

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

I used IntelliJ (most recent version from 2021) and thought something was broken or unreasonably slow.

### Modifications

Update docu / example code.

*(example:)*
  - Follow the changed documentation in an IDE like IntelliJ. It will print at random times. Problem is slightly less apparent, when started in a plain terminal, instead of reading the output from an IDE terminal.
  - Alternative fix: use `System.out.println`

