### PR TITLE
Fix `isLocalRun` check in `PulsarAdminTool`

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -301,7 +301,7 @@ public class PulsarAdminTool {
         PulsarAdminTool tool = new PulsarAdminTool(properties);
 
         int cmdPos;
-        for (cmdPos = 1; cmdPos < args.length; cmdPos++) {
+        for (cmdPos = 0; cmdPos < args.length; cmdPos++) {
             if (tool.commandMap.containsKey(args[cmdPos])) {
                 break;
             }


### PR DESCRIPTION
### Motivation

I was trying to debug a sink connector locally using `sinks localrun` command and seems the condition `isLocalRun` was not checked properly because `args` was shifted at the beginning of the `main` method without changing the initial `cmdPos` in a previous PR https://github.com/apache/pulsar/commit/232b32439687995dd3102d8c281cf50b7b91e0bf#diff-c349b18c29ddc6c10d7665a454c001515325943ea1f3315d07b3155f50b1ccafR281.

### Modifications

Initialize `cmdPos` at 0 rather than 1.