### PR TITLE
[Build] Fix java-test-functions dependencies and packaging

### DIFF
--- a/tests/docker-images/java-test-functions/pom.xml
+++ b/tests/docker-images/java-test-functions/pom.xml
@@ -20,90 +20,82 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.apache.pulsar.tests</groupId>
-        <artifactId>docker-images</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>java-test-functions</artifactId>
-    <name>Apache Pulsar :: Tests :: Docker Images :: Java Test Functions</name>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-io-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-        </dependency>
+  <parent>
+    <groupId>org.apache.pulsar.tests</groupId>
+    <artifactId>docker-images</artifactId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>java-test-functions</artifactId>
+  <name>Apache Pulsar :: Tests :: Docker Images :: Java Test Functions</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-io-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-functions-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- allow sinks to use native Avro and Json -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.databind.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <packaging>jar</packaging>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
-        </dependency>
-    </dependencies>
-    <packaging>jar</packaging>
-
-    <profiles>
+  <profiles>
     <profile>
-    <id>docker</id>
-    <activation>
+      <id>docker</id>
+      <activation>
         <property>
-            <name>integrationTests</name>
+          <name>integrationTests</name>
         </property>
-    </activation>
+      </activation>
 
-    <dependencies>
+      <dependencies>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
-            <artifactId>pulsar-functions-api-examples</artifactId>
-            <version>${project.version}</version>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-functions-api-examples</artifactId>
+          <version>${project.version}</version>
         </dependency>
-    </dependencies>
+      </dependencies>
 
-    <build>
+      <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>${shadePluginPhase}</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <!--Don't create dependency reduced pom.  This causes maven to go into a infinite loop.  May be a maven bug-->
-                            <createDependencyReducedPom>false</createDependencyReducedPom>>
-                            <transformers>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                </transformer>
-                            </transformers>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.pulsar:pulsar-client</include>
-                                    <include>org.apache.pulsar:pulsar-functions-api-examples</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>${shadePluginPhase}</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>org.apache.pulsar:pulsar-functions-api-examples</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
-    </build>
+      </build>
     </profile>
-    </profiles>
+  </profiles>
 
 </project>


### PR DESCRIPTION
### Motivation

- `tests/docker-images/java-test-functions` should depend on `pulsar-io-core` (and `pulsar-functions-api`)
  - there should be no dependency on `pulsar-client` library directly (`pulsar-client-api` dependency comes via `pulsar-functions-api`)
 
### Modifications

- revisit `tests/docker-images/java-test-functions/pom.xml`