### PR TITLE
Fix kinesis sink backoff class not found

### DIFF
--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/utils/Backoff.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/utils/Backoff.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.core.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Clock;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import lombok.Data;
+
+
+/**
+ * All variables are in TimeUnit millis by default.
+  */
+@Data
+public class Backoff {
+    public static final long DEFAULT_INTERVAL_IN_NANOSECONDS = TimeUnit.MILLISECONDS.toNanos(100);
+    public static final long MAX_BACKOFF_INTERVAL_NANOSECONDS = TimeUnit.SECONDS.toNanos(30);
+    private final long initial;
+    private final long max;
+    private final Clock clock;
+    private long next;
+    private long mandatoryStop;
+
+    private long firstBackoffTimeInMillis;
+    private boolean mandatoryStopMade = false;
+
+    private static final Random random = new Random();
+
+    @VisibleForTesting
+    Backoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax, long mandatoryStop,
+            TimeUnit unitMandatoryStop, Clock clock) {
+        this.initial = unitInitial.toMillis(initial);
+        this.max = unitMax.toMillis(max);
+        this.next = this.initial;
+        this.mandatoryStop = unitMandatoryStop.toMillis(mandatoryStop);
+        this.clock = clock;
+    }
+
+    public Backoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax, long mandatoryStop,
+                   TimeUnit unitMandatoryStop) {
+        this(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop, Clock.systemDefaultZone());
+    }
+
+    public long next() {
+        long current = this.next;
+        if (current < max) {
+            this.next = Math.min(this.next * 2, this.max);
+        }
+
+        // Check for mandatory stop
+        if (!mandatoryStopMade) {
+            long now = clock.millis();
+            long timeElapsedSinceFirstBackoff = 0;
+            if (initial == current) {
+                firstBackoffTimeInMillis = now;
+            } else {
+                timeElapsedSinceFirstBackoff = now - firstBackoffTimeInMillis;
+            }
+
+            if (timeElapsedSinceFirstBackoff + current > mandatoryStop) {
+                current = Math.max(initial, mandatoryStop - timeElapsedSinceFirstBackoff);
+                mandatoryStopMade = true;
+            }
+        }
+
+        // Randomly decrease the timeout up to 10% to avoid simultaneous retries
+        // If current < 10 then current/10 < 1 and we get an exception from Random saying "Bound must be positive"
+        if (current > 10) {
+            current -= random.nextInt((int) current / 10);
+        }
+        return Math.max(initial, current);
+    }
+
+    public void reduceToHalf() {
+        if (next > initial) {
+            this.next = Math.max(this.next / 2, this.initial);
+        }
+    }
+
+    public void reset() {
+        this.next = this.initial;
+        this.mandatoryStopMade = false;
+    }
+
+    @VisibleForTesting
+    long getFirstBackoffTimeInMillis() {
+        return firstBackoffTimeInMillis;
+    }
+
+    public static boolean shouldBackoff(long initialTimestamp, TimeUnit unitInitial, int failedAttempts,
+    									long defaultInterval, long maxBackoffInterval) {
+    	long initialTimestampInNano = unitInitial.toNanos(initialTimestamp);
+        long currentTime = System.nanoTime();
+        long interval = defaultInterval;
+        for (int i = 1; i < failedAttempts; i++) {
+            interval = interval * 2;
+            if (interval > maxBackoffInterval) {
+                interval = maxBackoffInterval;
+                break;
+            }
+        }
+
+        // if the current time is less than the time at which next retry should occur, we should backoff
+        return currentTime < (initialTimestampInNano + interval);
+    }
+
+    public static boolean shouldBackoff(long initialTimestamp, TimeUnit unitInitial, int failedAttempts) {
+        return Backoff.shouldBackoff(initialTimestamp, unitInitial, failedAttempts,
+        							 DEFAULT_INTERVAL_IN_NANOSECONDS, MAX_BACKOFF_INTERVAL_NANOSECONDS);
+    }
+}

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Backoff.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/Backoff.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.io.core.utils;
+package org.apache.pulsar.io.kinesis;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -37,8 +37,6 @@ import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -49,7 +47,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.aws.AbstractAwsConnector;
 import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
@@ -57,6 +54,7 @@ import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
+import org.apache.pulsar.io.core.utils.Backoff;
 import org.apache.pulsar.io.kinesis.KinesisSinkConfig.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,8 +112,6 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
     public static final String METRICS_TOTAL_INCOMING_BYTES = "_kinesis_total_incoming_bytes_";
     public static final String METRICS_TOTAL_SUCCESS = "_kinesis_total_success_";
     public static final String METRICS_TOTAL_FAILURE = "_kinesis_total_failure_";
-
-    private static Constructor<Backoff> backoffConstructor = null;
 
     private void sendUserRecord(ProducerSendCallback producerSendCallback) {
         ListenableFuture<UserRecordResult> addRecordResult = kinesisProducer.addUserRecord(this.streamName,
@@ -183,9 +179,6 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
         this.kinesisProducer = new KinesisProducer(kinesisConfig);
         IS_PUBLISH_FAILED.set(this, FALSE);
 
-        backoffConstructor = getBackoffConstructor(sinkContext.getClass().getClassLoader());
-        Backoff backoff = createBackoff(100, TimeUnit.MILLISECONDS, 1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS);
-        LOG.info("open create backoff " + backoff);
         LOG.info("Kinesis sink started. {}", (ReflectionToStringBuilder.toString(kinesisConfig, ToStringStyle.SHORT_PREFIX_STYLE)));
     }
 
@@ -203,9 +196,7 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             this.recyclerHandle = recyclerHandle;
         }
 
-        static ProducerSendCallback create(KinesisSink kinesisSink, Record<byte[]> resultContext, long startTime,
-                                           String partitionedKey, ByteBuffer data)
-                throws InvocationTargetException, InstantiationException, IllegalAccessException {
+        static ProducerSendCallback create(KinesisSink kinesisSink, Record<byte[]> resultContext, long startTime, String partitionedKey, ByteBuffer data) {
             ProducerSendCallback sendCallback = RECYCLER.get();
             sendCallback.resultContext = resultContext;
             sendCallback.kinesisSink = kinesisSink;
@@ -213,13 +204,8 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             sendCallback.partitionedKey = partitionedKey;
             sendCallback.data = data;
             if (kinesisSink.kinesisSinkConfig.isRetainOrdering() && sendCallback.backoff == null) {
-                sendCallback.backoff = createBackoff(
-                        kinesisSink.kinesisSinkConfig.getRetryInitialDelayInMillis(),
-                        TimeUnit.MILLISECONDS,
-                        kinesisSink.kinesisSinkConfig.getRetryMaxDelayInMillis(),
-                        TimeUnit.MILLISECONDS,
-                        0,
-                        TimeUnit.SECONDS);
+                sendCallback.backoff = new Backoff(kinesisSink.kinesisSinkConfig.getRetryInitialDelayInMillis(), TimeUnit.MILLISECONDS,
+                        kinesisSink.kinesisSinkConfig.getRetryMaxDelayInMillis(), TimeUnit.MILLISECONDS, 0, TimeUnit.SECONDS);
             }
             return sendCallback;
         }
@@ -299,24 +285,6 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             // send raw-message
             return ByteBuffer.wrap(record.getValue());
         }
-    }
-
-    private Constructor getBackoffConstructor(ClassLoader classLoader)
-            throws ClassNotFoundException, NoSuchMethodException, NoSuchFieldException {
-        Class<Backoff> backoffClass = (Class<Backoff>) Class.forName(
-                "org.apache.pulsar.client.impl.Backoff", true, classLoader);
-        Class longClass = backoffClass.getDeclaredField("initial").getType();
-        return backoffClass.getDeclaredConstructor(
-                        longClass, TimeUnit.class, longClass, TimeUnit.class, longClass, TimeUnit.class);
-    }
-
-    private static Backoff createBackoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax,
-                                         long mandatoryStop, TimeUnit unitMandatoryStop)
-            throws InvocationTargetException, InstantiationException, IllegalAccessException {
-        if (backoffConstructor == null) {
-            return new Backoff(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop);
-        }
-        return backoffConstructor.newInstance(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop);
     }
 
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -54,7 +54,6 @@ import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
-import org.apache.pulsar.io.core.utils.Backoff;
 import org.apache.pulsar.io.kinesis.KinesisSinkConfig.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -37,6 +37,8 @@ import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -113,6 +115,8 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
     public static final String METRICS_TOTAL_SUCCESS = "_kinesis_total_success_";
     public static final String METRICS_TOTAL_FAILURE = "_kinesis_total_failure_";
 
+    private static Constructor<Backoff> backoffConstructor = null;
+
     private void sendUserRecord(ProducerSendCallback producerSendCallback) {
         ListenableFuture<UserRecordResult> addRecordResult = kinesisProducer.addUserRecord(this.streamName,
                 producerSendCallback.partitionedKey, producerSendCallback.data);
@@ -179,6 +183,9 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
         this.kinesisProducer = new KinesisProducer(kinesisConfig);
         IS_PUBLISH_FAILED.set(this, FALSE);
 
+        backoffConstructor = getBackoffConstructor(sinkContext.getClass().getClassLoader());
+        Backoff backoff = createBackoff(100, TimeUnit.MILLISECONDS, 1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS);
+        LOG.info("open create backoff " + backoff);
         LOG.info("Kinesis sink started. {}", (ReflectionToStringBuilder.toString(kinesisConfig, ToStringStyle.SHORT_PREFIX_STYLE)));
     }
 
@@ -196,7 +203,9 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             this.recyclerHandle = recyclerHandle;
         }
 
-        static ProducerSendCallback create(KinesisSink kinesisSink, Record<byte[]> resultContext, long startTime, String partitionedKey, ByteBuffer data) {
+        static ProducerSendCallback create(KinesisSink kinesisSink, Record<byte[]> resultContext, long startTime,
+                                           String partitionedKey, ByteBuffer data)
+                throws InvocationTargetException, InstantiationException, IllegalAccessException {
             ProducerSendCallback sendCallback = RECYCLER.get();
             sendCallback.resultContext = resultContext;
             sendCallback.kinesisSink = kinesisSink;
@@ -204,8 +213,13 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             sendCallback.partitionedKey = partitionedKey;
             sendCallback.data = data;
             if (kinesisSink.kinesisSinkConfig.isRetainOrdering() && sendCallback.backoff == null) {
-                sendCallback.backoff = new Backoff(kinesisSink.kinesisSinkConfig.getRetryInitialDelayInMillis(), TimeUnit.MILLISECONDS,
-                        kinesisSink.kinesisSinkConfig.getRetryMaxDelayInMillis(), TimeUnit.MILLISECONDS, 0, TimeUnit.SECONDS);
+                sendCallback.backoff = createBackoff(
+                        kinesisSink.kinesisSinkConfig.getRetryInitialDelayInMillis(),
+                        TimeUnit.MILLISECONDS,
+                        kinesisSink.kinesisSinkConfig.getRetryMaxDelayInMillis(),
+                        TimeUnit.MILLISECONDS,
+                        0,
+                        TimeUnit.SECONDS);
             }
             return sendCallback;
         }
@@ -285,6 +299,24 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
             // send raw-message
             return ByteBuffer.wrap(record.getValue());
         }
+    }
+
+    private Constructor getBackoffConstructor(ClassLoader classLoader)
+            throws ClassNotFoundException, NoSuchMethodException, NoSuchFieldException {
+        Class<Backoff> backoffClass = (Class<Backoff>) Class.forName(
+                "org.apache.pulsar.client.impl.Backoff", true, classLoader);
+        Class longClass = backoffClass.getDeclaredField("initial").getType();
+        return backoffClass.getDeclaredConstructor(
+                        longClass, TimeUnit.class, longClass, TimeUnit.class, longClass, TimeUnit.class);
+    }
+
+    private static Backoff createBackoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax,
+                                         long mandatoryStop, TimeUnit unitMandatoryStop)
+            throws InvocationTargetException, InstantiationException, IllegalAccessException {
+        if (backoffConstructor == null) {
+            return new Backoff(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop);
+        }
+        return backoffConstructor.newInstance(initial, unitInitial, max, unitMax, mandatoryStop, unitMandatoryStop);
     }
 
 }


### PR DESCRIPTION
### Motivation

Currently, the class `Backoff` in the project Pulsar client impl, the Kinesis sink connector want to use this class, the dependency `org.apache.pulsar:pulsar-client-original` is needed, but this will increase the connector size, so we could add a new class `Backoff` in the function io-core, then the class `Backoff` could be reused by other connectors.

### Modifications

Add the class `Backoff` in the project function io-core.

### Verifying this change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

