### PR TITLE
[Security] Upgrade k8s client-java to 12.0.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -489,9 +489,9 @@ The Apache Software License, Version 2.0
   * @FreeBuilder
     - org.inferred-freebuilder-1.14.9.jar
   * Kubernetes Client
-    - io.kubernetes-client-java-12.0.0.jar
-    - io.kubernetes-client-java-api-12.0.0.jar
-    - io.kubernetes-client-java-proto-12.0.0.jar
+    - io.kubernetes-client-java-12.0.1.jar
+    - io.kubernetes-client-java-api-12.0.1.jar
+    - io.kubernetes-client-java-proto-12.0.1.jar
   * Dropwizard
     - io.dropwizard.metrics-metrics-core-3.2.5.jar
     - io.dropwizard.metrics-metrics-graphite-3.2.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jna.version>4.2.0</jna.version>
-    <kubernetesclient.version>12.0.0</kubernetesclient.version>
+    <kubernetesclient.version>12.0.1</kubernetesclient.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>


### PR DESCRIPTION
### Motivation

- address security vulnerability CVE-2021-25738 which has been reported as https://github.com/kubernetes-client/java/issues/1698

### Modifications

- upgrade kubernetes client-java to 12.0.1