### PR TITLE
[Issue 10860][pulsar-metadata] Ensure metadata cache consistency across brokers

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.metadata.api.CacheGetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -50,6 +51,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.Stat;
 
+@Slf4j
 public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notification> {
 
     private static final long CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
@@ -209,8 +211,17 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         store.put(path, content, Optional.of(-1L))
                 .thenAccept(stat -> {
                     // Make sure we have the value cached before the operation is completed
-                    objCache.put(path, FutureUtils.value(Optional.of(new CacheGetResult<>(value, stat))));
-                    future.complete(null);
+                    // In addition to caching the value, we need to add a watch on the path,
+                    // so when/if it changes on any other node, we are notified and we can
+                    // update the cache
+                    objCache.get(path).whenComplete( (stat2, ex) -> {
+                        if (ex == null) {
+                            future.complete(null);
+                        } else {
+                            log.error("Exception while getting path {}", path, ex);
+                            future.completeExceptionally(ex.getCause());
+                        }
+                    });
                 }).exceptionally(ex -> {
                     if (ex.getCause() instanceof BadVersionException) {
                         // Use already exists exception to provide more self-explanatory error message
@@ -229,7 +240,11 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         return store.delete(path, Optional.empty())
                 .thenAccept(v -> {
                     // Mark in the cache that the object was removed
-                    objCache.put(path, FutureUtils.value(Optional.empty()));
+                    // objCache.put(path, FutureUtils.value(Optional.empty()));
+                    // We shouldn't add this to the cache. If we add it to the cache, then local get requests
+                    // will be served from the cache. Since we are not watching this znode, we will not be
+                    // notified if this added on some other broker. We will continue the return `object not found`
+                    // errors even though it now exists in the system
                 });
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -28,6 +28,8 @@ import static org.testng.Assert.fail;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -50,6 +52,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializat
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.Stat;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class MetadataCacheTest extends BaseMetadataStoreTest {
@@ -87,6 +90,70 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
             fail("should have failed");
         } catch (CompletionException e) {
             assertEquals(e.getCause().getClass(), NotFoundException.class);
+        }
+    }
+
+    @DataProvider(name = "zk")
+    public Object[][] zkimplementations() {
+        return new Object[][] {
+            { "ZooKeeper", zks.getConnectionString() },
+        };
+    }
+
+    @Test(dataProvider = "zk")
+    public void crossStoreUpdates(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store1 = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        MetadataStore store2 = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        MetadataStore store3 = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> objCache1 = store1.getMetadataCache(MyClass.class);
+        MetadataCache<MyClass> objCache2 = store2.getMetadataCache(MyClass.class);
+        MetadataCache<MyClass> objCache3 = store3.getMetadataCache(MyClass.class);
+
+        List<MetadataCache<MyClass>> allCaches = new ArrayList<>();
+        allCaches.add(objCache1);
+        allCaches.add(objCache2);
+        allCaches.add(objCache3);
+
+        // Add on one cache and remove from another
+        multiStoreAddDelete(allCaches, 0, 1, "add cache0 del cache1");
+        // retry same order to rule out any stale state
+        multiStoreAddDelete(allCaches, 0, 1, "add cache0 del cache1");
+        // Reverse the operations
+        multiStoreAddDelete(allCaches, 1, 0, "add cache1 del cache0");
+        // Ensure that working on same cache continues to work.
+        multiStoreAddDelete(allCaches, 1, 1, "add cache1 del cache1");
+    }
+
+    private void multiStoreAddDelete(List<MetadataCache<MyClass>> caches, int addOn, int delFrom, String testName) {
+        MetadataCache<MyClass> addCache = caches.get(addOn);
+        MetadataCache<MyClass> delCache = caches.get(delFrom);
+
+        String key1 = "/test-key1";
+        assertEquals(addCache.getIfCached(key1), Optional.empty());
+
+        MyClass value1 = new MyClass(testName, 1);
+
+        addCache.create(key1, value1).join();
+        for (MetadataCache<MyClass> cache: caches) {
+            if (cache == addCache) {
+                assertEquals(cache.getIfCached(key1), Optional.of(value1));
+            }
+            assertEquals(cache.get(key1).join(), Optional.of(value1));
+            assertEquals(cache.getIfCached(key1), Optional.of(value1));
+        }
+
+        delCache.delete(key1).join();
+
+        // The entry should get removed from all caches
+        for (MetadataCache<MyClass> cache: caches) {
+            assertEquals(cache.getIfCached(key1), Optional.empty());
+            assertEquals(cache.get(key1).join(), Optional.empty());
         }
     }
 


### PR DESCRIPTION
Fixes #10860

### Motivation

When doing operations on multiple brokers, the state is not always consistent. Sometimes the operations don't seem to get replicated to other brokers in the cluster. The queries from the brokers returns different results. See #10860 for details

### Modifications

1. While creating a new object, we add the object to cache. However we are not adding a watch on the corresponding path in zookeeper. So when other brokers change/delete the object, the broker that added the object is not notified. With this change we will do a get(), which will add a watch on the corresponding path. This will also add the object to the cache.

2. Similarly while deleting, we are adding an empty object to the cache. Any local request will now return a `object not found` error, without needing to go the zookeeper. However if the object get re-added on any other broker, we will not be notified. We will continue to return `object not found` error, even though an instance of the object now exist. This change remove the addition of empty object to the cache. If a request is received for the object, we will do a get from the zookeeper and if it still doesn't exist, an empty object will get added. Also a watch will get added for the corresponding path. This will ensure that cache will get update the object is again added by some other broker.

### Verifying this change

- Added a test case that clearly demonstrates the issue and ensured that behavior is fixed after the change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
