### PR TITLE
Branch-2.7: getListOfNamespaces does not fail with non-existant tenant

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -239,6 +239,10 @@ public abstract class AdminResource extends PulsarWebResource {
     protected List<String> getListOfNamespaces(String property) throws Exception {
         List<String> namespaces = Lists.newArrayList();
 
+        if (!globalZkCache().exists(path(POLICIES, property))) {
+            throw new KeeperException.NoNodeException();
+        }
+
         // this will return a cluster in v1 and a namespace in v2
         for (String clusterOrNamespace : globalZkCache().getChildren(path(POLICIES, property))) {
             // Then get the list of namespaces


### PR DESCRIPTION
on branch-2.7 NamespacesTest.getNamespaces fails

```
java.lang.AssertionError: should have failed
	at org.testng.Assert.fail(Assert.java:99)
	at org.apache.pulsar.broker.admin.NamespacesTest.testGetNamespaces(NamespacesTest.java:264)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```

it looks like AdminResource is missing a check, that is present on master branch
https://github.com/apache/pulsar/blob/5dc5de849b582c7f312764db043da9483c17146a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java#L1094

```
    protected List<String> getListOfNamespaces(String tenant) throws Exception {
        List<String> namespaces = Lists.newArrayList();

        if (!tenantResources().exists(path(POLICIES, tenant))) {
            throw new RestException(Status.NOT_FOUND, tenant + " doesn't exist");
        }
```