### PR TITLE
[Transaction] Fix transaction ack one topic with multi sub.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import com.google.common.collect.Lists;
-import javafx.util.Pair;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException.InvalidTxnStatusException;
@@ -118,7 +118,7 @@ public class TransactionImpl implements Transaction {
         return checkIfOpen().thenCompose(value -> {
             synchronized (TransactionImpl.this) {
                 // we need to issue the request to TC to register the acked topic
-                return registerSubscriptionMap.compute(new Pair<>(topic, subscription), (key, future) -> {
+                return registerSubscriptionMap.compute(Pair.of(topic, subscription), (key, future) -> {
                     if (future != null) {
                         return future.thenCompose(ignored -> CompletableFuture.completedFuture(null));
                     } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import com.google.common.collect.Lists;
+import javafx.util.Pair;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
@@ -55,7 +56,7 @@ public class TransactionImpl implements Transaction {
     private final long txnIdMostBits;
 
     private final Map<String, CompletableFuture<Void>> registerPartitionMap;
-    private final Map<String, CompletableFuture<Void>> registerSubscriptionMap;
+    private final Map<Pair<String, String>, CompletableFuture<Void>> registerSubscriptionMap;
     private final TransactionCoordinatorClientImpl tcClient;
     private Map<ConsumerImpl<?>, Integer> cumulativeAckConsumers;
 
@@ -117,7 +118,7 @@ public class TransactionImpl implements Transaction {
         return checkIfOpen().thenCompose(value -> {
             synchronized (TransactionImpl.this) {
                 // we need to issue the request to TC to register the acked topic
-                return registerSubscriptionMap.compute(topic + "-" + subscription, (key, future) -> {
+                return registerSubscriptionMap.compute(new Pair<>(topic, subscription), (key, future) -> {
                     if (future != null) {
                         return future.thenCompose(ignored -> CompletableFuture.completedFuture(null));
                     } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -117,7 +117,7 @@ public class TransactionImpl implements Transaction {
         return checkIfOpen().thenCompose(value -> {
             synchronized (TransactionImpl.this) {
                 // we need to issue the request to TC to register the acked topic
-                return registerSubscriptionMap.compute(topic, (key, future) -> {
+                return registerSubscriptionMap.compute(topic + "-" + subscription, (key, future) -> {
                     if (future != null) {
                         return future.thenCompose(ignored -> CompletableFuture.completedFuture(null));
                     } else {


### PR DESCRIPTION
## Motivation
Now Transaction ack one topic with multi sub will be filtered. fix it.

## implement
add topic + subName filter.
This is transaction component status.
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (yes)
Anything that affects deployment: (no)

