### PR TITLE
force to refresh partition metadata info

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -86,6 +86,13 @@ public class BaseResources<T> {
         return cache.get(path);
     }
 
+    public CompletableFuture<Optional<T>> getAsync(String path, boolean forceRefresh) {
+        if (forceRefresh) {
+            cache.invalidate(path);
+        }
+        return cache.get(path);
+    }
+
     public void set(String path, Function<T, T> modifyFunction) throws MetadataStoreException {
         try {
             setAsync(path, modifyFunction).get(operationTimeoutSec, TimeUnit.SECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2290,7 +2290,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public CompletableFuture<PartitionedTopicMetadata> fetchPartitionedTopicMetadataAsync(TopicName topicName) {
         // gets the number of partitions from the configuration cache
         return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
-                .getAsync(partitionedTopicPath(topicName)).thenApply(metadata -> {
+                .getAsync(partitionedTopicPath(topicName), true).thenApply(metadata -> {
                     // if the partitioned topic is not found in zk, then the topic is not partitioned
                     return metadata.orElseGet(() -> new PartitionedTopicMetadata());
                 });


### PR DESCRIPTION
May resloves #10687 

## Motivation
When I was trying to solve #10687, I found that the partitioned-topic's metadata may not be updated timely. When I sent a create-topic request to brokerA, the partitioned-topic znode(i.e. znode: `/admin/partitioned-topics/public/default/persistent/X` and value: `{"partitions":1}`) was created after executing `MetadataCache#create`. However subsequently I noticed that the result of `getAsync(partitionedTopicPath(topicName)`  in delete-topic process on brokerB was `null`. And it led to a series of deletion behaviors that did not meet expectations.

The picture below is a brief description
![image](https://user-images.githubusercontent.com/14341827/119592817-c42af780-be0b-11eb-88ee-e3487cf09483.png)
