### PR TITLE
Rootless container mount user token secret in the default 644 permission for Function Kubernetes runtime

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -102,7 +102,8 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
         podSpec.getContainers().forEach(container -> container.setVolumeMounts(Collections.singletonList(
                 new V1VolumeMount()
                         .name(SECRET_NAME)
-                        .mountPath(DEFAULT_SECRET_MOUNT_DIR))));
+                        .mountPath(DEFAULT_SECRET_MOUNT_DIR)
+                        .readOnly(true))));
 
     }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProvider.java
@@ -97,14 +97,12 @@ public class KubernetesSecretsTokenAuthProvider implements KubernetesFunctionAut
                         .name(SECRET_NAME)
                         .secret(
                                 new V1SecretVolumeSource()
-                                        .secretName(getSecretName(new String(functionAuthData.get().getData())))
-                                        .defaultMode(256))));
+                                        .secretName(getSecretName(new String(functionAuthData.get().getData()))))));
 
         podSpec.getContainers().forEach(container -> container.setVolumeMounts(Collections.singletonList(
                 new V1VolumeMount()
                         .name(SECRET_NAME)
-                        .mountPath(DEFAULT_SECRET_MOUNT_DIR)
-                        .readOnly(true))));
+                        .mountPath(DEFAULT_SECRET_MOUNT_DIR))));
 
     }
 


### PR DESCRIPTION
### Motivation

In the rootless docker container, Function Kubernetes runtime needs to read /etc/auth/token. But currently the file permission is mounted as 400 under `root`.

### Modifications

Use the default Kubernetes secret mount permission, which allows non-root user to read the auth token.

### Verifying this change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
