### PR TITLE
[Docs]remove wrong step when run selected test packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ $ mvn test -Dtest=unit-test-name (e.g: ConsumerBuilderImplTest)
 Run Selected Test packages:
 
 ```bash
-$ cd module-name (e.g: pulsar-broker)
-$ mvn test -pl module-name -Dinclude=org/apache/pulsar/**/*.java
+$ mvn test -pl module-name (e.g: pulsar-broker) -Dinclude=org/apache/pulsar/**/*.java
 ```
 
 Start standalone Pulsar service:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ mvn test -Dtest=unit-test-name (e.g: ConsumerBuilderImplTest)
 Run Selected Test packages:
 
 ```bash
-$ mvn test -pl module-name (e.g: pulsar-broker) -Dinclude=org/apache/pulsar/**/*.java
+$ mvn test -pl module-name (for example, pulsar-broker) -Dinclude=org/apache/pulsar/**/*.java
 ```
 
 Start standalone Pulsar service:


### PR DESCRIPTION
### Motivation
when Run Selected Test packages, The original steps are wrong, we should remove the step of : cd module-name (e.g: pulsar-broker)

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API: (yes / no) no
  - The schema: (yes / no / don't know) no
  - The default values of configurations: (yes / no) no
  - The wire protocol: (yes / no) no
  - The rest endpoints: (yes / no) no
  - The admin cli options: (yes / no) no
  - Anything that affects deployment: (yes / no / don't know) no

### Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
