### PR TITLE
[ML] Fix solution for preventing race conditions between timeout and completion

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -253,7 +253,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
      */
     private boolean checkAndCompleteOp(Object ctx) {
         long addOpCount = (ctx instanceof Long) ? (long) ctx : -1;
-        if (addOpCount != -1 && ADD_OP_COUNT_UPDATER.compareAndSet(this, this.addOpCount, -1)) {
+        if (addOpCount != -1 && ADD_OP_COUNT_UPDATER.compareAndSet(this, addOpCount, -1)) {
             return true;
         }
         log.info("Add-entry already completed for {}-{}", ledger != null ? ledger.getId() : -1, entryId);


### PR DESCRIPTION
### Motivation

It seem that the solution for preventing race conditions between timeout and completion doesn't work.
The repro case in #10738 can reproduce this problem.

### Modifications

This small modification: 
`ADD_OP_COUNT_UPDATER.compareAndSet(this, this.addOpCount, -1)` -> `ADD_OP_COUNT_UPDATER.compareAndSet(this, addOpCount, -1)` .

It seems that passing `this.addOpCount` to the second argument wouldn't make sense. The method also contains a `addOpCount` variable which is unused. Therefore it seems that the actual intention has been to use the `addOpCount` local variable instead of the `addOpCount` field. 

### Additional context

Original solution was added in #4455.