### PR TITLE
fix retention policy in topic policy not work

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2975,6 +2975,9 @@ public class PersistentTopic extends AbstractTopic
         updateUnackedMessagesExceededOnConsumer(namespacePolicies.orElse(null));
 
         checkDeduplicationStatus();
+
+        // update managed ledger config
+        checkPersistencePolicies();
     }
 
     private Optional<Policies> getNamespacePolicies() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -2332,10 +2332,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // set and check retention policy on topic level
         RetentionPolicies topicRetentionPolicies = new RetentionPolicies(2, -1);
         admin.topics().setRetention(testTopic, topicRetentionPolicies);
-        managedLedgerConfig = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
-        Assert.assertEquals(managedLedgerConfig.getRetentionTimeMillis(),
-                TimeUnit.MINUTES.toMillis(topicRetentionPolicies.getRetentionTimeInMinutes()));
-        Assert.assertEquals(managedLedgerConfig.getRetentionSizeInMB(), topicRetentionPolicies.getRetentionSizeInMB());
+        Awaitility.await().untilAsserted(() -> {
+            ManagedLedgerConfig config = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
+            Assert.assertEquals(config.getRetentionTimeMillis(),
+                    TimeUnit.MINUTES.toMillis(topicRetentionPolicies.getRetentionTimeInMinutes()));
+            Assert.assertEquals(config.getRetentionSizeInMB(), topicRetentionPolicies.getRetentionSizeInMB());
+        });
     }
 
 }


### PR DESCRIPTION
### Motivation
Retention policy in topic policy doesn't work due to retention policy doesn't set into managed ledger configuration.

### Modifications
1. Set retention policy into managedLedger configuration on `onUpdate` listener method.
2. Add test to cover this case.