### PR TITLE
Fixes typo about initialize-cluster-metadata command in functions worker

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -315,5 +315,5 @@ functionsDirectory: ./functions
 validateConnectorConfig: false
 
 # Whether to initialize distributed log metadata by runtime.
-# If it is set to true, you must ensure that it has been initialized by "bin/pulsarinitialize-cluster-metadata" command.
+# If it is set to true, you must ensure that it has been initialized by "bin/pulsar initialize-cluster-metadata" command.
 initializedDlogMetadata: false

--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -34,7 +34,7 @@ In this mode, most of the settings are already inherited from your broker config
 Pay attention to the following required settings when configuring functions-worker in this mode.
 
 - `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
-- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsarinitialize-cluster-metadata` command.
+- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.
 

--- a/site2/website/versioned_docs/version-2.7.1/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.7.1/functions-worker.md
@@ -36,7 +36,7 @@ Pay attention to the following required settings when configuring functions-work
 
 - `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
 - `pulsarFunctionsCluster`: Set the value to your Pulsar cluster name (same as the `clusterName` setting in the broker configuration).
-- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsarinitialize-cluster-metadata` command.
+- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.
 

--- a/site2/website/versioned_docs/version-2.7.2/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.7.2/functions-worker.md
@@ -36,7 +36,7 @@ Pay attention to the following required settings when configuring functions-work
 
 - `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
 - `pulsarFunctionsCluster`: Set the value to your Pulsar cluster name (same as the `clusterName` setting in the broker configuration).
-- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsarinitialize-cluster-metadata` command.
+- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.
 

--- a/site2/website/versioned_docs/version-2.7.3/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.7.3/functions-worker.md
@@ -36,7 +36,7 @@ Pay attention to the following required settings when configuring functions-work
 
 - `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
 - `pulsarFunctionsCluster`: Set the value to your Pulsar cluster name (same as the `clusterName` setting in the broker configuration).
-- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsarinitialize-cluster-metadata` command.
+- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.
 

--- a/site2/website/versioned_docs/version-2.8.0/functions-overview.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-overview.md
@@ -35,7 +35,7 @@ Pulsar Functions provide a wide range of functionality, and the core programming
 
   * Apply some processing logic to the input and write output to:
     * An **output topic** in Pulsar
-    * [Apache BookKeeper](#state-storage)
+    * [Apache BookKeeper](functions-develop.md#state-storage)
   * Write logs to a **log topic** (potentially for debugging purposes)
   * Increment a [counter](#word-count-example)
 

--- a/site2/website/versioned_docs/version-2.8.0/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-worker.md
@@ -35,7 +35,7 @@ In this mode, most of the settings are already inherited from your broker config
 Pay attention to the following required settings when configuring functions-worker in this mode.
 
 - `numFunctionPackageReplicas`: The number of replicas to store function packages. The default value is `1`, which is good for standalone deployment. For production deployment, to ensure high availability, set it to be larger than `2`.
-- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsarinitialize-cluster-metadata` command.
+- `initializedDlogMetadata`: Whether to initialize distributed log metadata in runtime. If it is set to `true`, you must ensure that it has been initialized by `bin/pulsar initialize-cluster-metadata` command.
 
 If authentication is enabled on the BookKeeper cluster, configure the following BookKeeper authentication settings.
 


### PR DESCRIPTION
### Motivation

Fixes typo `bin/pulsarinitialize-cluster-metadata` in `functions-worker` doc and conf.

### Modifications

Replace above by `bin/pulsar initialize-cluster-metadata`.