### PR TITLE
Avoid warning logs on topic policies not present

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -82,10 +82,12 @@ public class BacklogQuotaManager {
         }
 
         try {
-            return Optional.ofNullable(pulsar.getTopicPoliciesService().getTopicPolicies(topicName))
-                    .map(TopicPolicies::getBackLogQuotaMap)
-                    .map(map -> map.get(BacklogQuotaType.destination_storage.name()))
-                    .orElseGet(() -> getBacklogQuota(topicName.getNamespace(), policyPath));
+            if (pulsar.getTopicPoliciesService().cacheIsInitialized(topicName)) {
+                return Optional.ofNullable(pulsar.getTopicPoliciesService().getTopicPolicies(topicName))
+                        .map(TopicPolicies::getBackLogQuotaMap)
+                        .map(map -> map.get(BacklogQuotaType.destination_storage.name()))
+                        .orElseGet(() -> getBacklogQuota(topicName.getNamespace(), policyPath));
+            }
         } catch (Exception e) {
             log.warn("Failed to read topic policies data, will apply the namespace backlog quota: topicName={}",
                     topicName, e);


### PR DESCRIPTION
### Motivation
If SystemTopic is enabled, but no policy is set for this topic, a warn log is printed every time

![image](https://user-images.githubusercontent.com/9758905/120519117-dbb64180-c404-11eb-8133-5e804674db3f.png)
