### PR TITLE
[Security] Upgrade bouncycastle version to 1.69

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -593,6 +593,7 @@ Bouncy Castle License
     - org.bouncycastle-bcpkix-jdk15on-1.69.jar
     - org.bouncycastle-bcprov-ext-jdk15on-1.69.jar
     - org.bouncycastle-bcprov-jdk15on-1.69.jar
+    - org.bouncycastle-bcutil-jdk15on-1.69.jar
 
 ------------------------
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -590,9 +590,9 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.68.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.68.jar
-    - org.bouncycastle-bcprov-jdk15on-1.68.jar
+    - org.bouncycastle-bcpkix-jdk15on-1.69.jar
+    - org.bouncycastle-bcprov-ext-jdk15on-1.69.jar
+    - org.bouncycastle-bcprov-jdk15on-1.69.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.14.0</log4j2.version>
-    <bouncycastle.version>1.68</bouncycastle.version>
+    <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.12.3</jackson.version>
     <jackson.databind.version>2.12.3</jackson.databind.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -557,6 +557,6 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
--    - bcpkix-jdk15on-1.68.jar
--    - bcprov-ext-jdk15on-1.68.jar
--    - bcprov-jdk15on-1.68.jar
+-    - bcpkix-jdk15on-1.69.jar
+-    - bcprov-ext-jdk15on-1.69.jar
+-    - bcprov-jdk15on-1.69.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -557,6 +557,7 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
--    - bcpkix-jdk15on-1.69.jar
--    - bcprov-ext-jdk15on-1.69.jar
--    - bcprov-jdk15on-1.69.jar
+   - bcpkix-jdk15on-1.69.jar
+   - bcprov-ext-jdk15on-1.69.jar
+   - bcprov-jdk15on-1.69.jar
+   - bcutil-jdk15on-1.69.jar


### PR DESCRIPTION
### Motivation

Sonatype IQ flags bouncycastle 1.68 with a low risk security vulnerability.

### Modifications

Upgrade bouncycastle to 1.69 (recently released).