### PR TITLE
[Security] Exclude grpc-okhttp dependency and set okhttp3 & okio version

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -447,11 +447,10 @@ The Apache Software License, Version 2.0
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.12.0.jar
- * OkHttp and OkHttp3
-     - com.squareup.okhttp-okhttp-2.7.4.jar
+ * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-3.14.9.jar
      - com.squareup.okhttp3-okhttp-3.14.9.jar
- * Okio - com.squareup.okio-okio-1.13.0.jar
+ * Okio - com.squareup.okio-okio-1.17.2.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * gRPC
     - io.grpc-grpc-all-1.33.0.jar
@@ -459,7 +458,6 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-context-1.33.0.jar
     - io.grpc-grpc-core-1.33.0.jar
     - io.grpc-grpc-netty-1.33.0.jar
-    - io.grpc-grpc-okhttp-1.33.0.jar
     - io.grpc-grpc-protobuf-1.33.0.jar
     - io.grpc-grpc-protobuf-lite-1.33.0.jar
     - io.grpc-grpc-stub-1.33.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,9 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jna.version>4.2.0</jna.version>
     <kubernetesclient.version>12.0.1</kubernetesclient.version>
+    <okhttp3.version>3.14.9</okhttp3.version>
+    <!-- use okio version that matches the okhttp3 version -->
+    <okio.version>1.17.2</okio.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
@@ -452,6 +455,18 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -464,6 +479,18 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.codehaus.jackson</groupId>
@@ -893,6 +920,18 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1124,6 +1163,22 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
         <version>${j2objc-annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-urlconnection</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${okio.version}</version>
       </dependency>
 
     </dependencies>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -344,8 +344,8 @@ The Apache Software License, Version 2.0
     - maven-settings-builder-3.0.5.jar
 	- wagon-provider-api-2.4.jar
   * OkHttp
-    - okhttp-3.9.0.jar
-    - okhttp-urlconnection-3.9.0.jar
+    - okhttp-3.14.9.jar
+    - okhttp-urlconnection-3.14.9.jar
   * OpenCSV
     - opencsv-2.3.jar
   * Plexus
@@ -375,7 +375,7 @@ The Apache Software License, Version 2.0
   * Objenesis
     - objenesis-2.6.jar
   * Okio
-    - okio-1.13.0.jar
+    - okio-1.17.2.jar
   * Presto
     - presto-array-332.jar
     - presto-cli-332.jar


### PR DESCRIPTION
### Motivation

- okhttp 2.7.4 dependency causes Pulsar to be flagged as vulnerable.
  this dependency is pulled in by the unnecessary grpc-okhttp dependency.

### Modifications

- exclude grprc-okhttp and it's transitive dependencies

- set okhttp3 and okio versions in dependency management since the okio versio
  changed when exclusions were added.