### PR TITLE
[Build] Fix building the Presto distribution without building everything

### DIFF
--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -34,6 +34,7 @@
   <version>2.8.0-SNAPSHOT</version>
 
   <properties>
+    <skipBuildDistribution>false</skipBuildDistribution>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <jersey.version>2.34</jersey.version>
@@ -345,7 +346,7 @@
       <activation>
         <property>
           <name>skipBuildDistribution</name>
-          <value>false</value>
+          <value>!true</value>
         </property>
       </activation>
       <dependencies>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -130,14 +130,6 @@
 
         <dependency>
           <groupId>org.apache.pulsar</groupId>
-          <artifactId>pulsar-broker</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-          <type>test-jar</type>
-        </dependency>
-
-        <dependency>
-          <groupId>org.apache.pulsar</groupId>
           <artifactId>testmocks</artifactId>
           <version>${project.version}</version>
           <scope>test</scope>
@@ -229,4 +221,25 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <!-- enables builds with -Dmaven.test.skip=true -->
+            <id>test-jar-dependencies</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>pulsar-broker</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Motivation

It should be possible to build the full Pulsar distribution in the fastest possible way with this command:
```
mvn clean install -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true \
  -pl distribution/server -am
```

This is broken since the Presto project dependencies are missing. The optimization to skip building the distribution when `-DskipBuildDistribution=true` (added as part of #10288) caused the issue. This PR will fix that.


### Modifications

- add dependency from pulsar-presto-distribution to pulsar-presto-connector when skipBuildDistribution != true
- support building Presto distribution with -Dmaven.test.skip=true