### PR TITLE
[Transaction] Fix transaction admin api path path param problem.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.admin.v3;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.Consumes;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -117,10 +117,11 @@ public class TransactionsImpl extends BaseResource implements Transactions {
 
     @Override
     public CompletableFuture<TransactionInBufferStats> getTransactionInBufferStatsAsync(TxnID txnID, String topic) {
+        TopicName topicName = TopicName.get(topic);
         WebTarget path = adminV3Transactions.path("transactionInBufferStats");
-        path = path.queryParam("mostSigBits", txnID.getMostSigBits());
-        path = path.queryParam("leastSigBits", txnID.getLeastSigBits());
-        path = path.queryParam("topic", topic);
+        path = path.path(topicName.getRestPath(false));
+        path = path.path(txnID.getMostSigBits() + "");
+        path = path.path(txnID.getLeastSigBits() + "");
         final CompletableFuture<TransactionInBufferStats> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<TransactionInBufferStats>() {
@@ -156,10 +157,10 @@ public class TransactionsImpl extends BaseResource implements Transactions {
                                                                                                 String topic,
                                                                                                 String subName) {
         WebTarget path = adminV3Transactions.path("transactionInPendingAckStats");
-        path = path.queryParam("mostSigBits", txnID.getMostSigBits());
-        path = path.queryParam("leastSigBits", txnID.getLeastSigBits());
-        path = path.queryParam("topic", topic);
-        path = path.queryParam("subName", subName);
+        path = path.path(TopicName.get(topic).getRestPath(false));
+        path = path.path(subName);
+        path = path.path(txnID.getMostSigBits() + "");
+        path = path.path(txnID.getLeastSigBits() + "");
         final CompletableFuture<TransactionInPendingAckStats> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<TransactionInPendingAckStats>() {
@@ -195,8 +196,8 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     @Override
     public CompletableFuture<TransactionMetadata> getTransactionMetadataAsync(TxnID txnID) {
         WebTarget path = adminV3Transactions.path("transactionMetadata");
-        path = path.queryParam("mostSigBits", txnID.getMostSigBits());
-        path = path.queryParam("leastSigBits", txnID.getLeastSigBits());
+        path = path.path(txnID.getMostSigBits() + "");
+        path = path.path(txnID.getLeastSigBits() + "");
         final CompletableFuture<TransactionMetadata> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<TransactionMetadata>() {
@@ -231,7 +232,7 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     @Override
     public CompletableFuture<TransactionBufferStats> getTransactionBufferStatsAsync(String topic) {
         WebTarget path = adminV3Transactions.path("transactionBufferStats");
-        path = path.queryParam("topic", topic);
+        path = path.path(TopicName.get(topic).getRestPath(false));
         final CompletableFuture<TransactionBufferStats> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<TransactionBufferStats>() {
@@ -265,8 +266,8 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     @Override
     public CompletableFuture<TransactionPendingAckStats> getPendingAckStatsAsync(String topic, String subName) {
         WebTarget path = adminV3Transactions.path("pendingAckStats");
-        path = path.queryParam("topic", topic);
-        path = path.queryParam("subName", subName);
+        path = path.path(TopicName.get(topic).getRestPath(false));
+        path = path.path(subName);
         final CompletableFuture<TransactionPendingAckStats> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<TransactionPendingAckStats>() {


### PR DESCRIPTION
## Motivation
now some transaction admin api get method don't use `uri` path pass param.

## implement
`required` param use `uri` transport.
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

