### PR TITLE
add advertised listenerName for geo-replicator

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1053,6 +1053,10 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                     log.info("Configuring proxy-url {} with protocol {}", data.getProxyServiceUrl(),
                             data.getProxyProtocol());
                 }
+                if (data.getListenerName() != null && StringUtils.isNotBlank(data.getListenerName())) {
+                    clientBuilder.listenerName(data.getListenerName());
+                    log.info("Configuring listenerName {}", data.getListenerName());
+                }
                 // Share all the IO threads across broker and client connections
                 ClientConfigurationData conf = ((ClientBuilderImpl) clientBuilder).getClientConfigurationData();
                 return new PulsarClientImpl(conf, workerGroup);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -396,14 +396,15 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
 
-        // Check authentication
+        // Check authentication and listener name
         try {
             clusters.createCluster("auth", new ClusterData("http://dummy.web.example.com", "",
                     "http://dummy.messaging.example.com", "",
-                    "authenticationPlugin", "authenticationParameters"));
+                    "authenticationPlugin", "authenticationParameters", "listenerName"));
             ClusterData cluster = clusters.getCluster("auth");
             assertEquals("authenticationPlugin", cluster.getAuthenticationPlugin());
             assertEquals("authenticationParameters", cluster.getAuthenticationParameters());
+            assertEquals("listenerName", cluster.getListenerName());
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -307,6 +307,9 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--tls-trust-certs-filepath", description = "path for the trusted TLS certificate file", required = false)
         protected String brokerClientTrustCertsFilePath;
 
+        @Parameter(names = "--listenerName", description = "listenerName", required = false)
+        private String listenerName;
+
         @Parameter(names = "--cluster-config-file", description = "The path to a YAML config file specifying the "
                 + "cluster's configuration")
         protected String clusterConfigFile;
@@ -367,6 +370,9 @@ public class CmdClusters extends CmdBase {
             }
             if (brokerClientTrustCertsFilePath != null) {
                 clusterData.setBrokerClientTrustCertsFilePath(brokerClientTrustCertsFilePath);
+            }
+            if (listenerName != null) {
+                clusterData.setListenerName(listenerName);
             }
             validateClusterData(clusterData);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -307,7 +307,7 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--tls-trust-certs-filepath", description = "path for the trusted TLS certificate file", required = false)
         protected String brokerClientTrustCertsFilePath;
 
-        @Parameter(names = "--listenerName", description = "listenerName", required = false)
+        @Parameter(names = "--listener-name", description = "listenerName when client would like to connect to cluster", required = false)
         private String listenerName;
 
         @Parameter(names = "--cluster-config-file", description = "The path to a YAML config file specifying the "

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -144,6 +144,12 @@ public class ClusterData {
         value = "Path for the trusted TLS certificate file for outgoing connection to a server (broker)"
     )
     private String brokerClientTrustCertsFilePath;
+    @ApiModelProperty(
+            name = "listenerName",
+            value = "listenerName when client would like to connect to cluster",
+            example = ""
+    )
+    private String listenerName;
 
     public ClusterData(String serviceUrl) {
         this(serviceUrl, "");
@@ -169,6 +175,17 @@ public class ClusterData {
         this.brokerServiceUrlTls = brokerServiceUrlTls;
         this.authenticationPlugin = authenticationPlugin;
         this.authenticationParameters = authenticationParameters;
+    }
+
+    public ClusterData(String serviceUrl, String serviceUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
+                       String authenticationPlugin, String authenticationParameters, String listenerName) {
+        this.serviceUrl = serviceUrl;
+        this.serviceUrlTls = serviceUrlTls;
+        this.brokerServiceUrl = brokerServiceUrl;
+        this.brokerServiceUrlTls = brokerServiceUrlTls;
+        this.authenticationPlugin = authenticationPlugin;
+        this.authenticationParameters = authenticationParameters;
+        this.listenerName = listenerName;
     }
 
     public ClusterData(String serviceUrl, String serviceUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
@@ -202,6 +219,7 @@ public class ClusterData {
         this.brokerClientTlsTrustStore = other.brokerClientTlsTrustStore;
         this.brokerClientTlsTrustStorePassword = other.brokerClientTlsTrustStorePassword;
         this.brokerClientTrustCertsFilePath = other.brokerClientTrustCertsFilePath;
+        this.listenerName = other.listenerName;
     }
 
     @Override
@@ -221,7 +239,8 @@ public class ClusterData {
                     && Objects.equals(brokerClientTlsTrustStoreType, other.brokerClientTlsTrustStoreType)
                     && Objects.equals(brokerClientTlsTrustStore, other.brokerClientTlsTrustStore)
                     && Objects.equals(brokerClientTlsTrustStorePassword, other.brokerClientTlsTrustStorePassword)
-                    && Objects.equals(brokerClientTrustCertsFilePath, other.brokerClientTrustCertsFilePath);
+                    && Objects.equals(brokerClientTrustCertsFilePath, other.brokerClientTrustCertsFilePath)
+                    && Objects.equals(listenerName, other.listenerName);
         }
 
         return false;


### PR DESCRIPTION
### Motivation

In case of geo-replicator, if replicator client can't connect to remote cluster unless using advertised listener, currently there is no way to set advertised listener for replicator.

### Modifications

Add listenerName to ClusterData.
When creating replicator producer for remote cluster, use listenerName if exists.
Add admin cli command to set listenerName for remote cluster.
