### PR TITLE
[Build] Upgrade Jackson version to 2.12.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,14 +312,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.78.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.7.3.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.11.1.jar
-     - com.fasterxml.jackson.core-jackson-core-2.11.1.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.11.1.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.11.1.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.11.1.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.11.1.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.11.1.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.11.1.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.12.3.jar
+     - com.fasterxml.jackson.core-jackson-core-2.12.3.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.12.3.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.12.3.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.12.3.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.12.3.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.12.3.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.12.3.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
@@ -443,7 +443,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.39.v20210325.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.39.v20210325.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.39.v20210325.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.26.jar
+ * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.12.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.14.0</log4j2.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.11.1</jackson.version>
-    <jackson.databind.version>2.11.1</jackson.databind.version>
+    <jackson.version>2.12.3</jackson.version>
+    <jackson.databind.version>2.12.3</jackson.databind.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.11.1.jar
-    - jackson-core-2.11.1.jar
-    - jackson-databind-2.11.1.jar
-    - jackson-dataformat-smile-2.11.1.jar
-    - jackson-datatype-guava-2.11.1.jar
-    - jackson-datatype-jdk8-2.11.1.jar
-    - jackson-datatype-joda-2.11.1.jar
-    - jackson-datatype-jsr310-2.11.1.jar
-    - jackson-dataformat-yaml-2.11.1.jar
-    - jackson-jaxrs-base-2.11.1.jar
-    - jackson-jaxrs-json-provider-2.11.1.jar
-    - jackson-module-jaxb-annotations-2.11.1.jar
-    - jackson-module-jsonSchema-2.11.1.jar
+    - jackson-annotations-2.12.3.jar
+    - jackson-core-2.12.3.jar
+    - jackson-databind-2.12.3.jar
+    - jackson-dataformat-smile-2.12.3.jar
+    - jackson-datatype-guava-2.12.3.jar
+    - jackson-datatype-jdk8-2.12.3.jar
+    - jackson-datatype-joda-2.12.3.jar
+    - jackson-datatype-jsr310-2.12.3.jar
+    - jackson-dataformat-yaml-2.12.3.jar
+    - jackson-jaxrs-base-2.12.3.jar
+    - jackson-jaxrs-json-provider-2.12.3.jar
+    - jackson-module-jaxb-annotations-2.12.3.jar
+    - jackson-module-jsonSchema-2.12.3.jar
  * Guava
     - guava-30.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -392,7 +392,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-6.10.2.jar
   * SnakeYAML
-    - snakeyaml-1.26.jar
+    - snakeyaml-1.27.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize
@@ -438,8 +438,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.7.jar
   * Jackson
-    - jackson-module-parameter-names-2.10.0.jar
-    - jackson-module-parameter-names-2.11.1.jar
+    - jackson-module-parameter-names-2.12.3.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Jetty

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -45,10 +45,10 @@
     <!-- Launcher properties -->
     <main-class>io.prestosql.server.PrestoServer</main-class>
     <process-name>${project.artifactId}</process-name>
-    <jackson.version>2.11.1</jackson.version>
+    <jackson.version>2.12.3</jackson.version>
     <!--fix Security Vulnerabilities-->
     <!--https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html-->
-    <jackson.databind.version>2.11.1</jackson.databind.version>
+    <jackson.databind.version>2.12.3</jackson.databind.version>
     <maven.version>3.0.5</maven.version>
     <guava.version>30.1-jre</guava.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
@@ -254,6 +254,13 @@
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Motivation

- the current version of Jackson is old, 2.11.1 . 
- keep up-to-date with important libraries
- Jackson 2.12.x has support for Java 14+ Records. This upgrade paves the path for JDK 17 (release date Sep-21-2021) support. JDK 17 is the next LTS version after JDK 11.

### Modifications

- Upgrade Jackson version to 2.12.3 .