### PR TITLE
[Broker] Remove redundant method for CompletableFuture timeout handling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -970,7 +970,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     private CompletableFuture<Optional<Topic>> createNonPersistentTopic(String topic) {
-        CompletableFuture<Optional<Topic>> topicFuture = FutureUtil.futureWithDeadline(executor());
+        CompletableFuture<Optional<Topic>> topicFuture = futureWithDeadline();
 
         if (!pulsar.getConfiguration().isEnableNonPersistentTopics()) {
             if (log.isDebugEnabled()) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -165,22 +165,6 @@ public class FutureUtil {
         }
     }
 
-    public static <T> CompletableFuture<T> futureWithDeadline(ScheduledExecutorService executor, Long delay,
-            TimeUnit unit, Exception exp) {
-        CompletableFuture<T> future = new CompletableFuture<T>();
-        executor.schedule(() -> {
-            if (!future.isDone()) {
-                future.completeExceptionally(exp);
-            }
-        }, delay, unit);
-        return future;
-    }
-
-    public static <T> CompletableFuture<T> futureWithDeadline(ScheduledExecutorService executor) {
-        return futureWithDeadline(executor, 60000L, TimeUnit.MILLISECONDS,
-                new TimeoutException("Future didn't finish within deadline"));
-    }
-
     public static <T> Optional<Throwable> getException(CompletableFuture<T> future) {
         if (future != null && future.isCompletedExceptionally()) {
             try {


### PR DESCRIPTION
### Motivation

- A redundant method was added to FutureUtil in #10847 to handle CompletableFuture timeouts.
- There's an existing way to handle timeouts for CompletableFutures in FutureUtil. This change was made in PR #10065 .

### Modifications

- Remove redundant methods added to FutureUtil & refactor code in BrokerService to use the existing solution for timeout handling.