### PR TITLE
Fix incorrect port of advertisedListener

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -50,6 +50,22 @@ public class ServiceConfigurationUtils {
         }
     }
 
+    public static int getAppliedPort(ServiceConfiguration configuration, int port) {
+        Map<String, AdvertisedListener> result = MultipleListenerValidator
+                .validateAndAnalysisAdvertisedListener(configuration);
+        if (configuration.getAdvertisedAddress() != null) {
+            return port;
+        }
+        AdvertisedListener advertisedListener = result.get(configuration.getInternalListenerName());
+        if (advertisedListener != null) {
+            int advertisedListenerPort = advertisedListener.getBrokerServiceUrl().getPort();
+            // AdvertisedListener has its own port.
+            if (advertisedListenerPort != 0) {
+                return advertisedListenerPort;
+            }
+        }
+        return port;
+    }
     /**
      * Get the address of Broker, first try to get it from AdvertisedAddress.
      * If it is not set, try to get the address set by advertisedListener.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1363,7 +1363,7 @@ public class PulsarService implements AutoCloseable {
     protected String brokerUrl(ServiceConfiguration config) {
         if (config.getBrokerServicePort().isPresent()) {
             return brokerUrl(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
-                    getBrokerListenPort().get());
+                    ServiceConfigurationUtils.getAppliedPort(config, getBrokerListenPort().get()));
         } else {
             return null;
         }
@@ -1376,7 +1376,7 @@ public class PulsarService implements AutoCloseable {
     public String brokerUrlTls(ServiceConfiguration config) {
         if (config.getBrokerServicePortTls().isPresent()) {
             return brokerUrlTls(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
-                    getBrokerListenPortTls().get());
+                    ServiceConfigurationUtils.getAppliedPort(config, getBrokerListenPortTls().get()));
         } else {
             return null;
         }
@@ -1389,7 +1389,7 @@ public class PulsarService implements AutoCloseable {
     public String webAddress(ServiceConfiguration config) {
         if (config.getWebServicePort().isPresent()) {
             return webAddress(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
-                    getListenPortHTTP().get());
+                    ServiceConfigurationUtils.getAppliedPort(config, getListenPortHTTP().get()));
         } else {
             return null;
         }
@@ -1402,7 +1402,7 @@ public class PulsarService implements AutoCloseable {
     public String webAddressTls(ServiceConfiguration config) {
         if (config.getWebServicePortTls().isPresent()) {
             return webAddressTls(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config),
-                    getListenPortHTTPS().get());
+                    ServiceConfigurationUtils.getAppliedPort(config, getListenPortHTTPS().get()));
         } else {
             return null;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -106,17 +106,32 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testAppliedAdvertised() throws Exception {
         useListenerName = true;
-        conf.setAdvertisedListeners("internal:pulsar://127.0.0.1, internal:pulsar+ssl://127.0.0.1");
+        conf.setAdvertisedListeners("internal:pulsar://127.0.0.1:7680, internal:pulsar+ssl://127.0.0.1:7688");
         conf.setInternalListenerName("internal");
         setup();
 
-        AssertJUnit.assertEquals(pulsar.getAdvertisedAddress(), "127.0.0.1");
+        assertEquals(pulsar.getAdvertisedAddress(), "127.0.0.1");
         assertNull(pulsar.getConfiguration().getAdvertisedAddress());
         assertEquals(conf, pulsar.getConfiguration());
-        assertEquals(pulsar.brokerUrlTls(conf), "pulsar+ssl://127.0.0.1:6651");
-        assertEquals(pulsar.brokerUrl(conf), "pulsar://127.0.0.1:6660");
-        assertEquals(pulsar.webAddress(conf), "http://127.0.0.1:8081");
-        assertEquals(pulsar.webAddressTls(conf), "https://127.0.0.1:8082");
+        assertEquals(pulsar.brokerUrlTls(conf), "pulsar+ssl://127.0.0.1:7680");
+        assertEquals(pulsar.brokerUrl(conf), "pulsar://127.0.0.1:7680");
+        assertEquals(pulsar.webAddress(conf), "http://127.0.0.1:7680");
+        assertEquals(pulsar.webAddressTls(conf), "https://127.0.0.1:7680");
+
+        cleanup();
+        resetConfig();
+        setup();
+        assertEquals(pulsar.getAdvertisedAddress(), "localhost");
+        assertEquals(conf, pulsar.getConfiguration());
+        assertEquals(pulsar.brokerUrlTls(conf),
+                "pulsar+ssl://localhost:" + pulsar.getBrokerListenPortTls().get());
+        assertEquals(pulsar.brokerUrl(conf),
+                "pulsar://localhost:" + pulsar.getBrokerListenPort().get());
+        assertEquals(pulsar.webAddress(conf),
+                "http://localhost:" + pulsar.getWebService().getListenPortHTTP().get());
+        assertEquals(pulsar.webAddressTls(conf),
+                "https://localhost:" + pulsar.getWebService().getListenPortHTTPS().get());
+
     }
 
 }


### PR DESCRIPTION

Fixes #10957
### Motivation
advertisedListener has its own port , raw port is only needed when advertisedListener is not used

### Modifications
When using advertisedListener, use the port of advertisedListener
When using advertisedAddress, use the raw brokerServicePort or webServicePort
