### PR TITLE
Fix pulsar sql issues when run select count(*) for the table with primary schema

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoder.java
@@ -66,6 +66,9 @@ public class PulsarPrimitiveRowDecoder implements PulsarRowDecoder {
 
     @Override
     public Optional<Map<DecoderColumnHandle, FieldValueProvider>> decodeRow(ByteBuf byteBuf) {
+        if (columnHandle == null) {
+            return Optional.empty();
+        }
         Object value = schema.decode(byteBuf);
         Map<DecoderColumnHandle, FieldValueProvider> primitiveColumn = new HashMap<>();
         if (value == null) {

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoderFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/primitive/PulsarPrimitiveRowDecoderFactory.java
@@ -64,7 +64,8 @@ public class PulsarPrimitiveRowDecoderFactory implements PulsarRowDecoderFactory
             return new PulsarPrimitiveRowDecoder((AbstractSchema<?>) AutoConsumeSchema.getSchema(schemaInfo),
                     columns.iterator().next());
         } else {
-            throw new RuntimeException("Primitive type must has only one ColumnHandle.");
+            return new PulsarPrimitiveRowDecoder((AbstractSchema<?>) AutoConsumeSchema.getSchema(schemaInfo),
+                    null);
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -258,6 +258,13 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
 
         log.info("Executing query: result for topic {} returnedTimestamps size: {}", topic, returnedTimestamps.size());
         assertThat(returnedTimestamps.size()).isEqualTo(0);
+
+        query = String.format("select count(*) from pulsar.\"%s\".\"%s\"", namespace, topic);
+        log.info("Executing query: {}", query);
+        res = connection.createStatement().executeQuery(query);
+        res.next();
+        int count = res.getInt("_col0");
+        assertThat(count).isGreaterThan(messageNum - 2);
     }
 
     public ContainerExecResult execQuery(final String query) throws Exception {


### PR DESCRIPTION



<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

### Motivation

Fix pulsar sql issues when run select count(*) for the table with primary schema

error log:

```
2021-06-06T14:36:41.669+0800 ERROR SplitRunner-3-106 io.prestosql.execution.executor.TaskExecutor Error processing Split 20210606_063634_00002_6j8bm.1.0-1 PulsarSplit{splitId=1, connectorId='pulsar', originSchemaName='Bytes', schemaName='public/default', tableName='my-topic', splitSize=39324, schema='', schemaType=BYTES, startPositionEntryId=39325, endPositionEntryId=78649, startPositionLedgerId=10, endPositionLedgerId=10, schemaInfoProperties={}} (start = 2.24098441109938E8, wall = 320 ms, cpu = 0 ms, wait = 1 ms, calls = 1)
java.lang.RuntimeException: Primitive type must has only one ColumnHandle.
 at org.apache.pulsar.sql.presto.decoder.primitive.PulsarPrimitiveRowDecoderFactory.createRowDecoder(PulsarPrimitiveRowDecoderFactory.java:67)
 at org.apache.pulsar.sql.presto.PulsarDispatchingRowDecoderFactory.createRowDecoder(PulsarDispatchingRowDecoderFactory.java:59)
 at org.apache.pulsar.sql.presto.PulsarRecordCursor.advanceNextPosition(PulsarRecordCursor.java:545)
 at io.prestosql.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:90)
 at io.prestosql.operator.TableScanOperator.getOutput(TableScanOperator.java:302)
 at io.prestosql.operator.Driver.processInternal(Driver.java:379)
 at io.prestosql.operator.Driver.lambda$processFor$8(Driver.java:283)
 at io.prestosql.operator.Driver.tryWithLock(Driver.java:675)
 at io.prestosql.operator.Driver.processFor(Driver.java:276)
 at io.prestosql.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1075)
 at io.prestosql.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
 at io.prestosql.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
 at io.prestosql.$gen.Presto_332__testversion____20210606_063438_2.run(Unknown Source)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
 at java.base/java.lang.Thread.run(Thread.java:834)
 ```

### Modifications

Remove check for the column size when on the primary schema since when run select count(*) on the presto, we will get empty column handlers

### Verifying this change

New integration test added.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
