### PR TITLE
[Build] Fix main profile activation by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1867,7 +1867,11 @@ flexible messaging model and an intuitive client API.</description>
       <activation>
         <!-- always activate this profile by default. Use "-main" or "!main" in the "-P" parameter to exclude it -->
         <!-- for example use "-Pcore-modules,-main" to activate the core-modules profile -->
-        <file><exists>pom.xml</exists></file>
+        <property>
+          <name>disableMainProfile</name>
+          <!-- always active unless true is passed as a value -->
+          <value>!true</value>
+        </property>
       </activation>
       <modules>
         <module>buildtools</module>


### PR DESCRIPTION
Fixes #10791

### Motivation

- Maven doesn't have an explicit feature to always activate a profile.
- The previous solution used `<exists><file>pom.xml</file></exists>` which doesn't work in all cases for some reason. That solution was added as part of JDK11 changes in #10340. There's a reported issue #10791 about the problem in activating the `main` profile.

### Additional context

- In maven, `activeByDefault` works only if no other profile is already active. 
- When JDK11 changes were made, a profile `jdk11` was added which gets activated when JDK version >= 11. This broke the `activeByDefault` solution for activating the `main` profile.

### Modifications

- Use a better solution to activate the `main` profile by default by using a property value with inversion (`!`) rule.