### PR TITLE
Fix set project version for the presto distribution

### DIFF
--- a/src/set-project-version.sh
+++ b/src/set-project-version.sh
@@ -38,7 +38,6 @@ OLD_VERSION=`python ${ROOT_DIR}/src/get-project-version.py`
 
 mvn versions:set -DnewVersion=$NEW_VERSION
 mvn versions:set -DnewVersion=$NEW_VERSION -pl buildtools
-mvn versions:set -DnewVersion=$NEW_VERSION -pl pulsar-sql/presto-distribution
 # Set terraform ansible deployment pulsar version
 sed -i -e "s/${OLD_VERSION}/${NEW_VERSION}/g" ${TERRAFORM_DIR}/deploy-pulsar.yaml
 


### PR DESCRIPTION
Fixes #10834 

### Motivation

Since the https://github.com/apache/pulsar/pull/10728
make the pulsar sql module to be a child of Pulsar main project
we don't need to run the specific set-version for the presto-distribution
