### PR TITLE
[Security] Upgrade caffeine to 2.9.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -320,7 +320,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.12.3.jar
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.12.3.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.12.3.jar
- * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.6.2.jar
+ * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ flexible messaging model and an intuitive client API.</description>
     <log4j.version>1.2.17</log4j.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
-    <caffeine.version>2.6.2</caffeine.version>
+    <caffeine.version>2.9.1</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
     <hppc.version>0.7.3</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -362,7 +362,7 @@ The Apache Software License, Version 2.0
     - avro-1.10.2.jar
     - avro-protobuf-1.10.2.jar
   * Caffeine
-    - caffeine-2.6.2.jar
+    - caffeine-2.9.1.jar
   * Javax
     - javax.inject-1.jar
     - javax.servlet-api-3.1.0.jar


### PR DESCRIPTION
### Motivation

caffeine version 2.6.2 gets flagged as vulnerable in Sonatype IQ because of issue https://github.com/ben-manes/caffeine/issues/301 .

### Modifications

Upgrade caffeine version to 2.9.1 . This is the newest version for Java 8. (Caffeine releases 3.x are Java 11+)