### PR TITLE
Fix javadoc issue in MockitoCleanupListener.java when deploy maven packages

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/MockitoCleanupListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/MockitoCleanupListener.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Mockito.reset method should be called at the end of a test in the same thread where the methods were
  * mocked/stubbed. There are some tests which mock methods in the ForkJoinPool thread and these leak memory.
  * This listener doesn't support parallel execution at TestNG level. This is not thread safe.
- * Separate forks (testForkCount > 1) controlled with Maven Surefire is the recommended solution
+ * Separate forks {@code testForkCount > 1} controlled with Maven Surefire is the recommended solution
  * for parallel test execution and that is fine.
  */
 public class MockitoCleanupListener extends BetweenTestClassesListenerAdapter {


### PR DESCRIPTION
### Motivation

Fix javadoc issue in MockitoCleanupListener.java when deploy maven packages

error log:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project buildtools: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /Users/lipenghui/Release/pulsar/buildtools/src/main/java/org/apache/pulsar/tests/MockitoCleanupListener.java:29: error: bad use of '>'
[ERROR]  * Separate forks (testForkCount > 1) controlled with Maven Surefire is the recommended solution
[ERROR]                                  ^
[ERROR]
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/jdk-11.0.7.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/Users/lipenghui/Release/pulsar/buildtools/target/apidocs' dir.
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
