### PR TITLE
Docker image: add vim and nettools (netstat)

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
      && apt-get install -y netcat dnsutils less procps iputils-ping \
                  python3.7 python3.7-dev python3-setuptools python3-yaml python3-kazoo \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
-                 curl \
+                 curl vim net-tools unzip \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Motivation

Now that we have rootless images the user (system administrator in this case) cannot install new tools easily, so it is better to add to the base image some common tools, like "vim" and "netstat"
e. What is the problem you're trying to solve.*

### Modifications

Add "vim" and "netstat" and "unzip" to the base image.
The image will become a little bigger but it is worth

### Verifying this change

This change is already covered by existing tests, the integration tests.
