### PR TITLE
Async the method onManagedLedgerLastLedgerInitialize for ManagedLedgerInterceptor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -165,6 +165,10 @@ public class ManagedLedgerException extends Exception {
         public ManagedLedgerInterceptException(String msg) {
             super(msg);
         }
+
+        public ManagedLedgerInterceptException(Throwable e) {
+            super(e);
+        }
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -356,12 +356,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                 ledgers.put(id, info);
                                 if (managedLedgerInterceptor != null) {
                                     managedLedgerInterceptor.onManagedLedgerLastLedgerInitialize(name, lh)
-                                        .whenComplete((__, ex) -> {
-                                            if (ex != null) {
-                                                callback.initializeFailed(new ManagedLedgerInterceptException(ex));
-                                            } else {
-                                                initializeBookKeeper(callback);
-                                            }
+                                        .thenRun(() -> initializeBookKeeper(callback))
+                                        .exceptionally(ex -> {
+                                            callback.initializeFailed(
+                                                    new ManagedLedgerInterceptException(ex.getCause()));
+                                            return null;
                                         });
                                 } else {
                                     initializeBookKeeper(callback);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -24,6 +24,7 @@ import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interceptor for ManagedLedger.
@@ -51,7 +52,7 @@ public interface ManagedLedgerInterceptor {
      * @param name name of ManagedLedger
      * @param ledgerHandle a LedgerHandle.
      */
-    void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
+    CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
 
     /**
      * @param propertiesMap  map of properties.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -21,9 +21,7 @@ package org.apache.pulsar.broker.intercept;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
@@ -96,10 +94,10 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
                         try {
                             LedgerEntry ledgerEntry = entries.getEntry(lh.getLastAddConfirmed());
                             if (ledgerEntry != null) {
+                                BrokerEntryMetadata brokerEntryMetadata =
+                                        Commands.parseBrokerEntryMetadataIfExist(ledgerEntry.getEntryBuffer());
                                 for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
                                     if (interceptor instanceof AppendIndexMetadataInterceptor) {
-                                        BrokerEntryMetadata brokerEntryMetadata =
-                                                Commands.parseBrokerEntryMetadataIfExist(ledgerEntry.getEntryBuffer());
                                         if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
                                             ((AppendIndexMetadataInterceptor) interceptor)
                                                     .recoveryIndexGenerator(brokerEntryMetadata.getIndex());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.intercept;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
@@ -80,31 +82,47 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle lh) {
-        LedgerEntries ledgerEntries = null;
-        try {
-            for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
-                if (interceptor instanceof AppendIndexMetadataInterceptor && lh.getLastAddConfirmed() >= 0) {
-                    ledgerEntries =
-                            lh.read(lh.getLastAddConfirmed(), lh.getLastAddConfirmed());
-                    for (LedgerEntry entry : ledgerEntries) {
-                        BrokerEntryMetadata brokerEntryMetadata =
-                                Commands.parseBrokerEntryMetadataIfExist(entry.getEntryBuffer());
-                        if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
-                            ((AppendIndexMetadataInterceptor) interceptor)
-                                    .recoveryIndexGenerator(brokerEntryMetadata.getIndex());
+    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle lh) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        boolean hasAppendIndexMetadataInterceptor = brokerEntryMetadataInterceptors.stream()
+                .anyMatch(interceptor -> interceptor instanceof AppendIndexMetadataInterceptor);
+        if (hasAppendIndexMetadataInterceptor && lh.getLastAddConfirmed() >= 0) {
+            lh.readAsync(lh.getLastAddConfirmed(), lh.getLastAddConfirmed()).whenComplete((entries, ex) -> {
+                if (ex != null) {
+                    log.error("[{}] Read last entry error.", name, ex);
+                    promise.completeExceptionally(ex);
+                } else {
+                    if (entries != null) {
+                        try {
+                            LedgerEntry ledgerEntry = entries.getEntry(lh.getLastAddConfirmed());
+                            if (ledgerEntry != null) {
+                                for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
+                                    if (interceptor instanceof AppendIndexMetadataInterceptor) {
+                                        BrokerEntryMetadata brokerEntryMetadata =
+                                                Commands.parseBrokerEntryMetadataIfExist(ledgerEntry.getEntryBuffer());
+                                        if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
+                                            ((AppendIndexMetadataInterceptor) interceptor)
+                                                    .recoveryIndexGenerator(brokerEntryMetadata.getIndex());
+                                        }
+                                    }
+                                }
+                            }
+                            entries.close();
+                            promise.complete(null);
+                        } catch (Exception e) {
+                            log.error("[{}] Failed to recover the index generator from the last add confirmed entry.",
+                                    name, e);
+                            promise.completeExceptionally(e);
                         }
+                    } else {
+                        promise.complete(null);
                     }
-
                 }
-            }
-        } catch (org.apache.bookkeeper.client.api.BKException | InterruptedException e) {
-            log.error("[{}] Read last entry error.", name, e);
-        } finally {
-            if (ledgerEntries != null) {
-                ledgerEntries.close();
-            }
+            });
+        } else {
+            promise.complete(null);
         }
+        return promise;
     }
 
     @Override

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Store max sequenceID in ManagedLedger properties, in order to recover transaction log.
@@ -47,8 +48,8 @@ public class MLTransactionLogInterceptor implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public void onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle) {
-
+    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle) {
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override


### PR DESCRIPTION
Fixes #10703 

### Motivation

Async the method onManagedLedgerLastLedgerInitialize for ManagedLedgerInterceptor. The root cause for issue #10703 is the ManagedLedger Interceptor is making a block read call from within a thread used for async operations. The interceptor shouldn’t be making any blocking calls. Thanks for @merlimat's help.

Here is the detailed stacktrace:

```
"BookKeeperClientWorker-OrderedExecutor-0-0" #67 prio=5 os_prio=0 cpu=50.69ms elapsed=14871.45s allocated=4671K defined_classes=63 tid=0x00007f8cee18e560 nid=0x9b01 waiting on condition  [0x00007f8b8fbfa000]
   java.lang.Thread.State: WAITING (parking)
 at jdk.internal.misc.Unsafe.park(java.base@11.0.11/Native Method)
 - parking to wait for  <0x0000000602818fc8> (a java.util.concurrent.CompletableFuture$Signaller)
 at java.util.concurrent.locks.LockSupport.park(java.base@11.0.11/LockSupport.java:194)
 at java.util.concurrent.CompletableFuture$Signaller.block(java.base@11.0.11/CompletableFuture.java:1796)
 at java.util.concurrent.ForkJoinPool.managedBlock(java.base@11.0.11/ForkJoinPool.java:3128)
 at java.util.concurrent.CompletableFuture.waitingGet(java.base@11.0.11/CompletableFuture.java:1823)
 at java.util.concurrent.CompletableFuture.get(java.base@11.0.11/CompletableFuture.java:1998)
 at org.apache.bookkeeper.common.concurrent.FutureUtils.result(FutureUtils.java:72)
 at org.apache.bookkeeper.client.api.ReadHandle.read(ReadHandle.java:58)
 at org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl.onManagedLedgerLastLedgerInitialize(ManagedLedgerInterceptorImpl.java:89)
 at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl$1.lambda$null$0(ManagedLedgerImpl.java:358)
 at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl$1$$Lambda$800/0x00000008406bb040.run(Unknown Source)
 at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32)
 at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36)
 at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.11/ThreadPoolExecutor.java:1128)
 at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.11/ThreadPoolExecutor.java:628)
 at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
 at java.lang.Thread.run(java.base@11.0.11/Thread.java:829)

   Locked ownable synchronizers:
 - <0x0000000601a92180> (a java.util.concurrent.ThreadPoolExecutor$Worker)
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
