### PR TITLE
Use jdk8 to build the project and run the binary license check.

### DIFF
--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         uses: apache/pulsar-test-infra/setup-maven@master
         with:
-          maven-version: 3.6.1
+          maven-version: 3.8.1
 
       - name: build and check license
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -65,12 +65,12 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 8
 
 
       - name: Replace maven's wagon-http version

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -257,7 +257,7 @@ The Apache Software License, Version 2.0
     - http2-http-client-transport-9.4.39.v20210325.jar
     - jetty-alpn-client-9.4.39.v20210325.jar
     - http2-server-9.4.39.v20210325.jar
-    - jetty-alpn-java-client-9.4.39.v20210325.jar
+    - jetty-alpn-openjdk8-client-9.4.39.v20210325.jar
     - jetty-client-9.4.39.v20210325.jar
     - jetty-http-9.4.39.v20210325.jar
     - jetty-io-9.4.39.v20210325.jar


### PR DESCRIPTION
I got the different behavior when using jdk8 and jdk11, since we are releasing binary based on jdk8, so we’d better to rollback to jdk8 for the CI check to make sure we get the consistent behavior when releasing 2.8.0