### PR TITLE
Fix consumer stuck issue due to reuse entry wrapper.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -98,13 +98,13 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
     public void filterEntriesForConsumer(List<Entry> entries, EntryBatchSizes batchSizes,
             SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
             ManagedCursor cursor, boolean isReplayRead) {
-        filterEntriesForConsumer(Optional.empty(), entries, batchSizes, sendMessageInfo, indexesAcks, cursor,
+        filterEntriesForConsumer(Optional.empty(), 0, entries, batchSizes, sendMessageInfo, indexesAcks, cursor,
                 isReplayRead);
     }
 
-    public void filterEntriesForConsumer(Optional<EntryWrapper[]> entryWrapper, List<Entry> entries,
-            EntryBatchSizes batchSizes, SendMessageInfo sendMessageInfo, EntryBatchIndexesAcks indexesAcks,
-            ManagedCursor cursor, boolean isReplayRead) {
+    public void filterEntriesForConsumer(Optional<EntryWrapper[]> entryWrapper, int entryWrapperOffset,
+             List<Entry> entries, EntryBatchSizes batchSizes, SendMessageInfo sendMessageInfo,
+             EntryBatchIndexesAcks indexesAcks, ManagedCursor cursor, boolean isReplayRead) {
         int totalMessages = 0;
         long totalBytes = 0;
         int totalChunkedMessages = 0;
@@ -114,9 +114,11 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
                 continue;
             }
             ByteBuf metadataAndPayload = entry.getDataBuffer();
-            MessageMetadata msgMetadata = entryWrapper.isPresent() && entryWrapper.get()[i] != null
-                    ? entryWrapper.get()[i].getMetadata()
+            int entryWrapperIndex = i + entryWrapperOffset;
+            MessageMetadata msgMetadata = entryWrapper.isPresent() && entryWrapper.get()[entryWrapperIndex] != null
+                    ? entryWrapper.get()[entryWrapperIndex].getMetadata()
                     : null;
+            System.out.println(msgMetadata.getNumMessagesInBatch());
             msgMetadata = msgMetadata == null
                     ? Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1)
                     : msgMetadata;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -118,7 +118,6 @@ public abstract class AbstractBaseDispatcher implements Dispatcher {
             MessageMetadata msgMetadata = entryWrapper.isPresent() && entryWrapper.get()[entryWrapperIndex] != null
                     ? entryWrapper.get()[entryWrapperIndex].getMetadata()
                     : null;
-            System.out.println(msgMetadata.getNumMessagesInBatch());
             msgMetadata = msgMetadata == null
                     ? Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1)
                     : msgMetadata;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -482,11 +482,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             return;
         }
         EntryWrapper[] entryWrappers = new EntryWrapper[entries.size()];
-        int totalMessages = updateEntryWrapperWithMetadata(entryWrappers, entries);
+        int remainingMessages = updateEntryWrapperWithMetadata(entryWrappers, entries);
         int start = 0;
         long totalMessagesSent = 0;
         long totalBytesSent = 0;
-        int avgBatchSizePerMsg = totalMessages > 0 ? Math.max(totalMessages / entries.size(), 1) : 1;
+        int avgBatchSizePerMsg = remainingMessages > 0 ? Math.max(remainingMessages / entries.size(), 1) : 1;
 
         int firstAvailableConsumerPermits, currentTotalAvailablePermits;
         boolean dispatchMessage;
@@ -514,7 +514,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                         c, c.getAvailablePermits());
             }
 
-            int messagesForC = Math.min(Math.min(totalMessages, availablePermits),
+            int messagesForC = Math.min(Math.min(remainingMessages, availablePermits),
                     serviceConfig.getDispatcherMaxRoundRobinBatchSize());
             messagesForC = Math.max(messagesForC / avgBatchSizePerMsg, 1);
 
@@ -539,7 +539,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                         sendMessageInfo.getTotalBytes(), sendMessageInfo.getTotalChunkedMessages(), redeliveryTracker);
 
                 int msgSent = sendMessageInfo.getTotalMessages();
-                totalMessages -= msgSent;
+                remainingMessages -= msgSent;
                 start += messagesForC;
                 entriesToDispatch -= messagesForC;
                 TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
@@ -57,9 +57,7 @@ public class DispatchAccordingPermitsTests extends ProducerConsumerBase {
      * 1. The consumer has 1000 available permits
      * 2. The producer send batches with different batch size
      *
-     * According the batch average size dispatching, the broker will dispatch all the three batch to the consumer
-     *
-     * Then we send more messages to the topic to check if the consumer can continues to receive messages.
+     * According the batch average size dispatching, the broker will dispatch all the batches to the consumer
      */
     @Test
     public void testFlowPermitsWithMultiBatchesDispatch() throws PulsarAdminException, PulsarClientException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
@@ -55,7 +55,7 @@ public class DispatchAccordingPermitsTests extends ProducerConsumerBase {
     /**
      * The test case is to simulate dispatch batches with different batch size to the consumer.
      * 1. The consumer has 1000 available permits
-     * 2. The producer send 3 batches, 500 messages in the first batch, 1 message in the second batch and third batch
+     * 2. The producer send batches with different batch size
      *
      * According the batch average size dispatching, the broker will dispatch all the three batch to the consumer
      *

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/DispatchAccordingPermitsTests.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.TopicStats;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+@Test(groups = "broker-impl")
+public class DispatchAccordingPermitsTests extends ProducerConsumerBase {
+
+    @Override
+    @BeforeMethod
+    public void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @Override
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    /**
+     * The test case is to simulate dispatch batches with different batch size to the consumer.
+     * 1. The consumer has 1000 available permits
+     * 2. The producer send 3 batches, 500 messages in the first batch, 1 message in the second batch and third batch
+     *
+     * According the batch average size dispatching, the broker will dispatch all the three batch to the consumer
+     *
+     * Then we send more messages to the topic to check if the consumer can continues to receive messages.
+     */
+    @Test
+    public void testFlowPermitsWithMultiBatchesDispatch() throws PulsarAdminException, PulsarClientException {
+        final String topic = "persistent://public/default/testFlowPermitsWithMultiBatchesDispatch";
+        final String subName = "test";
+        admin.topics().createSubscription(topic, "test", MessageId.earliest);
+
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .batchingMaxPublishDelay(Long.MAX_VALUE, TimeUnit.MILLISECONDS)
+                .create();
+
+        for (int i = 0; i < 100; i++) {
+            producer.sendAsync("msg - " + i);
+        }
+        producer.flush();
+
+        for (int i = 0; i < 350; i++) {
+            producer.sendAsync("msg - " + i);
+        }
+        producer.flush();
+
+        for (int i = 0; i < 50; i++) {
+            producer.sendAsync("msg - " + i);
+            producer.flush();
+        }
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+
+        for (int i = 0; i < 500; i++) {
+            consumer.acknowledge(consumer.receive());
+        }
+
+        ConsumerImpl<String> consumerImpl = (ConsumerImpl<String>) consumer;
+        Assert.assertEquals(consumerImpl.incomingMessages.size(), 0);
+
+        TopicStats stats = admin.topics().getStats(topic);
+        Assert.assertTrue(stats.subscriptions.get(subName).consumers.get(0).availablePermits > 0);
+    }
+}


### PR DESCRIPTION
Fixes #10813
The issue is introduced by #7266, it only affects the master branch.

### Motivation

1. Add wrapperOffset to make sure get the correct batch size from the metadata
2. Fix the issue that using (batch count / avgBatchSizePerMsg) to calculate messages for the consumer
   it should be (messages / avgBatchSizePerMsg)

### Verifying this change

     * The test case is to simulate dispatch batches with different batch size to the consumer.
     * 1. The consumer has 1000 available permits
     * 2. The producer send batches with different batch size
     *
     * According the batch average size dispatching, the broker will dispatch all the batches to the consumer

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
