### PR TITLE
fix pulsar-admin functions update drops user-configs

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -902,7 +902,7 @@ public class FunctionConfigUtils {
         if (!StringUtils.isEmpty(newConfig.getOutput())) {
             mergedConfig.setOutput(newConfig.getOutput());
         }
-        if (newConfig.getUserConfig() != null) {
+        if (newConfig.getUserConfig() != null && !newConfig.getUserConfig().isEmpty()) {
             mergedConfig.setUserConfig(newConfig.getUserConfig());
         }
         if (newConfig.getSecrets() != null) {

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -269,6 +269,13 @@ public class FunctionConfigUtilsTest {
                 mergedConfig.getUserConfig(),
                 myConfig
         );
+        FunctionConfig newFunctionConfig2 = createUpdatedFunctionConfig("parallelism", 2);
+        FunctionConfig mergedConfig2 = FunctionConfigUtils.validateUpdate(mergedConfig, newFunctionConfig2);
+        assertEquals(
+                mergedConfig2.getUserConfig(),
+                myConfig
+        );
+        mergedConfig.setParallelism(functionConfig.getParallelism());
         mergedConfig.setUserConfig(functionConfig.getUserConfig());
         assertEquals(
                 new Gson().toJson(functionConfig),


### PR DESCRIPTION
### Motivation

Fixes #10720

### Modifications

Update UserConfig only when it's not empty.

### Verifying this change

FunctionConfigUtilsTest.testMergeDifferentUserConfig()