### PR TITLE
Fix the incorrect class name of LOCAL_TIME

### DIFF
--- a/site2/website/versioned_docs/version-2.7.0/schema-understand.md
+++ b/site2/website/versioned_docs/version-2.7.0/schema-understand.md
@@ -171,8 +171,8 @@ The conversions between **Pulsar schema types** and **language-specific primitiv
 | DATE | java.util.Date | | |
 | INSTANT | java.time.Instant | | |
 | LOCAL_DATE | java.time.LocalDate | | |
-| LOCAL_TIME | java.time.LocalDateTime | |
-| LOCAL_DATE_TIME | java.time.LocalTime | |
+| LOCAL_TIME | java.time.LocalTime | |
+| LOCAL_DATE_TIME | java.time.LocalDateTime | |
 
 **Example**
 

--- a/site2/website/versioned_docs/version-2.7.1/schema-understand.md
+++ b/site2/website/versioned_docs/version-2.7.1/schema-understand.md
@@ -171,8 +171,8 @@ The conversions between **Pulsar schema types** and **language-specific primitiv
 | DATE | java.util.Date | | |
 | INSTANT | java.time.Instant | | |
 | LOCAL_DATE | java.time.LocalDate | | |
-| LOCAL_TIME | java.time.LocalDateTime | |
-| LOCAL_DATE_TIME | java.time.LocalTime | |
+| LOCAL_TIME | java.time.LocalTime | |
+| LOCAL_DATE_TIME | java.time.LocalDateTime | |
 
 **Example**
 

--- a/site2/website/versioned_docs/version-2.7.2/schema-understand.md
+++ b/site2/website/versioned_docs/version-2.7.2/schema-understand.md
@@ -171,8 +171,8 @@ The conversions between **Pulsar schema types** and **language-specific primitiv
 | DATE | java.util.Date | | |
 | INSTANT | java.time.Instant | | |
 | LOCAL_DATE | java.time.LocalDate | | |
-| LOCAL_TIME | java.time.LocalDateTime | |
-| LOCAL_DATE_TIME | java.time.LocalTime | |
+| LOCAL_TIME | java.time.LocalTime | |
+| LOCAL_DATE_TIME | java.time.LocalDateTime | |
 
 **Example**
 

--- a/site2/website/versioned_docs/version-2.7.3/schema-understand.md
+++ b/site2/website/versioned_docs/version-2.7.3/schema-understand.md
@@ -171,8 +171,8 @@ The conversions between **Pulsar schema types** and **language-specific primitiv
 | DATE | java.util.Date | | |
 | INSTANT | java.time.Instant | | |
 | LOCAL_DATE | java.time.LocalDate | | |
-| LOCAL_TIME | java.time.LocalDateTime | |
-| LOCAL_DATE_TIME | java.time.LocalTime | |
+| LOCAL_TIME | java.time.LocalTime | |
+| LOCAL_DATE_TIME | java.time.LocalDateTime | |
 
 **Example**
 


### PR DESCRIPTION

### Motivation

The class names of LOCAL_TIME and LOCAL_DATE_TIME have been swapped
