### PR TITLE
[Security] Upgrade Zookeeper to 3.6.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -510,9 +510,9 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-core-3.5.4.jar
     - io.vertx-vertx-web-3.5.4.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-3.6.2.jar
-    - org.apache.zookeeper-zookeeper-jute-3.6.2.jar
-    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.6.2.jar
+    - org.apache.zookeeper-zookeeper-3.6.3.jar
+    - org.apache.zookeeper-zookeeper-jute-3.6.3.jar
+    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.6.3.jar
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.7.jar
   * Google HTTP Client

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.19</commons-compress.version>
 
     <bookkeeper.version>4.14.1</bookkeeper.version>
-    <zookeeper.version>3.6.2</zookeeper.version>
+    <zookeeper.version>3.6.3</zookeeper.version>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -448,9 +448,9 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
   * Apache Zookeeper
-    - zookeeper-3.6.2.jar
-    - zookeeper-jute-3.6.2.jar
-    - zookeeper-prometheus-metrics-3.6.2.jar
+    - zookeeper-3.6.3.jar
+    - zookeeper-jute-3.6.3.jar
+    - zookeeper-prometheus-metrics-3.6.3.jar
   * Apache Yetus Audience Annotations
     - audience-annotations-0.5.0.jar
   * Swagger


### PR DESCRIPTION
### Motivation

- Zookeeper 3.6.2 gets flagged as vulnerable
  https://ossindex.sonatype.org/component/pkg:maven/org.apache.zookeeper/zookeeper@3.6.2
  because of using vulnerable Netty version

### Modifications

- Upgrade Zookeeper to 3.6.3 which uses Netty 4.1.63.Final