### PR TITLE
[ML] Release OpAddEntry.data when entry is copied and discarded

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1504,6 +1504,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 if (existsOp.ledger != null) {
                     existsOp.close();
                     existsOp = OpAddEntry.create(existsOp.ml, existsOp.data, existsOp.getNumberOfMessages(), existsOp.callback, existsOp.ctx);
+                    // release the extra retain
+                    ReferenceCountUtil.release(existsOp.data);
                 }
                 existsOp.setLedger(currentLedger);
                 if (beforeAddEntry(existsOp)) {


### PR DESCRIPTION
Fixes #10738

### Motivation

There's a ByteBuf leak that happens in ledger rollover. The repro case in #10738 reproduces some Netty ByteBuf leaks that are detected by the Netty Leak detector.

### Modifications

Release `OpAddEntry.data` when the original entry is copied and discarded

### Additional Context

This PR was split out of PR #10755 which was closed without merging.