### PR TITLE
Added org.apache.bookkeeper:cpu-affinity to shaded profile

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -112,9 +112,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.pulsar:pulsar-client-original</include>
-                  <include>org.apache.pulsar:pulsar-client-api</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
-                  <include>org.apache.pulsar:pulsar-client-admin-api</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>
@@ -128,7 +126,7 @@
                   <include>com.fasterxml.jackson.core</include>
                   <include>io.netty:*</include>
                   <include>org.apache.pulsar:pulsar-common</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>org.apache.bookkeeper:*</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>
@@ -148,7 +146,6 @@
                   <include>org.objenesis:*</include>
                   <include>org.yaml:snakeyaml</include>
                   <include>io.swagger:*</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
                 </includes>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -166,7 +166,7 @@
                   <include>io.airlift:*</include>
 
                   <include>org.apache.pulsar:pulsar-common</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>org.apache.bookkeeper:*</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>
@@ -191,7 +191,6 @@
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.tukaani:xz</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
                 </includes>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -130,7 +130,7 @@
                 <includes>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-transaction-common</include>
-                  <include>org.apache.bookkeeper:bookkeeper-common-allocator</include>
+                  <include>org.apache.bookkeeper:*</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>
@@ -159,7 +159,6 @@
                   <include>io.airlift:*</include>
 
                   <include>org.apache.pulsar:pulsar-common</include>
-                  <include>org.apache.bookkeeper:circe-checksum</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.objenesis:*</include>
                   <include>org.yaml:snakeyaml</include>


### PR DESCRIPTION
### Motivation

Since `org.apache.bookkeeper:cpu-affinity` was added as dependency for pulsar-client module, it also needs to be added to the shaded jar, otherwise it will be still pulling in some of the transitive dependencies.