### PR TITLE
Pulsar Client: missing return in ConsumerImpl#internalGetLastMessageIdAsync

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2027,6 +2027,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         String.format("The command `GetLastMessageId` is not supported for the protocol version %d. " +
                                 "The consumer is %s, topic %s, subscription %s", cnx.getRemoteEndpointProtocolVersion(),
                             consumerName, topicName.toString(), subscription)));
+                return;
             }
 
             long requestId = client.newRequestId();


### PR DESCRIPTION
This change adds a missing return statement in ConsumerImpl#internalGetLastMessageIdAsync.
The line before this change is completing exceptionally a CompletableFuture.
The execution should not continue.