### PR TITLE
[Broker] Replace use of Prometheus client CollectorRegistry.getSampleValue

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -104,14 +104,15 @@ public class BrokerOperabilityMetrics {
     Metrics getDimensionMetrics(String metricsName, String dimensionName, DimensionStats stats) {
         Metrics dMetrics = Metrics.create(getDimensionMap(metricsName));
 
-        dMetrics.put("brk_" + dimensionName + "_time_mean_ms", stats.getMeanDimension());
-        dMetrics.put("brk_" + dimensionName + "_time_median_ms", stats.getMedianDimension());
-        dMetrics.put("brk_" + dimensionName + "_time_75percentile_ms", stats.getDimension75());
-        dMetrics.put("brk_" + dimensionName + "_time_95percentile_ms", stats.getDimension95());
-        dMetrics.put("brk_" + dimensionName + "_time_99_percentile_ms", stats.getDimension99());
-        dMetrics.put("brk_" + dimensionName + "_time_99_9_percentile_ms", stats.getDimension999());
-        dMetrics.put("brk_" + dimensionName + "_time_99_99_percentile_ms", stats.getDimension9999());
-        dMetrics.put("brk_" + dimensionName + "_rate_s", stats.getDimensionCount());
+        DimensionStats.DimensionStatsSnapshot statsSnapshot = stats.getSnapshot();
+        dMetrics.put("brk_" + dimensionName + "_time_mean_ms", statsSnapshot.getMeanDimension());
+        dMetrics.put("brk_" + dimensionName + "_time_median_ms", statsSnapshot.getMedianDimension());
+        dMetrics.put("brk_" + dimensionName + "_time_75percentile_ms", statsSnapshot.getDimension75());
+        dMetrics.put("brk_" + dimensionName + "_time_95percentile_ms", statsSnapshot.getDimension95());
+        dMetrics.put("brk_" + dimensionName + "_time_99_percentile_ms", statsSnapshot.getDimension99());
+        dMetrics.put("brk_" + dimensionName + "_time_99_9_percentile_ms", statsSnapshot.getDimension999());
+        dMetrics.put("brk_" + dimensionName + "_time_99_99_percentile_ms", statsSnapshot.getDimension9999());
+        dMetrics.put("brk_" + dimensionName + "_rate_s", statsSnapshot.getDimensionCount());
 
         return dMetrics;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
@@ -22,7 +22,11 @@ import static io.prometheus.client.CollectorRegistry.defaultRegistry;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Summary;
 import io.prometheus.client.Summary.Builder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,10 +38,19 @@ public class DimensionStats {
     private final String dimensionSumLabel;
     private final String dimensionCountLabel;
     private final Summary summary;
-    private static final double[] QUANTILES = { 0.50, 0.75, 0.95, 0.99, 0.999, 0.9999 };
-    private static final String[] QUANTILE_LABEL = { "quantile" };
+    private static final double[] QUANTILES = {0.50, 0.75, 0.95, 0.99, 0.999, 0.9999};
+    private static final List<String> QUANTILE_LABEL = Collections.unmodifiableList(Arrays.asList("quantile"));
+    private static final List<List<String>> QUANTILE_LABEL_VALUES = Collections.unmodifiableList(
+            Arrays.stream(QUANTILES).mapToObj(Collector::doubleToGoString)
+                    .map(Collections::singletonList)
+                    .collect(Collectors.toList()));
+
 
     public DimensionStats(String name, long updateDurationInSec) {
+        this(name, updateDurationInSec, true);
+    }
+
+    DimensionStats(String name, long updateDurationInSec, boolean register) {
         this.name = name;
         this.dimensionSumLabel = name + "_sum";
         this.dimensionCountLabel = name + "_count";
@@ -46,11 +59,13 @@ public class DimensionStats {
             summaryBuilder.quantile(QUANTILES[i], 0.01);
         }
         this.summary = summaryBuilder.maxAgeSeconds(updateDurationInSec).create();
-        try {
-            defaultRegistry.register(summary);
-        } catch (IllegalArgumentException ie) {
-            // it only happens in test-cases when try to register summary multiple times in registry
-            log.warn("{} is already registred {}", name, ie.getMessage());
+        if (register) {
+            try {
+                defaultRegistry.register(summary);
+            } catch (IllegalArgumentException ie) {
+                // it only happens in test-cases when try to register summary multiple times in registry
+                log.warn("{} is already registred {}", name, ie.getMessage());
+            }
         }
     }
 
@@ -58,54 +73,83 @@ public class DimensionStats {
         summary.observe(unit.toMillis(latency));
     }
 
-    public double getMeanDimension() {
-        double sum = getDimensionSum();
-        double count = getDimensionCount();
-        if (!Double.isNaN(sum) && !Double.isNaN(count)) {
-            return sum / count;
+    public DimensionStatsSnapshot getSnapshot() {
+        return new DimensionStatsSnapshot(summary.collect());
+    }
+
+
+    public class DimensionStatsSnapshot {
+        private final List<Collector.MetricFamilySamples> samples;
+
+        public DimensionStatsSnapshot(List<Collector.MetricFamilySamples> samples) {
+            this.samples = samples;
         }
-        return 0;
-    }
 
-    public double getMedianDimension() {
-        return getQuantile(QUANTILES[0]);
-    }
+        public double getMeanDimension() {
+            double sum = getDimensionSum();
+            double count = getDimensionCount();
+            if (!Double.isNaN(sum) && !Double.isNaN(count)) {
+                return sum / count;
+            }
+            return 0;
+        }
 
-    public double getDimension75() {
-        return getQuantile(QUANTILES[1]);
-    }
+        public double getMedianDimension() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(0));
+        }
 
-    public double getDimension95() {
-        return getQuantile(QUANTILES[2]);
-    }
+        public double getDimension75() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(1));
+        }
 
-    public double getDimension99() {
-        return getQuantile(QUANTILES[3]);
-    }
+        public double getDimension95() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(2));
+        }
 
-    public double getDimension999() {
-        return getQuantile(QUANTILES[4]);
-    }
+        public double getDimension99() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(3));
+        }
 
-    public double getDimension9999() {
-        return getQuantile(QUANTILES[5]);
-    }
+        public double getDimension999() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(4));
+        }
 
-    public double getDimensionSum() {
-        return defaultRegistry.getSampleValue(dimensionSumLabel).doubleValue();
-    }
+        public double getDimension9999() {
+            return getQuantile(QUANTILE_LABEL_VALUES.get(5));
+        }
 
-    public double getDimensionCount() {
-        return defaultRegistry.getSampleValue(dimensionCountLabel).doubleValue();
+        public double getDimensionSum() {
+            return getSampleValue(dimensionSumLabel);
+        }
+
+        public double getDimensionCount() {
+            return getSampleValue(dimensionCountLabel);
+        }
+
+        private double getQuantile(List<String> labelValues) {
+            return getSampleValue(name, QUANTILE_LABEL, labelValues);
+        }
+
+        private double getSampleValue(String name) {
+            return getSampleValue(name, Collections.emptyList(), Collections.emptyList());
+        }
+
+        private double getSampleValue(String name, List<String> labelNames, List<String> labelValues) {
+            for (Collector.MetricFamilySamples metricFamilySamples : samples) {
+                for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
+                    if (sample.name.equals(name)
+                            && sample.labelNames.equals(labelNames)
+                            && sample.labelValues.equals(labelValues)) {
+                        return sample.value;
+                    }
+                }
+            }
+            return 0;
+        }
     }
 
     public void reset() {
         summary.clear();
-    }
-
-    private double getQuantile(double q) {
-        return defaultRegistry.getSampleValue(name, QUANTILE_LABEL, new String[] { Collector.doubleToGoString(q) })
-                .doubleValue();
     }
 
     private static final Logger log = LoggerFactory.getLogger(DimensionStats.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/DimensionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/DimensionStatsTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.testng.Assert.assertEquals;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+public class DimensionStatsTest {
+    @Test
+    void shouldCalculateQuantiles() {
+        DimensionStats dimensionStats = new DimensionStats("test", 100, false);
+        for (int i = 1; i <= 10000; i++) {
+            dimensionStats.recordDimensionTimeValue(i, TimeUnit.MILLISECONDS);
+        }
+        DimensionStats.DimensionStatsSnapshot snapshot = dimensionStats.getSnapshot();
+        assertEquals(snapshot.getMeanDimension(), 5000, 1);
+        assertEquals(snapshot.getMedianDimension(), 5000, 100);
+        assertEquals(snapshot.getDimension75(), 7500, 100);
+        assertEquals(snapshot.getDimension95(), 9500, 100);
+        assertEquals(snapshot.getDimension99(), 9900, 100);
+        assertEquals(snapshot.getDimension999(), 9990, 10);
+        assertEquals(snapshot.getDimension9999(), 9999, 1);
+        assertEquals(snapshot.getDimensionCount(), 10000);
+        assertEquals(snapshot.getDimensionSum(), 50005000);
+    }
+}


### PR DESCRIPTION
Fixes #10654

### Motivation

See #10654 for more details.

The javadoc of Prometheus client CollectorRegistry.getSampleValue method states:
["This is inefficient, and intended only for use in unittests."](https://github.com/prometheus/client_java/blob/8fcc7bc03dfbabd0c15776640d5fe52942aa9309/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java#L261).

### Modifications

- refactor DimensionStats to use a more efficient method where a snapshot of the metrics is created before
  individual quantile metric values are requested.
- add a unit test case for DimensionStats to verify it's behavior