### PR TITLE
fix improper class/method/field modifiers

### DIFF
--- a/build/docker/protobuf.patch
+++ b/build/docker/protobuf.patch
@@ -604,7 +604,7 @@ index 4c087db5..3ae1c14c 100644
 +    "  this.handle = handle;\n"
      "  maybeForceBuilderInitialization();\n"
      "}\n"
-+    "private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {\n"
++    "private static final io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {\n"
 +    "   protected Builder newObject(io.netty.util.Recycler.Handle handle) {\n"
 +    "         return new Builder(handle);\n"
 +    "       }\n"

--- a/buildtools/src/main/resources/pulsar/checkstyle.xml
+++ b/buildtools/src/main/resources/pulsar/checkstyle.xml
@@ -425,5 +425,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error"/>
         </module>
 
+        <module name="ModifierOrder"/>
+
     </module>
 </module>

--- a/buildtools/src/main/resources/pulsar/checkstyle.xml
+++ b/buildtools/src/main/resources/pulsar/checkstyle.xml
@@ -425,6 +425,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error"/>
         </module>
 
+        <module name="ClassMemberImpliedModifier" />
+
 
     </module>
 </module>

--- a/buildtools/src/main/resources/pulsar/checkstyle.xml
+++ b/buildtools/src/main/resources/pulsar/checkstyle.xml
@@ -425,8 +425,5 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error"/>
         </module>
 
-        <module name="ClassMemberImpliedModifier" />
-
-
     </module>
 </module>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class EntryCacheDefaultEvictionPolicy implements EntryCacheEvictionPolicy {
 
-    private final static double PercentOfSizeToConsiderForEviction = 0.5;
+    private  double PercentOfSizeToConsiderForEviction = 0.5;
 
     @Override
     public void doEviction(List<EntryCache> caches, long sizeToFree) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class EntryCacheDefaultEvictionPolicy implements EntryCacheEvictionPolicy {
 
-    private  double PercentOfSizeToConsiderForEviction = 0.5;
+    private static final double PercentOfSizeToConsiderForEviction = 0.5;
 
     @Override
     public void doEviction(List<EntryCache> caches, long sizeToFree) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -71,7 +71,7 @@ public class EntryCacheImpl implements EntryCache {
         return ml.getName();
     }
 
-    public final static PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(true, // preferDirect
+    public  PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(true, // preferDirect
             0, // nHeapArenas,
             PooledByteBufAllocator.defaultNumDirectArena(), // nDirectArena
             PooledByteBufAllocator.defaultPageSize(), // pageSize

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -71,7 +71,7 @@ public class EntryCacheImpl implements EntryCache {
         return ml.getName();
     }
 
-    public  PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(true, // preferDirect
+    public static final PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(true, // preferDirect
             0, // nHeapArenas,
             PooledByteBufAllocator.defaultNumDirectArena(), // nDirectArena
             PooledByteBufAllocator.defaultPageSize(), // pageSize

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -138,9 +138,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
-    private final static long MegaByte = 1024 * 1024;
+    private  long MegaByte = 1024 * 1024;
 
-    protected final static int AsyncOperationTimeoutSeconds = 30;
+    protected  int AsyncOperationTimeoutSeconds = 30;
 
     protected final BookKeeper bookKeeper;
     protected final String name;
@@ -198,7 +198,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final CallbackMutex trimmerMutex = new CallbackMutex();
 
     private final CallbackMutex offloadMutex = new CallbackMutex();
-    private final static CompletableFuture<PositionImpl> NULL_OFFLOAD_PROMISE = CompletableFuture
+    private static final CompletableFuture<PositionImpl> NULL_OFFLOAD_PROMISE = CompletableFuture
             .completedFuture(PositionImpl.latest);
     private volatile LedgerHandle currentLedger;
     private long currentLedgerEntries = 0;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -138,9 +138,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
-    private  long MegaByte = 1024 * 1024;
+    private static final long MegaByte = 1024 * 1024;
 
-    protected  int AsyncOperationTimeoutSeconds = 30;
+    protected static final int AsyncOperationTimeoutSeconds = 30;
 
     protected final BookKeeper bookKeeper;
     protected final String name;

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleToken.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleToken.java
@@ -43,7 +43,7 @@ public class SaslRoleToken implements Principal {
     private static final String EXPIRES = "e";
     private static final String SESSION = "i";
 
-    private final static Set<String> ATTRIBUTES =
+    private static final Set<String> ATTRIBUTES =
         new HashSet<String>(Arrays.asList(USER_ROLE,  EXPIRES,  SESSION));
 
     private String userRole;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 import java.util.*;
 
 public class AuthenticationProviderBasic implements AuthenticationProvider {
-    private final static String HTTP_HEADER_NAME = "Authorization";
-    private final static String CONF_SYSTEM_PROPERTY_KEY = "pulsar.auth.basic.conf";
+    private static final String HTTP_HEADER_NAME = "Authorization";
+    private static final String CONF_SYSTEM_PROPERTY_KEY = "pulsar.auth.basic.conf";
     private Map<String, String> users;
 
     @Override

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderToken.java
@@ -50,31 +50,31 @@ import io.jsonwebtoken.security.SignatureException;
 
 public class AuthenticationProviderToken implements AuthenticationProvider {
 
-    final static String HTTP_HEADER_NAME = "Authorization";
-    final static String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
+    static final String HTTP_HEADER_NAME = "Authorization";
+    static final String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
 
     // When symmetric key is configured
-    final static String CONF_TOKEN_SETTING_PREFIX = "";
+    static final String CONF_TOKEN_SETTING_PREFIX = "";
 
     // When symmetric key is configured
-    final static String CONF_TOKEN_SECRET_KEY = "tokenSecretKey";
+    static final String CONF_TOKEN_SECRET_KEY = "tokenSecretKey";
 
     // When public/private key pair is configured
-    final static String CONF_TOKEN_PUBLIC_KEY = "tokenPublicKey";
+    static final String CONF_TOKEN_PUBLIC_KEY = "tokenPublicKey";
 
     // The token's claim that corresponds to the "role" string
-    final static String CONF_TOKEN_AUTH_CLAIM = "tokenAuthClaim";
+    static final String CONF_TOKEN_AUTH_CLAIM = "tokenAuthClaim";
 
     // When using public key's, the algorithm of the key
-    final static String CONF_TOKEN_PUBLIC_ALG = "tokenPublicAlg";
+    static final String CONF_TOKEN_PUBLIC_ALG = "tokenPublicAlg";
 
     // The token audience "claim" name, e.g. "aud", that will be used to get the audience from token.
-    final static String CONF_TOKEN_AUDIENCE_CLAIM = "tokenAudienceClaim";
+    static final String CONF_TOKEN_AUDIENCE_CLAIM = "tokenAudienceClaim";
 
     // The token audience stands for this broker. The field `tokenAudienceClaim` of a valid token, need contains this.
-    final static String CONF_TOKEN_AUDIENCE = "tokenAudience";
+    static final String CONF_TOKEN_AUDIENCE = "tokenAudience";
 
-    final static String TOKEN = "token";
+    static final String TOKEN = "token";
 
     private static final Counter expiredTokenMetrics = Counter.build()
             .name("pulsar_expired_token_count")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -47,7 +47,7 @@ public class OverloadShedder implements LoadSheddingStrategy {
 
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
 
-    private final static double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
+    private static final double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
 
     /**
      * Attempt to shed some bundles off every broker which is overloaded.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -40,7 +40,7 @@ public class ThresholdShedder implements LoadSheddingStrategy {
 
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
 
-    private final static double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
+    private static final double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
 
     private static final double MB = 1024 * 1024;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
@@ -594,7 +594,7 @@ public class ResourceGroupService {
     // set the value to 4.
     // Setting this to 0 will make us report in every round.
     // Don't set to negative values; behavior will be "undefined".
-    protected final static int MaxUsageReportSuppressRounds = 5;
+    protected static final int MaxUsageReportSuppressRounds = 5;
 
     // Convenient shorthand, for MaxUsageReportSuppressRounds converted to a time interval in milliseconds.
     protected static long maxIntervalForSuppressingReportsMSecs;
@@ -602,5 +602,5 @@ public class ResourceGroupService {
     // The percentage difference that is considered "within limits" to suppress usage reporting.
     // Setting this to 0 will also make us report in every round.
     // Don't set it to negative values; behavior will be "undefined".
-    protected final static float UsageReportSuppressionTolerancePercentage = 5;
+    protected static final float UsageReportSuppressionTolerancePercentage = 5;
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -236,7 +236,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     private DistributedIdGenerator producerNameGenerator;
 
-    public final static String PRODUCER_NAME_GENERATOR_PATH = "/counters/producer-name";
+    public static final String PRODUCER_NAME_GENERATOR_PATH = "/counters/producer-name";
 
     private final BacklogQuotaManager backlogQuotaManager;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -66,7 +66,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     private final ConcurrentMap<String, ReplicatedSubscriptionsSnapshotBuilder> pendingSnapshots =
             new ConcurrentHashMap<>();
 
-    private final static Gauge pendingSnapshotsMetric = Gauge
+    private static final Gauge pendingSnapshotsMetric = Gauge
             .build("pulsar_replicated_subscriptions_pending_snapshots",
                     "Counter of currently pending snapshots")
             .register();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
@@ -53,7 +53,7 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
 
     private final Clock clock;
 
-    private final static Summary snapshotMetric = Summary.build("pulsar_replicated_subscriptions_snapshot_ms",
+    private static final Summary snapshotMetric = Summary.build("pulsar_replicated_subscriptions_snapshot_ms",
             "Time taken to create a consistent snapshot across clusters").register();
 
     public ReplicatedSubscriptionsSnapshotBuilder(ReplicatedSubscriptionsController controller,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AlwaysSchemaValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AlwaysSchemaValidator.java
@@ -25,7 +25,7 @@ import org.apache.avro.SchemaValidator;
  * A schema validator that always reports as compatible.
  */
 class AlwaysSchemaValidator implements SchemaValidator {
-    final static AlwaysSchemaValidator INSTANCE = new AlwaysSchemaValidator();
+    static final AlwaysSchemaValidator INSTANCE = new AlwaysSchemaValidator();
 
     @Override
     public void validate(Schema toValidate, Iterable<Schema> existing) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/NeverSchemaValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/NeverSchemaValidator.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
  * An avro schema validator that always reports as incompatible, if there is an existing schema.
  */
 class NeverSchemaValidator implements SchemaValidator {
-    private final static Logger log = LoggerFactory.getLogger(NeverSchemaValidator.class);
-    final static NeverSchemaValidator INSTANCE = new NeverSchemaValidator();
+    private static final Logger log = LoggerFactory.getLogger(NeverSchemaValidator.class);
+    static final NeverSchemaValidator INSTANCE = new NeverSchemaValidator();
 
     @Override
     public void validate(Schema toValidate, Iterable<Schema> existing)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ClusterReplicationMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/ClusterReplicationMetrics.java
@@ -29,7 +29,7 @@ public class ClusterReplicationMetrics {
     private final List<Metrics> metricsList;
     private final String localCluster;
     private final ConcurrentOpenHashMap<String, ReplicationMetrics> metricsMap;
-    public final static String SEPARATOR = "_";
+    public static final String SEPARATOR = "_";
     public final boolean metricsEnabled;
 
     public ClusterReplicationMetrics(String localCluster, boolean metricsEnabled) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -34,7 +34,7 @@ import org.apache.pulsar.transaction.coordinator.impl.TransactionMetadataStoreSt
 @Slf4j
 public class TransactionAggregator {
 
-    private final static FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
+    private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
             new FastThreadLocal<AggregatedTransactionCoordinatorStats>() {
                 @Override
                 protected AggregatedTransactionCoordinatorStats initialValue() throws Exception {
@@ -42,7 +42,7 @@ public class TransactionAggregator {
                 }
             };
 
-    private final static FastThreadLocal<ManagedLedgerStats> localManageLedgerStats =
+    private static final FastThreadLocal<ManagedLedgerStats> localManageLedgerStats =
             new FastThreadLocal<ManagedLedgerStats>() {
                 @Override
                 protected ManagedLedgerStats initialValue() throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -41,7 +41,7 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
     private final long tickTimeMillis;
     private final Clock clock;
     private Timeout currentTimeout;
-    private final static long INITIAL_TIMEOUT = 1L;
+    private static final long INITIAL_TIMEOUT = 1L;
 
     private volatile long nowTaskTimeoutTime = INITIAL_TIMEOUT;
     private final long tcId;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
@@ -77,7 +77,7 @@ public class RawMessageImpl implements RawMessage {
         return buf;
     }
 
-    static public RawMessage deserializeFrom(ByteBuf buffer) {
+    public static RawMessage deserializeFrom(ByteBuf buffer) {
         int idSize = buffer.readInt();
 
         MessageIdData id = new MessageIdData();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 public class RawReaderImpl implements RawReader {
 
-    final static int DEFAULT_RECEIVER_QUEUE_SIZE = 1000;
+    static final int DEFAULT_RECEIVER_QUEUE_SIZE = 1000;
     private final ConsumerConfigurationData<byte[]> consumerConfiguration;
     private RawConsumerImpl consumer;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -49,9 +49,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CompactedTopicImpl implements CompactedTopic {
-    final static long NEWER_THAN_COMPACTED = -0xfeed0fbaL;
-    final static long COMPACT_LEDGER_EMPTY = -0xfeed0fbbL;
-    final static int DEFAULT_STARTPOINT_CACHE_SIZE = 100;
+    static final long NEWER_THAN_COMPACTED = -0xfeed0fbaL;
+    static final long COMPACT_LEDGER_EMPTY = -0xfeed0fbbL;
+    static final int DEFAULT_STARTPOINT_CACHE_SIZE = 100;
 
     private final BookKeeper bk;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MockAuthentication implements Authentication {
-    private final static Logger log = LoggerFactory.getLogger(MockAuthentication.class);
+    private static final Logger log = LoggerFactory.getLogger(MockAuthentication.class);
     private final String user;
 
     public MockAuthentication(String user) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipCacheForCurrentServerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipCacheForCurrentServerTest.java
@@ -32,9 +32,9 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class OwnerShipCacheForCurrentServerTest extends OwnerShipForCurrentServerTestBase {
 
-    private final static String TENANT = "ownership";
-    private final static String NAMESPACE = TENANT + "/ns1";
-    private final static String TOPIC_TEST = NAMESPACE + "/test";
+    private static final String TENANT = "ownership";
+    private static final String NAMESPACE = TENANT + "/ns1";
+    private static final String TOPIC_TEST = NAMESPACE + "/test";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.*;
 @Slf4j
 public class OwnerShipForCurrentServerTestBase {
 
-    public final static String CLUSTER_NAME = "test";
+    public static final String CLUSTER_NAME = "test";
 
     @Setter
     private int brokerCount = 3;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -87,8 +87,8 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
 
     static final int TIME_TO_CHECK_BACKLOG_QUOTA = 5;
 
-    protected final static String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
-    protected final static String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
+    protected static final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
+    protected static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
 
     // Default frequency
     public int getBrokerServicePurgeInactiveFrequency() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -50,9 +50,9 @@ import static org.testng.Assert.assertTrue;
 @Test(groups = "broker")
 public class MessageDuplicationTest {
 
-    private final static int BROKER_DEDUPLICATION_ENTRIES_INTERVAL = 10;
-    private final static int BROKER_DEDUPLICATION_MAX_NUMBER_PRODUCERS = 10;
-    private final static String REPLICATOR_PREFIX = "foo";
+    private static final int BROKER_DEDUPLICATION_ENTRIES_INTERVAL = 10;
+    private static final int BROKER_DEDUPLICATION_MAX_NUMBER_PRODUCERS = 10;
+    private static final String REPLICATOR_PREFIX = "foo";
 
     @Test
     public void testIsDuplicate() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -55,24 +55,24 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
     private static final Clock MockClock = Clock.fixed(Instant.EPOCH, ZoneId.systemDefault());
 
     private final String schemaId1 = "1/2/3/4";
-    private final static String userId = "user";
+    private static final String userId = "user";
 
-    private final static String schemaJson1 =
+    private static final String schemaJson1 =
             "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
                     ".AvroSchemaCompatibilityCheckTest\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
-    private final static SchemaData schemaData1 = getSchemaData(schemaJson1);
+    private static final SchemaData schemaData1 = getSchemaData(schemaJson1);
 
-    private final static String schemaJson2 =
+    private static final String schemaJson2 =
             "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
                     ".AvroSchemaCompatibilityCheckTest\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
                     "{\"name\":\"field2\",\"type\":\"string\",\"default\":\"foo\"}]}";
-    private final static SchemaData schemaData2 = getSchemaData(schemaJson2);
+    private static final SchemaData schemaData2 = getSchemaData(schemaJson2);
 
-    private final static String schemaJson3 =
+    private static final String schemaJson3 =
             "{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"org.apache.pulsar.broker.service.schema" +
                     ".AvroSchemaCompatibilityCheckTest\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}," +
                     "{\"name\":\"field2\",\"type\":\"string\"}]}";
-    private final static SchemaData schemaData3 = getSchemaData(schemaJson3);
+    private static final SchemaData schemaData3 = getSchemaData(schemaJson3);
 
     private SchemaRegistryServiceImpl schemaRegistryService;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -72,13 +72,13 @@ import static org.testng.Assert.assertTrue;
 @Slf4j
 public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
-    private final static String RECOVER_COMMIT = NAMESPACE1 + "/recover-commit";
-    private final static String RECOVER_ABORT = NAMESPACE1 + "/recover-abort";
-    private final static String SUBSCRIPTION_NAME = "test-recover";
-    private final static String TAKE_SNAPSHOT = NAMESPACE1 + "/take-snapshot";
-    private final static String ABORT_DELETE = NAMESPACE1 + "/abort-delete";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
+    private static final String RECOVER_COMMIT = NAMESPACE1 + "/recover-commit";
+    private static final String RECOVER_ABORT = NAMESPACE1 + "/recover-abort";
+    private static final String SUBSCRIPTION_NAME = "test-recover";
+    private static final String TAKE_SNAPSHOT = NAMESPACE1 + "/take-snapshot";
+    private static final String ABORT_DELETE = NAMESPACE1 + "/abort-delete";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
@@ -45,7 +45,7 @@ import static org.testng.FileAssert.fail;
 
 public class TransactionClientReconnectTest extends TransactionTestBase {
 
-    private final static String RECONNECT_TOPIC = "persistent://public/txn/txn-client-reconnect-test";
+    private static final String RECONNECT_TOPIC = "persistent://public/txn/txn-client-reconnect-test";
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -59,9 +59,9 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class TransactionConsumeTest extends TransactionTestBase {
 
-    private final static String CONSUME_TOPIC = "persistent://public/txn/txn-consume-test";
-    private final static String NORMAL_MSG_CONTENT = "Normal - ";
-    private final static String TXN_MSG_CONTENT = "Txn - ";
+    private static final String CONSUME_TOPIC = "persistent://public/txn/txn-consume-test";
+    private static final String NORMAL_MSG_CONTENT = "Normal - ";
+    private static final String TXN_MSG_CONTENT = "Txn - ";
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -73,14 +73,14 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class TransactionProduceTest extends TransactionTestBase {
 
-    private final static int TOPIC_PARTITION = 3;
+    private static final int TOPIC_PARTITION = 3;
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
-    private final static String PRODUCE_COMMIT_TOPIC = NAMESPACE1 + "/produce-commit";
-    private final static String PRODUCE_ABORT_TOPIC = NAMESPACE1 + "/produce-abort";
-    private final static String ACK_COMMIT_TOPIC = NAMESPACE1 + "/ack-commit";
-    private final static String ACK_ABORT_TOPIC = NAMESPACE1 + "/ack-abort";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
+    private static final String PRODUCE_COMMIT_TOPIC = NAMESPACE1 + "/produce-commit";
+    private static final String PRODUCE_ABORT_TOPIC = NAMESPACE1 + "/produce-abort";
+    private static final String ACK_COMMIT_TOPIC = NAMESPACE1 + "/ack-commit";
+    private static final String ACK_ABORT_TOPIC = NAMESPACE1 + "/ack-abort";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -64,7 +64,7 @@ import org.apache.zookeeper.ZooKeeper;
 @Slf4j
 public abstract class TransactionTestBase extends TestRetrySupport {
 
-    public final static String CLUSTER_NAME = "test";
+    public static final String CLUSTER_NAME = "test";
 
     @Setter
     private int brokerCount = 3;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -80,7 +80,7 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
     TopicName partitionedTopicName = TopicName.get("persistent", "public", "test", "tb-client");
     int partitions = 10;
     BrokerService[] brokerServices;
-    private final static String namespace = "public/test";
+    private static final String namespace = "public/test";
 
     private EventLoopGroup eventLoopGroup;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -76,9 +76,9 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class TransactionLowWaterMarkTest extends TransactionTestBase {
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
-    private final static String TOPIC = NAMESPACE1 + "/test-topic";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
+    private static final String TOPIC = NAMESPACE1 + "/test-topic";
 
     @BeforeMethod(alwaysRun = true)
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
@@ -54,9 +54,9 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class TransactionStablePositionTest extends TransactionTestBase {
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
-    private final static String TOPIC = NAMESPACE1 + "/test-topic";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
+    private static final String TOPIC = NAMESPACE1 + "/test-topic";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -71,8 +71,8 @@ import static org.testng.Assert.assertTrue;
 @Test(groups = "broker")
 public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
@@ -59,7 +59,7 @@ import org.testng.annotations.Test;
 @Slf4j
 public class PendingAckPersistentTest extends TransactionTestBase {
 
-    private final static String PENDING_ACK_REPLAY_TOPIC = "persistent://public/txn/pending-ack-replay";
+    private static final String PENDING_ACK_REPLAY_TOPIC = "persistent://public/txn/pending-ack-replay";
 
     @BeforeMethod
     public void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -66,8 +66,8 @@ import org.testng.annotations.Test;
 public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(AuthorizationProducerConsumerTest.class);
 
-    private final static String clientRole = "plugbleRole";
-    private final static Set<String> clientAuthProviderSupportedRoles = Sets.newHashSet(clientRole);
+    private static final String clientRole = "plugbleRole";
+    private static final Set<String> clientAuthProviderSupportedRoles = Sets.newHashSet(clientRole);
 
     protected void setup() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckResponseTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-impl")
 public class ConsumerAckResponseTest extends ProducerConsumerBase {
 
-    private final static TransactionImpl transaction = mock(TransactionImpl.class);
+    private static final TransactionImpl transaction = mock(TransactionImpl.class);
 
     @BeforeClass
     public void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -87,12 +87,12 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class TransactionEndToEndTest extends TransactionTestBase {
 
-    private final static int TOPIC_PARTITION = 3;
+    private static final int TOPIC_PARTITION = 3;
 
-    private final static String TENANT = "tnx";
-    private final static String NAMESPACE1 = TENANT + "/ns1";
-    private final static String TOPIC_OUTPUT = NAMESPACE1 + "/output";
-    private final static String TOPIC_MESSAGE_ACK_TEST = NAMESPACE1 + "/message-ack-test";
+    private static final String TENANT = "tnx";
+    private static final String NAMESPACE1 = TENANT + "/ns1";
+    private static final String TOPIC_OUTPUT = NAMESPACE1 + "/output";
+    private static final String TOPIC_MESSAGE_ACK_TEST = NAMESPACE1 + "/message-ack-test";
 
     @BeforeMethod
     protected void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/PartitionedTopicSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/PartitionedTopicSchemaTest.java
@@ -42,9 +42,9 @@ import org.testng.annotations.Test;
 @Test(groups = "schema")
 public class PartitionedTopicSchemaTest extends MockedPulsarServiceBaseTest {
 
-    private final static String PARTITIONED_TOPIC = "public/default/partitioned-schema-topic";
-    private final static int MESSAGE_COUNT_PER_PARTITION  = 12;
-    private final static int TOPIC_PARTITION = 3;
+    private static final String PARTITIONED_TOPIC = "public/default/partitioned-schema-topic";
+    private static final int MESSAGE_COUNT_PER_PARTITION  = 12;
+    private static final int TOPIC_PARTITION = 3;
 
     @BeforeMethod
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -83,7 +83,7 @@ import org.testng.annotations.Test;
 @Test(groups = "schema")
 public class SchemaTest extends MockedPulsarServiceBaseTest {
 
-    private final static String CLUSTER_NAME = "test";
+    private static final String CLUSTER_NAME = "test";
 
     @BeforeMethod
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -55,7 +55,7 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "schema")
 public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
-    private final static String CLUSTER_NAME = "test";
+    private static final String CLUSTER_NAME = "test";
 
     @BeforeMethod
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckTest.java
@@ -51,10 +51,10 @@ import static org.testng.Assert.expectThrows;
 
 
 public class SchemaTypeCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
-    private final static String CLUSTER_NAME = "test";
-    private final static String PUBLIC_TENANT = "public";
-    private final static String namespace = "test-namespace";
-    private final static String namespaceName = PUBLIC_TENANT + "/" + namespace;
+    private static final String CLUSTER_NAME = "test";
+    private static final String PUBLIC_TENANT = "public";
+    private static final String namespace = "test-namespace";
+    private static final String namespaceName = PUBLIC_TENANT + "/" + namespace;
 
     @BeforeClass
     @Override

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/NamespaceBundleStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/NamespaceBundleStats.java
@@ -36,13 +36,13 @@ public class NamespaceBundleStats implements Comparable<NamespaceBundleStats>, S
     public long cacheSize;
 
     // Consider the throughput equal if difference is less than 100 KB/s
-    private final static double throughputDifferenceThreshold = 1e5;
+    private static final double throughputDifferenceThreshold = 1e5;
     // Consider the msgRate equal if the difference is less than 100
-    private final static double msgRateDifferenceThreshold = 100;
+    private static final double msgRateDifferenceThreshold = 100;
     // Consider the total topics/producers/consumers equal if the difference is less than 500
-    private final static long topicConnectionDifferenceThreshold = 500;
+    private static final long topicConnectionDifferenceThreshold = 500;
     // Consider the cache size equal if the difference is less than 100 kb
-    private final static long cacheSizeDifferenceThreshold = 100000;
+    private static final long cacheSizeDifferenceThreshold = 100000;
 
     public NamespaceBundleStats() {
         reset();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -91,9 +91,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     private final WebTarget adminTopics;
     private final WebTarget adminV2Topics;
     // CHECKSTYLE.OFF: MemberName
-    static private final String BATCH_HEADER = "X-Pulsar-num-batch-message";
-    static private final String MESSAGE_ID = "X-Pulsar-Message-ID";
-    static private final String PUBLISH_TIME = "X-Pulsar-publish-time";
+    private static final String BATCH_HEADER = "X-Pulsar-num-batch-message";
+    private static final String MESSAGE_ID = "X-Pulsar-Message-ID";
+    private static final String PUBLISH_TIME = "X-Pulsar-publish-time";
     // CHECKSTYLE.ON: MemberName
 
     public TopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
@@ -78,8 +78,8 @@ import org.apache.pulsar.common.sasl.JAASCredentialsContainer;
 public class AuthenticationSasl implements Authentication, EncodedAuthenticationParameterSupport {
     private static final long serialVersionUID = 1L;
     // this is a static object that shares amongst client.
-    static private JAASCredentialsContainer jaasCredentialsContainer;
-    static private volatile boolean initializedJAAS = false;
+    private static JAASCredentialsContainer jaasCredentialsContainer;
+    private static volatile boolean initializedJAAS = false;
 
     private Map<String, String> configuration;
     private String loginContextName;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -126,7 +126,7 @@ abstract class CliCommand {
         return arguments.get(0);
     }
 
-    static private String[] splitParameter(List<String> params, int n) {
+    private static String[] splitParameter(List<String> params, int n) {
         if (params.size() != 1) {
             throw new ParameterException("Need to provide just 1 parameter");
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -59,8 +59,8 @@ import org.asynchttpclient.netty.ssl.JsseSslEngineFactory;
 @Slf4j
 public class HttpClient implements Closeable {
 
-    protected final static int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
-    protected final static int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
+    protected static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
+    protected static final int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
 
     protected final AsyncHttpClient httpClient;
     protected final ServiceNameResolver serviceNameResolver;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -67,7 +67,7 @@ public class MessageImpl<T> implements Message<T> {
     private Optional<EncryptionContext> encryptionCtx = Optional.empty();
 
     private String topic; // only set for incoming messages
-    transient private Map<String, String> properties;
+    private transient Map<String, String> properties;
     private int redeliveryCount;
     private int uncompressedSize;
 
@@ -660,7 +660,7 @@ public class MessageImpl<T> implements Message<T> {
 
     private Handle<MessageImpl<?>> recyclerHandle;
 
-    private final static Recycler<MessageImpl<?>> RECYCLER = new Recycler<MessageImpl<?>>() {
+    private static final Recycler<MessageImpl<?>> RECYCLER = new Recycler<MessageImpl<?>>() {
         @Override
         protected MessageImpl<?> newObject(Handle<MessageImpl<?>> handle) {
             return new MessageImpl<>(handle);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataBasic.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataBasic.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.Base64;
 
 public class AuthenticationDataBasic implements AuthenticationDataProvider {
-    private final static String HTTP_HEADER_NAME = "Authorization";
+    private static final String HTTP_HEADER_NAME = "Authorization";
     private String httpAuthToken;
     private String commandAuthToken;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataToken.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataToken.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 
 public class AuthenticationDataToken implements AuthenticationDataProvider {
-    public final static String HTTP_HEADER_NAME = "Authorization";
+    public static final String HTTP_HEADER_NAME = "Authorization";
 
     private final Supplier<String> tokenSupplier;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationKeyStoreTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationKeyStoreTls.java
@@ -39,13 +39,13 @@ import org.apache.pulsar.client.impl.AuthenticationUtil;
 public class AuthenticationKeyStoreTls implements Authentication, EncodedAuthenticationParameterSupport {
     private static final long serialVersionUID = 1L;
 
-    private final static String AUTH_NAME = "tls";
+    private static final String AUTH_NAME = "tls";
 
     // parameter name
-    public final static String KEYSTORE_TYPE = "keyStoreType";
-    public final static String KEYSTORE_PATH= "keyStorePath";
-    public final static String KEYSTORE_PW = "keyStorePassword";
-    private final static String DEFAULT_KEYSTORE_TYPE = "JKS";
+    public static final String KEYSTORE_TYPE = "keyStoreType";
+    public static final String KEYSTORE_PATH= "keyStorePath";
+    public static final String KEYSTORE_PW = "keyStorePassword";
+    private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
 
     private transient KeyStoreParams keyStoreParams;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
@@ -41,7 +41,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  */
 public class AuthenticationTls implements Authentication, EncodedAuthenticationParameterSupport {
-    private final static String AUTH_NAME = "tls";
+    private static final String AUTH_NAME = "tls";
     private static final long serialVersionUID = 1L;
 
     private String certFilePath;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -40,8 +40,8 @@ import org.asynchttpclient.Response;
  */
 public class TokenClient implements ClientCredentialsExchanger {
 
-    protected final static int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
-    protected final static int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
+    protected static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
+    protected static final int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
 
     private final URL tokenUrl;
     private final AsyncHttpClient httpClient;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
@@ -30,7 +30,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 @Slf4j
 public class GenericAvroSchema extends GenericSchemaImpl {
 
-    public final static String OFFSET_PROP = "__AVRO_READ_OFFSET__";
+    public static final String OFFSET_PROP = "__AVRO_READ_OFFSET__";
 
     public GenericAvroSchema(SchemaInfo schemaInfo) {
         this(schemaInfo, true);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryMessageUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryMessageUtil.java
@@ -20,13 +20,13 @@ package org.apache.pulsar.client.util;
 
 public class RetryMessageUtil {
 
-    public final static String SYSTEM_PROPERTY_RECONSUMETIMES = "RECONSUMETIMES";
-    public final static String SYSTEM_PROPERTY_DELAY_TIME = "DELAY_TIME";
-    public final static String SYSTEM_PROPERTY_REAL_TOPIC = "REAL_TOPIC";
-    public final static String SYSTEM_PROPERTY_RETRY_TOPIC = "RETRY_TOPIC";
-    public final static String SYSTEM_PROPERTY_ORIGIN_MESSAGE_ID = "ORIGIN_MESSAGE_IDY_TIME";
+    public static final String SYSTEM_PROPERTY_RECONSUMETIMES = "RECONSUMETIMES";
+    public static final String SYSTEM_PROPERTY_DELAY_TIME = "DELAY_TIME";
+    public static final String SYSTEM_PROPERTY_REAL_TOPIC = "REAL_TOPIC";
+    public static final String SYSTEM_PROPERTY_RETRY_TOPIC = "RETRY_TOPIC";
+    public static final String SYSTEM_PROPERTY_ORIGIN_MESSAGE_ID = "ORIGIN_MESSAGE_IDY_TIME";
     
-    public final static int MAX_RECONSUMETIMES = 16;
-    public final static String RETRY_GROUP_TOPIC_SUFFIX = "-RETRY";
-    public final static String DLQ_GROUP_TOPIC_SUFFIX = "-DLQ";
+    public static final int MAX_RECONSUMETIMES = 16;
+    public static final String RETRY_GROUP_TOPIC_SUFFIX = "-RETRY";
+    public static final String DLQ_GROUP_TOPIC_SUFFIX = "-DLQ";
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 public class ConnectionTimeoutTest {
 
     // 192.0.2.0/24 is assigned for documentation, should be a deadend
-    final static String blackholeBroker = "pulsar://192.0.2.1:1234";
+    static final String blackholeBroker = "pulsar://192.0.2.1:1234";
 
     @Test
     public void testLowTimeout() throws Exception {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
@@ -79,7 +79,7 @@ public class GenericProtobufNativeReaderTest {
         assertEquals(nativeRecord.getField(nativeRecord.getDescriptorForType().findFieldByName("doubleField")), DOUBLE_FIELD_VLUE);
     }
 
-    private final static String STRING_FIELD_VLUE = "stringFieldValue";
-    private final static double DOUBLE_FIELD_VLUE = 0.2D;
+    private static final String STRING_FIELD_VLUE = "stringFieldValue";
+    private static final double DOUBLE_FIELD_VLUE = 0.2D;
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchemaTest.java
@@ -60,7 +60,7 @@ public class GenericProtobufNativeSchemaTest {
         assertEquals(message.getDoubleField(), DOUBLE_FIELD_VLUE);
     }
 
-    private final static String STRING_FIELD_VLUE = "stringFieldValue";
-    private final static double DOUBLE_FIELD_VLUE = 0.2D;
+    private static final String STRING_FIELD_VLUE = "stringFieldValue";
+    private static final double DOUBLE_FIELD_VLUE = 0.2D;
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/functions/Utils.java
@@ -28,9 +28,9 @@ import org.apache.pulsar.common.io.SourceConfig;
  * Helper class to work with configuration.
  */
 public class Utils {
-    public final static String HTTP = "http";
-    public final static String FILE = "file";
-    public final static String BUILTIN = "builtin";
+    public static final String HTTP = "http";
+    public static final String FILE = "file";
+    public static final String BUILTIN = "builtin";
 
     public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
         return isNotBlank(functionPkgUrl) && (functionPkgUrl.startsWith(HTTP)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NarUnpacker {
 
-    private final static String HASH_FILENAME = "nar-md5sum";
+    private static final String HASH_FILENAME = "nar-md5sum";
 
     /**
      * Unpacks the specified nar into the specified base working directory.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -45,9 +45,9 @@ import static org.apache.pulsar.common.util.FieldParser.value;
 @NoArgsConstructor
 public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
 
-    private final static long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
 
-    public final static List<Field> CONFIGURATION_FIELDS;
+    public static final List<Field> CONFIGURATION_FIELDS;
 
     static {
         List<Field> temp = new ArrayList<>();
@@ -61,20 +61,20 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
         CONFIGURATION_FIELDS = Collections.unmodifiableList(temp);
     }
 
-    public final static int DEFAULT_MAX_BLOCK_SIZE_IN_BYTES = 64 * 1024 * 1024;   // 64MB
-    public final static int DEFAULT_READ_BUFFER_SIZE_IN_BYTES = 1024 * 1024;      // 1MB
-    public final static int DEFAULT_OFFLOAD_MAX_THREADS = 2;
-    public final static int DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS = 1;
-    public final static ImmutableList<String> DRIVER_NAMES = ImmutableList
+    public static final int DEFAULT_MAX_BLOCK_SIZE_IN_BYTES = 64 * 1024 * 1024;   // 64MB
+    public static final int DEFAULT_READ_BUFFER_SIZE_IN_BYTES = 1024 * 1024;      // 1MB
+    public static final int DEFAULT_OFFLOAD_MAX_THREADS = 2;
+    public static final int DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS = 1;
+    public static final ImmutableList<String> DRIVER_NAMES = ImmutableList
             .of("S3", "aws-s3", "google-cloud-storage", "filesystem", "azureblob", "aliyun-oss");
-    public final static String DEFAULT_OFFLOADER_DIRECTORY = "./offloaders";
-    public final static Long DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES = null;
-    public final static Long DEFAULT_OFFLOAD_DELETION_LAG_IN_MILLIS = null;
+    public static final String DEFAULT_OFFLOADER_DIRECTORY = "./offloaders";
+    public static final Long DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES = null;
+    public static final Long DEFAULT_OFFLOAD_DELETION_LAG_IN_MILLIS = null;
 
-    public final static String OFFLOAD_THRESHOLD_NAME_IN_CONF_FILE =
+    public static final String OFFLOAD_THRESHOLD_NAME_IN_CONF_FILE =
             "managedLedgerOffloadAutoTriggerSizeThresholdBytes";
-    public final static String DELETION_LAG_NAME_IN_CONF_FILE = "managedLedgerOffloadDeletionLagMs";
-    public final static OffloadedReadPriority DEFAULT_OFFLOADED_READ_PRIORITY = OffloadedReadPriority.TIERED_STORAGE_FIRST;
+    public static final String DELETION_LAG_NAME_IN_CONF_FILE = "managedLedgerOffloadDeletionLagMs";
+    public static final OffloadedReadPriority DEFAULT_OFFLOADED_READ_PRIORITY = OffloadedReadPriority.TIERED_STORAGE_FIRST;
 
     // common config
     @Configuration

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1015,7 +1015,7 @@ public class Commands {
         return serializeWithSize(newGetTopicsOfNamespaceResponseCommand(topics, requestId));
     }
 
-    private final static ByteBuf cmdPing;
+    private static final ByteBuf cmdPing;
 
     static {
         BaseCommand cmd = new BaseCommand()
@@ -1030,7 +1030,7 @@ public class Commands {
         return cmdPing.retainedDuplicate();
     }
 
-    private final static ByteBuf cmdPong;
+    private static final ByteBuf cmdPong;
 
     static {
         BaseCommand cmd = new BaseCommand()

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/BytesSchemaVersion.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/BytesSchemaVersion.java
@@ -145,7 +145,7 @@ public class BytesSchemaVersion implements SchemaVersion, Comparable<BytesSchema
     /**
      * A byte array comparator based on lexicograpic ordering.
      */
-    public final static ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();
+    public static final ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();
 
     /**
      * This interface helps to compare byte arrays.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
@@ -51,7 +51,7 @@ public class JvmMetrics {
     private final JvmGCMetricsLogger gcLogger;
 
     private final String componentName;
-    private final static Map<String, Class<? extends JvmGCMetricsLogger>> gcLoggerMap = new HashMap<>();
+    private static final Map<String, Class<? extends JvmGCMetricsLogger>> gcLoggerMap = new HashMap<>();
     static {
         try {
             directMemoryUsage = io.netty.util.internal.PlatformDependent.class

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
@@ -26,7 +26,7 @@ import io.netty.buffer.ByteBuf;
  */
 public class SimpleTextOutputStream {
     private final ByteBuf buffer;
-    private final static char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
+    private static final char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
             'f' };
 
     public SimpleTextOutputStream(ByteBuf buffer) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
@@ -37,9 +37,9 @@ public class BitSetRecyclable implements Cloneable, java.io.Serializable {
      * a long, which consists of 64 bits, requiring 6 address bits.
      * The choice of word size is determined purely by performance concerns.
      */
-    private final static int ADDRESS_BITS_PER_WORD = 6;
-    private final static int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
-    private final static int BIT_INDEX_MASK = BITS_PER_WORD - 1;
+    private static final int ADDRESS_BITS_PER_WORD = 6;
+    private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
+    private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
 
     /* Used to shift left or right for a partial word mask */
     private static final long WORD_MASK = 0xffffffffffffffffL;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -475,7 +475,7 @@ public class ConcurrentLongPairSet implements LongPairSet {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static long hash(long key1, long key2) {
+    static final long hash(long key1, long key2) {
         long hash = key1 * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -430,7 +430,7 @@ public class ConcurrentOpenHashMap<K, V> {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static <K> long hash(K key) {
+    static final <K> long hash(K key) {
         long hash = key.hashCode() * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -443,7 +443,7 @@ public class ConcurrentOpenHashSet<V> {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static <K> long hash(K key) {
+    static final <K> long hash(K key) {
         long hash = key.hashCode() * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -426,7 +426,7 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
         }
     }
 
-    final static class PaddedInt {
+    static final class PaddedInt {
         private int value;
 
         // Padding to avoid false sharing

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueue.java
@@ -325,7 +325,7 @@ public class GrowablePriorityLongPairQueue {
     private static final long HashMixer = 0xc6a4a7935bd1e995L;
     private static final int R = 47;
 
-    final static long hash(long key1, long key2) {
+    static final long hash(long key1, long key2) {
         long hash = key1 * HashMixer;
         hash ^= hash >>> R;
         hash *= HashMixer;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
@@ -390,9 +390,9 @@ public class ConcurrentLongHashMapTest {
         assertEquals(map.get(2).intValue(), 2);
     }
 
-    final static int Iterations = 1;
-    final static int ReadIterations = 10000;
-    final static int N = 100_000;
+    static final int Iterations = 1;
+    static final int ReadIterations = 10000;
+    static final int N = 100_000;
 
     public void benchConcurrentLongHashMap() throws Exception {
         ConcurrentLongHashMap<String> map = new ConcurrentLongHashMap<>(N, 1);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
@@ -369,9 +369,9 @@ public class ConcurrentOpenHashMapTest {
         assertNull(map.get(t1_b));
     }
 
-    final static int Iterations = 1;
-    final static int ReadIterations = 1000;
-    final static int N = 1_000_000;
+    static final int Iterations = 1;
+    static final int ReadIterations = 1000;
+    static final int N = 1_000_000;
 
     public void benchConcurrentOpenHashMap() throws Exception {
         ConcurrentOpenHashMap<Long, String> map = new ConcurrentOpenHashMap<>(N, 1);

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/DiscoveryServiceTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/DiscoveryServiceTest.java
@@ -63,8 +63,8 @@ import org.awaitility.Awaitility;
 
 public class DiscoveryServiceTest extends BaseDiscoveryTestSetup {
 
-    private final static String TLS_CLIENT_CERT_FILE_PATH = "./src/test/resources/certificate/client.crt";
-    private final static String TLS_CLIENT_KEY_FILE_PATH = "./src/test/resources/certificate/client.key";
+    private static final String TLS_CLIENT_CERT_FILE_PATH = "./src/test/resources/certificate/client.crt";
+    private static final String TLS_CLIENT_KEY_FILE_PATH = "./src/test/resources/certificate/client.key";
 
     @BeforeMethod
     private void init() throws Exception {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -114,7 +114,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
 
     private final SubscriptionType subscriptionType;
 
-    private final static String[] userMetricsLabelNames;
+    private static final String[] userMetricsLabelNames;
 
     private boolean exposePulsarAdminClientEnabled;
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
@@ -42,7 +42,7 @@ public abstract class ComponentStatsManager implements AutoCloseable {
 
     protected final EvictingQueue EMPTY_QUEUE = EvictingQueue.create(0);
 
-    public final static String USER_METRIC_PREFIX = "user_metric_";
+    public static final String USER_METRIC_PREFIX = "user_metric_";
 
     public static final String[] metricsLabelNames = {"tenant", "namespace", "name", "instance_id", "cluster", "fqfn"};
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -68,8 +68,8 @@ import org.testng.annotations.Test;
 public class PulsarSourceTest {
 
 
-    private final static String TOPIC = "persistent://sample/ns1/test_result";
-    private final static ConsumerConfig CONSUMER_CONFIG =  ConsumerConfig.builder()
+    private static final String TOPIC = "persistent://sample/ns1/test_result";
+    private static final ConsumerConfig CONSUMER_CONFIG =  ConsumerConfig.builder()
             .serdeClassName(TopicSchema.DEFAULT_SERDE).isRegexPattern(false).build();
 
     private static Map<String, ConsumerConfig> consumerConfigs = new HashMap<>();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/BasicKubernetesManifestCustomizer.java
@@ -57,7 +57,7 @@ public class BasicKubernetesManifestCustomizer implements KubernetesManifestCust
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder(toBuilder = true)
-    static public class RuntimeOpts {
+    public static class RuntimeOpts {
         private String jobNamespace;
         private String jobName;
         private Map<String, String> extraLabels;

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -28,10 +28,10 @@ import org.apache.pulsar.io.kafka.connect.KafkaConnectSource;
 import org.apache.pulsar.io.kafka.connect.PulsarKafkaWorkerConfig;
 
 public abstract class DebeziumSource extends KafkaConnectSource {
-    static private final String DEFAULT_CONVERTER = "org.apache.kafka.connect.json.JsonConverter";
-    static private final String DEFAULT_HISTORY = "org.apache.pulsar.io.debezium.PulsarDatabaseHistory";
-    static private final String DEFAULT_OFFSET_TOPIC = "debezium-offset-topic";
-    static private final String DEFAULT_HISTORY_TOPIC = "debezium-history-topic";
+    private static final String DEFAULT_CONVERTER = "org.apache.kafka.connect.json.JsonConverter";
+    private static final String DEFAULT_HISTORY = "org.apache.pulsar.io.debezium.PulsarDatabaseHistory";
+    private static final String DEFAULT_OFFSET_TOPIC = "debezium-offset-topic";
+    private static final String DEFAULT_HISTORY_TOPIC = "debezium-history-topic";
 
     public static void throwExceptionIfConfigNotMatch(Map<String, Object> config,
                                                        String key,

--- a/pulsar-io/debezium/mongodb/src/main/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSource.java
+++ b/pulsar-io/debezium/mongodb/src/main/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSource.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * A pulsar source that runs debezium mongodb source
  */
 public class DebeziumMongoDbSource extends DebeziumSource {
-    static private final String DEFAULT_TASK = "io.debezium.connector.mongodb.MongoDbConnectorTask";
+    private static final String DEFAULT_TASK = "io.debezium.connector.mongodb.MongoDbConnectorTask";
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/mysql/src/main/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSource.java
+++ b/pulsar-io/debezium/mysql/src/main/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSource.java
@@ -27,7 +27,7 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium mysql source
  */
 public class DebeziumMysqlSource extends DebeziumSource {
-    static private final String DEFAULT_TASK = "io.debezium.connector.mysql.MySqlConnectorTask";
+    private static final String DEFAULT_TASK = "io.debezium.connector.mysql.MySqlConnectorTask";
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/postgres/src/main/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSource.java
+++ b/pulsar-io/debezium/postgres/src/main/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSource.java
@@ -28,7 +28,7 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium postgres source
  */
 public class DebeziumPostgresSource extends DebeziumSource {
-    static private final String DEFAULT_TASK = "io.debezium.connector.postgresql.PostgresConnectorTask";
+    private static final String DEFAULT_TASK = "io.debezium.connector.postgresql.PostgresConnectorTask";
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -63,8 +63,8 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
     private boolean unwrapKeyValueIfAvailable;
 
-    private final static ImmutableMap<Class<?>, Schema> primitiveTypeToSchema;
-    private final static ImmutableMap<SchemaType, Schema> pulsarSchemaTypeTypeToKafkaSchema;
+    private static final ImmutableMap<Class<?>, Schema> primitiveTypeToSchema;
+    private static final ImmutableMap<SchemaType, Schema> pulsarSchemaTypeTypeToKafkaSchema;
 
     static {
         primitiveTypeToSchema = ImmutableMap.<Class<?>, Schema>builder()

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -49,7 +49,7 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                     .expireAfterAccess(30, TimeUnit.MINUTES).build();
 
     private boolean jsonWithEnvelope = false;
-    static private final String JSON_WITH_ENVELOPE_CONFIG = "json-with-envelope";
+    private static final String JSON_WITH_ENVELOPE_CONFIG = "json-with-envelope";
 
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         if (config.get(JSON_WITH_ENVELOPE_CONFIG) != null) {

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -110,9 +110,9 @@ public class KinesisSinkTest {
 
     public static class AwsCredentialProviderPluginImpl implements AwsCredentialProviderPlugin {
 
-        public final static String accessKey = "ak";
-        public final static String secretKey = "sk";
-        public final static String sessionToken = "st";
+        public static final String accessKey = "ak";
+        public static final String secretKey = "sk";
+        public static final String sessionToken = "st";
 
         public void init(String param) {
             // no-op

--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
@@ -47,7 +47,7 @@ import org.apache.zookeeper.KeeperException;
 @Slf4j
 public class BookKeeperPackagesStorage implements PackagesStorage {
 
-    private final static String NS_CLIENT_ID = "packages-management";
+    private static final String NS_CLIENT_ID = "packages-management";
     final BookKeeperPackagesStorageConfiguration configuration;
     private Namespace namespace;
 

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/ZooKeeperUtil.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/ZooKeeperUtil.java
@@ -44,7 +44,7 @@ public class ZooKeeperUtil {
     static final Logger LOG = LoggerFactory.getLogger(org.apache.bookkeeper.test.ZooKeeperUtil.class);
 
     // ZooKeeper related variables
-    protected final static Integer zooKeeperPort = PortManager.nextFreePort();
+    protected static final Integer zooKeeperPort = PortManager.nextFreePort();
     private final InetSocketAddress zkaddr;
 
     protected ZooKeeperServer zks;

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarColumnMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarColumnMetadata.java
@@ -32,7 +32,7 @@ public class PulsarColumnMetadata extends ColumnMetadata {
     // need this because presto ColumnMetadata saves name in lowercase
     private String nameWithCase;
     private PulsarColumnHandle.HandleKeyValueType handleKeyValueType;
-    public final static String KEY_SCHEMA_COLUMN_PREFIX = "__key.";
+    public static final String KEY_SCHEMA_COLUMN_PREFIX = "__key.";
 
     private DecoderExtraInfo decoderExtraInfo;
 

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnector.java
@@ -96,7 +96,7 @@ public abstract class TestPulsarConnector {
 
     protected static PulsarDispatchingRowDecoderFactory dispatchingRowDecoderFactory;
 
-    protected final static PulsarConnectorId pulsarConnectorId = new PulsarConnectorId("test-connector");
+    protected static final PulsarConnectorId pulsarConnectorId = new PulsarConnectorId("test-connector");
 
     protected static List<TopicName> topicNames;
     protected static List<TopicName> partitionedTopicNames;
@@ -104,7 +104,7 @@ public abstract class TestPulsarConnector {
     protected static Map<String, SchemaInfo> topicsToSchemas;
     protected static Map<String, Long> topicsToNumEntries;
 
-    private final static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     protected static List<String> fooFieldNames = new ArrayList<>();
 

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
@@ -400,8 +400,8 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
     }
 
 
-    final static String KEY_SCHEMA_COLUMN_PREFIX = "__key.";
-    final static String PRIMITIVE_COLUMN_NAME = "__value__";
+    static final String KEY_SCHEMA_COLUMN_PREFIX = "__key.";
+    static final String PRIMITIVE_COLUMN_NAME = "__value__";
 
     @Data
     static class Foo {

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/DecoderTestMessage.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/DecoderTestMessage.java
@@ -75,14 +75,14 @@ public class DecoderTestMessage {
      * POJO for cyclic detect.
      */
     @Data
-    static public class CyclicFoo {
+    public static class CyclicFoo {
         private String field1;
         private Integer field2;
         private CyclicBoo boo;
     }
 
     @Data
-    static public class CyclicBoo {
+    public static class CyclicBoo {
         private String field1;
         private Boolean field2;
         private CyclicFoo foo;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/SimpleTestProducerSocket.java
@@ -49,7 +49,7 @@ public class SimpleTestProducerSocket {
     private final CountDownLatch closeLatch;
     private volatile Session session;
     private ConcurrentHashMap<String, Long> startTimeMap = new ConcurrentHashMap<>();
-    private final static String CONTEXT = "context";
+    private static final String CONTEXT = "context";
 
     public SimpleTestProducerSocket() {
         this.closeLatch = new CountDownLatch(2);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * this class are controlled across a network via LoadSimulationController.
  */
 public class LoadSimulationClient {
-    private final static Logger log = LoggerFactory.getLogger(LoadSimulationClient.class);
+    private static final Logger log = LoggerFactory.getLogger(LoadSimulationClient.class);
 
     // Values for command encodings.
     public static final byte CHANGE_COMMAND = 0;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
@@ -61,8 +61,8 @@ import org.slf4j.LoggerFactory;
  */
 public class LoadSimulationController {
     private static final Logger log = LoggerFactory.getLogger(LoadSimulationController.class);
-    private final static String QUOTA_ROOT = "/loadbalance/resource-quota/namespace";
-    private final static String BUNDLE_DATA_ROOT = "/loadbalance/bundle-data";
+    private static final String QUOTA_ROOT = "/loadbalance/resource-quota/namespace";
+    private static final String BUNDLE_DATA_ROOT = "/loadbalance/bundle-data";
 
     // Input streams for each client to send commands through.
     private final DataInputStream[] inputStreams;

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -54,11 +54,11 @@ public class MLTransactionLogImpl implements TransactionLog {
 
     private final ManagedLedger managedLedger;
 
-    public final static String TRANSACTION_LOG_PREFIX = "__transaction_log_";
+    public static final String TRANSACTION_LOG_PREFIX = "__transaction_log_";
 
     private final ManagedCursor cursor;
 
-    public final static String TRANSACTION_SUBSCRIPTION_NAME = "transaction.subscription";
+    public static final String TRANSACTION_SUBSCRIPTION_NAME = "transaction.subscription";
 
     private final SpscArrayQueue<Entry> entryQueue;
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapper.java
@@ -27,9 +27,9 @@ import org.eclipse.jetty.websocket.servlet.UpgradeHttpServletRequest;
  */
 public class WebSocketHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
-    final static String HTTP_HEADER_NAME = "Authorization";
-    final static String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
-    final static String TOKEN = "token";
+    static final String HTTP_HEADER_NAME = "Authorization";
+    static final String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
+    static final String TOKEN = "token";
 
     public WebSocketHttpServletRequestWrapper(HttpServletRequest request) {
         super(request);

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
@@ -30,12 +30,12 @@ import org.testng.annotations.Test;
  */
 public class WebSocketHttpServletRequestWrapperTest {
 
-    private final static String TOKEN = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.U387jG"
+    private static final String TOKEN = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.U387jG"
             + "-gmpEXNmTjbnnnk24jCXnfy7OTiQhhhOdXPgV2wEvZYr83KRSmH54wJQr4V2FCWIFb_6mBc_"
             + "E2acpfpfBOTTzrtietfhd6wE5uOP2NXaLpy_kUDsE3ZQGKPEsn18cWQUw54GAzS1oRcG9TnoqSCSFFGabvo"
             + "FTiOMHoBQ3ZHO3TqAGqlJlRF5ZXMkRtQ9vwbPC-mlwIfRrRIJfK5_ijPRkpgFSEvAwp0rX6roz08SyTj_"
             + "d4UNT96nsEL6sRNTpZMQ0qNj2_LMKFnwF3O_xe43-Uen3TllkAzhNd9Z6qIxyJyFbaFyWAVgiAfoFWQD0v4EmV96ZzKZvv3CbGjw";
-    private final static String BEARER_TOKEN = WebSocketHttpServletRequestWrapper.HTTP_HEADER_VALUE_PREFIX + TOKEN;
+    private static final String BEARER_TOKEN = WebSocketHttpServletRequestWrapper.HTTP_HEADER_VALUE_PREFIX + TOKEN;
 
     @Test
     public void testTokenParamWithBearerPrefix() {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
@@ -47,7 +47,7 @@ import org.testng.annotations.Test;
  */
 public class HealthCheckTest extends TestRetrySupport {
 
-    private final static Logger log = LoggerFactory.getLogger(HealthCheckTest.class);
+    private static final Logger log = LoggerFactory.getLogger(HealthCheckTest.class);
 
     private final PulsarClusterSpec spec = PulsarClusterSpec.builder()
         .clusterName("HealthCheckTest-" + UUID.randomUUID().toString().substring(0, 8))

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PackagesCliTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class PackagesCliTest extends TestRetrySupport {
 
-    private final static String clusterNamePrefix = "packages-service";
+    private static final String clusterNamePrefix = "packages-service";
     private PulsarCluster pulsarCluster;
 
     @BeforeClass(alwaysRun = true)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PulsarVersionTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PulsarVersionTest.java
@@ -35,7 +35,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class PulsarVersionTest extends TestRetrySupport {
 
-    private final static String clusterNamePrefix = "pulsar-version";
+    private static final String clusterNamePrefix = "pulsar-version";
     private PulsarCluster pulsarCluster;
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/SchemaUpdateStrategyTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/SchemaUpdateStrategyTest.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * Test setting the schema update strategy via the CLI.
  */
 public class SchemaUpdateStrategyTest extends PulsarTestSuite {
-    private final static Logger log = LoggerFactory.getLogger(SchemaUpdateStrategyTest.class);
+    private static final Logger log = LoggerFactory.getLogger(SchemaUpdateStrategyTest.class);
 
     private void testAutoUpdateBackward(String namespace, String topicName) throws Exception {
         ContainerExecResult result = pulsarCluster.runAdminCommandOnAnyBroker(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
@@ -41,16 +41,16 @@ import org.testng.collections.Maps;
 @Slf4j
 public abstract class SourceTester<ServiceContainerT extends GenericContainer> {
 
-    public final static String INSERT = "INSERT";
+    public static final String INSERT = "INSERT";
 
-    public final static String DELETE = "DELETE";
+    public static final String DELETE = "DELETE";
 
-    public final static String UPDATE = "UPDATE";
+    public static final String UPDATE = "UPDATE";
 
     protected final String sourceType;
     protected final Map<String, Object> sourceConfig;
 
-    public final static Set<String> DEBEZIUM_FIELD_SET = new HashSet<String>() {{
+    public static final Set<String> DEBEZIUM_FIELD_SET = new HashSet<String>() {{
         add("before");
         add("after");
         add("source");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxy.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
  * Test cases for proxy.
  */
 public class TestProxy extends PulsarTestSuite {
-    private final static Logger log = LoggerFactory.getLogger(TestProxy.class);
+    private static final Logger log = LoggerFactory.getLogger(TestProxy.class);
 
     @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/proxy/TestProxyWithWebSocket.java
@@ -50,7 +50,7 @@ import static org.apache.pulsar.tests.integration.containers.PulsarContainer.CS_
  * Test cases for proxy.
  */
 public class TestProxyWithWebSocket extends PulsarTestSuite {
-    private final static Logger log = LoggerFactory.getLogger(TestProxyWithWebSocket.class);
+    private static final Logger log = LoggerFactory.getLogger(TestProxyWithWebSocket.class);
 
     @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarSQLTestSuite.java
@@ -28,10 +28,10 @@ import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 @Slf4j
 public abstract class PulsarSQLTestSuite extends PulsarTestSuite {
 
-    public final static int ENTRIES_PER_LEDGER = 100;
-    public final static String OFFLOAD_DRIVER = "aws-s3";
-    public final static String BUCKET = "pulsar-integtest";
-    public final static String ENDPOINT = "http://" + S3Container.NAME + ":9090";
+    public static final int ENTRIES_PER_LEDGER = 100;
+    public static final String OFFLOAD_DRIVER = "aws-s3";
+    public static final String BUCKET = "pulsar-integtest";
+    public static final String ENDPOINT = "http://" + S3Container.NAME + ":9090";
 
     @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(String clusterName, PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockHeaderImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockHeaderImpl.java
@@ -73,11 +73,11 @@ public class DataBlockHeaderImpl implements DataBlockHeader {
     private final long blockLength;
     private final long firstEntryId;
 
-    static public int getBlockMagicWord() {
+    public static int getBlockMagicWord() {
         return MAGIC_WORD;
     }
 
-    static public int getDataStartOffset() {
+    public static int getDataStartOffset() {
         return HEADER_MAX_SIZE;
     }
 

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexBlockImpl.java
@@ -174,7 +174,7 @@ public class OffloadIndexBlockImpl implements OffloadIndexBlock {
         return new OffloadIndexBlock.IndexInputStream(new ByteBufInputStream(out, true), indexBlockLength);
     }
 
-    static private class InternalLedgerMetadata implements LedgerMetadata {
+    private static class InternalLedgerMetadata implements LedgerMetadata {
 
         private int ensembleSize;
         private int writeQuorumSize;

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/StreamingDataBlockHeaderImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/StreamingDataBlockHeaderImpl.java
@@ -59,11 +59,11 @@ public class StreamingDataBlockHeaderImpl implements DataBlockHeader {
     private final long blockLength;
     private final long firstEntryId;
 
-    static public int getBlockMagicWord() {
+    public static int getBlockMagicWord() {
         return MAGIC_WORD;
     }
 
-    static public int getDataStartOffset() {
+    public static int getDataStartOffset() {
         return HEADER_MAX_SIZE;
     }
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreTestBase.java
@@ -31,7 +31,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class BlobStoreTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(BlobStoreTestBase.class);
-    public final static String BUCKET = "pulsar-unittest";
+    public static final String BUCKET = "pulsar-unittest";
 
     protected BlobStoreContext context = null;
     protected BlobStore blobStore = null;

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderBase.java
@@ -44,7 +44,7 @@ import org.testng.Assert;
 
 public abstract class BlobStoreManagedLedgerOffloaderBase {
 
-    public final static String BUCKET = "pulsar-unittest";
+    public static final String BUCKET = "pulsar-unittest";
     protected static final int DEFAULT_BLOCK_SIZE = 5*1024*1024;
     protected static final int DEFAULT_READ_BUFFER_SIZE = 1*1024*1024;
 


### PR DESCRIPTION
### Motivation
The some java class/method/field modifiers are improper used.

Oracle java modifier order documentation:
https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.1.1

#### Class Modifiers
```
Class Modifier:
(one of)
Annotation public protected private
abstract static final strictfp
```

#### Method Modifiers
```
MethodModifier:
(one of)
Annotation public protected private
abstract static final synchronized native strictfp
```

#### Field Modifiers
```
FieldModifier:
(one of)
Annotation public protected private
static final transient volatile
```

### Modification
Change mis-ordered modifiers. 

