### PR TITLE
[Issue 10776][pulsar-client]Fixed dead letter queue name

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -332,7 +332,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             } else {
                 this.deadLetterPolicy = DeadLetterPolicy.builder()
                         .maxRedeliverCount(conf.getDeadLetterPolicy().getMaxRedeliverCount())
-                        .deadLetterTopic(String.format("%s-%s" + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX, topic, subscription))
+                        .deadLetterTopic(String.format("%s-%s" + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX, topic,
+                                StringUtils.replace(subscription, "/", "-")))
                         .build();
             }
 
@@ -340,7 +341,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 this.deadLetterPolicy.setRetryLetterTopic(conf.getDeadLetterPolicy().getRetryLetterTopic());
             } else {
                 this.deadLetterPolicy.setRetryLetterTopic(String.format("%s-%s" + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX,
-                        topic, subscription));
+                        topic, StringUtils.replace(subscription, "/", "-")));
             }
 
         } else {


### PR DESCRIPTION


Fixes #10776 


### Motivation

If no dead queue name is specified, a dead queue name will be automatically generated when a timeout occurs, which will cause the following exception when a slash appears in the subscription name:

Topic name:

```
public/default/sql-test
```
subscription name:

```
public/dev/sqs8-0e2bff7e
```

dead queue topic name:

```
public/default/sql-test-public/dev/sqs8-0e2bff7e-DLQ
```

```
03:27:50.828 [pulsar-timer-7-1] ERROR org.apache.pulsar.client.impl.ConsumerImpl - Dead letter producer exception with topic: public/default/sql-test-public/dev/sqs8-0e2bff7e-DLQ
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$InvalidTopicNameException: Invalid topic name: 'public/default/sql-test-public/dev/sqs8-0e2bff7e-DLQ'
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_292]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_292]
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:661) ~[?:1.8.0_292]
	at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:683) ~[?:1.8.0_292]
	at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2010) ~[?:1.8.0_292]
	at org.apache.pulsar.client.impl.ConsumerImpl.processPossibleToDLQ(ConsumerImpl.java:1694) ~[java-instance.jar:?]
	at org.apache.pulsar.client.impl.ConsumerImpl.lambda$getRedeliveryMessageIdData$31(ConsumerImpl.java:1666) ~[java-instance.jar:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:1.8.0_292]
	at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1082) ~[?:1.8.0_292]
	at org.apache.pulsar.client.impl.ConsumerImpl.getRedeliveryMessageIdData(ConsumerImpl.java:1665) ~[java-instance.jar:?]
	at org.apache.pulsar.client.impl.ConsumerImpl.lambda$redeliverUnacknowledgedMessages$29(ConsumerImpl.java:1630) ~[java-instance.jar:?]
	at java.lang.Iterable.forEach(Iterable.java:75) [?:1.8.0_292]
	at org.apache.pulsar.client.impl.ConsumerImpl.redeliverUnacknowledgedMessages(ConsumerImpl.java:1629) [java-instance.jar:?]
	at org.apache.pulsar.client.impl.UnAckedMessageTracker$2.run(UnAckedMessageTracker.java:145) [java-instance.jar:?]
	at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:672) [java-instance.jar:?]
	at io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:747) [java-instance.jar:?]
	at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:472) [java-instance.jar:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [java-instance.jar:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_292]
Caused by: org.apache.pulsar.client.api.PulsarClientException$InvalidTopicNameException: Invalid topic name: 'public/default/sql-test-public/dev-yyang/sqs8-0e2bff7e-DLQ'
	at org.apache.pulsar.client.impl.PulsarClientImpl.createProducerAsync(PulsarClientImpl.java:289) ~[java-instance.jar:?]
	at org.apache.pulsar.client.impl.ProducerBuilderImpl.createAsync(ProducerBuilderImpl.java:116) ~[java-instance.jar:?]
	at org.apache.pulsar.client.impl.ConsumerImpl.initDeadLetterProducerIfNeeded(ConsumerImpl.java:1739) ~[java-instance.jar:?]
	at org.apache.pulsar.client.impl.ConsumerImpl.processPossibleToDLQ(ConsumerImpl.java:1691) ~[java-instance.jar:?]
	... 13 more
```


### Modifications

* Automatically replace illegal characters, such as /, when automatically generating dead letter queue names

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
