### PR TITLE
Revert "[Issue 8751] Update Dockerfile for Pulsar and Dashboard to Cr…

### DIFF
--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -25,19 +25,7 @@ ARG PULSAR_OFFLOADER_TARBALL
 ADD ${PULSAR_IO_DIR} /connectors
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
-RUN chmod -R g=u /connectors /offloaders
 
 FROM apachepulsar/pulsar:latest
-
-# Need permission to create directories and update file permissions
-USER root
-
-RUN mkdir /pulsar/connectors /pulsar/offloaders && \
-    chown pulsar:root /pulsar/connectors /pulsar/offloaders && \
-    chmod g=u /pulsar/connectors /pulsar/offloaders
-
-# Return to pulsar (non root) user
-USER pulsar
-
-COPY --from=pulsar-all --chown=pulsar:0 /connectors /pulsar/connectors
-COPY --from=pulsar-all --chown=pulsar:0 /offloaders /pulsar/offloaders
+COPY --from=pulsar-all /connectors /pulsar/connectors
+COPY --from=pulsar-all /offloaders /pulsar/offloaders

--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -26,9 +26,6 @@ FROM apachepulsar/pulsar-dashboard:latest as dashboard
 # Restart from
 FROM openjdk:11-jdk
 
-# Help to make these directories persist between container restarts
-VOLUME  ["/pulsar/conf", "/pulsar/data"]
-
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -17,8 +17,7 @@
 # under the License.
 #
 
-# First create a stage with the Pulsar tarball, the scripts, the python client,
-# the cpp client, and the data directory. Then ensure correct file permissions.
+# First create a stage with just the Pulsar tarball and scripts
 FROM busybox as pulsar
 
 ARG PULSAR_TARBALL
@@ -34,23 +33,12 @@ COPY scripts/pulsar-zookeeper-ruok.sh /pulsar/bin
 COPY scripts/watch-znode.py /pulsar/bin
 COPY scripts/install-pulsar-client-37.sh /pulsar/bin
 
-COPY target/python-client/ /pulsar/pulsar-client
-
 RUN mkdir /pulsar/data
-
-# In order to support running this docker image as a container on OpenShift
-# the final image needs to give the root group enough permission.
-# The file permissions are maintained when copied into the target image.
-RUN chmod -R g=u /pulsar
 
 ### Create 2nd stage from OpenJDK image
 ### and add Python dependencies (for Pulsar functions)
 
 FROM openjdk:11-jdk-slim
-
-# Create the pulsar group and user to make docker container run as a non root user by default
-RUN groupadd -g 10001 pulsar
-RUN adduser -u 10000 --gid 10001 --disabled-login --disabled-password --gecos '' pulsar
 
 # Install some utilities
 RUN apt-get update \
@@ -66,21 +54,16 @@ RUN python3.7 get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
-# The pulsar directory is staged correctly in the first stage, above.
-# The chown and chmod ensure proper permissions for running as a non root user and non root group
-# as well as running on OpenShift with a random user that is part of the root group
-RUN mkdir /pulsar && chown pulsar:0 /pulsar && chmod g=u /pulsar
-COPY --from=pulsar --chown=pulsar:0 /pulsar /pulsar
-
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
+ADD target/python-client/ /pulsar/pulsar-client
+
+VOLUME  ["/pulsar/conf", "/pulsar/data"]
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 
+
+COPY --from=pulsar /pulsar /pulsar
 WORKDIR /pulsar
 
-# This script is intentionally run as the root user to make the dependencies
-# available to the root user and the pulsar user
 RUN /pulsar/bin/install-pulsar-client-37.sh
 
-# Switch to the pulsar user to ensure container defaults to run as a non root user
-USER pulsar

--- a/site2/docs/getting-started-docker.md
+++ b/site2/docs/getting-started-docker.md
@@ -27,11 +27,6 @@ and follow the instructions for your OS.
 A few things to note about this command:
  * The data, metadata, and configuration are persisted on Docker volumes in order to not start "fresh" every 
 time the container is restarted. For details on the volumes you can use `docker volume inspect <sourcename>`
- * The pulsar docker image runs as user 10000, by default. In order for the pulsar process to
- access the mounted volumes, the host volumes (`pulsardata` and `pulsarconf` in this example)
- must give user 10000 read and write permissions. Alternatively, you can specify the user to run with and then make sure
- that the host volume gives that user read and write permissions. Otherwise, the process will fail due to insufficient
- permissions.
  * For Docker on Windows make sure to configure it to use Linux containers
 
 If you start Pulsar successfully, you will see `INFO`-level log messages like this:

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -55,12 +55,6 @@ FROM apachepulsar/pulsar-all:latest as pulsar-all
 ########################################
 FROM apachepulsar/pulsar:latest
 
-# Switch to run as the root user to simplify building container and then running
-# supervisord. Each of the pulsar components are spawned by supervisord and their
-# process configuration files specify that the process will be run as the "pulsar" user
-# However, any processes exec'ing into the containers will run as root, by default.
-USER root
-
 RUN rm -rf /var/lib/apt/lists/* && apt update
 
 RUN apt-get clean && apt-get update && apt-get install -y supervisor vim procps curl

--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -24,4 +24,3 @@ stdout_logfile=/var/log/pulsar/bookie.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar bookie
-user=pulsar

--- a/tests/docker-images/latest-version-image/conf/broker.conf
+++ b/tests/docker-images/latest-version-image/conf/broker.conf
@@ -24,5 +24,4 @@ stdout_logfile=/var/log/pulsar/broker.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar broker
-user=pulsar
 

--- a/tests/docker-images/latest-version-image/conf/functions_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/functions_worker.conf
@@ -24,5 +24,4 @@ stdout_logfile=/var/log/pulsar/functions_worker.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar functions-worker
-user=pulsar
 

--- a/tests/docker-images/latest-version-image/conf/global-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/global-zk.conf
@@ -24,5 +24,4 @@ stdout_logfile=/var/log/pulsar/global-zk.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar configuration-store
-user=pulsar
 

--- a/tests/docker-images/latest-version-image/conf/local-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/local-zk.conf
@@ -24,5 +24,4 @@ stdout_logfile=/var/log/pulsar/local-zk.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar zookeeper
-user=pulsar
 

--- a/tests/docker-images/latest-version-image/conf/presto_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/presto_worker.conf
@@ -24,4 +24,3 @@ stdout_logfile=/var/log/pulsar/presto_worker.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar sql-worker start
-user=pulsar

--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -24,5 +24,4 @@ stdout_logfile=/var/log/pulsar/proxy.log
 directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseG1GC"
 command=/pulsar/bin/pulsar proxy
-user=pulsar
 


### PR DESCRIPTION
…eate and Use pulsar User (nonroot user) (#8796)"

This reverts commit 4264a67a84d9a9f4a49cebc591c46b252dcf4e45.

### Motivation

The change https://github.com/apache/pulsar/pull/8796 has broken the Pulsar
Functions running on Kubernetes.

The Pulsar Functions Kubernetes runtime generates a secret and mounts it
using mode `256`. That means the secret is only able to read by the user.
The StatefulSet created by Kubernetes runtime mounts the secrets under the
`root` user. Hence only the root user is able to read the secret. This
results in any functions submitted will fail to read the authentication
information.

Because all the Kubernetes resources generated by the Kubernetes runtime
are hardcoded. There is no easy way to change the security context for the
function statefulsets. 

Let's revert this change for 2.8.0, until we can address the issues in the Kubernetes runtime.

