### PR TITLE
[Broker] Fix direct memory leak in getLastMessageId

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2586,13 +2586,18 @@ public class PersistentTopic extends AbstractTopic
         ledgerImpl.asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
             @Override
             public void readEntryComplete(Entry entry, Object ctx) {
-                MessageMetadata metadata = Commands.parseMessageMetadata(entry.getDataBuffer());
-                if (metadata.hasNumMessagesInBatch()) {
-                    completableFuture.complete(new BatchMessageIdImpl(position.getLedgerId(), position.getEntryId(),
-                            partitionIndex, metadata.getNumMessagesInBatch() - 1));
-                } else {
-                    completableFuture
-                            .complete(new MessageIdImpl(position.getLedgerId(), position.getEntryId(), partitionIndex));
+                try {
+                    MessageMetadata metadata = Commands.parseMessageMetadata(entry.getDataBuffer());
+                    if (metadata.hasNumMessagesInBatch()) {
+                        completableFuture.complete(new BatchMessageIdImpl(position.getLedgerId(), position.getEntryId(),
+                                partitionIndex, metadata.getNumMessagesInBatch() - 1));
+                    } else {
+                        completableFuture
+                                .complete(new MessageIdImpl(position.getLedgerId(), position.getEntryId(),
+                                        partitionIndex));
+                    }
+                } finally {
+                    entry.release();
                 }
             }
 


### PR DESCRIPTION
Fixes #7304

### Motivation

See #7304 for the details. There's a memory leak when calling lastMessageId API.

I used the instructions by @megfigura in https://github.com/apache/pulsar/issues/7304#issuecomment-854943245 to reproduce.

In one terminal window I started pulsar-perf produce to create 5 msg/second to the topic called "test"
```bash
pulsar-perf produce -r 5 -m 100000 test
```

Then in another window I ran the loop to call lastMessageId in a tight loop:
```bash
while true; do curl http://pulsar-testenv-deployment-broker.pulsar-testenv.svc.cluster.local:8080/admin/v2/persistent/public/default/test/lastMessageId; echo ; done
```

In a third terminal window, I had the broker logs filtered for errors or leak logs :
```bash
kubectl -n pulsar-testenv logs -f pod/pulsar-testenv-deployment-broker-0 |tee broker_logs_`date +%s`.txt | egrep 'ERROR|OOM|LEAK'
```

The test environment was deployed with these values.yaml settings: https://github.com/lhotari/pulsar-playground/blob/f39b83b9e08f80af57fb70b1439f6c466c1f4405/test-env/1node/values.yaml

The memory leak problem reproduces almost immediately.

### Modifications

Add the missing `entry.release()` call to `PersistentTopic.getLastMessageId`