### PR TITLE
When topic does not exist, optimize the prompt message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -986,7 +986,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 .thenCompose(optTopic -> {
                                     if (!optTopic.isPresent()) {
                                         return FutureUtil
-                                                .failedFuture(new TopicNotFoundException("Topic does not exist"));
+                                                .failedFuture(new TopicNotFoundException(
+                                                        "Topic " + topicName + " does not exist"));
                                     }
 
                                     Topic topic = optTopic.get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4051,6 +4051,24 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(1, res.getFields().size());
     }
 
+    @Test
+    public void testTopicDoesNotExists() throws Exception {
+        cleanup();
+        conf.setAllowAutoTopicCreation(false);
+        setup();
+        String topic = "persistent://my-property/my-ns/none" + UUID.randomUUID();
+        try {
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                    .topic(topic).subscriptionName("sub").subscribe();
+            fail("should fail");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Topic " + topic + " does not exist"));
+        } finally {
+            conf.setAllowAutoTopicCreation(true);
+        }
+    }
+
     /**
      * Test validates that consumer of partitioned-topic utilizes threads of all partitioned-consumers and slow-listener
      * of one of the partition doesn't impact listener-processing of other partition.


### PR DESCRIPTION
### Motivation
If we set enableRetry=true, the client will subscribe to the retry topic.
If we set AllowAutoTopicCreation=false, the client will receive `Topic dose not exists`, which means that the retry Topic does not exists.
Therefore, the prompt information is improved to facilitate users to troubleshoot problems.

### Modifications
add topic name to the returning message
