### PR TITLE
Revert "Creating a topic does not wait for creating cursor of replicators"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -251,11 +251,6 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
     }
 
     @Override
-    protected CompletableFuture<Void> openCursorAsync() {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public boolean isConnected() {
         ProducerImpl<?> producer = this.producer;
         return producer != null && producer.isConnected();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -31,13 +31,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
-import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.TooManyRequestsException;
@@ -46,7 +44,6 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.AbstractReplicator;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
-import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyException;
 import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
@@ -56,7 +53,6 @@ import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.SendCallback;
-import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
@@ -69,9 +65,7 @@ public class PersistentReplicator extends AbstractReplicator
         implements Replicator, ReadEntriesCallback, DeleteCallback {
 
     private final PersistentTopic topic;
-    private final String replicatorName;
-    private final ManagedLedger ledger;
-    protected volatile ManagedCursor cursor;
+    protected final ManagedCursor cursor;
 
     private Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
 
@@ -101,20 +95,17 @@ public class PersistentReplicator extends AbstractReplicator
     private final Backoff readFailureBackoff = new Backoff(1, TimeUnit.SECONDS,
             1, TimeUnit.MINUTES, 0, TimeUnit.MILLISECONDS);
 
-    private PersistentMessageExpiryMonitor expiryMonitor;
+    private final PersistentMessageExpiryMonitor expiryMonitor;
     // for connected subscriptions, message expiry will be checked if the backlog is greater than this threshold
     private static final int MINIMUM_BACKLOG_FOR_EXPIRY_CHECK = 1000;
 
     private final ReplicatorStats stats = new ReplicatorStats();
 
-    // Only for test
     public PersistentReplicator(PersistentTopic topic, ManagedCursor cursor, String localCluster, String remoteCluster,
                                 BrokerService brokerService) throws NamingException {
         super(topic.getName(), topic.getReplicatorPrefix(), localCluster, remoteCluster, brokerService);
-        this.replicatorName = cursor.getName();
-        this.ledger = cursor.getManagedLedger();
-        this.cursor = cursor;
         this.topic = topic;
+        this.cursor = cursor;
         this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName,
                 Codec.decode(cursor.getName()), cursor, null);
         HAVE_PENDING_READ_UPDATER.set(this, FALSE);
@@ -123,26 +114,6 @@ public class PersistentReplicator extends AbstractReplicator
         readBatchSize = Math.min(
                 producerQueueSize,
                 topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadBatchSize());
-        readMaxSizeBytes = topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadSizeBytes();
-        producerQueueThreshold = (int) (producerQueueSize * 0.9);
-
-        this.initializeDispatchRateLimiterIfNeeded(Optional.empty());
-
-        startProducer();
-    }
-
-    public PersistentReplicator(PersistentTopic topic, String replicatorName, String localCluster, String remoteCluster,
-            BrokerService brokerService, ManagedLedger ledger) throws NamingException {
-        super(topic.getName(), topic.getReplicatorPrefix(), localCluster, remoteCluster, brokerService);
-        this.replicatorName = replicatorName;
-        this.ledger = ledger;
-        this.topic = topic;
-        HAVE_PENDING_READ_UPDATER.set(this, FALSE);
-        PENDING_MESSAGES_UPDATER.set(this, 0);
-
-        readBatchSize = Math.min(
-            producerQueueSize,
-            topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadBatchSize());
         readMaxSizeBytes = topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadSizeBytes();
         producerQueueThreshold = (int) (producerQueueSize * 0.9);
 
@@ -195,40 +166,6 @@ public class PersistentReplicator extends AbstractReplicator
             this.cursor.setInactive();
         }
     }
-
-    @Override
-    protected CompletableFuture<Void> openCursorAsync() {
-        log.info("[{}][{} -> {}] Starting open cursor for replicator", topicName, localCluster, remoteCluster);
-        if (cursor != null) {
-            log.info("[{}][{} -> {}] Using the exists cursor for replicator", topicName, localCluster, remoteCluster);
-            if (expiryMonitor == null) {
-                this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName,
-                        Codec.decode(cursor.getName()), cursor, null);
-            }
-            return CompletableFuture.completedFuture(null);
-        }
-        CompletableFuture<Void> res = new CompletableFuture<>();
-        ledger.asyncOpenCursor(replicatorName, InitialPosition.Earliest, new OpenCursorCallback() {
-            @Override
-            public void openCursorComplete(ManagedCursor cursor, Object ctx) {
-                log.info("[{}][{} -> {}] Open cursor succeed for replicator", topicName, localCluster, remoteCluster);
-                PersistentReplicator.this.cursor = cursor;
-                PersistentReplicator.this.expiryMonitor = new PersistentMessageExpiryMonitor(topicName,
-                        Codec.decode(cursor.getName()), cursor, null);
-                res.complete(null);
-            }
-
-            @Override
-            public void openCursorFailed(ManagedLedgerException exception, Object ctx) {
-                log.warn("[{}][{} -> {}] Open cursor failed for replicator", topicName,
-                        localCluster, remoteCluster, exception);
-                res.completeExceptionally(new PersistenceException(exception));
-            }
-
-        }, null);
-        return res;
-    }
-
 
     /**
      * Calculate available permits for read entries.
@@ -686,9 +623,7 @@ public class PersistentReplicator extends AbstractReplicator
         msgExpired.calculateRate();
         stats.msgRateOut = msgOut.getRate();
         stats.msgThroughputOut = msgOut.getValueRate();
-        if (expiryMonitor != null) {
-            stats.msgRateExpired = msgExpired.getRate() + expiryMonitor.getMessageExpiryRate();
-        }
+        stats.msgRateExpired = msgExpired.getRate() + expiryMonitor.getMessageExpiryRate();
     }
 
     public ReplicatorStats getStats() {
@@ -726,17 +661,12 @@ public class PersistentReplicator extends AbstractReplicator
             // don't do anything for almost caught-up connected subscriptions
             return false;
         }
-        if (expiryMonitor != null) {
-            return expiryMonitor.expireMessages(messageTTLInSeconds);
-        }
-        return false;
+
+        return expiryMonitor.expireMessages(messageTTLInSeconds);
     }
 
     public boolean expireMessages(Position position) {
-        if (expiryMonitor != null) {
-            return expiryMonitor.expireMessages(position);
-        }
-        return false;
+        return expiryMonitor.expireMessages(position);
     }
 
     @Override


### PR DESCRIPTION


This reverts  #6364 commit 336e971f4d41d6ffb26b3b53a20f36a360c070e8.

### Motivation

There are few issues that were introduced in that commit: 
 1. If a new replication cursor is create after the topic is loaded, that cursor might be missing some of the latest messages
 2. Many places in the code are assuming that the cursor is always present on the replicator and are failing with NPE when the cursor is not created (or fails to get created).

One such example is that metrics will stop getting reported because of an exception: 

```
ERROR org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet - Failed to generate prometheus stats 
java.lang.NullPointerException: null                                                                                                                
         at org.apache.pulsar.broker.service.persistent.PersistentReplicator.getStats(PersistentReplicator.java:676) ~[org.apache.pulsar-pulsar-broker-2.7.
         at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$getStats$45(PersistentTopic.java:1624) ~[org.apache.pulsar-pulsar-broker-2.7
```

