### PR TITLE
[Broker] Fix possible data race in getFirstAvailableConsumerPermits

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -673,7 +673,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         }
         for (Consumer consumer : consumerList) {
             if (isConsumerAvailable(consumer)) {
-                return consumer.getAvailablePermits();
+                int availablePermits = consumer.getAvailablePermits();
+                if (availablePermits > 0) {
+                    return availablePermits;
+                }
             }
         }
         return 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -672,7 +672,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             return 0;
         }
         for (Consumer consumer : consumerList) {
-            if (isConsumerAvailable(consumer)) {
+            if (consumer != null && !consumer.isBlocked()) {
                 int availablePermits = consumer.getAvailablePermits();
                 if (availablePermits > 0) {
                     return availablePermits;


### PR DESCRIPTION
### Motivation

- there's a chance for a data race so that the consumer's available permits goes
  below zero after it has been checked in `isConsumerAvailable`

### Modifications

- check that `availablePermits > 0` before returning