### PR TITLE
[Issue-10808] Fixed flaky test testAccumulativeStats()

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -70,7 +70,6 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertEquals(stats.msgOutCounter, 0);
 
         producer.newMessage().value("test").eventTime(5).send();
-        producer.newMessage().value("test").eventTime(5).send();
 
         Message<String> msg = consumer1.receive();
         assertNotNull(msg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -213,7 +213,6 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertEquals(stats.msgOutCounter, 0);
 
         producer.newMessage().value("test").eventTime(5).send();
-        producer.newMessage().value("test").eventTime(5).send();
 
         Message<String> msg = consumer1.receive();
         assertNotNull(msg);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #10808 

### Motivation

I could not repro the failure locally without any modifications.
It reproed after I added send of 10+ messages (without consumer receiving them).
It looks like there is some kind of tailing.prefetch (I am not familiar with the consumer at that level) so sent but not consumed message may result in consumer's metrics increment. In some cases it seems to happen after `statsBeforeUnsubscribe` were fetched and before the consumer.unsubscribe.
The test had extra send (without consumer receiving it), I removed it.

### Modifications

removed send of extra non-consumed message

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests/fixes the tests

### Does this pull request potentially affect one of the following parts:

NO
