### PR TITLE
[SECURITY] Add Security Policy and Supported Versions page to website

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+Feature release branches will, generally, be maintained with security fix and bug fix releases for a period of 12 months
+after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
+the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even for security fixes.
+
+Security fixes will be given priority when it comes to back porting fixes to older versions that are within the
+supported time window. It is challenging to decide which bug fixes to back port to old versions. As such, the latest
+versions will have the most bug fixes.
+
+When 3.0.0 is released, the community will decide how to continue supporting 2.x. It is possible that the last minor
+release within 2.x will be maintained for longer as an “LTS” release, but it has not been officially decided.
+
+The following table shows version support timelines and will be updated with releases.
+
+| Version | Supported          | Initial Release | Until         |
+|:-------:|:------------------:|:---------------:|:-------------:|
+| 2.7.x   | :white_check_mark: | November 2020   | November 2021 |
+| 2.6.x   | :white_check_mark: | June 2020       | June 2021     |
+| 2.5.x   | :x:                | January 2020    | January 2021  |
+| 2.4.x   | :x:                | July 2019       | July 2020     |
+| < 2.3.x | :x:                | -               | -             |
+
+## Release Frequency
+
+With the acceptance of [PIP-47 - A Time Based Release Plan](https://github.com/apache/pulsar/wiki/PIP-47%3A-Time-Based-Release-Plan),
+the Pulsar community aims to complete 4 minor releases each year.
+
+## Reporting a Vulnerability
+
+The current process for reporting vulnerabilities is outlined here: https://www.apache.org/security/.
+
+## Using Pulsar's Security Features
+
+You can find documentation on Pulsar's available security features and how to use them here: 
+https://pulsar.apache.org/docs/en/security-overview/.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,38 +1,3 @@
 # Security Policy
 
-## Supported Versions
-
-Feature release branches will, generally, be maintained with security fix and bug fix releases for a period of 12 months
-after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
-the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even for security fixes.
-
-Security fixes will be given priority when it comes to back porting fixes to older versions that are within the
-supported time window. It is challenging to decide which bug fixes to back port to old versions. As such, the latest
-versions will have the most bug fixes.
-
-When 3.0.0 is released, the community will decide how to continue supporting 2.x. It is possible that the last minor
-release within 2.x will be maintained for longer as an “LTS” release, but it has not been officially decided.
-
-The following table shows version support timelines and will be updated with releases.
-
-| Version | Supported          | Initial Release | Until         |
-|:-------:|:------------------:|:---------------:|:-------------:|
-| 2.7.x   | :white_check_mark: | November 2020   | November 2021 |
-| 2.6.x   | :white_check_mark: | June 2020       | June 2021     |
-| 2.5.x   | :x:                | January 2020    | January 2021  |
-| 2.4.x   | :x:                | July 2019       | July 2020     |
-| < 2.3.x | :x:                | -               | -             |
-
-## Release Frequency
-
-With the acceptance of [PIP-47 - A Time Based Release Plan](https://github.com/apache/pulsar/wiki/PIP-47%3A-Time-Based-Release-Plan),
-the Pulsar community aims to complete 4 minor releases each year.
-
-## Reporting a Vulnerability
-
-The current process for reporting vulnerabilities is outlined here: https://www.apache.org/security/.
-
-## Using Pulsar's Security Features
-
-You can find documentation on Pulsar's available security features and how to use them here: 
-https://pulsar.apache.org/docs/en/security-overview/.
+The security policy and related versioning policy is outlined on the Pulsar website here: https://pulsar.apache.org/docs/security-and-versioning-policy/.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-The security policy and related versioning policy is outlined on the Pulsar website here: https://pulsar.apache.org/docs/security-and-versioning-policy/.
+The security policy and supported versions are outlined on the Pulsar website here: https://pulsar.apache.org/docs/security-policy-and-supported-versions/.

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -25,6 +25,9 @@ For instructions on how to subscribe, please see https://pulsar.apache.org/conta
 The Pulsar project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). Existing releases can expect
 patches for bugs and security vulnerabilities. New features will target minor releases.
 
+When upgrading an existing cluster, it is important to upgrade components linearly through each minor version. For
+example, when upgrading from 2.8.x to 2.10.x, it is important to upgrade to 2.9.x before going to 2.10.x.
+
 ## Supported Versions
 
 Feature release branches will be maintained with security fix and bug fix releases for a period of at least 12 months

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -21,6 +21,9 @@ Feature release branches will, generally, be maintained with security fix and bu
 after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
 the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even for security fixes.
 
+Note that a minor version can be maintained past it's 12 month initial support period. For example, version 2.7 is still
+actively maintained.
+
 Security fixes will be given priority when it comes to back porting fixes to older versions that are within the
 supported time window. It is challenging to decide which bug fixes to back port to old versions. As such, the latest
 versions will have the most bug fixes.

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -15,11 +15,17 @@ to send your report to the Apache Pulsar Project Management Committee. This is a
 You can find documentation on Pulsar's available security features and how to use them here:
 https://pulsar.apache.org/docs/en/security-overview/.
 
+## Security Vulnerability Announcements
+
+The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
+For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+
 ## Supported Versions
 
-Feature release branches will, generally, be maintained with security fix and bug fix releases for a period of 12 months
+Feature release branches will be maintained with security fix and bug fix releases for a period of at least 12 months
 after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
-the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even for security fixes.
+the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even to fix security
+vulnerabilities.
 
 Note that a minor version can be maintained past it's 12 month initial support period. For example, version 2.7 is still
 actively maintained.
@@ -31,9 +37,9 @@ versions will have the most bug fixes.
 When 3.0.0 is released, the community will decide how to continue supporting 2.x. It is possible that the last minor
 release within 2.x will be maintained for longer as an “LTS” release, but it has not been officially decided.
 
-The following table shows version support timelines and will be updated with releases.
+The following table shows version support timelines and will be updated with each release.
 
-| Version | Supported          | Initial Release | At least Until |
+| Version | Supported          | Initial Release | At Least Until |
 |:-------:|:------------------:|:---------------:|:--------------:|
 | 2.9.x   | :white_check_mark: | November 2021   | November 2022  |
 | 2.8.x   | :white_check_mark: | June 2021       | June 2022      |

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -1,0 +1,50 @@
+---
+id: security-and-versioning-policy
+title: Security and Versioning Policy
+sidebar_label: Security and Versioning Policy
+---
+
+## Reporting a Vulnerability
+
+The current process for reporting vulnerabilities is outlined here: https://www.apache.org/security/. When reporting a
+vulnerability to security@apache.org, you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org)
+to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
+## Using Pulsar's Security Features
+
+You can find documentation on Pulsar's available security features and how to use them here:
+https://pulsar.apache.org/docs/en/security-overview/.
+
+## Supported Versions
+
+Feature release branches will, generally, be maintained with security fix and bug fix releases for a period of 12 months
+after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
+the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even for security fixes.
+
+Security fixes will be given priority when it comes to back porting fixes to older versions that are within the
+supported time window. It is challenging to decide which bug fixes to back port to old versions. As such, the latest
+versions will have the most bug fixes.
+
+When 3.0.0 is released, the community will decide how to continue supporting 2.x. It is possible that the last minor
+release within 2.x will be maintained for longer as an “LTS” release, but it has not been officially decided.
+
+The following table shows version support timelines and will be updated with releases.
+
+| Version | Supported          | Initial Release | At least Until |
+|:-------:|:------------------:|:---------------:|:--------------:|
+| 2.9.x   | :white_check_mark: | November 2021   | November 2022  |
+| 2.8.x   | :white_check_mark: | June 2021       | June 2022      |
+| 2.7.x   | :white_check_mark: | November 2020   | November 2021  |
+| 2.6.x   | :x:                | June 2020       | June 2021      |
+| 2.5.x   | :x:                | January 2020    | January 2021   |
+| 2.4.x   | :x:                | July 2019       | July 2020      |
+| < 2.3.x | :x:                | -               | -              |
+
+If there is ambiguity about which versions of Pulsar are actively supported, please ask on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org)
+mailing list.
+
+## Release Frequency
+
+With the acceptance of [PIP-47 - A Time Based Release Plan](https://github.com/apache/pulsar/wiki/PIP-47%3A-Time-Based-Release-Plan),
+the Pulsar community aims to complete 4 minor releases each year. Patch releases are completed based on demand as well
+as need, in the event of security fixes.

--- a/site2/docs/security-versioning-policy.md
+++ b/site2/docs/security-versioning-policy.md
@@ -1,7 +1,7 @@
 ---
-id: security-and-versioning-policy
-title: Security and Versioning Policy
-sidebar_label: Security and Versioning Policy
+id: security-policy-and-supported-versions
+title: Security Policy and Supported Versions
+sidebar_label: Security Policy and Supported Versions
 ---
 
 ## Reporting a Vulnerability
@@ -19,6 +19,11 @@ https://pulsar.apache.org/docs/en/security-overview/.
 
 The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
 For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+
+## Versioning Policy
+
+The Pulsar project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). Existing releases can expect
+patches for bugs and security vulnerabilities. New features will target minor releases.
 
 ## Supported Versions
 

--- a/site2/website-next/docs/security-versioning-policy.md
+++ b/site2/website-next/docs/security-versioning-policy.md
@@ -1,0 +1,67 @@
+---
+id: security-policy-and-supported-versions
+title: Security Policy and Supported Versions
+sidebar_label: Security Policy and Supported Versions
+---
+
+## Reporting a Vulnerability
+
+The current process for reporting vulnerabilities is outlined here: https://www.apache.org/security/. When reporting a
+vulnerability to security@apache.org, you can copy your email to [private@pulsar.apache.org](mailto:private@pulsar.apache.org)
+to send your report to the Apache Pulsar Project Management Committee. This is a private mailing list.
+
+## Using Pulsar's Security Features
+
+You can find documentation on Pulsar's available security features and how to use them here:
+https://pulsar.apache.org/docs/en/security-overview/.
+
+## Security Vulnerability Announcements
+
+The Pulsar community will announce security vulnerabilities and how to mitigate them on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org).
+For instructions on how to subscribe, please see https://pulsar.apache.org/contact/.
+
+## Versioning Policy
+
+The Pulsar project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). Existing releases can expect
+patches for bugs and security vulnerabilities. New features will target minor releases.
+
+When upgrading an existing cluster, it is important to upgrade components linearly through each minor version. For
+example, when upgrading from 2.8.x to 2.10.x, it is important to upgrade to 2.9.x before going to 2.10.x.
+
+## Supported Versions
+
+Feature release branches will be maintained with security fix and bug fix releases for a period of at least 12 months
+after initial release. For example, branch 2.5.x is no longer considered maintained as of January 2021, 12 months after
+the release of 2.5.0 in January 2020. No more 2.5.x releases should be expected at this point, even to fix security
+vulnerabilities.
+
+Note that a minor version can be maintained past it's 12 month initial support period. For example, version 2.7 is still
+actively maintained.
+
+Security fixes will be given priority when it comes to back porting fixes to older versions that are within the
+supported time window. It is challenging to decide which bug fixes to back port to old versions. As such, the latest
+versions will have the most bug fixes.
+
+When 3.0.0 is released, the community will decide how to continue supporting 2.x. It is possible that the last minor
+release within 2.x will be maintained for longer as an “LTS” release, but it has not been officially decided.
+
+The following table shows version support timelines and will be updated with each release.
+
+| Version | Supported          | Initial Release | At Least Until |
+|:-------:|:------------------:|:---------------:|:--------------:|
+| 2.9.x   | :white_check_mark: | November 2021   | November 2022  |
+| 2.8.x   | :white_check_mark: | June 2021       | June 2022      |
+| 2.7.x   | :white_check_mark: | November 2020   | November 2021  |
+| 2.6.x   | :x:                | June 2020       | June 2021      |
+| 2.5.x   | :x:                | January 2020    | January 2021   |
+| 2.4.x   | :x:                | July 2019       | July 2020      |
+| < 2.3.x | :x:                | -               | -              |
+
+If there is ambiguity about which versions of Pulsar are actively supported, please ask on the [users@pulsar.apache.org](mailto:users@pulsar.apache.org)
+mailing list.
+
+## Release Frequency
+
+With the acceptance of [PIP-47 - A Time Based Release Plan](https://github.com/apache/pulsar/wiki/PIP-47%3A-Time-Based-Release-Plan),
+the Pulsar community aims to complete 4 minor releases each year. Patch releases are completed based on demand as well
+as need, in the event of security fixes.

--- a/site2/website-next/sidebars.json
+++ b/site2/website-next/sidebars.json
@@ -131,6 +131,7 @@
       "label": "Security",
       "items": [
         "security-overview",
+        "security-policy-and-supported-versions",
         "security-tls-transport",
         "security-tls-authentication",
         "security-tls-keystore",

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -94,7 +94,7 @@
     ],
     "Security": [
       "security-overview",
-      "security-and-versioning-policy",
+      "security-policy-and-supported-versions",
       "security-tls-transport",
       "security-tls-authentication",
       "security-tls-keystore",

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -94,6 +94,7 @@
     ],
     "Security": [
       "security-overview",
+      "security-and-versioning-policy",
       "security-tls-transport",
       "security-tls-authentication",
       "security-tls-keystore",


### PR DESCRIPTION
The original context for this PR is on the dev mailing list here: https://lists.apache.org/thread.html/ra2db06e8da85bff67d8d588dc1e93d965f2e1d70c95bda2f08d14138%40%3Cdev.pulsar.apache.org%3E

### Motivation

The Pulsar project does not explicitly declare version support time lines. By declaring support time lines, we can give our users more confidence that they will receive relevant security fixes before vulnerabilities are announced. Additionally, these time lines will guide the PMC when determining which branches need to receive security fixes.

I decided to start with a 12 month support window instead of 18. If we use 18 months, 2.5.x should still technically be supported. Additionally, PIP-47 indicates that we should be doing 4 minor releases a year. If we tried to support releases for 18 months, that could mean a _lot_ of extra releases if there are security vulnerabilities discovered in all active branches. I am open to debate/feedback on this point.

### Modifications

Add a `SECURITY.md` file and pages on the website.

### Release Process

If this PR is accepted, I'll follow up with a change to the pulsar wiki to update the release process. Each minor and major release will require an update to the table in the `SECURITY.md` file.

### Other Changes

It might be worth adding the content in this PR to a page on the pulsar website. I'm not sure where to add that yet, so I'd like to get feedback on this content before duplicating it to the website.

### Reference

I used the Apache Spark version policy (https://spark.apache.org/versioning-policy.html) as a guide for creating this doc.