### PR TITLE
[issue 10989 ] Java Client: KeyValueSchema with AutoConsume component - make it work if the topic schema is still not set

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -80,6 +80,17 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         };
     }
 
+    @DataProvider(name = "batchingModesAndValueEncodingType")
+    public static Object[][] batchingModesAndValueEncodingType() {
+        return new Object[][] {
+                { true, KeyValueEncodingType.INLINE },
+                { true, KeyValueEncodingType.SEPARATED },
+                { false, KeyValueEncodingType.INLINE },
+                { false, KeyValueEncodingType.SEPARATED }
+        };
+    }
+
+
     @DataProvider(name = "schemaValidationModes")
     public static Object[][] schemaValidationModes() {
         return new Object[][] {
@@ -546,14 +557,14 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         }
     }
 
-    @Test(dataProvider = "batchingModes")
-    public void testAutoKeyValueConsume(boolean batching) throws Exception {
-        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-" + batching;
+    @Test(dataProvider = "batchingModesAndValueEncodingType")
+    public void testAutoKeyValueConsume(boolean batching, KeyValueEncodingType keyValueEncodingType) throws Exception {
+        String topic = "my-property/my-ns/schema-test-auto-keyvalue-consume-" + batching+"-"+keyValueEncodingType;
 
         Schema<KeyValue<V1Data, V1Data>> pojoSchema = Schema.KeyValue(
                 Schema.AVRO(V1Data.class),
                 Schema.AVRO(V1Data.class),
-                KeyValueEncodingType.SEPARATED);
+                keyValueEncodingType);
 
         try (Consumer<KeyValue<GenericRecord, V1Data>> c3before = pulsarClient.newConsumer(
                 // this consumer is the same as 'c3' Consumer below, but it subscribes to the
@@ -566,7 +577,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 Schema.KeyValue(
                         Schema.AUTO_CONSUME(),
                         Schema.AVRO(V1Data.class),
-                        KeyValueEncodingType.SEPARATED))
+                        keyValueEncodingType))
                 .topic(topic)
                 .subscriptionName("sub3b")
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -589,7 +600,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                          Schema.KeyValue(
                                  Schema.AUTO_CONSUME(),
                                  Schema.AUTO_CONSUME(),
-                                 KeyValueEncodingType.SEPARATED))
+                                 keyValueEncodingType))
                          .topic(topic)
                          .subscriptionName("sub1")
                          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -598,7 +609,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                          Schema.KeyValue(
                                  Schema.AVRO(V1Data.class),
                                  Schema.AVRO(V1Data.class),
-                                 KeyValueEncodingType.SEPARATED))
+                                 keyValueEncodingType))
                          .topic(topic)
                          .subscriptionName("sub2")
                          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -607,7 +618,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                          Schema.KeyValue(
                                  Schema.AUTO_CONSUME(),
                                  Schema.AVRO(V1Data.class),
-                                 KeyValueEncodingType.SEPARATED))
+                                 keyValueEncodingType))
                          .topic(topic)
                          .subscriptionName("sub3")
                          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -616,7 +627,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                          Schema.KeyValue(
                                  Schema.AVRO(V1Data.class),
                                  Schema.AUTO_CONSUME(),
-                                 KeyValueEncodingType.SEPARATED))
+                                 keyValueEncodingType))
                          .topic(topic)
                          .subscriptionName("sub4")
                          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -708,13 +719,13 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         Schema<KeyValue<V2Data, V2Data>> pojoSchemaV2 = Schema.KeyValue(
                 Schema.AVRO(V2Data.class),
                 Schema.AVRO(V2Data.class),
-                KeyValueEncodingType.SEPARATED);
+                keyValueEncodingType);
 
         try (Consumer<KeyValue<GenericRecord, V2Data>> c3before = pulsarClient.newConsumer(
                 Schema.KeyValue(
                         Schema.AUTO_CONSUME(),
                         Schema.AVRO(V2Data.class),
-                        KeyValueEncodingType.SEPARATED))
+                        keyValueEncodingType))
                 .topic(topic)
                 .subscriptionName("sub3b")
                 .subscribe();
@@ -730,7 +741,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                      Schema.KeyValue(
                              Schema.AUTO_CONSUME(),
                              Schema.AUTO_CONSUME(),
-                             KeyValueEncodingType.SEPARATED))
+                             keyValueEncodingType))
                      .topic(topic)
                      .subscriptionName("sub1")
                      .subscribe();
@@ -738,7 +749,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                      Schema.KeyValue(
                              Schema.AVRO(V2Data.class),
                              Schema.AVRO(V2Data.class),
-                             KeyValueEncodingType.SEPARATED))
+                             keyValueEncodingType))
                      .topic(topic)
                      .subscriptionName("sub2")
                      .subscribe();
@@ -746,7 +757,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                      Schema.KeyValue(
                              Schema.AUTO_CONSUME(),
                              Schema.AVRO(V2Data.class),
-                             KeyValueEncodingType.SEPARATED))
+                             keyValueEncodingType))
                      .topic(topic)
                      .subscriptionName("sub3")
                      .subscribe();
@@ -754,7 +765,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                      Schema.KeyValue(
                              Schema.AVRO(V2Data.class),
                              Schema.AUTO_CONSUME(),
-                             KeyValueEncodingType.SEPARATED))
+                             keyValueEncodingType))
                      .topic(topic)
                      .subscriptionName("sub4")
                      .subscribe()

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.impl.schema.AbstractSchema;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
@@ -417,6 +418,8 @@ public class MessageImpl<T> implements Message<T> {
     private void ensureSchemaIsLoaded() {
         if (schema instanceof AutoConsumeSchema) {
             ((AutoConsumeSchema) schema).fetchSchemaIfNeeded(BytesSchemaVersion.of(getSchemaVersion()));
+        } else if (schema instanceof KeyValueSchemaImpl) {
+            ((KeyValueSchemaImpl) schema).fetchSchemaIfNeeded(getTopicName(), BytesSchemaVersion.of(getSchemaVersion()));
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
 import org.apache.pulsar.client.api.transaction.TransactionBuilder;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -1012,7 +1013,8 @@ public class PulsarClientImpl implements PulsarClient {
                 @SuppressWarnings("rawtypes") Schema finalSchema = schema;
                 return schemaInfoProvider.getLatestSchema().thenCompose(schemaInfo -> {
                     if (null == schemaInfo) {
-                        if (!(finalSchema instanceof AutoConsumeSchema)) {
+                        if (!(finalSchema instanceof AutoConsumeSchema)
+                            && !(finalSchema instanceof KeyValueSchema)) {
                             // no schema info is found
                             return FutureUtil.failedFuture(
                                     new PulsarClientException.NotFoundException(


### PR DESCRIPTION
Fixes #10989

### Motivation

When you use KeyValueSchema together with Schema.AUTO_CONSUME() for the key or for the value, currently (Pulsar 2.8.0) the "consumerBuilder.subscribe()"  method fails because in this case the KeyValueSchema requires to fetch the schema, because one of the BK components uses AutoConsumeSchema, but the schema is not set on the topic.  

### Modifications

- Add some special handling in the subscribe code path in order to deal with KeyValueSchema, the same way we are doing for AutoConsumeSchema
- Add special handling in MessageImpl in order to support schema versioning even in this case, the same way we are doing for AutoConsumeSchema 

### Verifying this change

This change added a case to an existing test.


### Documentation
No need for documentation updates, this is a bug fix