### PR TITLE
[Broker] Optimize getTopicPolicies: skip unnecessarily thrown exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -148,7 +148,7 @@ public abstract class AbstractTopic implements Topic {
 
     protected boolean isProducersExceeded() {
         Integer maxProducers = null;
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null) {
             maxProducers = topicPolicies.getMaxProducerPerTopic();
         }
@@ -198,7 +198,7 @@ public abstract class AbstractTopic implements Topic {
 
     protected boolean isConsumersExceededOnTopic() {
         Integer maxConsumers = null;
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null) {
             maxConsumers = topicPolicies.getMaxConsumerPerTopic();
         }
@@ -779,7 +779,7 @@ public abstract class AbstractTopic implements Topic {
 
     private void updatePublishDispatcher(Policies policies) {
         //if topic-level policy exists, try to use topic-level publish rate policy
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null && topicPolicies.isPublishRateSet()) {
             log.info("Using topic policy publish rate instead of namespace level topic publish rate on topic {}",
                     this.topic);
@@ -850,24 +850,10 @@ public abstract class AbstractTopic implements Topic {
 
     /**
      * Get {@link TopicPolicies} for this topic.
-     * @param topicName
      * @return TopicPolicies is exist else return null.
      */
-    public TopicPolicies getTopicPolicies(TopicName topicName) {
-        TopicName cloneTopicName = topicName;
-        if (topicName.isPartitioned()) {
-            cloneTopicName = TopicName.get(topicName.getPartitionedTopicName());
-        }
-        try {
-            return brokerService.pulsar().getTopicPoliciesService().getTopicPolicies(cloneTopicName);
-        } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            log.debug("Topic {} policies have not been initialized yet.", topicName.getPartitionedTopicName());
-            return null;
-        } catch (NullPointerException e) {
-            log.debug("Topic level policies are not enabled. "
-                    + "Please refer to systemTopicEnabled and topicLevelPoliciesEnabled on broker.conf");
-            return null;
-        }
+    public TopicPolicies getTopicPolicies() {
+        return brokerService.getTopicPolicies(TopicName.get(topic));
     }
 
     protected int getWaitingProducersCount() {
@@ -876,7 +862,7 @@ public abstract class AbstractTopic implements Topic {
 
     protected boolean isExceedMaximumMessageSize(int size) {
         Integer maxMessageSize = null;
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null && topicPolicies.isMaxMessageSizeSet()) {
             maxMessageSize = topicPolicies.getMaxMessageSize();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2555,35 +2555,29 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     /**
-     * Get {@link TopicPolicies} for this topic.
+     * Get {@link TopicPolicies} for the parameterized topic.
      * @param topicName
      * @return TopicPolicies is exist else return null.
      */
     public TopicPolicies getTopicPolicies(TopicName topicName) {
+        if (!pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
+            return null;
+        }
         TopicName cloneTopicName = topicName;
         if (topicName.isPartitioned()) {
             cloneTopicName = TopicName.get(topicName.getPartitionedTopicName());
         }
         try {
-            checkTopicLevelPolicyEnable();
             return pulsar.getTopicPoliciesService().getTopicPolicies(cloneTopicName);
         } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
             log.debug("Topic {} policies have not been initialized yet.", topicName.getPartitionedTopicName());
             return null;
-        } catch (RestException | NullPointerException e) {
+        } catch (NullPointerException e) {
             log.debug("Topic level policies are not enabled. "
                     + "Please refer to systemTopicEnabled and topicLevelPoliciesEnabled on broker.conf");
             return null;
         }
     }
-
-    private void checkTopicLevelPolicyEnable() {
-        if (!pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
-            throw new RestException(Response.Status.METHOD_NOT_ALLOWED,
-                    "Topic level policies is disabled, to enable the topic level policy and retry.");
-        }
-    }
-
 
     private <T> boolean checkMaxTopicsPerNamespace(TopicName topicName, int numPartitions,
                                             CompletableFuture<T> topicFuture) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -426,12 +426,12 @@ public class MessageDeduplication {
     }
 
     private CompletableFuture<Boolean> isDeduplicationEnabled() {
-        TopicName name = TopicName.get(topic.getName());
         //Topic level setting has higher priority than namespace level
-        TopicPolicies topicPolicies = topic.getTopicPolicies(name);
+        TopicPolicies topicPolicies = topic.getTopicPolicies();
         if (topicPolicies != null && topicPolicies.isDeduplicationSet()) {
             return CompletableFuture.completedFuture(topicPolicies.getDeduplicationEnabled());
         }
+        TopicName name = TopicName.get(topic.getName());
         return pulsar.getConfigurationCache().policiesCache()
                 .getAsync(AdminResource.path(POLICIES, name.getNamespace())).thenApply(policies -> {
                     // If namespace policies have the field set, it will override the broker-level setting
@@ -490,7 +490,7 @@ public class MessageDeduplication {
     public void takeSnapshot() {
         Integer interval = null;
         // try to get topic-level policies
-        TopicPolicies topicPolicies = topic.getTopicPolicies(TopicName.get(topic.getName()));
+        TopicPolicies topicPolicies = topic.getTopicPolicies();
         if (topicPolicies != null) {
             interval = topicPolicies.getDeduplicationSnapshotIntervalSeconds();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -790,7 +790,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     public void updateUnackedMessagesAppliedOnSubscription(Policies policies) {
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null && topicPolicies.isMaxUnackedMessagesOnSubscriptionSet()) {
             maxUnackedMessagesOnSubscriptionApplied = topicPolicies.getMaxUnackedMessagesOnSubscription();
         } else {
@@ -802,7 +802,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     private void updateUnackedMessagesExceededOnConsumer(Policies data) {
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (topicPolicies != null && topicPolicies.isMaxUnackedMessagesOnConsumerSet()) {
             maxUnackedMessagesOnConsumerAppilied = topicPolicies.getMaxUnackedMessagesOnConsumer();
         } else {
@@ -1345,7 +1345,7 @@ public class PersistentTopic extends AbstractTopic
     public void checkCompaction() {
         TopicName name = TopicName.get(topic);
         try {
-            Long compactionThreshold = Optional.ofNullable(getTopicPolicies(name))
+            Long compactionThreshold = Optional.ofNullable(getTopicPolicies())
                 .map(TopicPolicies::getCompactionThreshold)
                 .orElse(null);
             if (compactionThreshold == null) {
@@ -2181,13 +2181,13 @@ public class PersistentTopic extends AbstractTopic
      * marked as inactive.
      */
     private boolean shouldTopicBeRetained() {
-        TopicName name = TopicName.get(topic);
         RetentionPolicies retentionPolicies = null;
         try {
-            retentionPolicies = Optional.ofNullable(getTopicPolicies(name))
+            retentionPolicies = Optional.ofNullable(getTopicPolicies())
                     .map(TopicPolicies::getRetentionPolicies)
                     .orElse(null);
             if (retentionPolicies == null){
+                TopicName name = TopicName.get(topic);
                 retentionPolicies = brokerService.pulsar().getConfigurationCache().policiesCache()
                         .get(AdminResource.path(POLICIES, name.getNamespace()))
                         .map(p -> p.retention_policies)
@@ -2238,7 +2238,7 @@ public class PersistentTopic extends AbstractTopic
             delayedDeliveryEnabled = data.delayed_delivery_policies.isActive();
         }
         //If the topic-level policy already exists, the namespace-level policy cannot override the topic-level policy.
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         if (data.inactive_topic_policies != null) {
             if (topicPolicies == null || !topicPolicies.isInactiveTopicPoliciesSet()) {
                 this.inactiveTopicPolicies = data.inactive_topic_policies;
@@ -2656,7 +2656,7 @@ public class PersistentTopic extends AbstractTopic
         //Return Topic level message TTL if exist. If topic level policy or message ttl is not set,
         //fall back to namespace level message ttl then message ttl set for current broker.
         TopicName name = TopicName.get(topic);
-        TopicPolicies topicPolicies = getTopicPolicies(name);
+        TopicPolicies topicPolicies = getTopicPolicies();
         Policies policies = brokerService.pulsar().getConfigurationCache().policiesCache()
                 .get(AdminResource.path(POLICIES, name.getNamespace()))
                 .orElseThrow(KeeperException.NoNodeException::new);
@@ -2866,7 +2866,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     public long getDelayedDeliveryTickTimeMillis() {
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         //Topic level setting has higher priority than namespace level
         if (topicPolicies != null && topicPolicies.isDelayedDeliveryTickTimeMillisSet()) {
             return topicPolicies.getDelayedDeliveryTickTimeMillis();
@@ -2879,7 +2879,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     public boolean isDelayedDeliveryEnabled() {
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         //Topic level setting has higher priority than namespace level
         if (topicPolicies != null && topicPolicies.isDelayedDeliveryEnabledSet()) {
             return topicPolicies.getDelayedDeliveryEnabled();
@@ -2995,7 +2995,7 @@ public class PersistentTopic extends AbstractTopic
         if (StringUtils.isNotEmpty(subscriptionName) && getSubscription(subscriptionName) != null) {
             return false;
         }
-        TopicPolicies topicPolicies = getTopicPolicies(TopicName.get(topic));
+        TopicPolicies topicPolicies = getTopicPolicies();
         Integer maxSubsPerTopic = null;
         if (topicPolicies != null && topicPolicies.isMaxSubscriptionsPerTopicSet()) {
             maxSubsPerTopic = topicPolicies.getMaxSubscriptionsPerTopic();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -51,7 +51,7 @@ public class SubscribeRateLimiter {
         subscribeRateLimiter = new ConcurrentHashMap<>();
         this.executorService = brokerService.pulsar().getExecutor();
         // get subscribeRate from topic level policies
-        this.subscribeRate = Optional.ofNullable(brokerService.getTopicPolicies(TopicName.get(this.topicName)))
+        this.subscribeRate = Optional.ofNullable(topic.getTopicPolicies())
                 .map(TopicPolicies::getSubscribeRate)
                 .orElse(null);
 


### PR DESCRIPTION
### Motivation

It is better to return null than to create an exception, catch it, then return null. The modified code will no longer throw an unnecessary exception.

### Modifications

This PR updates the `getTopicPolicies` to check a config to return null instead of throwing an exception. Additionally, this PR reduces some code duplication by simplifying the two `getTopicPolicies` methods and removing an unnecessary parameter.

### Verifying this change

This change is a trivial rework of the `getTopicPolicies` methods. Passing tests should be sufficient verification.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no