### PR TITLE
[Build] Fix build_java_test_image.sh script

### DIFF
--- a/build/build_java_test_image.sh
+++ b/build/build_java_test_image.sh
@@ -26,5 +26,6 @@ SQUASH_PARAM=""
 if [[ "$(docker version -f '{{.Server.Experimental}}' 2>/dev/null)" == "true" ]]; then
   SQUASH_PARAM="-Ddockerfile.build.squash=true"
 fi
-mvn -am -pl tests/docker-images/java-test-image install -Pcore-modules,-main,integrationTests,docker \
-  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true $SQUASH_PARAM "$@"
+mvn -am -pl tests/docker-images/java-test-image -Pcore-modules,-main,integrationTests,docker \
+  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true $SQUASH_PARAM \
+  "$@" install

--- a/pulsar-broker-auth-sasl/pom.xml
+++ b/pulsar-broker-auth-sasl/pom.xml
@@ -69,14 +69,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-broker</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-proxy</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -97,4 +89,26 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <!-- enables builds with -Dmaven.test.skip=true -->
+      <id>test-jar-dependencies</id>
+      <activation>
+        <property>
+          <name>maven.test.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>pulsar-broker</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+          <type>test-jar</type>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -128,14 +128,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>managed-ledger</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-zookeeper-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -150,14 +142,6 @@
     <dependency>
        <groupId>org.xerial.snappy</groupId>
        <artifactId>snappy-java</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-zookeeper-utils</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
     </dependency>
 
     <!-- functions related dependencies (begin) -->
@@ -377,13 +361,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-package-core</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -528,6 +505,41 @@
   </build>
 
   <profiles>
+    <profile>
+      <!-- enables builds with -Dmaven.test.skip=true -->
+      <id>test-jar-dependencies</id>
+      <activation>
+        <property>
+          <name>maven.test.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>managed-ledger</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>pulsar-zookeeper-utils</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>pulsar-package-core</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>swagger</id>
       <build>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -165,14 +165,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-broker</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>testmocks</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -183,4 +175,26 @@
       <artifactId>jcommander</artifactId>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <!-- enables builds with -Dmaven.test.skip=true -->
+      <id>test-jar-dependencies</id>
+      <activation>
+        <property>
+          <name>maven.test.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>pulsar-broker</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -72,14 +72,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>pulsar-broker</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 		</dependency>
@@ -102,4 +94,26 @@
 
 
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- enables builds with -Dmaven.test.skip=true -->
+			<id>test-jar-dependencies</id>
+			<activation>
+				<property>
+					<name>maven.test.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>pulsar-broker</artifactId>
+					<version>${project.version}</version>
+					<type>test-jar</type>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
### Motivation & Modifications

- The `build_java_test_image.sh` script is currently broken. When starting with a clean `~/.mvn/repository/org/apache/pulsar`, the script will fail with errors about not finding `test-jar` type of dependencies.

- `build_java_test_image.sh` script passes `-Dmaven.test.skip=true` to the mvn build to
  speed up the build by skipping the test classes compilation and packaging of `test-jar` dependencies

- `test-jar` dependencies have to be part of a separate profile for this to work. The profile
  gets activated if `maven.test.skip` != true

- the benefit of skipping test compilation is the quicker feedback loop in developing Pulsar where docker images are required as part of the development testing process. This is the case for more complex usage scenarios where a test case might be leveraging a helm deployment to k8s. 
  - The `build_java_test_image.sh` script can be used in Pulsar development to quickly build a minimal Docker image that is used in a development time k8s environment such as minikube, kind or microk8s.
  - Removing even just 10 seconds from the build time is useful in this type of use case.