### PR TITLE
[test] use Awaitility replace Thread.sleep for pulsar-zookeeper-utils module.

### DIFF
--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -125,6 +125,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-common</artifactId>
       <version>${project.parent.version}</version>

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.zookeeper;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -28,15 +28,12 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
-
 import io.netty.util.concurrent.DefaultThreadFactory;
-
+import java.time.Duration;
 import java.util.Collections;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -47,7 +44,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-
 import lombok.Cleanup;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -59,15 +55,15 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.data.Stat;
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ZookeeperCacheTest {
     private static final Logger log = LoggerFactory.getLogger(ZookeeperCacheTest.class);
@@ -120,7 +116,7 @@ public class ZookeeperCacheTest {
         zkClient.setData("/my_test", newValue.getBytes(), -1);
 
         // Wait for the watch to be triggered
-        Thread.sleep(100);
+        Awaitility.await().until(() -> zkClient.exists("/my_test", false) != null);
 
         assertEquals(zkCache.get("/my_test").get(), newValue);
 
@@ -165,18 +161,15 @@ public class ZookeeperCacheTest {
         zkClient.create("/test/z2", new byte[0], null, null);
 
         // Wait for cache to be updated in background
-        while (notificationCount.get() < 2) {
-            Thread.sleep(1);
-        }
+        Awaitility.await().until(() -> notificationCount.get() >= 2);
 
         assertEquals(cache.get(), new TreeSet<String>(Lists.newArrayList("z1", "z2")));
         assertEquals(cache.get("/test"), new TreeSet<String>(Lists.newArrayList("z1", "z2")));
         assertEquals(notificationCount.get(), 2);
 
         zkClient.delete("/test/z2", -1);
-        while (notificationCount.get() < 3) {
-            Thread.sleep(1);
-        }
+
+        Awaitility.await().until(() -> notificationCount.get() >= 3);
 
         assertEquals(cache.get(), new TreeSet<String>(Lists.newArrayList("z1")));
         assertEquals(cache.get(), new TreeSet<String>(Lists.newArrayList("z1")));
@@ -220,9 +213,8 @@ public class ZookeeperCacheTest {
         zkClient.create("/test/z1", new byte[0], null, null);
 
         // Wait for cache to be updated in background
-        while (notificationCount.get() < 1) {
-            Thread.sleep(1);
-        }
+        Awaitility.await().until(() -> notificationCount.get() >= 1);
+
 
         final int recvNotifications = notificationCount.get();
 
@@ -231,9 +223,7 @@ public class ZookeeperCacheTest {
         assertTrue(recvNotifications == 1 || recvNotifications == 2);
 
         zkClient.delete("/test/z1", -1);
-        while (notificationCount.get() < (recvNotifications + 1)) {
-            Thread.sleep(1);
-        }
+        Awaitility.await().until(() -> notificationCount.get() >= recvNotifications + 1);
 
         assertTrue(cache.get().isEmpty());
         assertTrue(cache.get().isEmpty());
@@ -255,14 +245,14 @@ public class ZookeeperCacheTest {
     public void testExistsCache() throws Exception {
         // Check existence after creation of the node
         zkClient.create("/test", new byte[0], null, null);
-        Thread.sleep(20);
+        Awaitility.await().until(() -> zkClient.exists("/test", false) != null);
         ZooKeeperCache zkCacheService = new LocalZooKeeperCache(zkClient, 30, executor);
         boolean exists = zkCacheService.exists("/test");
         Assert.assertTrue(exists, "/test should exists in the cache");
 
         // Check existence after deletion if the node
         zkClient.delete("/test", -1);
-        Thread.sleep(20);
+        Awaitility.await().until(() -> zkClient.exists("/test", false) == null);
         boolean shouldNotExist = zkCacheService.exists("/test");
         Assert.assertFalse(shouldNotExist, "/test should not exist in the cache");
     }
@@ -272,7 +262,7 @@ public class ZookeeperCacheTest {
         zkClient.create("/test", new byte[0], null, null);
         zkClient.create("/test/c1", new byte[0], null, null);
         zkClient.create("/test/c2", new byte[0], null, null);
-        Thread.sleep(20);
+        Awaitility.await().until(() -> zkClient.exists("/test/c2", false) != null);
         ZooKeeperCache zkCacheService = new LocalZooKeeperCache(zkClient, 30, executor);
         boolean exists = zkCacheService.exists("/test");
         Assert.assertTrue(exists, "/test should exists in the cache");
@@ -346,9 +336,7 @@ public class ZookeeperCacheTest {
         zkClient.create("/my_test2", value.getBytes(), null, null);
 
         // Wait for the watch to be triggered
-        while (notificationCount.get() < 1) {
-            Thread.sleep(1);
-        }
+        Awaitility.await().until(() -> notificationCount.get() >= 1);
 
         // retrieve the data from the cache and verify it is the updated/new data
         assertEquals(zkCache.get("/my_test").get(), newValue);
@@ -496,7 +484,7 @@ public class ZookeeperCacheTest {
         }
 
         // (2) sleep to let cache to be invalidated async
-        Thread.sleep(1000);
+        Awaitility.await().until(()->zkCache.getAsync(key1).get().isPresent());
         // (3) now, cache should be invalidate failed-future and should refetch the data
         assertEquals(zkCache.getAsync(key1).get().get(), value);
 
@@ -514,7 +502,7 @@ public class ZookeeperCacheTest {
         // global-Zk session is connected now
         zkCacheService.zkSession.set(zkSession);
         // (5) sleep to let cache to be invalidated async
-        Thread.sleep(1000);
+        Awaitility.await().until(()->zkCache.getAsync(key1).get().isPresent());
         // (6) now, cache should be invalidate failed-future and should refetch the data
         assertEquals(zkCache.getAsync(key1).get().get(), value);
     }
@@ -621,11 +609,7 @@ public class ZookeeperCacheTest {
 
     private static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
-        for (int i = 0; i < retryCount; i++) {
-            if (predicate.test(null) || i == (retryCount - 1)) {
-                break;
-            }
-            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
-        }
+        Awaitility.await().between(Duration.ZERO, Duration.ofMillis(intSleepTimeInMillis * retryCount))
+                .until(() -> predicate.test(null));
     }
 }


### PR DESCRIPTION
### Motivation


Currently the testcase use Thead.sleep in the pulsar-zookeeper-utils module.

### Modifications

 use Awaitility replace Thread.sleep
