### PR TITLE
[Kinesis] Fix kinesis sink connector does not ack messages

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -237,6 +237,7 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<byte[]> {
                 kinesisSink.sinkContext.recordMetric(METRICS_TOTAL_SUCCESS, 1);
             }
             kinesisSink.previousPublishFailed = FALSE;
+            this.resultContext.ack();
             recycle();
         }
 


### PR DESCRIPTION

### Motivation

Currently, when the kinesis sink connector sends the message successfully, it will not ack the message.

### Modifications

* Ack messages after the sink connector send messages successfully.

