### PR TITLE
[Schema] Fix AutoConsumeSchema decode null schema version data

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -311,7 +311,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         }
     }
 
-    private SchemaVersion getSchemaVersion(byte[] schemaVersion) {
+    private static SchemaVersion getSchemaVersion(byte[] schemaVersion) {
         if (schemaVersion != null) {
             return BytesSchemaVersion.of(schemaVersion);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -81,6 +81,12 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         schemaMap.get(SchemaVersion.Latest).validate(message);
     }
 
+    public void validate(byte[] message, byte[] schemaVersion) {
+        SchemaVersion sv = getSchemaVersion(schemaVersion);
+        ensureSchemaInitialized(sv);
+        schemaMap.get(sv).validate(message);
+    }
+
     @Override
     public byte[] encode(GenericRecord message) {
         throw new UnsupportedOperationException("AutoConsumeSchema is not intended to be used for encoding");
@@ -92,7 +98,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     }
 
     public Schema<?> atSchemaVersion(byte[] schemaVersion) {
-        SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
+        SchemaVersion sv = getSchemaVersion(schemaVersion);
         fetchSchemaIfNeeded(sv);
         ensureSchemaInitialized(sv);
         Schema<?> topicVersionedSchema = schemaMap.get(sv);
@@ -105,7 +111,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
 
     @Override
     public GenericRecord decode(byte[] bytes, byte[] schemaVersion) {
-        SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
+        SchemaVersion sv = getSchemaVersion(schemaVersion);
         fetchSchemaIfNeeded(sv);
         ensureSchemaInitialized(sv);
         return adapt(schemaMap.get(sv).decode(bytes, schemaVersion), schemaVersion);
@@ -114,8 +120,8 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     @Override
     public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
         this.schemaInfoProvider = schemaInfoProvider;
-        if (schemaMap.containsKey(SchemaVersion.Latest)) {
-            schemaMap.get(SchemaVersion.Latest).setSchemaInfoProvider(schemaInfoProvider);
+        for (Schema<?> schema : schemaMap.values()) {
+            schema.setSchemaInfoProvider(schemaInfoProvider);
         }
     }
 
@@ -128,10 +134,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     }
 
     public SchemaInfo getSchemaInfo(byte[] schemaVersion) {
-        if (schemaVersion == null) {
-            return Schema.BYTES.getSchemaInfo();
-        }
-        SchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
+        SchemaVersion sv = getSchemaVersion(schemaVersion);
         if (schemaMap.containsKey(sv)) {
             return schemaMap.get(sv).getSchemaInfo();
         }
@@ -251,7 +254,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         if (value instanceof GenericRecord) {
             return (GenericRecord) value;
         }
-        BytesSchemaVersion sv = BytesSchemaVersion.of(schemaVersion);
+        SchemaVersion sv = getSchemaVersion(schemaVersion);
         if (!schemaMap.containsKey(sv)) {
             throw new IllegalStateException("Cannot decode a message without schema");
         }
@@ -267,7 +270,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     }
 
     public Schema<?> getInternalSchema(byte[] schemaVersion) {
-        return schemaMap.get(BytesSchemaVersion.of(schemaVersion));
+        return schemaMap.get(getSchemaVersion(schemaVersion));
     }
 
     /**
@@ -308,13 +311,26 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         }
     }
 
+    private SchemaVersion getSchemaVersion(byte[] schemaVersion) {
+        if (schemaVersion != null) {
+            return BytesSchemaVersion.of(schemaVersion);
+        }
+        return BytesSchemaVersion.of(new byte[0]);
+    }
+
     @Override
     public String toString() {
-        if (schemaMap.containsKey(SchemaVersion.Latest)
-                && schemaMap.get(SchemaVersion.Latest).getSchemaInfo() != null) {
-            return "AUTO_CONSUME(schematype=" + schemaMap.get(SchemaVersion.Latest).getSchemaInfo().getType() + ")";
-        } else {
+        if (schemaMap.isEmpty()) {
             return "AUTO_CONSUME(uninitialized)";
         }
+        StringBuilder sb = new StringBuilder("AUTO_CONSUME(");
+        for (Map.Entry<SchemaVersion, Schema<?>> entry : schemaMap.entrySet()) {
+            sb.append("{schemaVersion=").append(entry.getKey())
+                    .append(",schemaType=").append(entry.getValue().getSchemaInfo().getType())
+                    .append("}");
+        }
+        sb.append(")");
+        return sb.toString();
     }
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -226,12 +226,4 @@ public class TypedMessageBuilderImplTest {
         }
     }
 
-    @Test
-    public void test() {
-        producerBase = mock(ProducerBase.class);
-        TypedMessageBuilderImpl builder =  new TypedMessageBuilderImpl(producerBase, null);
-        AutoConsumeSchema autoConsumeSchema = new AutoConsumeSchema();
-    }
-
-
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils;
 import org.apache.pulsar.common.schema.KeyValue;
@@ -223,6 +224,13 @@ public class TypedMessageBuilderImplTest {
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("This method is not allowed to set keys when in encoding type is SEPARATED"));
         }
+    }
+
+    @Test
+    public void test() {
+        producerBase = mock(ProducerBase.class);
+        TypedMessageBuilderImpl builder =  new TypedMessageBuilderImpl(producerBase, null);
+        AutoConsumeSchema autoConsumeSchema = new AutoConsumeSchema();
     }
 
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
@@ -1,0 +1,27 @@
+package org.apache.pulsar.client.impl.schema;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+@Slf4j
+public class AutoConsumeSchemaTest {
+
+    @Test
+    public void decodeDataWithNullSchemaVersion() {
+        Schema<GenericRecord> autoConsumeSchema = new AutoConsumeSchema();
+        byte[] bytes = "bytes data".getBytes();
+        MessageImpl<GenericRecord> message = MessageImpl.create(
+                new MessageMetadata(), ByteBuffer.wrap(bytes), autoConsumeSchema);
+        Assert.assertNull(message.getSchemaVersion());
+        GenericRecord genericRecord = message.getValue();
+        Assert.assertEquals(genericRecord.getNativeObject(), bytes);
+    }
+
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
@@ -1,5 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.client.impl.schema;
 
+import java.nio.ByteBuffer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -8,8 +27,9 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
-import java.nio.ByteBuffer;
-
+/**
+ * AutoConsumeSchema test.
+ */
 @Slf4j
 public class AutoConsumeSchemaTest {
 


### PR DESCRIPTION
### Motivation

Currently, the AutoConsumeSchema decode messages which has a null schema version will cause the NPE problem.

```
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:1.8.0_181]
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964) ~[?:1.8.0_181]
	at org.apache.pulsar.client.impl.schema.AutoConsumeSchema.ensureSchemaInitialized(AutoConsumeSchema.java:73) ~[io.streamnative-pulsar-client-original-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.client.impl.schema.AutoConsumeSchema.decode(AutoConsumeSchema.java:110) ~[io.streamnative-pulsar-client-original-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.client.impl.schema.AutoConsumeSchema.decode(AutoConsumeSchema.java:45) ~[io.streamnative-pulsar-client-original-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.client.api.Schema.decode(Schema.java:107) ~[io.streamnative-pulsar-client-api-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.client.impl.MessageImpl.decode(MessageImpl.java:469) ~[io.streamnative-pulsar-client-original-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.client.impl.MessageImpl.getValue(MessageImpl.java:449) ~[io.streamnative-pulsar-client-original-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.functions.source.PulsarRecord.getValue(PulsarRecord.java:81) ~[io.streamnative-pulsar-functions-instance-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.readInput(JavaInstanceRunnable.java:386) ~[io.streamnative-pulsar-functions-instance-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:248) ~[io.streamnative-pulsar-functions-instance-2.8.0-rc-202105291235.jar:2.8.0-rc-202105291235]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]

```

### Modifications

Check the schema version, if the schema version is null, fallback uses the BYTES schema to decode.

### Verifying this change

Test decode message data which has a null schema version.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

