### PR TITLE
[ML] Cancel scheduled tasks as the first step in closing

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1319,6 +1319,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         factory.close(this);
         STATE_UPDATER.set(this, State.Closed);
 
+        if (this.timeoutTask != null) {
+            this.timeoutTask.cancel(false);
+        }
+
+        if (this.checkLedgerRollTask != null) {
+            this.checkLedgerRollTask.cancel(false);
+        }
+
         LedgerHandle lh = currentLedger;
 
         if (lh == null) {
@@ -1349,13 +1357,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             closeAllCursors(callback, ctx);
         }, null);
 
-        if (this.timeoutTask != null) {
-            this.timeoutTask.cancel(false);
-        }
-
-        if (this.checkLedgerRollTask != null) {
-            this.checkLedgerRollTask.cancel(false);
-        }
 
     }
 


### PR DESCRIPTION
### Motivation

- when `currentLedger` was null, the scheduled tasks `timeoutTask` and `checkLedgerRollTask` wouldn't get cancelled in `asyncClose` method since the method gets exited before the tasks are cancelled.

### Modifications

- move the scheduled task cancellation to happen earlier in the `asyncClose` method, before there is any `return;` call.

