### PR TITLE
Make MetadataCacheTest reliable.

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -67,6 +67,12 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Fixes #10872 

### Motivation

Cache updates are asynchronous. Due to this the test could sometime fail. This makes the test flaky
MetadataCacheTest

### Modifications

Use Awaitility module to more reliably check for the test conditions

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema:  (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

A simple bugfix in test code. Doen't need any doc updates

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? 
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
