### PR TITLE
[Proxy] Limit replay buffer size in AdminProxyHandler

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -481,6 +481,16 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private int httpOutputBufferSize = 32*1024;
 
     @FieldContext(
+            minValue = 1,
+            category = CATEGORY_HTTP,
+            doc = "Http input buffer max size.\n\n"
+                    + "The maximum amount of data that will be buffered for incoming http requests "
+                    + "so that the request body can be replayed when the backend broker "
+                    + "issues a redirect response."
+    )
+    private int httpInputMaxReplayBufferSize = 5 * 1024 * 1024;
+
+    @FieldContext(
            minValue = 1,
            category = CATEGORY_HTTP,
            doc = "Number of threads to use for HTTP requests processing"

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AdminProxyHandlerTest.java
@@ -18,33 +18,55 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static org.mockito.Mockito.*;
-
-import org.eclipse.jetty.client.api.Request;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import java.io.InputStream;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.lang.reflect.Field;
-
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class AdminProxyHandlerTest {
+    private AdminProxyHandler adminProxyHandler;
+
+    @BeforeClass
+    public void setupMocks() throws ServletException {
+        // given
+        HttpClient httpClient = mock(HttpClient.class);
+        adminProxyHandler = new AdminProxyHandler(mock(ProxyConfiguration.class),
+                mock(BrokerDiscoveryProvider.class)) {
+            @Override
+            protected HttpClient createHttpClient() throws ServletException {
+                return httpClient;
+            }
+        };
+        ServletConfig servletConfig = mock(ServletConfig.class);
+        when(servletConfig.getServletName()).thenReturn("AdminProxyHandler");
+        when(servletConfig.getServletContext()).thenReturn(mock(ServletContext.class));
+        adminProxyHandler.init(servletConfig);
+    }
 
     @Test
     public void replayableProxyContentProviderTest() throws Exception {
-
-        AdminProxyHandler adminProxyHandler = new AdminProxyHandler(mock(ProxyConfiguration.class),
-                mock(BrokerDiscoveryProvider.class));
-
         HttpServletRequest request = mock(HttpServletRequest.class);
         doReturn(-1).when(request).getContentLength();
 
         try {
-            AdminProxyHandler.ReplayableProxyContentProvider replayableProxyContentProvider = adminProxyHandler.new ReplayableProxyContentProvider(
-                    request, mock(HttpServletResponse.class), mock(Request.class), mock(InputStream.class));
+            AdminProxyHandler.ReplayableProxyContentProvider replayableProxyContentProvider =
+                    adminProxyHandler.new ReplayableProxyContentProvider(
+                            request, mock(HttpServletResponse.class), mock(Request.class), mock(InputStream.class));
             Field field = replayableProxyContentProvider.getClass().getDeclaredField("bodyBuffer");
             field.setAccessible(true);
             Assert.assertEquals(((ByteArrayOutputStream) field.get(replayableProxyContentProvider)).size(), 0);
@@ -52,5 +74,66 @@ public class AdminProxyHandlerTest {
             Assert.fail("IllegalArgumentException should not be thrown");
         }
 
+    }
+
+    @Test
+    public void shouldLimitReplayBodyBufferSize() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        int requestBodySize = AdminProxyHandler.ReplayableProxyContentProvider.MAX_REPLAY_BODY_BUFFER_SIZE + 1;
+        doReturn(requestBodySize).when(request).getContentLength();
+        byte[] inputBuffer = new byte[requestBodySize];
+
+        AdminProxyHandler.ReplayableProxyContentProvider replayableProxyContentProvider =
+                adminProxyHandler.new ReplayableProxyContentProvider(request, mock(HttpServletResponse.class),
+                        mock(Request.class), new ByteArrayInputStream(inputBuffer));
+
+        // when
+
+        // content is consumed
+        Iterator<ByteBuffer> byteBufferIterator = replayableProxyContentProvider.iterator();
+        int consumedBytes = 0;
+        while (byteBufferIterator.hasNext()) {
+            ByteBuffer byteBuffer = byteBufferIterator.next();
+            consumedBytes += byteBuffer.limit();
+        }
+
+        // then
+        Assert.assertEquals(consumedBytes, requestBodySize);
+        Field field = replayableProxyContentProvider.getClass().getDeclaredField("bodyBufferMaxSizeReached");
+        field.setAccessible(true);
+        Assert.assertEquals(((boolean) field.get(replayableProxyContentProvider)), true);
+    }
+
+    @Test
+    public void shouldReplayBodyBuffer() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        byte[] inputBuffer = new byte[AdminProxyHandler.ReplayableProxyContentProvider.MAX_REPLAY_BODY_BUFFER_SIZE - 1];
+        for (int i = 0; i < inputBuffer.length; i++) {
+            inputBuffer[i] = (byte) (i & 0xff);
+        }
+        doReturn(inputBuffer.length).when(request).getContentLength();
+
+        AdminProxyHandler.ReplayableProxyContentProvider replayableProxyContentProvider =
+                adminProxyHandler.new ReplayableProxyContentProvider(request, mock(HttpServletResponse.class),
+                        mock(Request.class), new ByteArrayInputStream(inputBuffer));
+
+        ByteBuffer consumeBuffer = ByteBuffer.allocate(
+                AdminProxyHandler.ReplayableProxyContentProvider.MAX_REPLAY_BODY_BUFFER_SIZE);
+        // content can be consumed multiple times
+        for (int i = 0; i < 3; i++) {
+            // when
+            consumeBuffer.clear();
+            Iterator<ByteBuffer> byteBufferIterator = replayableProxyContentProvider.iterator();
+            while (byteBufferIterator.hasNext()) {
+                ByteBuffer byteBuffer = byteBufferIterator.next();
+                consumeBuffer.put(byteBuffer);
+            }
+            consumeBuffer.flip();
+            byte[] consumedBytes = new byte[consumeBuffer.limit()];
+            consumeBuffer.get(consumedBytes);
+            // then
+            Assert.assertEquals(consumedBytes, inputBuffer);
+        }
     }
 }


### PR DESCRIPTION
Fixes #10908

### Motivation

Pulsar Proxy uses a lot of heap memory when uploading large function jar files. This also leads to high GC activity since a continuous block of memory (byte array for the size of the upload) is allocated. GC will have to do compaction for the heap (which gets fragmented) to find a continuous block of memory. This is the reason why allocating large arrays are costly from GC perspective. 

The buffering solution added as part of #5361. The solution buffers also very large uploads to memory.

### Modifications

* Limit the replay buffer size to a configurable limit which defaults to 5MB. This is configured with the `httpInputMaxReplayBufferSize` proxy configuration parameter.
* Add unit test to see that buffer size gets limited
* Add unit test for #5361
 
 





