### PR TITLE
Fix binary license check issues and update jersey to 2.34 for Pulsar SQL

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -559,22 +559,20 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - org.glassfish.hk2-osgi-resource-locator-1.0.3.jar
     - org.glassfish.hk2.external-aopalliance-repackaged-2.6.1.jar
  * Jersey
-    - org.glassfish.jersey.containers-jersey-container-servlet-2.31.jar
-    - org.glassfish.jersey.containers-jersey-container-servlet-core-2.31.jar
-    - org.glassfish.jersey.core-jersey-client-2.31.jar
-    - org.glassfish.jersey.core-jersey-common-2.31.jar
-    - org.glassfish.jersey.core-jersey-server-2.31.jar
-    - org.glassfish.jersey.ext-jersey-entity-filtering-2.31.jar
-    - org.glassfish.jersey.media-jersey-media-jaxb-2.31.jar
-    - org.glassfish.jersey.media-jersey-media-json-jackson-2.31.jar
-    - org.glassfish.jersey.media-jersey-media-multipart-2.31.jar
-    - org.glassfish.jersey.inject-jersey-hk2-2.31.jar
+    - org.glassfish.jersey.containers-jersey-container-servlet-2.34.jar
+    - org.glassfish.jersey.containers-jersey-container-servlet-core-2.34.jar
+    - org.glassfish.jersey.core-jersey-client-2.34.jar
+    - org.glassfish.jersey.core-jersey-common-2.34.jar
+    - org.glassfish.jersey.core-jersey-server-2.34.jar
+    - org.glassfish.jersey.ext-jersey-entity-filtering-2.34.jar
+    - org.glassfish.jersey.media-jersey-media-json-jackson-2.34.jar
+    - org.glassfish.jersey.media-jersey-media-multipart-2.34.jar
+    - org.glassfish.jersey.inject-jersey-hk2-2.34.jar
  * Mimepull -- org.jvnet.mimepull-mimepull-1.9.13.jar
 
 Eclipse Distribution License 1.0 -- licenses/LICENSE-EDL-1.0.txt
  * Jakarta Activation
-   - jakarta.activation-jakarta.activation-api-1.2.2.jar
-   - com.sun.activation-jakarta.activation-1.2.2.jar
+    - jakarta.activation-jakarta.activation-api-1.2.2.jar
  * Jakarta XML Binding -- jakarta.xml.bind-jakarta.xml.bind-api-2.3.3.jar
 
 Eclipse Public License - v2.0 -- licenses/LICENSE-EPL-2.0.txt

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ flexible messaging model and an intuitive client API.</description>
     <netty-tc-native.version>2.0.38.Final</netty-tc-native.version>
     <jetty.version>9.4.39.v20210325</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
-    <jersey.version>2.31</jersey.version>
+    <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.5.4</vertx.version>
@@ -679,6 +679,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
         <version>${jersey.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1016,6 +1022,12 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>
+        <version>${jakarta.activation.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
         <version>${jakarta.activation.version}</version>
       </dependency>
 

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -231,6 +231,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
     </dependency>

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -105,6 +105,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
     </dependency>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -49,7 +49,18 @@
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
   		<version>3.1.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+        </exclusions>
   	</dependency>
+
+    <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
 
   </dependencies>
   

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -526,6 +526,7 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-media-multipart-2.34.jar
     - jersey-server-2.34.jar
     - jersey-common-2.34.jar
+    - jetty-alpn-java-client-9.4.27.v20200227.jar
  * JAXB
     - jaxb-api-2.3.1.jar
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -256,7 +256,6 @@ The Apache Software License, Version 2.0
     - http2-common-9.4.27.v20200227.jar
     - http2-hpack-9.4.27.v20200227.jar
     - http2-http-client-transport-9.4.27.v20200227.jar
-    - jetty-alpn-java-client-9.4.27.v20200227.jar
     - http2-server-9.4.27.v20200227.jar
     - jetty-alpn-client-9.4.27.v20200227.jar
     - jetty-client-9.4.27.v20200227.jar
@@ -511,7 +510,6 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - javax.annotation-api-1.3.2.jar
    - javax.activation-1.2.0.jar
    - javax.activation-api-1.2.0.jar
-   - jakarta.activation-api-1.2.1.jar
  * HK2 - Dependency Injection Kernel
    - hk2-api-2.6.1.jar
    - hk2-locator-2.6.1.jar
@@ -519,16 +517,15 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
    - aopalliance-repackaged-2.6.1.jar
  * Jersey
     - jaxrs-0.195.jar
-    - jersey-client-2.31.jar
-    - jersey-container-servlet-2.31.jar
-    - jersey-container-servlet-core-2.31.jar
-    - jersey-hk2-2.31.jar
-    - jersey-media-jaxb-2.31.jar
-    - jersey-server-2.31.jar
-    - jersey-common-2.31.jar
-    - jersey-entity-filtering-2.31.jar
-    - jersey-media-json-jackson-2.31.jar
-    - jersey-media-multipart-2.31.jar
+    - jersey-client-2.34.jar
+    - jersey-container-servlet-2.34.jar
+    - jersey-container-servlet-core-2.34.jar
+    - jersey-entity-filtering-2.34.jar
+    - jersey-hk2-2.34.jar
+    - jersey-media-json-jackson-2.34.jar
+    - jersey-media-multipart-2.34.jar
+    - jersey-server-2.34.jar
+    - jersey-common-2.34.jar
  * JAXB
     - jaxb-api-2.3.1.jar
 
@@ -554,7 +551,6 @@ Eclipse Public License - v2.0 -- licenses/LICENSE-EPL-2.0.txt
  * jakarta.inject-2.6.1.jar
  * jakarta.validation-api-2.0.2.jar
  * jakarta.ws.rs-api-2.1.6.jar
- * jakarta.activation-1.2.2.jar
  * jakarta.activation-api-1.2.2.jar
  * jakarta.xml.bind-api-2.3.3.jar
 

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -256,6 +256,7 @@ The Apache Software License, Version 2.0
     - http2-common-9.4.27.v20200227.jar
     - http2-hpack-9.4.27.v20200227.jar
     - http2-http-client-transport-9.4.27.v20200227.jar
+    - jetty-alpn-java-client-9.4.27.v20200227.jar
     - http2-server-9.4.27.v20200227.jar
     - jetty-alpn-client-9.4.27.v20200227.jar
     - jetty-client-9.4.27.v20200227.jar
@@ -526,7 +527,6 @@ CDDL-1.1 -- licenses/LICENSE-CDDL-1.1.txt
     - jersey-media-multipart-2.34.jar
     - jersey-server-2.34.jar
     - jersey-common-2.34.jar
-    - jetty-alpn-java-client-9.4.27.v20200227.jar
  * JAXB
     - jaxb-api-2.3.1.jar
 

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jersey.version>2.31</jersey.version>
+    <jersey.version>2.34</jersey.version>
     <presto.version>332</presto.version>
     <airlift.version>0.170</airlift.version>
     <objenesis.version>2.6</objenesis.version>


### PR DESCRIPTION
- Update jersey version to 2.34 for the Pulsar SQL to keep consistent with the other components.
- Using a consistent version(1.22) for `jakarta.activation-api`