### PR TITLE
fix flaky test testBlockByPublishRateLimiting

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -126,7 +126,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
             producer.sendAsync(payload);
         }
 
-        assertEquals(pulsar.getBrokerService().getPausedConnections(), 1);
+        Awaitility.await().untilAsserted(() -> assertEquals(pulsar.getBrokerService().getPausedConnections(), 1));
 
         CompletableFuture<Void> flushFuture = producer.flushAsync();
 


### PR DESCRIPTION
Fixes #10787

### Motivation
Due to the use of `producer.sendAsync`, it may be asserted before the message is sent.

After the modification, I executed this unit test 200 times in loop,  all passed


