### PR TITLE
AutoConsumeSchema: use decode(payload, schemaversion)

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -108,7 +108,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
         fetchSchemaIfNeeded(sv);
         ensureSchemaInitialized(sv);
-        return adapt(schemaMap.get(sv).decode(bytes), schemaVersion);
+        return adapt(schemaMap.get(sv).decode(bytes, schemaVersion), schemaVersion);
     }
 
     @Override


### PR DESCRIPTION
In `AutoConsumeSchema.decode `we should proxy the call to "`decode(payload, schemaversion)`" correctly to the wrapped Schema.

Even if the Schema is picked up from a map (`schemaMap`) that keeps track of the _schemaversion_, we must pass the correct `schemaversion` to the underlying Schema.

Some Schema implementations may fall back to using the "latest schema" if you pass "null" as _schemaversion_ or call `decode(payload)` (without _schemaversion_), leading to non consistent behaviour