### PR TITLE
[Build] Run OWASP Dependency Check as a scheduled build once per day

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - OWASP Dependency Check
+on:
+  schedule:
+    - cron: '15 0 * * *'
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  run-owasp-dependency-check:
+    name: Run OWASP Dependency Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-owasp-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Replace maven's wagon-http version
+        run: sudo ./build/replace_maven-wagon-http-version.sh
+
+      - name: run install by skip tests
+        run: mvn -q -B -ntp clean install -DskipTests
+
+      - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
+        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
+
+      - name: run OWASP Dependency Check for distribution/offloaders, distribution/io and pulsar-sql/presto-distribution
+        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io,pulsar-sql/presto-distribution
+
+      - name: Upload OWASP Dependency Check reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: owasp-dependency-check-reports
+          path: |
+            distribution/server/target/dependency-check-report.html
+            distribution/offloaders/target/dependency-check-report.html
+            distribution/io/target/dependency-check-report.html
+            pulsar-sql/presto-distribution/target/dependency-check-report.html

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>6.1.5</dependency-check-maven.version>
+    <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -2167,6 +2167,10 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>dependency-check-maven</artifactId>
             <version>${dependency-check-maven.version}</version>
             <configuration>
+              <suppressionFiles>
+                <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-false-positives.xml</suppressionFile>
+                <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-suppressions.xml</suppressionFile>
+              </suppressionFiles>
               <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
               <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
               <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- add supressions for false-positives detected by OWASP Dependency Check -->
+  <suppress>
+    <notes>
+      apache:http_server is not used.
+    </notes>
+    <cpe>cpe:/a:apache:http_server</cpe>
+  </suppress>
+  <suppress>
+    <notes>pulsar-zookeeper-utils gets mixed with zookeeper.</notes>
+    <gav regex="true">org\.apache\.pulsar:.*</gav>
+    <cpe>cpe:/a:apache:zookeeper</cpe>
+  </suppress>
+  <suppress>
+    <notes>kubernetes client doesn't contain CVE-2020-8554</notes>
+    <gav regex="true">io\.kubernetes:.*</gav>
+    <cve>CVE-2020-8554</cve>
+  </suppress>
+  <suppress>
+    <notes>avro doesn't contain CVE-2019-17195</notes>
+    <gav regex="true">org\.apache\.avro:.*</gav>
+    <cve>CVE-2019-17195</cve>
+  </suppress>
+</suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
+  <suppress>
+    <notes>Ignore netty CVEs in GRPC shaded Netty.</notes>
+    <filePath regex="true">.*grpc-netty-shaded.*</filePath>
+    <cpe>cpe:/a:netty:netty</cpe>
+  </suppress>
+  <suppress>
+    <notes>Suppress all pulsar-presto-distribution vulnerabilities</notes>
+    <filePath regex="true">.*pulsar-presto-distribution-.*</filePath>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress libthrift-0.12.0.jar vulnerabilities</notes>
+    <gav>org.apache.thrift:libthrift:0.12.0</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress vert.x 3.5.4 vulnerabilities</notes>
+    <gav regex="true">io\.vertx:.*:3\.5\.4</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
+    <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
### Motivation

Monitoring for new library vulnerabilities without having an automated solution is prone to errors.  

There's an enhancement request #8815 about "Automated security and update routine before every release". This PR will help address those aspects.

New library vulnerabilities can be detected earlier when there's a scheduled build once per day. 

### Modifications

- add suppressions for false positives
- add suppressions for known issues in distribution/server and make the check
  fail if new vulnerabilities are introduced
- run reports for distribution/offloaders, distribution/io and
  pulsar-sql/presto-distribution to get a complete report of all
  vulnerabilities
- upload report files as GitHub Actions artifact

### Additional context

The current master branch contains a few vulnerabilities:
- libthrift-0.12.0.jar (pkg:maven/org.apache.thrift/libthrift@0.12.0, cpe:2.3:a:apache:thrift:0.12.0:*:*:*:*:*:*:*) : CVE-2019-0205, CVE-2019-0210, CVE-2020-13949
  - issue #9248
- vertx-core-3.5.4.jar (pkg:maven/io.vertx/vertx-core@3.5.4, cpe:2.3:a:eclipse:vert.x:3.5.4:*:*:*:*:*:*:*) : CVE-2018-12541, CVE-2019-17640
  - more details in #10295 . Waiting for vert.x 3.9.8 release.
- zookeeper-3.6.2.jar (pkg:maven/org.apache.zookeeper/zookeeper@3.6.2, cpe:2.3:a:apache:zookeeper:3.6.2:*:*:*:*:*:*:*) : CVE-2021-21409
  - fixed by #10852

The vulnerabilities mentioned above are suppressed in `src/owasp-dependency-check-suppressions.xml` file so that it's possible to run OWASP Dependency Check with `-DfailBuildOnAnyVulnerability=true` for failing the build if any new vulnerabilities are detected. This is the way how this PR sets a baseline and llbrary vulnerabilities can be tracked.


