### PR TITLE
[Build] Fix functions main profile activation by default

### DIFF
--- a/pulsar-functions/pom.xml
+++ b/pulsar-functions/pom.xml
@@ -35,7 +35,11 @@
     <profile>
       <id>main</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>disableFunctionsMainProfile</name>
+          <!-- always active unless true is passed as a value -->
+          <value>!true</value>
+        </property>
       </activation>
         <modules>
           <module>proto</module>


### PR DESCRIPTION
### Motivation

Similar to #10814, functions module build failed due to the falg `activeByDefault` fail to activate the profile if any other profile is activated.

### Modifications

- Use a better solution to activate the `main` profile by default by using a property value with inversion (`!`) rule.