### PR TITLE
Ensure all the ReadHandle gets properly closed on cache invalidation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -213,7 +213,7 @@ public class EntryCacheImpl implements EntryCache {
             lh.readAsync(position.getEntryId(), position.getEntryId()).whenCompleteAsync(
                     (ledgerEntries, exception) -> {
                         if (exception != null) {
-                            ml.invalidateLedgerHandle(lh, exception);
+                            ml.invalidateLedgerHandle(lh);
                             callback.readEntryFailed(createManagedLedgerException(exception), ctx);
                             return;
                         }
@@ -236,7 +236,7 @@ public class EntryCacheImpl implements EntryCache {
                             ledgerEntries.close();
                         }
                     }, ml.getExecutor().chooseThread(ml.getName())).exceptionally(exception->{
-                    	  ml.invalidateLedgerHandle(lh, exception);
+                          ml.invalidateLedgerHandle(lh);
                           callback.readEntryFailed(createManagedLedgerException(exception), ctx);
                           return null;
                     }
@@ -305,7 +305,7 @@ public class EntryCacheImpl implements EntryCache {
                                 && ((BKException)exception).getCode() == BKException.Code.TooManyRequestsException) {
                                 callback.readEntriesFailed(createManagedLedgerException(exception), ctx);
                             } else {
-                                ml.invalidateLedgerHandle(lh, exception);
+                                ml.invalidateLedgerHandle(lh);
                                 ManagedLedgerException mlException = createManagedLedgerException(exception);
                                 callback.readEntriesFailed(mlException, ctx);
                             }
@@ -339,7 +339,7 @@ public class EntryCacheImpl implements EntryCache {
                                   && ((BKException)exception).getCode() == BKException.Code.TooManyRequestsException) {
                                   callback.readEntriesFailed(createManagedLedgerException(exception), ctx);
                               } else {
-                                  ml.invalidateLedgerHandle(lh, exception);
+                                  ml.invalidateLedgerHandle(lh);
                                   ManagedLedgerException mlException = createManagedLedgerException(exception);
                                   callback.readEntriesFailed(mlException, ctx);
                               }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -227,7 +227,7 @@ public class EntryCacheManager {
             lh.readAsync(position.getEntryId(), position.getEntryId()).whenCompleteAsync(
                     (ledgerEntries, exception) -> {
                         if (exception != null) {
-                            ml.invalidateLedgerHandle(lh, exception);
+                            ml.invalidateLedgerHandle(lh);
                             callback.readEntryFailed(createManagedLedgerException(exception), ctx);
                             return;
                         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
@@ -40,6 +40,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
 import org.apache.bookkeeper.client.api.LedgerEntries;
@@ -112,6 +114,10 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         }
         verify(offloader, times(2))
                 .readOffloaded(anyLong(), (UUID) any(), anyMap());
+
+        ledger.close();
+        // Ensure that all the read handles had been closed
+        assertEquals(offloader.openedReadHandles.get(), 0);
     }
 
     @Test
@@ -225,10 +231,11 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
             return promise;
         }
 
+        @SneakyThrows
         @Override
         public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid,
                                                            Map<String, String> offloadDriverMetadata) {
-            return CompletableFuture.completedFuture(offloads.get(uuid));
+            return CompletableFuture.completedFuture(new VerifyClosingReadHandle(offloads.get(uuid)));
         }
 
         @Override
@@ -246,6 +253,21 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         @Override
         public void close() {
 
+        }
+
+        private final AtomicInteger openedReadHandles = new AtomicInteger(0);
+
+        class VerifyClosingReadHandle extends MockOffloadReadHandle {
+            VerifyClosingReadHandle(ReadHandle toCopy) throws Exception {
+                super(toCopy);
+                openedReadHandles.incrementAndGet();
+            }
+
+            @Override
+            public CompletableFuture<Void> closeAsync() {
+                openedReadHandles.decrementAndGet();
+                return super.closeAsync();
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

The `ReadHandle` instances used in ManagedLedger are not properly closed on either cache invalidation or when the managed ledger instance is closed.

While this does not cause any issue with regular BK LedgerHandle instances (since there are no resources to dispose of and the objects just get garbage collected), this is a problem with some of the offloader implementations which might keep file descriptions, sockets or other resources open.

