### PR TITLE
Fix repeat track msgId for asyncReceived

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -410,7 +410,6 @@ void ConsumerImpl::notifyPendingReceivedCallback(Result result, Message& msg,
                                                  const ReceiveCallback& callback) {
     if (result == ResultOk && config_.getReceiverQueueSize() != 0) {
         messageProcessed(msg);
-        unAckedMessageTrackerPtr_->add(msg.getMessageId());
     }
     callback(result, msg);
 }


### PR DESCRIPTION
### Motivation
The consumer repeats track messageID when processing messages，although this does not result in duplicate consumption of messages, because MessageTracker has been de-processed

### Modifications
Removes duplicate track messageid logic in `notifyPendingReceivedCallback`

