### PR TITLE
[Performance] Use single instance of parser

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -87,8 +87,9 @@ public class AuthenticationProviderTokenTest {
                 .compact();
 
         @SuppressWarnings("unchecked")
-        Jwt<?, Claims> jwt = Jwts.parser()
+        Jwt<?, Claims> jwt = Jwts.parserBuilder()
                 .setSigningKey(AuthTokenUtils.decodeSecretKey(secretKey.getEncoded()))
+                .build()
                 .parse(token);
 
         assertNotNull(jwt);
@@ -108,8 +109,9 @@ public class AuthenticationProviderTokenTest {
                 Optional.empty());
 
         @SuppressWarnings("unchecked")
-        Jwt<?, Claims> jwt = Jwts.parser()
+        Jwt<?, Claims> jwt = Jwts.parserBuilder()
                 .setSigningKey(AuthTokenUtils.decodePublicKey(Decoders.BASE64.decode(publicKey), SignatureAlgorithm.RS256))
+                .build()
                 .parse(token);
 
         assertNotNull(jwt);


### PR DESCRIPTION
Fixes #10652

This is a minor change that optimizes the AuthProviderToken class to use
the same instance of the parser instead of many instance.

This minor change is covered by existing tests, with a small improvement
to not use a deprecated method


