### PR TITLE
Fix issues in advanceNonDurableCursors

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3021,7 +3021,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      * @return the count of entries
      */
     long getNumberOfEntries(Range<PositionImpl> range) {
-        log.info("!-----------getNumberOfEntries {} ---------------!", range);
         PositionImpl fromPosition = range.lowerEndpoint();
         boolean fromIncluded = range.lowerBoundType() == BoundType.CLOSED;
         PositionImpl toPosition = range.upperEndpoint();
@@ -3038,32 +3037,21 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             // If the from & to are pointing to different ledgers, then we need to :
             // 1. Add the entries in the ledger pointed by toPosition
             count += toPosition.getEntryId();
-            log.info("count: {}", count);
             count += toIncluded ? 1 : 0;
-            log.info("count: {}", count);
 
             // 2. Add the entries in the ledger pointed by fromPosition
             LedgerInfo li = ledgers.get(fromPosition.getLedgerId());
-            log.info("li: {}", li);
             if (li != null) {
                 count += li.getEntries() - (fromPosition.getEntryId() + 1);
                 count += fromIncluded ? 1 : 0;
             }
 
-            log.info("count: {}", count);
-
-
             // 3. Add the whole ledgers entries in between
-            log.info("ledgers.subMap(fromPosition.getLedgerId(), false, toPosition.getLedgerId(), false): {}", ledgers.subMap(fromPosition.getLedgerId(), false, toPosition.getLedgerId(), false));
             for (LedgerInfo ls : ledgers.subMap(fromPosition.getLedgerId(), false, toPosition.getLedgerId(), false)
                     .values()) {
                 count += ls.getEntries();
             }
-
-            log.info("count: {}", count);
-
-            log.info("!-----------end getNumberOfEntries ---------------!");
-
+            
             return count;
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2458,7 +2458,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         }
 
-        // need to move mark delete to the first non deleted ledger for non durable cursor since ledgers before it will be deleted
+        // need to move mark delete for non-durable cursors to the first ledger NOT marked for deletion
         // calling getNumberOfEntries latter for a ledger that is already deleted will be problematic and return incorrect results
         long firstNonDeletedLedger = ledgers.higherKey(ledgersToDelete.get(ledgersToDelete.size() - 1).getLedgerId());
         PositionImpl highestPositionToDelete = new PositionImpl(firstNonDeletedLedger, -1);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3051,7 +3051,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     .values()) {
                 count += ls.getEntries();
             }
-            
+
             return count;
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2463,8 +2463,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         cursors.forEach(cursor -> {
             if (!cursor.isDurable()) {
-                // Advance mark delete position if the highest position that can be deleted to is greater than the current mark deletion position
-                // if
                 if (highestPositionToDelete.compareTo((PositionImpl) cursor.getMarkDeletedPosition()) > 0) {
                     cursor.asyncMarkDelete(highestPositionToDelete, new MarkDeleteCallback() {
                         @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2381,7 +2381,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 return;
             }
 
-            advanceNonDurableCursors(ledgersToDelete);
+            advanceCursorsIfNecessary(ledgersToDelete);
 
             PositionImpl currentLastConfirmedEntry = lastConfirmedEntry;
             // Update metadata
@@ -2450,10 +2450,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     /**
      * Non-durable cursors have to be moved forward when data is trimmed since they are not retain that data.
+     * This method also addresses a corner case for durable cursors in which the cursor is caught up, i.e. the mark delete position
+     * happens to be the last entry in a ledger.  If the ledger is deleted, then subsequent calculations for backlog
+     * size may not be accurate since the method getNumberOfEntries we use in backlog calculation will not be able to fetch
+     * the ledger info of a deleted ledger.  Thus, we need to update the mark delete position to the "-1" entry of the first ledger
+     * that is not marked for deletion.
      * This is to make sure that the `consumedEntries` counter is correctly updated with the number of skipped
      * entries and the stats are reported correctly.
      */
-    private void advanceNonDurableCursors(List<LedgerInfo> ledgersToDelete) {
+    private void advanceCursorsIfNecessary(List<LedgerInfo> ledgersToDelete) {
         if (ledgersToDelete.isEmpty()) {
             return;
         }
@@ -2464,23 +2469,21 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         PositionImpl highestPositionToDelete = new PositionImpl(firstNonDeletedLedger, -1);
 
         cursors.forEach(cursor -> {
-            if (!cursor.isDurable()) {
-                // move the mark delete position to the highestPositionToDelete only if it is smaller than the add confirmed
-                // to prevent the edge case where the cursor is caught up to the latest and highestPositionToDelete may be larger than the last add confirmed
-                if (highestPositionToDelete.compareTo((PositionImpl) cursor.getMarkDeletedPosition()) > 0
-                        && highestPositionToDelete.compareTo((PositionImpl) cursor.getManagedLedger().getLastConfirmedEntry()) <= 0 ) {
-                    cursor.asyncMarkDelete(highestPositionToDelete, new MarkDeleteCallback() {
-                        @Override
-                        public void markDeleteComplete(Object ctx) {
-                        }
+            // move the mark delete position to the highestPositionToDelete only if it is smaller than the add confirmed
+            // to prevent the edge case where the cursor is caught up to the latest and highestPositionToDelete may be larger than the last add confirmed
+            if (highestPositionToDelete.compareTo((PositionImpl) cursor.getMarkDeletedPosition()) > 0
+                    && highestPositionToDelete.compareTo((PositionImpl) cursor.getManagedLedger().getLastConfirmedEntry()) <= 0 ) {
+                cursor.asyncMarkDelete(highestPositionToDelete, new MarkDeleteCallback() {
+                    @Override
+                    public void markDeleteComplete(Object ctx) {
+                    }
 
-                        @Override
-                        public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-                            log.warn("[{}] Failed to mark delete while trimming data ledgers: {}", name,
-                                    exception.getMessage());
-                        }
-                    }, null);
-                }
+                    @Override
+                    public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                        log.warn("[{}] Failed to mark delete while trimming data ledgers: {}", name,
+                                exception.getMessage());
+                    }
+                }, null);
             }
         });
     }


### PR DESCRIPTION
### Motivation

There are a couple of issues in advanceNonDurableCursors

1. Durable cursors unnecessarily run through this logic
2. For Non-durable and durable cursors that are caught up reading the topic.  The following warning message can be printed

```
message: [public/default/persistent/test] Failed to mark delete while trimming data ledgers: Invalid mark deleted position
```

This happens because highestPositionToDelete calculated when the reader/consumer is caught up is going to be higher than the last confirmed for the of the managed ledger.  There is also no point in trying to advance the mark delete position if the reader/consumer is caught up.


