### PR TITLE
Fix improper modifier used in pulsar-io related module code

### DIFF
--- a/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalAbstractSource.java
+++ b/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalAbstractSource.java
@@ -143,7 +143,7 @@ public abstract class CanalAbstractSource<V> extends PushSource<V> {
 
     @Getter
     @Setter
-    static private class CanalRecord<V> implements Record<V> {
+    private static class CanalRecord<V> implements Record<V> {
 
         private V record;
         private Long id;

--- a/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/source/AbstractSource.java
+++ b/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/source/AbstractSource.java
@@ -112,7 +112,7 @@ public abstract class AbstractSource<V> extends PushSource<V> {
 
     @Getter
     @Setter
-    static private class FlumeRecord<V> implements Record<V> {
+    private static class FlumeRecord<V> implements Record<V> {
         private V record;
         private Long id;
 

--- a/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/http/NettyHttpServerHandler.java
+++ b/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/http/NettyHttpServerHandler.java
@@ -137,7 +137,7 @@ public class NettyHttpServerHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     @Data
-    static private class NettyHttpRecord implements Record<byte[]>, Serializable {
+    private static class NettyHttpRecord implements Record<byte[]>, Serializable {
         private final Optional<String> key;
         private final byte[] value;
     }

--- a/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/tcp/NettyTCPServerHandler.java
+++ b/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/tcp/NettyTCPServerHandler.java
@@ -57,7 +57,7 @@ public class NettyTCPServerHandler extends SimpleChannelInboundHandler<byte[]> {
     }
 
     @Data
-    static private class NettyTCPRecord implements Record<byte[]>, Serializable {
+    private static class NettyTCPRecord implements Record<byte[]>, Serializable {
         private final Optional<String> key;
         private final byte[] value;
     }

--- a/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/udp/NettyUDPServerHandler.java
+++ b/pulsar-io/netty/src/main/java/org/apache/pulsar/io/netty/udp/NettyUDPServerHandler.java
@@ -59,7 +59,7 @@ public class NettyUDPServerHandler extends SimpleChannelInboundHandler<DatagramP
     }
 
     @Data
-    static private class NettyUDPRecord implements Record<byte[]>, Serializable {
+    private static class NettyUDPRecord implements Record<byte[]>, Serializable {
         private final Optional<String> key;
         private final byte[] value;
     }

--- a/pulsar-io/nsq/src/main/java/org/apache/pulsar/io/nsq/NSQSource.java
+++ b/pulsar-io/nsq/src/main/java/org/apache/pulsar/io/nsq/NSQSource.java
@@ -102,7 +102,7 @@ public class NSQSource extends PushSource<byte[]> {
     }
 
     @Data
-    static private class NSQRecord implements Record<byte[]> {
+    private static class NSQRecord implements Record<byte[]> {
         private final byte[] value;
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -108,7 +108,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
     }
 
     @Data
-    static private class RabbitMQRecord implements Record<byte[]> {
+    private static class RabbitMQRecord implements Record<byte[]> {
         private final Optional<String> key;
         private final byte[] value;
     }


### PR DESCRIPTION
When I looked at the pulsar-io related module code, I found that in the implementation classes of Record (Pulsar Connect's Record interface), some implementation classes used inappropriate modifier order.

Oracle Java modifier order documentation: https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.1