### PR TITLE
[Security] Upgrade vertx to 3.9.8 to address CVE-2019-17640

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -505,10 +505,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.5.4.jar
-    - io.vertx-vertx-bridge-common-3.5.4.jar
-    - io.vertx-vertx-core-3.5.4.jar
-    - io.vertx-vertx-web-3.5.4.jar
+    - io.vertx-vertx-auth-common-3.9.8.jar
+    - io.vertx-vertx-bridge-common-3.9.8.jar
+    - io.vertx-vertx-core-3.9.8.jar
+    - io.vertx-vertx-web-3.9.8.jar
+    - io.vertx-vertx-web-common-3.9.8.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.6.3.jar
     - org.apache.zookeeper-zookeeper-jute-3.6.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.9</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
-    <vertx.version>3.5.4</vertx.version>
+    <vertx.version>3.9.8</vertx.version>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -37,11 +37,6 @@
     <vulnerabilityName regex="true">.*</vulnerabilityName>
   </suppress>
   <suppress>
-    <notes>Suppress vert.x 3.5.4 vulnerabilities</notes>
-    <gav regex="true">io\.vertx:.*:3\.5\.4</gav>
-    <vulnerabilityName regex="true">.*</vulnerabilityName>
-  </suppress>
-  <suppress>
     <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
     <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
     <vulnerabilityName regex="true">.*</vulnerabilityName>


### PR DESCRIPTION
### Motivation

- The current vert.x version 3.5.4 contains [CVE-2019-17640](https://nvd.nist.gov/vuln/detail/CVE-2019-17640) vulnerability and causes Pulsar to get flagged in security vulnerability scanning.

### Modifications

- Upgrade vert.x version to [3.9.8](https://github.com/eclipse-vertx/vert.x/releases/tag/3.9.8).