### PR TITLE
[Elasticsearch-sink] support multi Elasticsearch hosts

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -63,6 +63,11 @@ public class ElasticSearchSink implements Sink<byte[]> {
     private CredentialsProvider credentialsProvider;
     private ElasticSearchConfig elasticSearchConfig;
 
+    protected void loadConfig(Map<String, Object> config) throws Exception {
+        elasticSearchConfig = ElasticSearchConfig.load(config);
+        elasticSearchConfig.validate();
+    }
+
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
         elasticSearchConfig = ElasticSearchConfig.load(config);
@@ -145,7 +150,7 @@ public class ElasticSearchSink implements Sink<byte[]> {
         }).toArray(HttpHost[]::new);
     }
 
-    private RestHighLevelClient getClient() throws MalformedURLException {
+    protected RestHighLevelClient getClient() throws MalformedURLException {
         if (client == null) {
           CredentialsProvider cp = getCredentialsProvider();
           RestClientBuilder builder = RestClient.builder(getHttpHost());

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java
@@ -137,7 +137,7 @@ public class ElasticSearchSink implements Sink<byte[]> {
         return credentialsProvider;
     }
 
-    private HttpHost[] getHttpHost() {
+    private HttpHost[] getHttpHosts() {
         String url = elasticSearchConfig.getElasticSearchUrl();
         return Arrays.stream(url.split(",")).map(host -> {
             try {
@@ -153,7 +153,7 @@ public class ElasticSearchSink implements Sink<byte[]> {
     protected RestHighLevelClient getClient() throws MalformedURLException {
         if (client == null) {
           CredentialsProvider cp = getCredentialsProvider();
-          RestClientBuilder builder = RestClient.builder(getHttpHost());
+          RestClientBuilder builder = RestClient.builder(getHttpHosts());
 
           if (cp != null) {
               builder.setHttpClientConfigCallback(httpClientBuilder ->

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -22,8 +22,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,6 +34,8 @@ import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.elasticsearch.data.Profile;
 import org.apache.pulsar.io.elasticsearch.data.UserProfile;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -91,6 +95,19 @@ public class ElasticSearchSinkTests {
     @AfterMethod(alwaysRun = true)
     public final void tearDown() throws Exception {
         sink.close();
+    }
+
+    @Test
+    public final void multiNodesClientTest() throws Exception {
+        map.put("indexName", "myIndex");
+        map.put("typeName", "doc");
+        map.put("username", "racerX");
+        map.put("password", "go-speedie-go");
+        map.put("elasticSearchUrl", "http://node1:90902,http://node2:90902,http://node3:90902");
+        sink.loadConfig(map);
+        RestHighLevelClient client = sink.getClient();
+        List<Node> nodeList = client.getLowLevelClient().getNodes();
+        assertEquals(nodeList.size(), 3);
     }
     
     @Test(enabled = false, expectedExceptions = ElasticsearchStatusException.class)


### PR DESCRIPTION
### Motivation

Current Elasticsearch-sink do not support multi Elasticsearch hosts like "http://172.16.0.1:9200,172.16.0.2:9200"

### Modifications

Add support for multi Elasticsearch hosts
