### PR TITLE
fix NoClassDefFoundError - io.airlift.compress.lz4.UnsafeUtil

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -419,7 +419,7 @@ The Apache Software License, Version 2.0
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.13.jar
  * AirCompressor
-    - io.airlift-aircompressor-0.16.jar
+    - io.airlift-aircompressor-0.19.jar
  * AsyncHttpClient
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka.confluent.schemaregistryclient.version>5.3.0</kafka.confluent.schemaregistryclient.version>
     <kafka.confluent.avroserializer.version>5.3.0</kafka.confluent.avroserializer.version>
     <kafka-avro-convert-jackson.version>1.9.13</kafka-avro-convert-jackson.version>
-    <aircompressor.version>0.16</aircompressor.version>
+    <aircompressor.version>0.19</aircompressor.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <jcommander.version>1.78</jcommander.version>
     <commons-lang3.version>3.11</commons-lang3.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -274,7 +274,7 @@ The Apache Software License, Version 2.0
   * CGLIB Nodep
     - cglib-nodep-3.3.0.jar
   * Airlift
-    - aircompressor-0.16.jar
+    - aircompressor-0.19.jar
     - airline-0.8.jar
     - bootstrap-0.199.jar
     - bootstrap-0.195.jar


### PR DESCRIPTION
### Motivation

Java client fails with `Java 16` while receiving a message. Error:

```
[org.apa.pul.cli.imp.ClientCnx] (pulsar-client-io-2-1) [localhost/127.0.0.1:6650] Got exception java.lang.NoClassDefFoundError: Could not initialize class io.airlift.compress.lz4.UnsafeUtil
	at io.airlift.compress.lz4.Lz4RawDecompressor.decompress(Lz4RawDecompressor.java:60)
	at org.apache.pulsar.common.compression.CompressionCodecLZ4.decode(CompressionCodecLZ4.java:91)
	at org.apache.pulsar.client.impl.ConsumerImpl.uncompressPayloadIfNeeded(ConsumerImpl.java:1507)
	at org.apache.pulsar.client.impl.ConsumerImpl.messageReceived(ConsumerImpl.java:1037)
	at org.apache.pulsar.client.impl.ClientCnx.handleMessage(ClientCnx.java:447)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:186)
...
```

Can be reproduced with the official example for Java Client from the docu while using JDK 16.

### Workaround

Locally I use `pulsar-client-original`, and exclude the aircompressor 16. Example:

```
<dependency>
  <groupId>org.apache.pulsar</groupId>
  <artifactId>pulsar-client-original</artifactId>
  <version>${pulsar.version}</version>
  <exclusions>
    <exclusion>
      <groupId>io.airlift</groupId>
      <artifactId>aircompressor</artifactId>
    </exclusion>
  </exclusions>
</dependency>

<!-- https://mvnrepository.com/artifact/io.airlift/aircompressor -->
<dependency>
  <groupId>io.airlift</groupId>
  <artifactId>aircompressor</artifactId>
  <version>0.19</version>
</dependency>
```

### Modifications

Upgrade io.airlift.aircompressor to version 19. 

### Does this pull request potentially affect one of the following parts:

  - **Dependencies** yes upgrade