### PR TITLE
Fix website build failure caused by python doc generate script

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -27,7 +27,7 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
-BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04}"
+BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"
 

--- a/site2/tools/python-doc-gen.sh
+++ b/site2/tools/python-doc-gen.sh
@@ -30,12 +30,14 @@ find $ROOT_DIR -name CMakeFiles | xargs rm -rf
 find $ROOT_DIR -name PulsarApi.pb.h | xargs rm -rf
 find $ROOT_DIR -name PulsarApi.pb.cc | xargs rm -rf
 cd $ROOT_DIR/pulsar-client-cpp
-cmake .
+export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_DYNAMIC_LIB=OFF -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so"
+cmake . $CMAKE_ARGS
 make -j8 _pulsar
 pip install enum34
 pip install six
 pip install fastavro
 pip install certifi
+pip install pdoc
 
 # Create documentation
 DESTINATION=$ROOT_DIR/generated-site/api/python/${VERSION}


### PR DESCRIPTION
### Motivation

The CI - Pulsar Website Build has been broken for a long time. Here's an example run: https://github.com/apache/pulsar/runs/2635024657?check_suite_focus=true

```
CMake Error at python/CMakeLists.txt:85 (MESSAGE):
-- Using Boost Python libs: 
  Could not find Boost Python library
```

It looks like to be the same issue with https://github.com/apache/pulsar/issues/9682. https://github.com/apache/pulsar/pull/9690 fixed the broken CI for cpp client but the `ci-pulsar-website-build.yaml` wasn't modified.

Another issue is after I fixed the cpp build for website build, the `python-doc-gen.sh` still failed because the default `pdoc` is a Python3 tool

```
+ pdoc pulsar --html --html-dir /pulsar/generated-site/api/python/2.8.0-SNAPSHOT
Traceback (most recent call last):
  File "/usr/local/bin/pdoc", line 7, in <module>
    from pdoc.__main__ import cli
  File "/usr/local/lib/python3.5/dist-packages/pdoc/__init__.py", line 328
    ) -> str:
    ^
```

So we need to install a Python2 version `pdoc` as well.

### Modifications

- Use `ubuntu-16.04-py2` tag instead of old `ubuntu-16.04` tag in `docker-build-site.sh` and force CMake to find Python2 in `python-doc-gen.sh`. The the Pulsar Python client library could be built successfully.
- Install a Python2 version `pdoc` in `python-doc-gen.sh`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.