### PR TITLE
Remove duplicate dependency of awaitility.

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -42,14 +42,14 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>
-    
+
     <!-- zookeeper server -->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <!-- zookeeper server -->
     <dependency>
       <groupId>org.xerial.snappy</groupId>
@@ -73,11 +73,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation

```xml
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-metadata:jar:2.9.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.awaitility:awaitility:jar -> duplicate declaration of version (?) @ line 76, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
The  warn was introduced from this change https://github.com/apache/pulsar/commit/21ea76c15531976326e7319e551646ab698f9bc7

### Modifications

delete the duplicate `awaitility` dependency.


