### PR TITLE
[Security] Upgrade commons-codec to 1.15

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -342,7 +342,7 @@ The Apache Software License, Version 2.0
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
  * Apache Commons
     - commons-cli-commons-cli-1.2.jar
-    - commons-codec-commons-codec-1.10.jar
+    - commons-codec-commons-codec-1.15.jar
     - commons-collections-commons-collections-3.2.2.jar
     - commons-configuration-commons-configuration-1.10.jar
     - commons-io-commons-io-2.8.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.8.0</commons-io.version>
-    <commons-codec.version>1.10</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <log4j.version>1.2.17</log4j.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -426,7 +426,7 @@ The Apache Software License, Version 2.0
     - codahale-metrics-provider-4.14.1.jar
   * Apache Commons
     - commons-cli-1.2.jar
-    - commons-codec-1.10.jar
+    - commons-codec-1.15.jar
     - commons-collections4-4.1.jar
     - commons-configuration-1.10.jar
     - commons-io-2.8.0.jar


### PR DESCRIPTION
### Motivation

Sonatype IQ vulnerability scanning flags commons-codec 1.11 as vulnerable.
It references the security fixes https://issues.apache.org/jira/browse/CODEC-134 (in 1.13) and https://issues.apache.org/jira/browse/CODEC-270 (in 1.14).

### Modifications

Upgrade commons-codec to 1.15