### PR TITLE
[ISSUE-10875]feat(community): add contributor over time graph to website

### DIFF
--- a/site2/website/contributing.md
+++ b/site2/website/contributing.md
@@ -335,3 +335,7 @@ new committers or PMC members to the project. PMC members also have
 binding votes on any project matters. Refer to
 [ASF PMCs governance](http://www.apache.org/foundation/governance/pmcs.html)
 for a more detailed explanation of the duties and roles of the PMC.
+
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/pulsar)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/pulsar)


### PR DESCRIPTION
Fix #10875

### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Hi community!

We're the maintainers of [Apache APISIX](https://github.com/apache/apisix). To better present how our community grows, we develop a tool to show contributors growing history on https://github.com/api7/contributor-graph. Since we found it helpful, we think maybe if it could help some other community.
(And actually, streamio have already used the graph [in the blog](https://streamnative.io/en/blog/community/2021-06-14-pulsar-hits-its-400th-contributor-and-passes-kafka-in-monthly-active-contributors#apache-pulsar-surpasses-apache-kafka))

### WHAT IT IS

Basically, it just shows the contributors growth over time. All of the procedures are running on GCP, and it would automatically update the graph each day, so the link would always present the real-time data. There is some other stuff to [play around](https://www.apiseven.com/en/contributor-graph) with if you would like to give it a try~

[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/pulsar)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/pulsar)

### HOW IT WORKS

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each contributor. We also support importing contributors from svn, and aggregating contributors from multiple repos if needed.

Currently I find it might be a good place to place it at https://pulsar.apache.org/en/contributing/. Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻 



### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

no

### Documentation

no