### PR TITLE
[Broker] Add multi roles support for authentication and authorization

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -73,6 +73,10 @@ public interface AuthenticationProvider extends Closeable {
         throw new AuthenticationException(MULTI_ROLE_NOT_SUPPORTED);
     }
 
+    default boolean isSupportMultiRoles() {
+        return false;
+    }
+
     /**
      * Create an authentication data State use passed in AuthenticationDataSource.
      */

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.IOException;
 
 import java.net.SocketAddress;
+import java.util.List;
 import javax.naming.AuthenticationException;
 
 import javax.net.ssl.SSLSession;
@@ -35,6 +36,8 @@ import org.apache.pulsar.common.api.AuthData;
  * Provider of authentication mechanism
  */
 public interface AuthenticationProvider extends Closeable {
+
+    String MULTI_ROLE_NOT_SUPPORTED = "Multi role not supported";
 
     /**
      * Perform initialization for the authentication provider
@@ -63,7 +66,11 @@ public interface AuthenticationProvider extends Closeable {
      *             if the credentials are not valid
      */
     default String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
-        throw new AuthenticationException("Not supported");
+        return authenticate(authData, false).get(0);
+    }
+
+    default List<String> authenticate(AuthenticationDataSource authData, boolean multiRoles) throws AuthenticationException {
+        throw new AuthenticationException(MULTI_ROLE_NOT_SUPPORTED);
     }
 
     /**

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -66,7 +66,7 @@ public interface AuthenticationProvider extends Closeable {
      *             if the credentials are not valid
      */
     default String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
-        return authenticate(authData, false).get(0);
+        throw new AuthenticationException("Not supported");
     }
 
     default List<String> authenticate(AuthenticationDataSource authData, boolean multiRoles) throws AuthenticationException {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderList.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderList.java
@@ -89,6 +89,11 @@ public class AuthenticationProviderList implements AuthenticationProvider {
         }
 
         @Override
+        public List<String> getAuthRoles() throws AuthenticationException {
+            return getAuthState().getAuthRoles();
+        }
+
+        @Override
         public AuthData authenticate(AuthData authData) throws AuthenticationException {
             return applyAuthProcessor(
                 states,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -144,6 +144,15 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
     }
 
     @Override
+    public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
+        List<String> principals = authenticate(authData, false);
+        if (principals == null) {
+            return null;
+        }
+        return principals.get(0);
+    }
+
+    @Override
     public List<String> authenticate(AuthenticationDataSource authData, boolean multiRoles) throws AuthenticationException {
         try {
             // Get Token

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -152,7 +152,7 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
             // Parse Token by validating
             String role;
             List<String> principals = getPrincipals(authenticateToken(token));
-            if (principals == null) {
+            if (principals == null) { // Empty list check has been done in getPrincipals.
                 role = null;
             } else {
                 role = principals.get(0);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -161,11 +161,11 @@ public class AuthenticationProviderToken implements AuthenticationProvider {
             // Parse Token by validating
             List<String> principals = getPrincipals(authenticateToken(token));
             AuthenticationMetrics.authenticateSuccess(getClass().getSimpleName(), getAuthMethodName());
-            if(multiRoles){
+            if (multiRoles) {
                 return principals;
-            }else if(principals == null){ // Empty list check has been done in getPrincipals.
+            } else if (principals == null) { // Empty list check has been done in getPrincipals.
                 return null;
-            }else{
+            } else {
                 return Collections.singletonList(principals.get(0));
             }
         } catch (AuthenticationException exception) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
@@ -40,6 +40,9 @@ public interface AuthenticationState {
     String getAuthRole() throws AuthenticationException;
 
     default List<String> getAuthRoles() throws AuthenticationException {
+        if (getAuthRole() == null) {
+            return Collections.emptyList();
+        }
         return Collections.singletonList(getAuthRole());
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.authentication;
 
+import java.util.Collections;
 import java.util.List;
 import javax.naming.AuthenticationException;
 
@@ -38,7 +39,9 @@ public interface AuthenticationState {
      */
     String getAuthRole() throws AuthenticationException;
 
-    List<String> getAuthRoles() throws AuthenticationException;
+    default List<String> getAuthRoles() throws AuthenticationException {
+        return Collections.singletonList(getAuthRole());
+    }
 
     /**
      * Challenge passed in auth data and get response data.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.authentication;
 
+import java.util.List;
 import javax.naming.AuthenticationException;
 
 import org.apache.pulsar.common.api.AuthData;
@@ -36,6 +37,8 @@ public interface AuthenticationState {
      * It should throw exception if auth not complete.
      */
     String getAuthRole() throws AuthenticationException;
+
+    List<String> getAuthRoles() throws AuthenticationException;
 
     /**
      * Challenge passed in auth data and get response data.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -59,6 +59,9 @@ public class OneStageAuthenticationState implements AuthenticationState {
 
     @Override
     public String getAuthRole() {
+        if (authRoles == null || authRoles.isEmpty()) {
+            return null;
+        }
         return authRoles.get(0);
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -46,13 +46,14 @@ public class OneStageAuthenticationState implements AuthenticationState {
                                        AuthenticationProvider provider) throws AuthenticationException {
         this.authenticationDataSource = new AuthenticationDataCommand(
             new String(authData.getBytes(), UTF_8), remoteAddress, sslSession);
-        try {
+        if (provider.isSupportMultiRoles()) {
             this.authRoles = provider.authenticate(authenticationDataSource, true);
-        } catch (AuthenticationException e) {
-            if (e.getMessage().equals(MULTI_ROLE_NOT_SUPPORTED)) {
-                this.authRoles = Collections.singletonList(provider.authenticate(authenticationDataSource));
+        } else {
+            String role = provider.authenticate(authenticationDataSource);
+            if (role == null) {
+                this.authRoles = Collections.emptyList();
             } else {
-                throw e;
+                this.authRoles = Collections.singletonList(role);
             }
         }
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -19,8 +19,8 @@
 
 package org.apache.pulsar.broker.authentication;
 
-import com.google.common.collect.Lists;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.List;
 import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
@@ -50,7 +50,7 @@ public class OneStageAuthenticationState implements AuthenticationState {
             this.authRoles = provider.authenticate(authenticationDataSource, true);
         } catch (AuthenticationException e) {
             if (e.getMessage().equals(MULTI_ROLE_NOT_SUPPORTED)) {
-                this.authRoles = Lists.newArrayList(provider.authenticate(authenticationDataSource));
+                this.authRoles = Collections.singletonList(provider.authenticate(authenticationDataSource));
             } else {
                 throw e;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -32,6 +32,7 @@ import com.google.gson.JsonObject;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -240,7 +241,7 @@ public class PersistentTopicsBase extends AdminResource {
             validateAdminAccessForTenant(topicName.getTenant());
         } catch (Exception ve) {
             try {
-                checkAuthorization(pulsar(), topicName, clientAppId(), clientAuthData());
+                checkAuthorization(pulsar(), topicName, Collections.singletonList(clientAppId()), clientAuthData());
             } catch (RestException re) {
                 throw re;
             } catch (Exception e) {
@@ -3315,7 +3316,7 @@ public class PersistentTopicsBase extends AdminResource {
         try {
             // (1) authorize client
             try {
-                checkAuthorization(pulsar, topicName, clientAppId, authenticationData);
+                checkAuthorization(pulsar, topicName, Collections.singletonList(clientAppId), authenticationData);
             } catch (RestException e) {
                 try {
                     validateAdminAccessForTenant(pulsar,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.common.protocol.Commands.newLookupResponse;
 import io.netty.buffer.ByteBuf;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -171,7 +172,8 @@ public class TopicLookupBase extends PulsarWebResource {
      * @return
      */
     public static CompletableFuture<ByteBuf> lookupTopicAsync(PulsarService pulsarService, TopicName topicName,
-            boolean authoritative, String clientAppId, AuthenticationDataSource authenticationData, long requestId) {
+            boolean authoritative, List<String> clientAppId, AuthenticationDataSource authenticationData,
+                                                              long requestId) {
         return lookupTopicAsync(pulsarService, topicName, authoritative, clientAppId,
                 authenticationData, requestId, null);
     }
@@ -199,7 +201,7 @@ public class TopicLookupBase extends PulsarWebResource {
      * @return
      */
     public static CompletableFuture<ByteBuf> lookupTopicAsync(PulsarService pulsarService, TopicName topicName,
-                                                              boolean authoritative, String clientAppId,
+                                                              boolean authoritative, List<String> clientAppId,
                                                               AuthenticationDataSource authenticationData,
                                                               long requestId, final String advertisedListenerName) {
 
@@ -208,7 +210,8 @@ public class TopicLookupBase extends PulsarWebResource {
         final String cluster = topicName.getCluster();
 
         // (1) validate cluster
-        getClusterDataIfDifferentCluster(pulsarService, cluster, clientAppId).thenAccept(differentClusterData -> {
+        getClusterDataIfDifferentCluster(pulsarService, cluster, clientAppId.get(0))
+                .thenAccept(differentClusterData -> {
 
             if (differentClusterData != null) {
                 if (log.isDebugEnabled()) {
@@ -221,7 +224,15 @@ public class TopicLookupBase extends PulsarWebResource {
             } else {
                 // (2) authorize client
                 try {
-                    checkAuthorization(pulsarService, topicName, clientAppId, authenticationData);
+                    for (int i = 0; i < clientAppId.size(); i++) {
+                        try {
+                            checkAuthorization(pulsarService, topicName, clientAppId.get(i), authenticationData);
+                        } catch (RestException authException) {
+                            if (i == clientAppId.size() - 1) {
+                                throw authException;
+                            }
+                        }
+                    }
                 } catch (RestException authException) {
                     log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName.toString());
                     validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -210,7 +210,8 @@ public class TopicLookupBase extends PulsarWebResource {
         final String cluster = topicName.getCluster();
 
         // (1) validate cluster
-        getClusterDataIfDifferentCluster(pulsarService, cluster, clientAppId.get(0))
+        getClusterDataIfDifferentCluster(pulsarService, cluster,
+                clientAppId != null && !clientAppId.isEmpty() ? clientAppId.get(0) : null)
                 .thenAccept(differentClusterData -> {
 
             if (differentClusterData != null) {
@@ -224,15 +225,7 @@ public class TopicLookupBase extends PulsarWebResource {
             } else {
                 // (2) authorize client
                 try {
-                    for (int i = 0; i < clientAppId.size(); i++) {
-                        try {
-                            checkAuthorization(pulsarService, topicName, clientAppId.get(i), authenticationData);
-                        } catch (RestException authException) {
-                            if (i == clientAppId.size() - 1) {
-                                throw authException;
-                            }
-                        }
-                    }
+                    checkAuthorization(pulsarService, topicName, clientAppId, authenticationData);
                 } catch (RestException authException) {
                     log.warn("Failed to authorized {} on cluster {}", clientAppId, topicName.toString());
                     validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -625,10 +625,17 @@ public class Producer {
         TopicName topicName = TopicName.get(topic.getName());
         if (cnx.getBrokerService().getAuthorizationService() != null) {
             try {
-                for (String appId : appIds) {
-                    if (cnx.getBrokerService().getAuthorizationService().canProduce(topicName, appId,
+                if (appIds == null) {
+                    if (cnx.getBrokerService().getAuthorizationService().canProduce(topicName, null,
                             cnx.getAuthenticationData())) {
                         return;
+                    }
+                } else {
+                    for (String appId : appIds) {
+                        if (cnx.getBrokerService().getAuthorizationService().canProduce(topicName, appId,
+                                cnx.getAuthenticationData())) {
+                            return;
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -356,7 +356,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             return true;
                         }
                     } catch (InterruptedException | ExecutionException e) {
-                        e.printStackTrace();
+                        log.warn("Exception occurred while trying to authorize topic operation {}: {}", operation, e);
                     }
                 }
                 return false;
@@ -794,12 +794,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // Not find provider named authMethod. Most used for tests.
             // In AuthenticationDisabled, it will set authMethod "none".
             if (authenticationProvider == null) {
-                authRoles = Collections.singletonList(getBrokerService()
-                        .getAuthenticationService()
-                        .getAnonymousUserRole()
-                        .orElseThrow(() ->
+                final String anonymousUserRole = getBrokerService().getAuthenticationService().getAnonymousUserRole().
+                        orElseThrow(() ->
                                 new AuthenticationException("No anonymous role, and no authentication provider "
-                                        + "configured")));
+                                        + "configured"));
+                authRoles = StringUtils.isNotEmpty(anonymousUserRole)
+                        ? Collections.singletonList(anonymousUserRole) : Collections.emptyList();
                 completeConnect(clientProtocolVersion, clientVersion);
                 return;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -349,7 +349,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 isProxyAuthorizedFuture = CompletableFuture.completedFuture(true);
             }
             isAuthorizedFuture = CompletableFuture.supplyAsync(() -> {
-                log.debug("Start authorization");
                 for (String authRole : authRoles) {
                     try {
                         if (service.getAuthorizationService().allowTopicOperationAsync(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -356,6 +356,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             return true;
                         }
                     } catch (InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
                     }
                 }
                 return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -788,11 +788,14 @@ public abstract class PulsarWebResource {
             return;
         }
         // get zk policy manager
-        if (!pulsarService.getBrokerService().getAuthorizationService().allowTopicOperation(topicName,
-                TopicOperation.LOOKUP, null, role, authenticationData)) {
-            log.warn("[{}] Role {} is not allowed to lookup topic", topicName, role);
-            throw new RestException(Status.UNAUTHORIZED, "Don't have permission to connect to this namespace");
+        for (String role : roles) {
+            if (pulsarService.getBrokerService().getAuthorizationService().allowTopicOperation(topicName,
+                    TopicOperation.LOOKUP, null, role, authenticationData)) {
+                return;
+            }
         }
+        log.warn("[{}] Roles {} are all not allowed to lookup topic", topicName, roles);
+        throw new RestException(Status.UNAUTHORIZED, "Don't have permission to connect to this namespace");
     }
 
     // Used for unit tests access

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -781,7 +781,7 @@ public abstract class PulsarWebResource {
         return null;
     }
 
-    protected static void checkAuthorization(PulsarService pulsarService, TopicName topicName, String role,
+    protected static void checkAuthorization(PulsarService pulsarService, TopicName topicName, List<String> roles,
             AuthenticationDataSource authenticationData) throws Exception {
         if (!pulsarService.getConfiguration().isAuthorizationEnabled()) {
             // No enforcing of authorization policies

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -393,7 +393,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     public void testAddRemoveProducer() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
 
-        String role = "appid1";
+        List<String> role = Collections.singletonList("appid1");
         // 1. simple add producer
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, false,
@@ -433,7 +433,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     @Test
     public void testProducerOverwrite() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        String role = "appid1";
+        List<String> role = Collections.singletonList("appid1");
         Producer producer1 = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                 role, false, null, SchemaVersion.Latest, 0, true, ProducerAccessMode.Shared, Optional.empty());
         Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name",
@@ -502,7 +502,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     private void testMaxProducers() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        String role = "appid1";
+        List<String> role = Collections.singletonList("appid1");
         // 1. add producer1
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role,
                 false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());
@@ -551,7 +551,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     private Producer getMockedProducerWithSpecificAddress(Topic topic, long producerId, InetAddress address)
             throws Exception {
         final String producerNameBase = "producer";
-        final String role = "appid1";
+        final List<String> role = Collections.singletonList("appid1");
 
         ServerCnx cnx = spy(new ServerCnx(pulsar));
         doReturn(true).when(cnx).isActive();
@@ -1175,7 +1175,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         assertFalse((boolean) isFencedField.get(topic));
         assertFalse((boolean) isClosingOrDeletingField.get(topic));
 
-        String role = "appid1";
+        List<String> role = Collections.singletonList("appid1");
         // 1. delete inactive topic
         topic.delete().get();
         assertFalse(brokerService.getTopicReference(successTopicName).isPresent());
@@ -1385,7 +1385,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         }).get();
 
         try {
-            String role = "appid1";
+            List<String> role = Collections.singletonList("appid1");
             Thread.sleep(10); /* delay to ensure that the delete gets executed first */
             Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
                     role, false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMo
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.matches;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -500,6 +502,60 @@ public class ServerCnxTest {
     }
 
     @Test(timeOut = 30000)
+    public void testProducerCommandWithMultiRolesAuthPositive() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+        AuthenticationState authenticationState = mock(AuthenticationState.class);
+        AuthenticationDataSource authenticationDataSource = mock(AuthenticationDataSource.class);
+        AuthData authData = AuthData.of(null);
+
+        doReturn(authenticationService).when(brokerService).getAuthenticationService();
+        doReturn(authenticationProvider).when(authenticationService).getAuthenticationProvider(Mockito.anyString());
+        doReturn(authenticationState).when(authenticationProvider)
+                .newAuthState(Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authData).when(authenticationState)
+                .authenticate(authData);
+        doReturn(true).when(authenticationState)
+                .isComplete();
+
+        doReturn(Arrays.asList("not-allowed","allowed")).when(authenticationState)
+                .getAuthRoles();
+
+        doReturn(true).when(brokerService).isAuthenticationEnabled();
+        doReturn(true).when(brokerService).isAuthorizationEnabled();
+
+        AuthorizationService authorizationService = mock(AuthorizationService.class);
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), eq("not-allowed"), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), eq("allowed"), Mockito.any());
+        doReturn(authorizationService).when(brokerService).getAuthorizationService();
+        doReturn(true).when(brokerService).isAuthenticationEnabled();
+        resetChannel();
+
+        // test server response to CONNECT
+        ByteBuf connectCommand = Commands.newConnect("none", "", null);
+        channel.writeInbound(connectCommand);
+
+        assertEquals(serverCnx.getState(), State.Connected);
+        assertTrue(getResponse() instanceof CommandConnected);
+
+        // test PRODUCER success case
+        ByteBuf clientCommand = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
+                "prod-name", Collections.emptyMap());
+        channel.writeInbound(clientCommand);
+        assertEquals(getResponse().getClass(), CommandProducerSuccess.class);
+
+        PersistentTopic topicRef = (PersistentTopic) brokerService.getTopicReference(successTopicName).get();
+
+        assertNotNull(topicRef);
+        assertEquals(topicRef.getProducers().size(), 1);
+
+        channel.finish();
+        assertEquals(topicRef.getProducers().size(), 0);
+    }
+
+    @Test(timeOut = 30000)
     public void testNonExistentTopic() throws Exception {
         ZooKeeperDataCache<Policies> zkDataCache = mock(ZooKeeperDataCache.class);
         ConfigurationCacheService configCacheService = mock(ConfigurationCacheService.class);
@@ -618,6 +674,50 @@ public class ServerCnxTest {
         doReturn("prod1").when(brokerService).generateUniqueProducerName();
         resetChannel();
         setChannelConnected();
+
+        ByteBuf clientCommand = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
+                null, Collections.emptyMap());
+        channel.writeInbound(clientCommand);
+        assertTrue(getResponse() instanceof CommandError);
+
+        channel.finish();
+    }
+
+    @Test(timeOut = 30000)
+    public void testProducerCommandWithMultiRolesAuthNegative() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+        AuthenticationState authenticationState = mock(AuthenticationState.class);
+        AuthenticationDataSource authenticationDataSource = mock(AuthenticationDataSource.class);
+        AuthData authData = AuthData.of(null);
+
+        doReturn(authenticationService).when(brokerService).getAuthenticationService();
+        doReturn(authenticationProvider).when(authenticationService).getAuthenticationProvider(Mockito.anyString());
+        doReturn(authenticationState).when(authenticationProvider)
+                .newAuthState(Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authData).when(authenticationState)
+                .authenticate(authData);
+        doReturn(true).when(authenticationState)
+                .isComplete();
+
+        doReturn(Arrays.asList("role-1","role-2")).when(authenticationState)
+                .getAuthRoles();
+
+        AuthorizationService authorizationService = mock(AuthorizationService.class);
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authorizationService).when(brokerService).getAuthorizationService();
+        doReturn(true).when(brokerService).isAuthenticationEnabled();
+        doReturn(true).when(brokerService).isAuthorizationEnabled();
+        doReturn("prod1").when(brokerService).generateUniqueProducerName();
+        resetChannel();
+
+        // test server response to CONNECT
+        ByteBuf connectCommand = Commands.newConnect("none", "", null);
+        channel.writeInbound(connectCommand);
+
+        assertEquals(serverCnx.getState(), State.Connected);
+        assertTrue(getResponse() instanceof CommandConnected);
 
         ByteBuf clientCommand = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
                 null, Collections.emptyMap());
@@ -1222,6 +1322,54 @@ public class ServerCnxTest {
     }
 
     @Test(timeOut = 30000)
+    public void testSubscribeCommandWithMultiRolesAuthPositive() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+        AuthenticationState authenticationState = mock(AuthenticationState.class);
+        AuthenticationDataSource authenticationDataSource = mock(AuthenticationDataSource.class);
+        AuthData authData = AuthData.of(null);
+
+        doReturn(authenticationService).when(brokerService).getAuthenticationService();
+        doReturn(authenticationProvider).when(authenticationService).getAuthenticationProvider(Mockito.anyString());
+        doReturn(authenticationState).when(authenticationProvider)
+                .newAuthState(Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authData).when(authenticationState)
+                .authenticate(authData);
+        doReturn(true).when(authenticationState)
+                .isComplete();
+
+        doReturn(Arrays.asList("not-allowed","allowed")).when(authenticationState)
+                .getAuthRoles();
+
+        AuthorizationService authorizationService = mock(AuthorizationService.class);
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), eq("not-allowed"), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), eq("allowed"), Mockito.any());
+        doReturn(authorizationService).when(brokerService).getAuthorizationService();
+        doReturn(true).when(brokerService).isAuthenticationEnabled();
+        doReturn(true).when(brokerService).isAuthorizationEnabled();
+        resetChannel();
+
+        // test server response to CONNECT
+        ByteBuf connectCommand = Commands.newConnect("none", "", null);
+        channel.writeInbound(connectCommand);
+
+        assertEquals(serverCnx.getState(), State.Connected);
+        assertTrue(getResponse() instanceof CommandConnected);
+
+        // test SUBSCRIBE on topic and cursor creation success
+        ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
+                "test" /* consumer name */, 0 /* avoid reseting cursor */);
+        channel.writeInbound(clientCommand);
+
+        assertTrue(getResponse() instanceof CommandSuccess);
+
+        channel.finish();
+    }
+
+    @Test(timeOut = 30000)
     public void testSubscribeCommandWithAuthorizationNegative() throws Exception {
         AuthorizationService authorizationService = mock(AuthorizationService.class);
         doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
@@ -1232,6 +1380,51 @@ public class ServerCnxTest {
 
         resetChannel();
         setChannelConnected();
+
+        // test SUBSCRIBE on topic and cursor creation success
+        ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */, 0 /*avoid reseting cursor*/);
+        channel.writeInbound(clientCommand);
+        assertTrue(getResponse() instanceof CommandError);
+
+        channel.finish();
+    }
+
+    @Test(timeOut = 30000)
+    public void testSubscribeCommandWithMultiRolesAuthNegative() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+        AuthenticationState authenticationState = mock(AuthenticationState.class);
+        AuthenticationDataSource authenticationDataSource = mock(AuthenticationDataSource.class);
+        AuthData authData = AuthData.of(null);
+
+        doReturn(authenticationService).when(brokerService).getAuthenticationService();
+        doReturn(authenticationProvider).when(authenticationService).getAuthenticationProvider(Mockito.anyString());
+        doReturn(authenticationState).when(authenticationProvider)
+                .newAuthState(Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authData).when(authenticationState)
+                .authenticate(authData);
+        doReturn(true).when(authenticationState)
+                .isComplete();
+
+        doReturn(Arrays.asList("role-1","role-2")).when(authenticationState)
+                .getAuthRoles();
+
+        AuthorizationService authorizationService = mock(AuthorizationService.class);
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationService).allowTopicOperationAsync(Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any());
+        doReturn(authorizationService).when(brokerService).getAuthorizationService();
+        doReturn(true).when(brokerService).isAuthenticationEnabled();
+        doReturn(true).when(brokerService).isAuthorizationEnabled();
+
+        resetChannel();
+
+        // test server response to CONNECT
+        ByteBuf connectCommand = Commands.newConnect("none", "", null);
+        channel.writeInbound(connectCommand);
+
+        assertEquals(serverCnx.getState(), State.Connected);
+        assertTrue(getResponse() instanceof CommandConnected);
 
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -93,7 +93,6 @@ import org.apache.pulsar.common.protocol.PulsarHandler;
 import org.apache.pulsar.common.api.proto.AuthMethod;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
-import org.apache.pulsar.common.api.proto.CommandConnect;
 import org.apache.pulsar.common.api.proto.CommandConnected;
 import org.apache.pulsar.common.api.proto.CommandError;
 import org.apache.pulsar.common.api.proto.CommandLookupTopicResponse;
@@ -103,7 +102,6 @@ import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
-import org.apache.pulsar.common.api.proto.EncryptionKeys;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.ServerError;
@@ -1467,7 +1465,7 @@ public class ServerCnxTest {
             channel.close().get();
         }
         serverCnx = new ServerCnx(pulsar);
-        serverCnx.authRole = Collections.singletonList("");
+        serverCnx.authRoles = Collections.singletonList("");
         channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(
                 MaxMessageSize,
                 0,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1467,7 +1467,7 @@ public class ServerCnxTest {
             channel.close().get();
         }
         serverCnx = new ServerCnx(pulsar);
-        serverCnx.authRole = "";
+        serverCnx.authRole = Collections.singletonList("");
         channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(
                 MaxMessageSize,
                 0,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -598,6 +598,7 @@ public class ServerCnxTest {
                 successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
                 "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(newSubscribeCmd);
+        Thread.sleep(500); // Waiting for processing newSubscribeCmd
         topicRef = (PersistentTopic) brokerService.getTopicReference(nonExistentTopicName).get();
         assertNotNull(topicRef);
         assertTrue(topicRef.getSubscriptions().containsKey(successSubName));


### PR DESCRIPTION

### Motivation

In https://github.com/apache/pulsar/pull/10375, we add multi roles support for JWT authentication. But the authorization does not support multi roles currently. Only the first one in the roles array will be used during authorization. This PR adds multi roles support for both authentication and authorization.

### Modifications

* Change the `AuthenticationState` interface to make it keep an array of principals
* Change the authorization logic to do the permission verification over an array of principals iteratively. Return true when the principal has permission, or return false if all principals verified failed.
