### PR TITLE
[Issue 10938] [pulsar-functions] Include common-io in java function instance

### DIFF
--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -61,6 +61,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-functions-api</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION

Fixes #10938 

### Motivation

Pulsar-functions has dependency on pulsar-io-common, but it is not captured in pom.xml

### Modifications

Modified pom.xml to capture the dependency

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] verified that the pulsar-io-common.jar gets packaged in the distribution tar image after modifying pom.xml

This change is a trivial rework / code cleanup without any test coverage.
