### PR TITLE
[broker] Add REST API to enable or disable replicated subscriptions

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -82,6 +82,20 @@ public interface ManagedCursor {
     Map<String, Long> getProperties();
 
     /**
+     * If the last stored position exists and its properties map is mutable, add a property to it.
+     *
+     * @return true if the property was added successfully, false otherwise
+     */
+    boolean putPropertyIfPossible(String key, Long value);
+
+    /**
+     * If the last stored position exists and its properties map is mutable, remove a property from it.
+     *
+     * @return true if the property was removed successfully, false otherwise
+     */
+    boolean removePropertyIfPossible(String key);
+
+    /**
      * Read entries from the ManagedLedger, up to the specified number. The returned list can be smaller.
      *
      * @param numberOfEntriesToRead

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -82,18 +82,14 @@ public interface ManagedCursor {
     Map<String, Long> getProperties();
 
     /**
-     * If the last stored position exists and its properties map is mutable, add a property to it.
-     *
-     * @return true if the property was added successfully, false otherwise
+     * Add a property associated with the last stored position.
      */
-    boolean putPropertyIfPossible(String key, Long value);
+    boolean putProperty(String key, Long value);
 
     /**
-     * If the last stored position exists and its properties map is mutable, remove a property from it.
-     *
-     * @return true if the property was removed successfully, false otherwise
+     * Remove a property associated with the last stored position.
      */
-    boolean removePropertyIfPossible(String key);
+    boolean removeProperty(String key);
 
     /**
      * Read entries from the ManagedLedger, up to the specified number. The returned list can be smaller.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -285,6 +285,32 @@ public class ManagedCursorImpl implements ManagedCursor {
         return lastMarkDeleteEntry != null ? lastMarkDeleteEntry.properties : Collections.emptyMap();
     }
 
+    @Override
+    public boolean putPropertyIfPossible(String key, Long value) {
+        if (lastMarkDeleteEntry != null) {
+            try {
+                lastMarkDeleteEntry.properties.put(key, value);
+                return true;
+            } catch (UnsupportedOperationException e) {
+                // lastMarkDeleteEntry.properties can be Collections.emptyMap(), i.e. an immutable object
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removePropertyIfPossible(String key) {
+        if (lastMarkDeleteEntry != null) {
+            try {
+                lastMarkDeleteEntry.properties.remove(key);
+                return true;
+            } catch (UnsupportedOperationException e) {
+                // lastMarkDeleteEntry.properties can be Collections.emptyMap(), i.e. an immutable object
+            }
+        }
+        return false;
+    }
+
     /**
      * Performs the initial recovery, reading the mark-deleted position from the ledger and then calling initialize to
      * have a new opened ledger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -286,26 +286,30 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     @Override
-    public boolean putPropertyIfPossible(String key, Long value) {
+    public boolean putProperty(String key, Long value) {
         if (lastMarkDeleteEntry != null) {
-            try {
-                lastMarkDeleteEntry.properties.put(key, value);
-                return true;
-            } catch (UnsupportedOperationException e) {
-                // lastMarkDeleteEntry.properties can be Collections.emptyMap(), i.e. an immutable object
+            MarkDeleteEntry currentLastMarkDeleteEntry = lastMarkDeleteEntry;
+            Map<String, Long> properties = currentLastMarkDeleteEntry.properties;
+            if (properties == null || properties.isEmpty()) {
+                Map<String, Long> newProperties = Maps.newHashMap();
+                newProperties.put(key, value);
+                lastMarkDeleteEntry = new MarkDeleteEntry(currentLastMarkDeleteEntry.newPosition, newProperties,
+                        currentLastMarkDeleteEntry.callback, currentLastMarkDeleteEntry.ctx);
+            } else {
+                properties.put(key, value);
             }
+            return true;
         }
         return false;
     }
 
     @Override
-    public boolean removePropertyIfPossible(String key) {
+    public boolean removeProperty(String key) {
         if (lastMarkDeleteEntry != null) {
-            try {
-                lastMarkDeleteEntry.properties.remove(key);
+            Map<String, Long> properties = lastMarkDeleteEntry.properties;
+            if (properties != null && properties.containsKey(key)) {
+                properties.remove(key);
                 return true;
-            } catch (UnsupportedOperationException e) {
-                // lastMarkDeleteEntry.properties can be Collections.emptyMap(), i.e. an immutable object
             }
         }
         return false;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -295,6 +295,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 newProperties.put(key, value);
                 lastMarkDeleteEntry = new MarkDeleteEntry(currentLastMarkDeleteEntry.newPosition, newProperties,
                         currentLastMarkDeleteEntry.callback, currentLastMarkDeleteEntry.ctx);
+                lastMarkDeleteEntry.callbackGroup = currentLastMarkDeleteEntry.callbackGroup;
             } else {
                 properties.put(key, value);
             }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -67,12 +67,12 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public boolean putPropertyIfPossible(String key, Long value) {
+        public boolean putProperty(String key, Long value) {
             return false;
         }
 
         @Override
-        public boolean removePropertyIfPossible(String key) {
+        public boolean removeProperty(String key) {
             return false;
         }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -67,6 +67,16 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
+        public boolean putPropertyIfPossible(String key, Long value) {
+            return false;
+        }
+
+        @Override
+        public boolean removePropertyIfPossible(String key) {
+            return false;
+        }
+
+        @Override
         public boolean isDurable() {
             return true;
         }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -585,6 +585,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             case EXPIRE_MESSAGES:
             case PEEK_MESSAGES:
             case RESET_CURSOR:
+            case SET_REPLICATED_SUBSCRIPTION_STATUS:
                 isAuthorizedFuture = canConsumeAsync(topicName, role, authData, authData.getSubscription());
                 break;
             case TERMINATE:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4042,14 +4042,9 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalSetReplicatedSubscriptionStatus(AsyncResponse asyncResponse, String subName,
-            boolean authoritative, Boolean enabled) {
+            boolean authoritative, boolean enabled) {
         log.info("[{}] Attempting to change replicated subscription status to {} - {} {}", clientAppId(), enabled,
                 topicName, subName);
-
-        if (enabled == null) {
-            asyncResponse.resume(new RestException(Status.BAD_REQUEST, "Boolean type request body is required"));
-            return;
-        }
 
         // Reject the request if the topic is not persistent
         if (!topicName.isPersistent()) {
@@ -4139,7 +4134,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     private void internalSetReplicatedSubscriptionStatusForNonPartitionedTopic(AsyncResponse asyncResponse,
-            String subName, boolean authoritative, Boolean enabled) {
+            String subName, boolean authoritative, boolean enabled) {
         try {
             // Redirect the request to the appropriate broker if this broker is not the owner of the topic
             validateTopicOwnership(topicName, authoritative);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4152,7 +4152,12 @@ public class PersistentTopicsBase extends AdminResource {
             }
 
             if (topic instanceof PersistentTopic && sub instanceof PersistentSubscription) {
-                ((PersistentSubscription) sub).setReplicated(enabled);
+                if (!((PersistentSubscription) sub).setReplicated(enabled)) {
+                    asyncResponse.resume(
+                            new RestException(Status.INTERNAL_SERVER_ERROR, "Failed to update cursor properties"));
+                    return;
+                }
+
                 ((PersistentTopic) topic).checkReplicatedSubscriptionControllerState();
                 log.info("[{}] Changed replicated subscription status to {} - {} {}", clientAppId(), enabled, topicName,
                         subName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4073,6 +4073,14 @@ public class PersistentTopicsBase extends AdminResource {
             return;
         }
 
+        // Redirect the request to the peer-cluster if the local cluster is not included in the replication clusters
+        try {
+            validateGlobalNamespaceOwnership(namespaceName);
+        } catch (Exception e) {
+            resumeAsyncResponseExceptionally(asyncResponse, e);
+            return;
+        }
+
         // If the topic name is a partition name, no need to get partition topic metadata again
         if (topicName.isPartitioned()) {
             internalSetReplicatedSubscriptionStatusForNonPartitionedTopic(asyncResponse, subName, authoritative,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -831,7 +831,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Whether to enable replicated subscription", required = true)
-            Boolean enabled) {
+            boolean enabled) {
         try {
             validateTopicName(tenant, cluster, namespace, encodedTopic);
             internalSetReplicatedSubscriptionStatus(asyncResponse, decode(encodedSubName), authoritative, enabled);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -802,4 +802,43 @@ public class PersistentTopics extends PersistentTopicsBase {
             asyncResponse.resume(new RestException(e));
         }
     }
+
+    @POST
+    @Path("/{tenant}/{cluster}/{namespace}/{topic}/subscription/{subName}/replicatedSubscriptionStatus")
+    @ApiOperation(value = "Enable or disable a replicated subscription on a topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or "
+                    + "subscriber is not authorized to access this operation"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic or subscription does not exist"),
+            @ApiResponse(code = 405, message = "Operation not allowed on this topic"),
+            @ApiResponse(code = 412, message = "Can't find owner for topic"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")})
+    public void setReplicatedSubscriptionStatus(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the cluster", required = true)
+            @PathParam("cluster") String cluster,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Name of subscription", required = true)
+            @PathParam("subName") String encodedSubName,
+            @ApiParam(value = "Is authentication required to perform this operation")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Whether to enable replicated subscription", required = true)
+            Boolean enabled) {
+        try {
+            validateTopicName(tenant, cluster, namespace, encodedTopic);
+            internalSetReplicatedSubscriptionStatus(asyncResponse, decode(encodedSubName), authoritative, enabled);
+        } catch (WebApplicationException wae) {
+            asyncResponse.resume(wae);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -3156,7 +3156,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Whether to enable replicated subscription", required = true)
-            Boolean enabled) {
+            boolean enabled) {
         try {
             validateTopicName(tenant, namespace, encodedTopic);
             internalSetReplicatedSubscriptionStatus(asyncResponse, decode(encodedSubName), authoritative, enabled);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -3130,5 +3130,42 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     }
 
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/subscription/{subName}/replicatedSubscriptionStatus")
+    @ApiOperation(value = "Enable or disable a replicated subscription on a topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant or "
+                    + "subscriber is not authorized to access this operation"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic or subscription does not exist"),
+            @ApiResponse(code = 405, message = "Operation not allowed on this topic"),
+            @ApiResponse(code = 412, message = "Can't find owner for topic"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 503, message = "Failed to validate global cluster configuration")})
+    public void setReplicatedSubscriptionStatus(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Name of subscription", required = true)
+            @PathParam("subName") String encodedSubName,
+            @ApiParam(value = "Is authentication required to perform this operation")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Whether to enable replicated subscription", required = true)
+            Boolean enabled) {
+        try {
+            validateTopicName(tenant, namespace, encodedTopic);
+            internalSetReplicatedSubscriptionStatus(asyncResponse, decode(encodedSubName), authoritative, enabled);
+        } catch (WebApplicationException wae) {
+            asyncResponse.resume(wae);
+        } catch (Exception e) {
+            asyncResponse.resume(new RestException(e));
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -178,7 +178,7 @@ public class PersistentSubscription implements Subscription {
         return replicatedSubscriptionSnapshotCache != null;
     }
 
-    public void setReplicated(boolean replicated) {
+    public boolean setReplicated(boolean replicated) {
         ServiceConfiguration config = topic.getBrokerService().getPulsar().getConfig();
 
         if (!replicated || !config.isEnableReplicatedSubscriptions()) {
@@ -190,11 +190,13 @@ public class PersistentSubscription implements Subscription {
 
         if (this.cursor != null) {
             if (replicated) {
-                this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
+                return this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
             } else {
-                this.cursor.removeProperty(REPLICATED_SUBSCRIPTION_PROPERTY);
+                return this.cursor.removeProperty(REPLICATED_SUBSCRIPTION_PROPERTY);
             }
         }
+
+        return false;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -190,9 +190,9 @@ public class PersistentSubscription implements Subscription {
 
         if (this.cursor != null) {
             if (replicated) {
-                this.cursor.putPropertyIfPossible(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
+                this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
             } else {
-                this.cursor.removePropertyIfPossible(REPLICATED_SUBSCRIPTION_PROPERTY);
+                this.cursor.removeProperty(REPLICATED_SUBSCRIPTION_PROPERTY);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -189,15 +189,10 @@ public class PersistentSubscription implements Subscription {
         }
 
         if (this.cursor != null) {
-            Map<String, Long> properties = this.cursor.getProperties();
-            try {
-                if (replicated) {
-                    properties.put(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
-                } else {
-                    properties.remove(REPLICATED_SUBSCRIPTION_PROPERTY);
-                }
-            } catch (UnsupportedOperationException e) {
-                // ManagedCursorImpl#lastMarkDeleteEntry has not been initialized yet
+            if (replicated) {
+                this.cursor.putPropertyIfPossible(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
+            } else {
+                this.cursor.removePropertyIfPossible(REPLICATED_SUBSCRIPTION_PROPERTY);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -179,9 +179,9 @@ public class PersistentSubscription implements Subscription {
     }
 
     public void setReplicated(boolean replicated) {
-        ServiceConfiguration config = topic.getBrokerService().pulsar().getConfiguration();
+        ServiceConfiguration config = topic.getBrokerService().getPulsar().getConfig();
 
-        if (!config.isEnableReplicatedSubscriptions() || !replicated) {
+        if (!replicated || !config.isEnableReplicatedSubscriptions()) {
             this.replicatedSubscriptionSnapshotCache = null;
         } else if (this.replicatedSubscriptionSnapshotCache == null) {
             this.replicatedSubscriptionSnapshotCache = new ReplicatedSubscriptionSnapshotCache(subName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2702,7 +2702,7 @@ public class PersistentTopic extends AbstractTopic
             });
     }
 
-    private synchronized void checkReplicatedSubscriptionControllerState() {
+    public synchronized void checkReplicatedSubscriptionControllerState() {
         AtomicBoolean shouldBeEnabled = new AtomicBoolean(false);
         subscriptions.forEach((name, subscription) -> {
             if (subscription.isReplicated()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -711,4 +711,86 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @Test
+    public void testSetReplicatedSubscriptionStatus() {
+        final String topicName = "topic-with-repl-sub";
+        final String partitionName = topicName + "-partition-0";
+        final String subName = "sub";
+
+        // 1) Return 404 if that the topic does not exist
+        AsyncResponse response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
+                true);
+        ArgumentCaptor<RestException> errorCaptor = ArgumentCaptor.forClass(RestException.class);
+        verify(response, timeout(5000).times(1)).resume(errorCaptor.capture());
+        Assert.assertEquals(errorCaptor.getValue().getResponse().getStatus(),
+                Response.Status.NOT_FOUND.getStatusCode());
+
+        // 2) Return 404 if that the partitioned topic does not exist
+        response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
+                true, true);
+        errorCaptor = ArgumentCaptor.forClass(RestException.class);
+        verify(response, timeout(5000).times(1)).resume(errorCaptor.capture());
+        Assert.assertEquals(errorCaptor.getValue().getResponse().getStatus(),
+                Response.Status.NOT_FOUND.getStatusCode());
+
+        // 3) Create the partitioned topic
+        response = mock(AsyncResponse.class);
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 4) Create a subscription
+        response = mock(AsyncResponse.class);
+        persistentTopics.createSubscription(response, testTenant, testNamespace, topicName, subName, true,
+                (MessageIdImpl) MessageId.latest, false);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 5) Enable replicated subscription on the partitioned topic
+        response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
+                true);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 6) Disable replicated subscription on the partitioned topic
+        response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
+                false);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 7) Enable replicated subscription on the partition
+        response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
+                true, true);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 8) Disable replicated subscription on the partition
+        response = mock(AsyncResponse.class);
+        persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
+                true, false);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 9) Delete the subscription
+        response = mock(AsyncResponse.class);
+        persistentTopics.deleteSubscription(response, testTenant, testNamespace, topicName, subName, false, true);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        // 10) Delete the partitioned topic
+        response = mock(AsyncResponse.class);
+        persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, topicName, true, true, false);
+        responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -722,7 +722,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
                 true);
         ArgumentCaptor<RestException> errorCaptor = ArgumentCaptor.forClass(RestException.class);
-        verify(response, timeout(5000).times(1)).resume(errorCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(errorCaptor.capture());
         Assert.assertEquals(errorCaptor.getValue().getResponse().getStatus(),
                 Response.Status.NOT_FOUND.getStatusCode());
 
@@ -731,7 +731,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
                 true, true);
         errorCaptor = ArgumentCaptor.forClass(RestException.class);
-        verify(response, timeout(5000).times(1)).resume(errorCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(errorCaptor.capture());
         Assert.assertEquals(errorCaptor.getValue().getResponse().getStatus(),
                 Response.Status.NOT_FOUND.getStatusCode());
 
@@ -739,7 +739,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         response = mock(AsyncResponse.class);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
         persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 4) Create a subscription
@@ -747,49 +747,49 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         persistentTopics.createSubscription(response, testTenant, testNamespace, topicName, subName, true,
                 (MessageIdImpl) MessageId.latest, false);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 5) Enable replicated subscription on the partitioned topic
         response = mock(AsyncResponse.class);
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
                 true);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 6) Disable replicated subscription on the partitioned topic
         response = mock(AsyncResponse.class);
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, topicName, subName, true,
                 false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 7) Enable replicated subscription on the partition
         response = mock(AsyncResponse.class);
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
                 true, true);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 8) Disable replicated subscription on the partition
         response = mock(AsyncResponse.class);
         persistentTopics.setReplicatedSubscriptionStatus(response, testTenant, testNamespace, partitionName, subName,
                 true, false);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 9) Delete the subscription
         response = mock(AsyncResponse.class);
         persistentTopics.deleteSubscription(response, testTenant, testNamespace, topicName, subName, false, true);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
         // 10) Delete the partitioned topic
         response = mock(AsyncResponse.class);
         persistentTopics.deletePartitionedTopic(response, testTenant, testNamespace, topicName, true, true, false);
         responseCaptor = ArgumentCaptor.forClass(Response.class);
-        verify(response, timeout(5000).times(1)).resume(responseCaptor.capture());
+        verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -260,25 +260,25 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         createReplicatedSubscription(client2, topicName, subName, true);
 
         TopicStats stats = admin1.topics().getStats(topicName);
-        assertTrue(stats.subscriptions.get(subName).isReplicated);
+        assertTrue(stats.getSubscriptions().get(subName).isReplicated());
 
         // Disable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, false);
         stats = admin1.topics().getStats(topicName);
-        assertFalse(stats.subscriptions.get(subName).isReplicated);
+        assertFalse(stats.getSubscriptions().get(subName).isReplicated());
         stats = admin2.topics().getStats(topicName);
-        assertTrue(stats.subscriptions.get(subName).isReplicated);
+        assertTrue(stats.getSubscriptions().get(subName).isReplicated());
 
         // Disable replicated subscription in r2
         admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, false);
         stats = admin2.topics().getStats(topicName);
-        assertFalse(stats.subscriptions.get(subName).isReplicated);
+        assertFalse(stats.getSubscriptions().get(subName).isReplicated());
 
         // Unload topic in r1
         admin1.topics().unload(topicName);
         Thread.sleep(1000);
         stats = admin1.topics().getStats(topicName);
-        assertFalse(stats.subscriptions.get(subName).isReplicated);
+        assertFalse(stats.getSubscriptions().get(subName).isReplicated());
 
         // Make sure the replicated subscription is actually disabled
         final int numMessages = 20;
@@ -305,14 +305,14 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         // Enable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
         stats = admin1.topics().getStats(topicName);
-        assertTrue(stats.subscriptions.get(subName).isReplicated);
+        assertTrue(stats.getSubscriptions().get(subName).isReplicated());
         stats = admin2.topics().getStats(topicName);
-        assertFalse(stats.subscriptions.get(subName).isReplicated);
+        assertFalse(stats.getSubscriptions().get(subName).isReplicated());
 
         // Enable replicated subscription in r2
         admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
         stats = admin2.topics().getStats(topicName);
-        assertTrue(stats.subscriptions.get(subName).isReplicated);
+        assertTrue(stats.getSubscriptions().get(subName).isReplicated());
 
         // Make sure the replicated subscription is actually enabled
         sentMessages.clear();
@@ -371,22 +371,22 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         createReplicatedSubscription(client2, topicName, subName, true);
 
         PartitionedTopicStats partitionedStats = admin1.topics().getPartitionedStats(topicName, true);
-        for (TopicStats stats : partitionedStats.partitions.values()) {
-            assertTrue(stats.subscriptions.get(subName).isReplicated);
+        for (TopicStats stats : partitionedStats.getPartitions().values()) {
+            assertTrue(stats.getSubscriptions().get(subName).isReplicated());
         }
 
         // Disable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, false);
         partitionedStats = admin1.topics().getPartitionedStats(topicName, true);
-        for (TopicStats stats : partitionedStats.partitions.values()) {
-            assertFalse(stats.subscriptions.get(subName).isReplicated);
+        for (TopicStats stats : partitionedStats.getPartitions().values()) {
+            assertFalse(stats.getSubscriptions().get(subName).isReplicated());
         }
 
         // Disable replicated subscription in r2
         admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, false);
         partitionedStats = admin2.topics().getPartitionedStats(topicName, true);
-        for (TopicStats stats : partitionedStats.partitions.values()) {
-            assertFalse(stats.subscriptions.get(subName).isReplicated);
+        for (TopicStats stats : partitionedStats.getPartitions().values()) {
+            assertFalse(stats.getSubscriptions().get(subName).isReplicated());
         }
 
         // Make sure the replicated subscription is actually disabled
@@ -415,15 +415,15 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         // Enable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
         partitionedStats = admin1.topics().getPartitionedStats(topicName, true);
-        for (TopicStats stats : partitionedStats.partitions.values()) {
-            assertTrue(stats.subscriptions.get(subName).isReplicated);
+        for (TopicStats stats : partitionedStats.getPartitions().values()) {
+            assertTrue(stats.getSubscriptions().get(subName).isReplicated());
         }
 
         // Enable replicated subscription in r2
         admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
         partitionedStats = admin2.topics().getPartitionedStats(topicName, true);
-        for (TopicStats stats : partitionedStats.partitions.values()) {
-            assertTrue(stats.subscriptions.get(subName).isReplicated);
+        for (TopicStats stats : partitionedStats.getPartitions().values()) {
+            assertTrue(stats.getSubscriptions().get(subName).isReplicated());
         }
 
         // Make sure the replicated subscription is actually enabled

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -238,6 +238,9 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
         final String topicName = "persistent://" + namespace + "/topic-rest-api1";
         final String subName = "sub";
+        // Subscription replication produces duplicates, https://github.com/apache/pulsar/issues/10054
+        // TODO: duplications shouldn't be allowed, change to "false" when fixing the issue
+        final boolean allowDuplicates = true;
 
         admin1.namespaces().createNamespace(namespace);
         admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
@@ -273,8 +276,31 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
 
         // Unload topic in r1
         admin1.topics().unload(topicName);
+        Thread.sleep(1000);
         stats = admin1.topics().getStats(topicName);
         assertFalse(stats.subscriptions.get(subName).isReplicated);
+
+        // Make sure the replicated subscription is actually disabled
+        final int numMessages = 20;
+        final Set<String> sentMessages = new LinkedHashSet<>();
+        final Set<String> receivedMessages = new LinkedHashSet<>();
+
+        Producer<byte[]> producer = client1.newProducer().topic(topicName).enableBatching(false).create();
+        sentMessages.clear();
+        publishMessages(producer, 0, numMessages, sentMessages);
+        producer.close();
+
+        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        receivedMessages.clear();
+        readMessages(consumer1, receivedMessages, numMessages, false);
+        assertEquals(receivedMessages, sentMessages);
+        consumer1.close();
+
+        Consumer<byte[]> consumer2 = client2.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        receivedMessages.clear();
+        readMessages(consumer2, receivedMessages, numMessages, false);
+        assertEquals(receivedMessages, sentMessages);
+        consumer2.close();
 
         // Enable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
@@ -282,6 +308,39 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         assertTrue(stats.subscriptions.get(subName).isReplicated);
         stats = admin2.topics().getStats(topicName);
         assertFalse(stats.subscriptions.get(subName).isReplicated);
+
+        // Enable replicated subscription in r2
+        admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
+        stats = admin2.topics().getStats(topicName);
+        assertTrue(stats.subscriptions.get(subName).isReplicated);
+
+        // Make sure the replicated subscription is actually enabled
+        sentMessages.clear();
+        receivedMessages.clear();
+
+        producer = client1.newProducer().topic(topicName).enableBatching(false).create();
+        publishMessages(producer, 0, numMessages / 2, sentMessages);
+        producer.close();
+        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+
+        consumer1 = client1.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        final int numReceivedMessages1 = readMessages(consumer1, receivedMessages, numMessages / 2, allowDuplicates);
+        consumer1.close();
+
+        producer = client1.newProducer().topic(topicName).enableBatching(false).create();
+        publishMessages(producer, numMessages / 2, numMessages / 2, sentMessages);
+        producer.close();
+        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+
+        consumer2 = client2.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        final int numReceivedMessages2 = readMessages(consumer2, receivedMessages, -1, allowDuplicates);
+        consumer2.close();
+
+        assertEquals(receivedMessages, sentMessages);
+        assertTrue(numReceivedMessages1 < numMessages,
+                String.format("numReceivedMessages1 (%d) should be less than %d", numReceivedMessages1, numMessages));
+        assertTrue(numReceivedMessages2 < numMessages,
+                String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
     }
 
     @Test(timeOut = 30000)
@@ -289,9 +348,12 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
         final String topicName = "persistent://" + namespace + "/topic-rest-api2";
         final String subName = "sub";
+        // Subscription replication produces duplicates, https://github.com/apache/pulsar/issues/10054
+        // TODO: duplications shouldn't be allowed, change to "false" when fixing the issue
+        final boolean allowDuplicates = true;
 
         admin1.namespaces().createNamespace(namespace);
-        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1"));
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
         admin1.topics().createPartitionedTopic(topicName, 2);
 
         @Cleanup
@@ -300,6 +362,13 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
 
         // Create subscription in r1
         createReplicatedSubscription(client1, topicName, subName, true);
+
+        @Cleanup
+        final PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
+
+        // Create subscription in r2
+        createReplicatedSubscription(client2, topicName, subName, true);
 
         PartitionedTopicStats partitionedStats = admin1.topics().getPartitionedStats(topicName, true);
         for (TopicStats stats : partitionedStats.partitions.values()) {
@@ -313,15 +382,91 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
             assertFalse(stats.subscriptions.get(subName).isReplicated);
         }
 
+        // Disable replicated subscription in r2
+        admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, false);
+        partitionedStats = admin2.topics().getPartitionedStats(topicName, true);
+        for (TopicStats stats : partitionedStats.partitions.values()) {
+            assertFalse(stats.subscriptions.get(subName).isReplicated);
+        }
+
+        // Make sure the replicated subscription is actually disabled
+        final int numMessages = 20;
+        final Set<String> sentMessages = new LinkedHashSet<>();
+        final Set<String> receivedMessages = new LinkedHashSet<>();
+
+        Producer<byte[]> producer = client1.newProducer().topic(topicName).enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        sentMessages.clear();
+        publishMessages(producer, 0, numMessages, sentMessages);
+        producer.close();
+
+        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        receivedMessages.clear();
+        readMessages(consumer1, receivedMessages, numMessages, false);
+        assertEquals(receivedMessages, sentMessages);
+        consumer1.close();
+
+        Consumer<byte[]> consumer2 = client2.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        receivedMessages.clear();
+        readMessages(consumer2, receivedMessages, numMessages, false);
+        assertEquals(receivedMessages, sentMessages);
+        consumer2.close();
+
         // Enable replicated subscription in r1
         admin1.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
         partitionedStats = admin1.topics().getPartitionedStats(topicName, true);
         for (TopicStats stats : partitionedStats.partitions.values()) {
             assertTrue(stats.subscriptions.get(subName).isReplicated);
         }
+
+        // Enable replicated subscription in r2
+        admin2.topics().setReplicatedSubscriptionStatus(topicName, subName, true);
+        partitionedStats = admin2.topics().getPartitionedStats(topicName, true);
+        for (TopicStats stats : partitionedStats.partitions.values()) {
+            assertTrue(stats.subscriptions.get(subName).isReplicated);
+        }
+
+        // Make sure the replicated subscription is actually enabled
+        sentMessages.clear();
+        receivedMessages.clear();
+
+        producer = client1.newProducer().topic(topicName).enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        publishMessages(producer, 0, numMessages / 2, sentMessages);
+        producer.close();
+        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+
+        consumer1 = client1.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        final int numReceivedMessages1 = readMessages(consumer1, receivedMessages, numMessages / 2, allowDuplicates);
+        consumer1.close();
+
+        producer = client1.newProducer().topic(topicName).enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition).create();
+        publishMessages(producer, numMessages / 2, numMessages / 2, sentMessages);
+        producer.close();
+        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+
+        consumer2 = client2.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        final int numReceivedMessages2 = readMessages(consumer2, receivedMessages, -1, allowDuplicates);
+        consumer2.close();
+
+        assertEquals(receivedMessages, sentMessages);
+        assertTrue(numReceivedMessages1 < numMessages,
+                String.format("numReceivedMessages1 (%d) should be less than %d", numReceivedMessages1, numMessages));
+        assertTrue(numReceivedMessages2 < numMessages,
+                String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
     }
 
-    void readMessages(Consumer<byte[]> consumer, Set<String> messages, int maxMessages, boolean allowDuplicates)
+    void publishMessages(Producer<byte[]> producer, int startIndex, int numMessages, Set<String> sentMessages)
+            throws PulsarClientException {
+        for (int i = startIndex; i < startIndex + numMessages; i++) {
+            final String msg = "msg" + i;
+            producer.send(msg.getBytes(StandardCharsets.UTF_8));
+            sentMessages.add(msg);
+        }
+    }
+
+    int readMessages(Consumer<byte[]> consumer, Set<String> messages, int maxMessages, boolean allowDuplicates)
             throws PulsarClientException {
         int count = 0;
         while (count < maxMessages || maxMessages == -1) {
@@ -333,10 +478,12 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
                     assertFalse(messages.contains(body), "Duplicate message '" + body + "' detected.");
                 }
                 messages.add(body);
+                consumer.acknowledge(message);
             } else {
                 break;
             }
         }
+        return count;
     }
 
     void createReplicatedSubscription(PulsarClient pulsarClient, String topicName, String subscriptionName,

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -3301,4 +3301,24 @@ public interface Topics {
      * @return a future that can be used to track when the topic is truncated
      */
     CompletableFuture<Void> truncateAsync(String topic);
+
+    /**
+     * Enable or disable a replicated subscription on a topic.
+     *
+     * @param topic
+     * @param subName
+     * @param enabled
+     * @throws PulsarAdminException
+     */
+    void setReplicatedSubscriptionStatus(String topic, String subName, boolean enabled) throws PulsarAdminException;
+
+    /**
+     * Enable or disable a replicated subscription on a topic asynchronously.
+     *
+     * @param topic
+     * @param subName
+     * @param enabled
+     * @return
+     */
+    CompletableFuture<Void> setReplicatedSubscriptionStatusAsync(String topic, String subName, boolean enabled);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -3481,7 +3481,29 @@ public class TopicsImpl extends BaseResource implements Topics {
         return asyncDeleteRequest(path);
     }
 
+    @Override
+    public void setReplicatedSubscriptionStatus(String topic, String subName, boolean enabled)
+            throws PulsarAdminException {
+        try {
+            setReplicatedSubscriptionStatusAsync(topic, subName, enabled).get(this.readTimeoutMs,
+                    TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
 
+    @Override
+    public CompletableFuture<Void> setReplicatedSubscriptionStatusAsync(String topic, String subName, boolean enabled) {
+        TopicName topicName = validateTopic(topic);
+        String encodedSubName = Codec.encode(subName);
+        WebTarget path = topicPath(topicName, "subscription", encodedSubName, "replicatedSubscriptionStatus");
+        return asyncPostRequest(path, Entity.entity(enabled, MediaType.APPLICATION_JSON));
+    }
 
     private static final Logger log = LoggerFactory.getLogger(TopicsImpl.class);
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -939,6 +939,9 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
 
+        cmdTopics.run(split("set-replicated-subscription-status persistent://myprop/clust/ns1/ds1 -s sub1 -e"));
+        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://myprop/clust/ns1/ds1", "sub1", true);
+
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);
         cmdTopics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -p 1:1 -e"));
@@ -1227,6 +1230,9 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("remove-message-ttl persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeMessageTTL("persistent://myprop/clust/ns1/ds1");
+
+        cmdTopics.run(split("set-replicated-subscription-status persistent://myprop/clust/ns1/ds1 -s sub1 -d"));
+        verify(mockTopics).setReplicatedSubscriptionStatus("persistent://myprop/clust/ns1/ds1", "sub1", false);
 
         //cmd with option cannot be executed repeatedly.
         cmdTopics = new CmdTopics(() -> admin);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -221,6 +221,8 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("set-subscribe-rate", new SetSubscribeRate());
         jcommander.addCommand("remove-subscribe-rate", new RemoveSubscribeRate());
 
+        jcommander.addCommand("set-replicated-subscription-status", new SetReplicatedSubscriptionStatus());
+
         initDeprecatedCommands();
     }
 
@@ -2295,6 +2297,31 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             getTopics().removeSubscribeRate(persistentTopic);
+        }
+    }
+
+    @Parameters(commandDescription = "Enable or disable a replicated subscription on a topic")
+    private class SetReplicatedSubscriptionStatus extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-s",
+                "--subscription" }, description = "Subscription name to enable or disable replication", required = true)
+        private String subName;
+
+        @Parameter(names = { "--enable", "-e" }, description = "Enable replication")
+        private boolean enable = false;
+
+        @Parameter(names = { "--disable", "-d" }, description = "Disable replication")
+        private boolean disable = false;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            if (enable == disable) {
+                throw new ParameterException("Need to specify either --enable or --disable");
+            }
+            getTopics().setReplicatedSubscriptionStatus(persistentTopic, subName, enable);
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicOperation.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicOperation.java
@@ -50,4 +50,6 @@ public enum TopicOperation {
 
     GET_STATS,
     GET_METADATA,
+
+    SET_REPLICATED_SUBSCRIPTION_STATUS,
 }


### PR DESCRIPTION
### Motivation

Currently, once a replicated subscription is created on a topic, there is no way for users to disable it. I think it is useful to have a REST API that allows users to enable or disable replicated subscriptions.

### Modifications

Added the following REST API endpoints:
```
/admin/persistent/{tenant}/{cluster}/{namespace}/{topic}/subscription/{subName}/replicatedSubscriptionStatus
/admin/v2/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/replicatedSubscriptionStatus
```
We can enable/disable a replicated subscription by posting true or false to these endpoints.