### PR TITLE
Do not expose meaningless stats for consumer.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -29,12 +32,14 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -168,5 +173,47 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
 
         Assert.assertEquals(updatedStats.getMsgOutCounter(), 10);
         Assert.assertEquals(updatedStats.getBytesOutCounter(), 1280);
+    }
+
+    @Test
+    public void testConsumerStatsOutput() throws Exception {
+        Set<String> allowedFields = Sets.newHashSet(
+                "msgRateOut",
+                "msgThroughputOut",
+                "bytesOutCounter",
+                "msgOutCounter",
+                "msgRateRedeliver",
+                "chunkedMessageRate",
+                "consumerName",
+                "availablePermits",
+                "unackedMessages",
+                "avgMessagesPerEntry",
+                "blockedConsumerOnUnackedMsgs",
+                "readPositionWhenJoining",
+                "lastAckedTimestamp",
+                "lastConsumedTimestamp",
+                "keyHashRanges",
+                "metadata");
+
+        final String topicName = "persistent://prop/use/ns-abc/testConsumerStatsOutput";
+        final String subName = "my-subscription";
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName(subName)
+                .subscribe();
+
+        TopicStats stats = admin.topics().getStats(topicName);
+        ObjectMapper mapper = ObjectMapperFactory.create();
+        JsonNode node = mapper.readTree(mapper.writer().writeValueAsString(stats.getSubscriptions()
+                .get(subName).getConsumers().get(0)));
+        if (node.fieldNames().hasNext()) {
+            String field = node.fieldNames().next();
+            System.out.println(field);
+            Assert.assertTrue(allowedFields.contains(field));
+        }
+
+        consumer.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -210,7 +210,6 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 .get(subName).getConsumers().get(0)));
         if (node.fieldNames().hasNext()) {
             String field = node.fieldNames().next();
-            System.out.println(field);
             Assert.assertTrue(allowedFields.contains(field));
         }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.policies.data.stats;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import java.util.List;
@@ -66,15 +67,21 @@ public class ConsumerStatsImpl implements ConsumerStats {
     public String readPositionWhenJoining;
 
     /** Address of this consumer. */
+    @JsonIgnore
     private int addressOffset = -1;
+    @JsonIgnore
     private int addressLength;
 
     /** Timestamp of connection. */
+    @JsonIgnore
     private int connectedSinceOffset = -1;
+    @JsonIgnore
     private int connectedSinceLength;
 
     /** Client library version. */
+    @JsonIgnore
     private int clientVersionOffset = -1;
+    @JsonIgnore
     private int clientVersionLength;
 
     public long lastAckedTimestamp;
@@ -90,6 +97,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
      * In order to prevent multiple string object allocation under stats: create a string-buffer
      * that stores data for all string place-holders.
      */
+    @JsonIgnore
     private StringBuilder stringBuffer = new StringBuilder();
 
     public ConsumerStatsImpl add(ConsumerStatsImpl stats) {


### PR DESCRIPTION
### Motivation

Currently, we have exposed some meaningless consumer stats to users such as

```
addressLength
addressOffset
connectedSinceOffset
connectedSinceLength
clientVersionOffset
clientVersionLength
stringBuffer
```

All of these stats are not used by users but used internally.
So remove these stats from the exposed consumer stats.

