### PR TITLE
[Transactions] Prevent NPE in case of closeAsync() without a successful execution of startAsync()

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -134,11 +134,13 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
             LOG.warn("The transaction meta store is closing or closed, doing nothing.");
             result.complete(null);
         } else {
-            for (TransactionMetaStoreHandler handler : handlers) {
-                try {
-                    handler.close();
-                } catch (IOException e) {
-                    LOG.warn("Close transaction meta store handler error", e);
+            if (handlers != null) {
+                for (TransactionMetaStoreHandler handler : handlers) {
+                    try {
+                        handler.close();
+                    } catch (IOException e) {
+                        LOG.warn("Close transaction meta store handler error", e);
+                    }
                 }
             }
             this.handlers = null;


### PR DESCRIPTION
Fixes #10947
### Motivation

If the initialisation of TransactionCoordinatorClientImpl is not completed calling closeAsync will result in a NPE.

### Modifications

Add a null check

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
