### PR TITLE
[Issue 9888] add python3.9 on manylinux2014 build support

### DIFF
--- a/.github/workflows/ci-cpp-build-python3.9.yaml
+++ b/.github/workflows/ci-cpp-build-python3.9.yaml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - Python3.9 client build
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+      - 'pulsar-client-cpp/**'
+  push:
+    branches:
+      - branch-*
+    paths:
+      - '.github/workflows/**'
+      - 'pulsar-client-cpp/**'
+jobs:
+
+  cpp-build-manylinux2014:
+    name:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Detect changed files
+        id:   changes
+        uses: apache/pulsar-test-infra/paths-filter@master
+        with:
+          filters: .github/changes-filter.yaml
+
+      - name: Check changed files
+        id: check_changes
+        run: echo "::set-output name=docs_only::${{ fromJSON(steps.changes.outputs.all_count) == fromJSON(steps.changes.outputs.docs_count) && fromJSON(steps.changes.outputs.docs_count) > 0 }}"
+
+      - name: build python3.9 client
+        if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
+        run: |
+          echo "Build Python3.9 client library"
+          pulsar-client-cpp/docker-build-python3.9.sh

--- a/.github/workflows/ci-python-build-3.9-client.yaml
+++ b/.github/workflows/ci-python-build-3.9-client.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: CI - Python3.9 client build
+name: CI - Python - Build 3.9 client
 on:
   pull_request:
     branches:
@@ -33,7 +33,7 @@ on:
       - 'pulsar-client-cpp/**'
 jobs:
 
-  cpp-build-manylinux2014:
+  build-wheel:
     name:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/pulsar-client-cpp/docker-build-python3.9.sh
+++ b/pulsar-client-cpp/docker-build-python3.9.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Build Pulsar Python3.9 client
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd $ROOT_DIR/pulsar-client-cpp
+
+
+# Build manylinux2014 build image
+PYTHON_VERSION="3.9"
+PYTHON_SPEC="cp39-cp39"
+IMAGE_NAME=pulsar-build:manylinux-$PYTHON_SPEC
+
+docker build -t $IMAGE_NAME ./docker/manylinux2014 \
+        --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+        --build-arg PYTHON_SPEC=$PYTHON_SPEC
+
+
+# Build wheel file
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
+IMAGE=$BUILD_IMAGE_NAME:manylinux-$PYTHON_SPEC
+
+VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
+COMMAND="/pulsar/pulsar-client-cpp/docker/build-wheel-file-within-docker.sh"
+DOCKER_CMD="docker run -i ${VOLUME_OPTION} -e USE_FULL_POM_NAME -e NAME_POSTFIX ${IMAGE}"
+
+$DOCKER_CMD bash -c "${COMMAND}"

--- a/pulsar-client-cpp/docker-build-python3.9.sh
+++ b/pulsar-client-cpp/docker-build-python3.9.sh
@@ -37,7 +37,7 @@ docker build -t $IMAGE_NAME ./docker/manylinux2014 \
 
 
 # Build wheel file
-BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
+BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-pulsar-build}"
 IMAGE=$BUILD_IMAGE_NAME:manylinux-$PYTHON_SPEC
 
 VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}

--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -34,6 +34,7 @@ PYTHON_VERSIONS=(
    '3.6 cp36-cp36m'
    '3.7 cp37-cp37m'
    '3.8 cp38-cp38'
+   '3.9 cp39-cp39'
 )
 
 function contains() {

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -24,24 +24,25 @@
 set -e
 
 PYTHON_VERSIONS=(
-   '2.7 cp27-cp27mu'
-   '2.7 cp27-cp27m'
-   '3.5 cp35-cp35m'
-   '3.6 cp36-cp36m'
-   '3.7 cp37-cp37m'
-   '3.8 cp38-cp38'
-   '3.9 cp39-cp39'
+   '2.7 cp27-cp27mu manylinux1'
+   '2.7 cp27-cp27m manylinux1'
+   '3.5 cp35-cp35m manylinux2014'
+   '3.6 cp36-cp36m manylinux2014'
+   '3.7 cp37-cp37m manylinux2014'
+   '3.8 cp38-cp38 manylinux2014'
+   '3.9 cp39-cp39 manylinux2014'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do
     read -r -a PY <<< "$line"
     PYTHON_VERSION=${PY[0]}
     PYTHON_SPEC=${PY[1]}
+    BASE_IMAGE=${PY[2]}
     echo "--------- Build Docker image for $PYTHON_VERSION -- $PYTHON_SPEC"
 
     IMAGE_NAME=pulsar-build:manylinux-$PYTHON_SPEC
 
-    docker build -t $IMAGE_NAME . \
+    docker build -t $IMAGE_NAME $BASE_IMAGE \
             --build-arg PYTHON_VERSION=$PYTHON_VERSION \
             --build-arg PYTHON_SPEC=$PYTHON_SPEC
 

--- a/pulsar-client-cpp/docker/manylinux1/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux1/Dockerfile
@@ -62,7 +62,7 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz 
     rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz && \
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz && \
     tar xvfz boost_1_68_0.tar.gz && \
     cd /boost_1_68_0 && \
     ./bootstrap.sh --with-libraries=program_options,filesystem,regex,thread,system,python && \
@@ -126,14 +126,6 @@ RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.12.1.tar.gz && \
     make && make install && \
     rm -rf /v3.12.1.tar.gz /CMake-3.12.1
 
-# LibCurl
-RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
-    tar xvfz curl-7.61.0.tar.gz && \
-    cd curl-7.61.0 && \
-    CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
-    make && make install && \
-    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
-
 # Zstandard
 RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \
     tar xvfz zstd-1.3.7.tar.gz && \
@@ -150,6 +142,14 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
     make && make install && \
     rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
 
+# LibCurl
+RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
+    tar xvfz curl-7.61.0.tar.gz && \
+    cd curl-7.61.0 && \
+    CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
+    make && make install && \
+    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
+
 RUN pip install twine
 RUN pip install fastavro
 RUN pip install six
@@ -159,6 +159,3 @@ RUN pip install enum34
 ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include
 ENV PYTHON_LIBRARIES   /opt/python/${PYTHON_SPEC}/lib/python${PYTHON_VERSION}
 ENV OPENSSL_ROOT_DIR   /usr/local/ssl/
-
-COPY build-wheel-file-within-docker.sh /
-COPY build-client-lib-within-docker.sh /

--- a/pulsar-client-cpp/docker/manylinux2014/Dockerfile
+++ b/pulsar-client-cpp/docker/manylinux2014/Dockerfile
@@ -1,0 +1,161 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+FROM quay.io/pypa/manylinux2014_x86_64
+
+RUN yum install -y gtest-devel
+
+ARG PYTHON_VERSION
+ARG PYTHON_SPEC
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYTHON_SPEC=${PYTHON_SPEC}
+
+ENV PATH="/opt/python/${PYTHON_SPEC}/bin:${PATH}"
+
+RUN ln -s /opt/python/${PYTHON_SPEC}/include/python${PYTHON_VERSION}m /opt/python/${PYTHON_SPEC}/include/python${PYTHON_VERSION}
+
+# Perl (required for building OpenSSL)
+RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.10.0.tar.gz && \
+    tar xvfz perl-5.10.0.tar.gz && \
+    cd perl-5.10.0 && \
+    ./configure.gnu --prefix=/usr/local/ && \
+    make && make install && \
+    rm -rf /perl-5.10.0.tar.gz /perl-5.10.0
+
+####################################
+# These dependencies can be found in Ubuntu but they're not compiled with -fPIC,
+# so they cannot be statically linked into a shared library
+####################################
+
+# ZLib
+RUN curl -O -L https://zlib.net/zlib-1.2.11.tar.gz && \
+    tar xvfz zlib-1.2.11.tar.gz && \
+    cd zlib-1.2.11 && \
+    CFLAGS="-fPIC -O3" ./configure && \
+    make && make install && \
+    rm -rf /zlib-1.2.11.tar.gz /zlib-1.2.11
+
+# Compile OpenSSL
+RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_0j.tar.gz && \
+    tar xvfz OpenSSL_1_1_0j.tar.gz && \
+    cd openssl-OpenSSL_1_1_0j/ && \
+    ./Configure -fPIC --prefix=/usr/local/ssl/ no-shared linux-x86_64 && \
+    make && make install && \
+    rm -rf /OpenSSL_1_1_0j.tar.gz /openssl-OpenSSL_1_1_0j
+
+# Download and compile boost
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz && \
+    tar xvfz boost_1_68_0.tar.gz && \
+    cd /boost_1_68_0 && \
+    ./bootstrap.sh --with-libraries=program_options,filesystem,regex,thread,system,python && \
+    ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
+    rm -rf /boost_1_68_0.tar.gz /boost_1_68_0
+
+# Download and copile protoubf
+RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz && \
+    tar xvfz protobuf-cpp-3.3.0.tar.gz && \
+    cd protobuf-3.3.0/ && \
+    CXXFLAGS=-fPIC ./configure && \
+    make && make install && ldconfig && \
+    rm -rf /protobuf-cpp-3.3.0.tar.gz /protobuf-3.3.0
+
+# Compile APR
+RUN curl -O -L  http://archive.apache.org/dist/apr/apr-1.5.2.tar.gz && \
+    tar xvfz apr-1.5.2.tar.gz && \
+    cd apr-1.5.2 && \
+    CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure && \
+    make && make install && \
+    rm -rf /apr-1.5.2.tar.gz /apr-1.5.2
+
+# Compile APR-Util
+RUN curl -O -L  http://archive.apache.org/dist/apr/apr-util-1.5.4.tar.gz && \
+    tar xvfz apr-util-1.5.4.tar.gz && \
+    cd apr-util-1.5.4 && \
+    CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure -with-apr=/usr/local/apr && \
+    make && make install && \
+    rm -rf /apr-util-1.5.4.tar.gz /apr-util-1.5.4
+
+# Libtool
+RUN curl -L -O https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz && \
+    tar xvfz libtool-2.4.6.tar.gz && \
+    cd libtool-2.4.6 && \
+    ./configure && \
+    make && make install && \
+    rm -rf /libtool-2.4.6.tar.gz /libtool-2.4.6
+
+# Compile log4cxx
+RUN curl -O -L https://github.com/apache/logging-log4cxx/archive/v0.11.0.tar.gz && \
+    tar xvfz v0.11.0.tar.gz && \
+    cd logging-log4cxx-0.11.0 && \
+    ./autogen.sh && \
+    CXXFLAGS=-fPIC ./configure && \
+    make && make install && \
+    rm -rf /v0.11.0.tar.gz /logging-log4cxx-0.11.0
+
+# Compile expat
+RUN curl -O -L  https://github.com/libexpat/libexpat/archive/R_2_2_0.tar.gz && \
+    tar xfvz R_2_2_0.tar.gz && \
+    cd libexpat-R_2_2_0/expat && \
+    ./buildconf.sh && \
+    CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure  && \
+    make && make installlib && \
+    rm -rf /R_2_2_0.tar.gz /libexpat-R_2_2_0
+
+RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.12.1.tar.gz && \
+    tar xvfz v3.12.1.tar.gz && \
+    cd CMake-3.12.1 && \
+    ./configure && \
+    make && make install && \
+    rm -rf /v3.12.1.tar.gz /CMake-3.12.1
+
+# Zstandard
+RUN curl -O -L https://github.com/facebook/zstd/releases/download/v1.3.7/zstd-1.3.7.tar.gz && \
+    tar xvfz zstd-1.3.7.tar.gz && \
+    cd zstd-1.3.7 && \
+    CFLAGS="-fPIC -O3" make -j8 && \
+    make install && \
+    rm -rf /zstd-1.3.7 /zstd-1.3.7.tar.gz
+
+# Snappy
+RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1.1.3.tar.gz && \
+    tar xvfz snappy-1.1.3.tar.gz && \
+    cd snappy-1.1.3 && \
+    CXXFLAGS="-fPIC -O3" ./configure && \
+    make && make install && \
+    rm -rf /snappy-1.1.3 /snappy-1.1.3.tar.gz
+
+# LibCurl
+RUN curl -O -L  https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.gz && \
+    tar xvfz curl-7.61.0.tar.gz && \
+    cd curl-7.61.0 && \
+    CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ && \
+    make && make install && \
+    rm -rf /curl-7.61.0.tar.gz /curl-7.61.0
+
+RUN pip install twine
+RUN pip install fastavro
+RUN pip install six
+RUN pip install enum34
+
+
+ENV PYTHON_INCLUDE_DIR /opt/python/${PYTHON_SPEC}/include
+ENV PYTHON_LIBRARIES   /opt/python/${PYTHON_SPEC}/lib/python${PYTHON_VERSION}
+ENV OPENSSL_ROOT_DIR   /usr/local/ssl/


### PR DESCRIPTION
Fixes #9888

### Motivation

We want to add support for Python 3.9

### Modifications

Separated building Python 3.5+ from Python 2.7 because of [cryptography dropping its manylinux1 builds](https://cryptography.io/en/latest/changelog/#v3-4).

I'm not 100% sure how the build system works, but the docker image builds passed locally for me.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes

### Documentation

  - Does this pull request introduce a new feature? - no
