### PR TITLE
[ML] Fix ByteBuf leaks when execution fails

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1536,6 +1536,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
+    synchronized OpAddEntry pollPendingAddEntry() {
+        return pendingAddEntries.poll();
+    }
+
+
     // //////////////////////////////////////////////////////////////////////
     // Private helpers
 
@@ -1664,7 +1669,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return managedLedgerInterceptor;
     }
 
-    void clearPendingAddEntries(ManagedLedgerException e) {
+    synchronized void clearPendingAddEntries(ManagedLedgerException e) {
         while (!pendingAddEntries.isEmpty()) {
             OpAddEntry op = pendingAddEntries.poll();
             op.failed(e);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1504,6 +1504,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 if (existsOp.ledger != null) {
                     existsOp.close();
                     existsOp = OpAddEntry.create(existsOp.ml, existsOp.data, existsOp.getNumberOfMessages(), existsOp.callback, existsOp.ctx);
+                    // release the extra retain
+                    ReferenceCountUtil.release(existsOp.data);
                 }
                 existsOp.setLedger(currentLedger);
                 if (beforeAddEntry(existsOp)) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -179,7 +179,10 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
     public void safeRun() {
         // Remove this entry from the head of the pending queue
         OpAddEntry firstInQueue = ml.pendingAddEntries.poll();
-        checkArgument(this == firstInQueue);
+        if (this != firstInQueue) {
+            ReferenceCountUtil.release(data);
+            throw new IllegalStateException("This OpAddEntry wasn't first in queue.");
+        }
 
         ManagedLedgerImpl.NUMBER_OF_ENTRIES_UPDATER.incrementAndGet(ml);
         ManagedLedgerImpl.TOTAL_SIZE_UPDATER.addAndGet(ml, dataLength);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2688,7 +2688,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             } else {
                 Assert.assertEquals(oldOp.getState(), OpAddEntry.State.INITIATED);
             }
-            OpAddEntry newOp = ledger.pendingAddEntries.poll();
+            OpAddEntry newOp = ledger.pollPendingAddEntry();
             Assert.assertEquals(newOp.getState(), OpAddEntry.State.INITIATED);
             if (i > 4) {
                 Assert.assertNotSame(oldOp, newOp);
@@ -2962,7 +2962,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 1);
         Assert.assertEquals(managedLedger.getTotalSize(), 0);
     }
-  
+
     @Test(timeOut = 20000)
     public void testAsyncTruncateLedgerRetention() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();


### PR DESCRIPTION
### Motivation

The repro case in #10738 reproduces some Netty ByteBuf leaks that are detected by the Netty Leak detector. There are a few exceptional execution paths where the data ByteBuf of OpAddEntry isn't released. 

### Modifications

- release the data ByteBuf in a try-finally block
- release the data ByteBuf when execution is rejected in the invalid state case where the entry isn't the first in the queue.
- release extra retain for OpAddEntry.data when entry is copied at ledger rollover

This seems to stop the detected leaks in #10738 case.