### PR TITLE
Restore netty-tc-native version to 2.0.38.Final

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -369,7 +369,7 @@ The Apache Software License, Version 2.0
     - io.netty-netty-transport-native-epoll-4.1.63.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.63.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.63.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.33.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.38.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ flexible messaging model and an intuitive client API.</description>
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.63.Final</netty.version>
-    <netty-tc-native.version>2.0.33.Final</netty-tc-native.version>
+    <netty-tc-native.version>2.0.38.Final</netty-tc-native.version>
     <jetty.version>9.4.39.v20210325</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -243,7 +243,7 @@ The Apache Software License, Version 2.0
     - netty-reactive-streams-2.0.4.jar
     - netty-resolver-4.1.63.Final.jar
     - netty-resolver-dns-4.1.63.Final.jar
-    - netty-tcnative-boringssl-static-2.0.33.Final.jar
+    - netty-tcnative-boringssl-static-2.0.38.Final.jar
     - netty-transport-4.1.63.Final.jar
     - netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.63.Final.jar


### PR DESCRIPTION
This reverts commit 6e747ec0db9cad46739ab0d88acd8dd93f4ae0a5.

### Motivation
The problem in #10798  is more about "epoll" and not about tc-native.
With adoptopenjdk/openjdk15:alpine-slim docker image the problem does not reproduce, so it is better to stick to 2.0.38.Final