### PR TITLE
In LockManager use concurrent hash map to handle locks notifiications

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -19,19 +19,17 @@
 package org.apache.pulsar.metadata.coordination.impl;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
-
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
@@ -42,17 +40,16 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
-import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 class LockManagerImpl<T> implements LockManager<T> {
 
-    private final Set<ResourceLockImpl<T>> locks = new HashSet<>();
+    private final Map<String, ResourceLockImpl<T>> locks = new HashMap<>();
     private final MetadataStoreExtended store;
     private final MetadataCache<T> cache;
     private final MetadataSerde<T> serde;
 
-    private static enum State {
+    private enum State {
         Ready, Closed
     }
 
@@ -79,11 +76,11 @@ class LockManagerImpl<T> implements LockManager<T> {
         lock.acquire().thenRun(() -> {
             synchronized (LockManagerImpl.this) {
                 if (state == State.Ready) {
-                    locks.add(lock);
+                    locks.put(path, lock);
                     lock.getLockExpiredFuture().thenRun(() -> {
                         log.info("Released resource lock on {}", path);
                         synchronized (LockManagerImpl.this) {
-                            locks.remove(lock);
+                            locks.remove(path, lock);
                         }
                     });
                 } else {
@@ -91,7 +88,7 @@ class LockManagerImpl<T> implements LockManager<T> {
                     lock.release();
                 }
             }
-      result.complete(lock);
+            result.complete(lock);
         }).exceptionally(ex -> {
             if (ex.getCause() instanceof BadVersionException) {
                 result.completeExceptionally(
@@ -108,15 +105,20 @@ class LockManagerImpl<T> implements LockManager<T> {
     private void handleSessionEvent(SessionEvent se) {
         if (se == SessionEvent.SessionReestablished) {
             log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
-            locks.forEach(ResourceLockImpl::revalidate);
+            synchronized (this) {
+                locks.values().forEach(ResourceLockImpl::revalidate);
+            }
         }
     }
 
     private void handleDataNotification(Notification n) {
         if (n.getType() == NotificationType.Deleted) {
-            locks.stream()
-                    .filter(l -> l.getPath().equals(n.getPath()))
-                    .forEach(l -> l.lockWasInvalidated());
+            synchronized (this) {
+                ResourceLockImpl<T> lock = locks.get(n.getPath());
+                if (lock != null) {
+                    lock.lockWasInvalidated();
+                }
+            }
         }
     }
 
@@ -136,18 +138,19 @@ class LockManagerImpl<T> implements LockManager<T> {
 
     @Override
     public CompletableFuture<Void> asyncClose() {
-        Set<ResourceLock<T>> locks;
+        Map<String, ResourceLock<T>> locks;
         synchronized (this) {
             if (state != State.Ready) {
                 return CompletableFuture.completedFuture(null);
             }
 
-            locks = new HashSet<>(this.locks);
+            locks = new HashMap<>(this.locks);
             this.state = State.Closed;
         }
 
         return FutureUtils.collect(
-                locks.stream().map(ResourceLock::release)
+                locks.values().stream()
+                        .map(ResourceLock::release)
                         .collect(Collectors.toList()))
                 .thenApply(x -> null);
     }


### PR DESCRIPTION
### Motivation

In `LockManagerImpl`, the notification will use the locks set to re-check the status of the lock against the metadata store. The access needs to be synchronized because new locks could be added again to the list from other threads.

That leads to these exceptions: 

```
08:50:22.921 [metadata-store-5-1] ERROR org.apache.pulsar.metadata.impl.AbstractMetadataStore - Failed to process metadata store notification
java.util.ConcurrentModificationException: null
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1610) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
	at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl.handleDataNotification(LockManagerImpl.java:119) ~[classes/:?]
	at org.apache.pulsar.metadata.impl.AbstractMetadataStore.lambda$receivedNotification$0(AbstractMetadataStore.java:149) ~[classes/:?]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:804) ~[?:?]
	at org.apache.pulsar.metadata.impl.AbstractMetadataStore.lambda$receivedNotification$1(AbstractMetadataStore.java:147) ~[classes/:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1771) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.63.Final.jar:4.1.63.Final]
	at java.lang.Thread.run(Thread.java:830) [?:?]
```

Additionally, we should use a `Map` instead of a `Set` to avoid going through the list when one single node is deleted.