### PR TITLE
[Security] Exclude and remove freebuilder dependency

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -486,8 +486,6 @@ The Apache Software License, Version 2.0
     - org.apache.curator-curator-recipes-5.1.0.jar
   * Apache Yetus
     - org.apache.yetus-audience-annotations-0.5.0.jar
-  * @FreeBuilder
-    - org.inferred-freebuilder-1.14.9.jar
   * Kubernetes Client
     - io.kubernetes-client-java-12.0.0.jar
     - io.kubernetes-client-java-api-12.0.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.inferred</groupId>
+            <artifactId>freebuilder</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -64,6 +64,10 @@
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.inferred</groupId>
+          <artifactId>freebuilder</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicy.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pulsar.zookeeper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.util.HashedWheelTimer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,15 +30,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl;
-import org.apache.bookkeeper.common.util.JsonUtil;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.feature.FeatureProvider;
+import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.DNSToSwitchMapping;
+import org.apache.bookkeeper.proto.BookieAddressResolver;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.commons.configuration.Configuration;
@@ -44,21 +46,13 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
+import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
-import org.inferred.freebuilder.shaded.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.netty.util.HashedWheelTimer;
-import org.apache.bookkeeper.net.BookieId;
-import org.apache.bookkeeper.proto.BookieAddressResolver;
-
-import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 
 public class ZkIsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlacementPolicy
         implements Deserializer<BookiesRackConfiguration> {
@@ -210,10 +204,10 @@ public class ZkIsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePl
             String primaryIsolationGroupString = castToString(properties.getOrDefault(ISOLATION_BOOKIE_GROUPS, ""));
             String secondaryIsolationGroupString = castToString(properties.getOrDefault(SECONDARY_ISOLATION_BOOKIE_GROUPS, ""));
             if (!primaryIsolationGroupString.isEmpty()) {
-                pair.setLeft(Sets.newHashSet(primaryIsolationGroupString.split(",")));
+                pair.setLeft(new HashSet(Arrays.asList(primaryIsolationGroupString.split(","))));
             }
             if (!secondaryIsolationGroupString.isEmpty()) {
-                pair.setRight(Sets.newHashSet(secondaryIsolationGroupString.split(",")));
+                pair.setRight(new HashSet(Arrays.asList(secondaryIsolationGroupString.split(","))));
             }
         }
         return pair;


### PR DESCRIPTION
### Motivation

[Freebuilder](https://github.com/inferred/FreeBuilder) is an annotation processor used in Bookkeeper's StorageClientSetting interface:

https://github.com/apache/bookkeeper/blob/16e8ba772bb5cf4c7546fb559bd9d455d4e42625/stream/clients/java/base/src/main/java/org/apache/bookkeeper/clients/config/StorageClientSettings.java#L27-L33

The annotation processor is only needed at compile time.

The Freebuilder library gets flagged as a vulnerable library by Sonatype IQ. This causes Pulsar distribution to be flagged as vulnerable since Freebuilder is a transitive dependency.

### Additional context

There's a separate issue in Bookkeeper to change the dependency to optional / compileOnly: https://github.com/apache/bookkeeper/issues/2732 

### Modifications

Exclude freebuilder library and replace the code that used shaded dependencies from the freebuilder library.