### PR TITLE
[broker] Fix issue where Key_Shared consumers could get stuck

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -121,8 +121,14 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     @Override
     public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
-        super.removeConsumer(consumer);
+        // The consumer must be removed from the selector before calling the superclass removeConsumer method.
+        // In the superclass removeConsumer method, the pending acks that the consumer has are added to
+        // messagesToRedeliver. If the consumer has not been removed from the selector at this point,
+        // the broker will try to redeliver the messages to the consumer that has already been closed.
+        // As a result, the messages are not redelivered to any consumer, and the mark-delete position does not move,
+        // eventually causing all consumers to get stuck.
         selector.removeConsumer(consumer);
+        super.removeConsumer(consumer);
         if (recentlyJoinedConsumers != null) {
             recentlyJoinedConsumers.remove(consumer);
             if (consumerList.size() == 1) {


### PR DESCRIPTION
### Motivation

Repeatedly opening and closing consumers on a Key_Shared subscription can occasionally stop dispatching to all consumers. The following is stats of the topic when the phenomenon occurred.

<details>
<summary>stats.json</summary>
<pre>
<code>
{
  "msgRateIn" : 0.0,
  "msgThroughputIn" : 0.0,
  "msgRateOut" : 0.0,
  "msgThroughputOut" : 0.0,
  "averageMsgSize" : 0.0,
  "storageSize" : 888206,
  "backlogSize" : 153264,
  "publishers" : [ ],
  "subscriptions" : {
    "sub1" : {
      "msgRateOut" : 0.0,
      "msgThroughputOut" : 0.0,
      "msgRateRedeliver" : 0.0,
      "msgBacklog" : 2324,
      "blockedSubscriptionOnUnackedMsgs" : false,
      "msgDelayed" : 0,
      "unackedMessages" : 1,
      "type" : "Key_Shared",
      "msgRateExpired" : 0.0,
      "consumers" : [ {
        "msgRateOut" : 0.0,
        "msgThroughputOut" : 0.0,
        "msgRateRedeliver" : 0.0,
        "consumerName" : "5a9ed",
        "availablePermits" : 607,
        "unackedMessages" : 0,
        "blockedConsumerOnUnackedMsgs" : false,
        "metadata" : { },
        "connectedSince" : "2021-06-11T18:57:08.475+09:00",
        "clientVersion" : "2.4.2.36-yjrelease",
        "address" : "/xxx.xxx.xxx.xxx:59196"
      }, {
        "msgRateOut" : 0.0,
        "msgThroughputOut" : 0.0,
        "msgRateRedeliver" : 0.0,
        "consumerName" : "0e74e",
        "availablePermits" : 686,
        "unackedMessages" : 0,
        "blockedConsumerOnUnackedMsgs" : false,
        "metadata" : { },
        "connectedSince" : "2021-06-11T18:57:31.293+09:00",
        "clientVersion" : "2.4.2.36-yjrelease",
        "address" : "/xxx.xxx.xxx.xxx:59198"
      }, {
        "msgRateOut" : 0.0,
        "msgThroughputOut" : 0.0,
        "msgRateRedeliver" : 0.0,
        "consumerName" : "b8ac0",
        "availablePermits" : 952,
        "unackedMessages" : 0,
        "blockedConsumerOnUnackedMsgs" : false,
        "metadata" : { },
        "connectedSince" : "2021-06-11T18:57:58.618+09:00",
        "clientVersion" : "2.4.2.36-yjrelease",
        "address" : "/xxx.xxx.xxx.xxx:59188"
      }, {
        "msgRateOut" : 0.0,
        "msgThroughputOut" : 0.0,
        "msgRateRedeliver" : 0.0,
        "consumerName" : "43e0a",
        "availablePermits" : 1000,
        "unackedMessages" : 0,
        "blockedConsumerOnUnackedMsgs" : false,
        "metadata" : { },
        "connectedSince" : "2021-06-11T18:58:24.501+09:00",
        "clientVersion" : "2.4.2.36-yjrelease",
        "address" : "/xxx.xxx.xxx.xxx:59190"
      } ],
      "isReplicated" : false,
      "consumersAfterMarkDeletePosition" : {
        "43e0a" : "3860483:12549"
      }
    }
  },
  "replication" : { },
  "deduplicationStatus" : "Disabled"
}
</code>
</pre>
</details>

The strange thing is that every consumer has an `unackedMessages` value of 0, but the subscription-level `unackedMessages` value is 1.

### Modifications

The cause of this issue is the following part: 
https://github.com/apache/pulsar/blob/894d92b2be3bee334e7ce32760c4d2e7978603aa/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L124-L125

When `removeConsumer()` of the superclass is called, the pending acks owned by that consumer are added to `messagesToRedeliver`.
https://github.com/apache/pulsar/blob/894d92b2be3bee334e7ce32760c4d2e7978603aa/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L184-L188

However, the consumer has not yet been removed from `selector`, so the broker attempts to send messages to the consumer that has already been closed. Those messages are removed from `messagesToRedeliver`, but they aren't actually sent to any consumer.
https://github.com/apache/pulsar/blob/894d92b2be3bee334e7ce32760c4d2e7978603aa/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L204-L210

As a result, the mark-delete position does not move and all consumers will get stuck.

Therefore, in `PersistentStickyKeyDispatcherMultipleConsumers#removeConsumer()`, we need to remove the consumer from `selector` before calling `removeConsumer()` of the superclass. 