### PR TITLE
[Transaction] Fix transaction ack delete marker position when don't have transaction ack.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -396,7 +396,7 @@ public class PersistentSubscription implements Subscription {
         }
 
         if (topic.getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled()
-                && this.pendingAckHandle.isTransactionAckExisted()) {
+                && this.pendingAckHandle.isTransactionAckPresent()) {
             Position currentMarkDeletePosition = cursor.getMarkDeletedPosition();
             if ((lastMarkDeleteForTransactionMarker == null
                     || ((PositionImpl) lastMarkDeleteForTransactionMarker)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -394,7 +394,8 @@ public class PersistentSubscription implements Subscription {
             }
         }
 
-        if (topic.getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+        if (topic.getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled()
+                && this.pendingAckHandle.isTransactionAckExisted()) {
             Position currentMarkDeletePosition = cursor.getMarkDeletedPosition();
             if ((lastMarkDeleteForTransactionMarker == null
                     || ((PositionImpl) lastMarkDeleteForTransactionMarker)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -154,9 +154,9 @@ public interface PendingAckHandle {
     CompletableFuture<Void> close();
 
     /**
-     * Is transaction ack existed.
+     * Is transaction ack present.
      *
-     * @return the the boolean of teansaction ack existed.
+     * @return the the boolean of transaction ack present.
      */
-    boolean isTransactionAckExisted();
+    boolean isTransactionAckPresent();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -152,4 +152,11 @@ public interface PendingAckHandle {
      * @return the future of this operation.
      */
     CompletableFuture<Void> close();
+
+    /**
+     * Is transaction ack existed.
+     *
+     * @return the the boolean of teansaction ack existed.
+     */
+    boolean isTransactionAckExisted();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -97,7 +97,7 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
     }
 
     @Override
-    public boolean isTransactionAckExisted() {
+    public boolean isTransactionAckPresent() {
         return false;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -96,4 +96,9 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
         return CompletableFuture.completedFuture(null);
     }
 
+    @Override
+    public boolean isTransactionAckExisted() {
+        return false;
+    }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -733,4 +733,14 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     public CompletableFuture<Void> close() {
         return this.pendingAckStoreFuture.thenAccept(PendingAckStore::closeAsync);
     }
+
+    @Override
+    public boolean isTransactionAckExisted() {
+        if ((this.cumulativeAckOfTransaction == null
+                && (this.individualAckOfTransaction == null || this.individualAckOfTransaction.isEmpty()))) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -736,7 +736,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     @Override
-    public boolean isTransactionAckExisted() {
+    public boolean isTransactionAckPresent() {
         if ((this.cumulativeAckOfTransaction == null
                 && (this.individualAckOfTransaction == null || this.individualAckOfTransaction.isEmpty()))) {
             return false;


### PR DESCRIPTION
## Motivation
Now when broke enable transaction, every ack will check the next position is transaction marker position whether or not. When don't have transaction ack, we don' need to check the next position is transaction marker position.

## implement
add the judgement for pending ack delete transaction marker position.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (yes)
Anything that affects deployment: (no)

