### PR TITLE
[Tests] Convert Junit tests to TestNG

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleSplitAlgorithmTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pulsar.common.naming;
 
-import org.junit.Assert;
-import org.junit.Test;
 
 import static org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm.RANGE_EQUALLY_DIVIDE_NAME;
 import static org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm.TOPIC_COUNT_EQUALLY_DIVIDE;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class NamespaceBundleSplitAlgorithmTest {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithmTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/RangeEquallyDivideBundleSplitAlgorithmTest.java
@@ -20,11 +20,10 @@ package org.apache.pulsar.common.naming;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
-import org.junit.Test;
+import java.util.concurrent.CompletableFuture;
 import org.mockito.Mockito;
 import org.testng.Assert;
-
-import java.util.concurrent.CompletableFuture;
+import org.testng.annotations.Test;
 
 public class RangeEquallyDivideBundleSplitAlgorithmTest {
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaceIsolationPolicy.java
@@ -19,12 +19,11 @@
 package org.apache.pulsar.admin.cli;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
-import org.testng.Assert;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class TestCmdNamespaceIsolationPolicy {
@@ -41,8 +40,9 @@ public class TestCmdNamespaceIsolationPolicy {
                 innerMethod.setAccessible(true);
                 List<String> calculatedList = (List<String>) innerMethod.invoke(cmdNamespaceIsolationPolicy, mockList);
                 Assert.assertEquals(calculatedList.size(), resultList.size());
-                for (int i = 0; i < resultList.size(); i++)
+                for (int i = 0; i < resultList.size(); i++) {
                     Assert.assertEquals(resultList.get(i), calculatedList.get(i));
+                }
             } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
             }

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionInstanceIdTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionInstanceIdTest.java
@@ -18,10 +18,9 @@
  */
 package org.apache.pulsar.functions.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import org.junit.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * Unit test of {@link FunctionInstanceId}.
@@ -30,33 +29,33 @@ public class FunctionInstanceIdTest {
 
     @Test
     public void testThrowsExceptionWhenTenantNamespaceFunctionNameNotProperlyDelimited() {
-	try {
-	    FunctionInstanceId id = new FunctionInstanceId("tenant/namespace:function");
-	    
-	    fail("Expected exception!");
-	} catch (IllegalArgumentException e) {
-	    //pass
-	}
+        try {
+            FunctionInstanceId id = new FunctionInstanceId("tenant/namespace:function");
+
+            fail("Expected exception!");
+        } catch (IllegalArgumentException e) {
+            //pass
+        }
     }
-    
+
     @Test
     public void testThrowsExceptionWhenFunctionInstanceIdNotPropertyDelimited() {
-	try {
-	    FunctionInstanceId id = new FunctionInstanceId("tenant/namespace/function-1");
-	    
-	    fail("Expected exception!");
-	} catch (IllegalArgumentException e) {
-	    //pass
-	}	
+        try {
+            FunctionInstanceId id = new FunctionInstanceId("tenant/namespace/function-1");
+
+            fail("Expected exception!");
+        } catch (IllegalArgumentException e) {
+            //pass
+        }
     }
-    
+
     @Test
     public void testAllowsColonsInFunctionName() {
         FunctionInstanceId id = new FunctionInstanceId("tenant/namespace/my:function:name:-1");
-        
-        assertEquals("tenant", id.getTenant());
-        assertEquals("namespace", id.getNamespace());
-        assertEquals("my:function:name", id.getName());
-        assertEquals(-1, id.getInstanceId());
+
+        assertEquals(id.getTenant(), "tenant");
+        assertEquals(id.getNamespace(), "namespace");
+        assertEquals(id.getName(), "my:function:name");
+        assertEquals(id.getInstanceId(), -1);
     }
 }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/GenerateDocumentionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/GenerateDocumentionTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class GenerateDocumentionTest {
 


### PR DESCRIPTION
### Motivation

- Pulsar uses TestNG, but some Junit tests have slipped into the code base

### Modifications
- Convert the tests to use TestNG