### PR TITLE
[Security] Use ubuntu:20.04 base image for Pulsar docker images

### DIFF
--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -24,19 +24,18 @@ FROM apachepulsar/pulsar-all:latest as pulsar
 FROM apachepulsar/pulsar-dashboard:latest as dashboard
 
 # Restart from
-FROM openjdk:11-jdk
+FROM ubuntu:20.04
 
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update \
-    && apt-get -y install python3.7 python3.7-dev python3-pip postgresql sudo nginx supervisor libpq-dev
+    && apt-get -y install openjdk-11-jdk-headless python3 python3-dev python3-pip postgresql sudo nginx supervisor libpq-dev
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 RUN update-ca-certificates
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Postgres configuration
-COPY --from=dashboard /etc/postgresql/11/main/postgresql.conf /etc/postgresql/11/main/postgresql.conf
+COPY --from=dashboard /etc/postgresql/11/main/postgresql.conf /etc/postgresql/12/main/postgresql.conf
 
 # Configure supervisor
 COPY --from=dashboard /etc/supervisor/conf.d/supervisor-app.conf /etc/supervisor/conf.d/supervisor-app.conf
@@ -73,7 +72,7 @@ RUN pip install -r /pulsar/django/requirements.txt
 COPY --from=dashboard /pulsar/init-postgres.sh /pulsar/django/init-postgres.sh
 RUN mkdir /data
 RUN /pulsar/django/init-postgres.sh
-RUN sudo -u postgres /etc/init.d/postgresql stop 
+RUN sudo -u postgres /etc/init.d/postgresql stop
 # Add postgresql to supervisord. Redirect logs to stdout
 RUN echo "\n[program:postgresql]\n\
 command = /etc/init.d/postgresql start\n\

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -60,7 +60,7 @@ RUN python3 get-pip.py
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
+RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security
 ADD target/python-client/ /pulsar/pulsar-client
 
 VOLUME  ["/pulsar/conf", "/pulsar/data"]

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -40,6 +40,8 @@ RUN mkdir /pulsar/data
 
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install some utilities
 RUN apt-get update \
      && apt-get -y dist-upgrade \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -42,10 +42,13 @@ FROM ubuntu:20.04
 
 # Install some utilities
 RUN apt-get update \
+     && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
                  python3 python3-dev python3-setuptools python3-yaml python3-kazoo \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
                  curl \
+     && apt-get -y --purge autoremove \
+     && apt-get autoclean \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -31,26 +31,26 @@ COPY scripts/gen-yml-from-env.py /pulsar/bin
 COPY scripts/generate-zookeeper-config.sh /pulsar/bin
 COPY scripts/pulsar-zookeeper-ruok.sh /pulsar/bin
 COPY scripts/watch-znode.py /pulsar/bin
-COPY scripts/install-pulsar-client-37.sh /pulsar/bin
+COPY scripts/install-pulsar-client.sh /pulsar/bin
 
 RUN mkdir /pulsar/data
 
-### Create 2nd stage from OpenJDK image
-### and add Python dependencies (for Pulsar functions)
+### Create 2nd stage from Ubuntu image
+### and add OpenJDK and Python dependencies (for Pulsar functions)
 
-FROM openjdk:11-jdk-slim
+FROM ubuntu:20.04
 
 # Install some utilities
 RUN apt-get update \
-     && apt-get install -y netcat dnsutils less procps iputils-ping \
-                 python3.7 python3.7-dev python3-setuptools python3-yaml python3-kazoo \
+     && apt-get -y install openjdk-11-jdk-headless netcat dnsutils less procps iputils-ping \
+                 python3 python3-dev python3-setuptools python3-yaml python3-kazoo \
                  libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
                  curl \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN python3.7 get-pip.py
+RUN python3 get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
@@ -65,5 +65,4 @@ ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 COPY --from=pulsar /pulsar /pulsar
 WORKDIR /pulsar
 
-RUN /pulsar/bin/install-pulsar-client-37.sh
-
+RUN /pulsar/bin/install-pulsar-client.sh

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -59,6 +59,7 @@ RUN python3 get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
 ADD target/python-client/ /pulsar/pulsar-client
 

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -74,8 +74,8 @@
                   <workingDirectory>${project.basedir}/target</workingDirectory>
                   <executable>${project.basedir}/../../pulsar-client-cpp/docker/build-wheels.sh</executable>
                   <arguments>
-                    <!-- build python 3.7 -->
-                    <argument>3.7 cp37-cp37m</argument>
+                    <!-- build python 3.8 -->
+                    <argument>3.8 cp38-cp38</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -20,5 +20,6 @@
 
 set -x
 
-WHEEL_FILE=$(ls /pulsar/pulsar-client | grep cp37)
-pip3.7 install /pulsar/pulsar-client/${WHEEL_FILE}[all]
+PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
+WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
+pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM openjdk:11-jdk-slim
+FROM ubuntu:20.04
 
 RUN groupadd -g 10001 pulsar
 RUN adduser -u 10000 --gid 10001 --disabled-login --disabled-password --gecos '' pulsar
@@ -34,7 +34,7 @@ RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
 
 WORKDIR /pulsar
 
-RUN apt-get update
+RUN apt-get update && apt-get -y install openjdk-11-jdk-headless
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -34,6 +34,8 @@ RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
 
 WORKDIR /pulsar
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -30,9 +30,6 @@ RUN chown -R root:root /pulsar
 COPY target/scripts /pulsar/bin
 RUN chmod a+rx /pulsar/bin/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security
-
 WORKDIR /pulsar
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -40,6 +37,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install openjdk-11-jdk-headless
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -30,6 +30,7 @@ RUN chown -R root:root /pulsar
 COPY target/scripts /pulsar/bin
 RUN chmod a+rx /pulsar/bin/*
 
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
 
 WORKDIR /pulsar

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -34,7 +34,9 @@ RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
 
 WORKDIR /pulsar
 
-RUN apt-get update && apt-get -y install openjdk-11-jdk-headless
+RUN apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install openjdk-11-jdk-headless
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf
@@ -64,5 +66,7 @@ ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar
 
 # cleanup
-RUN apt-get clean \
+RUN apt-get -y --purge autoremove \
+    && apt-get autoclean \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -31,7 +31,7 @@ COPY target/scripts /pulsar/bin
 RUN chmod a+rx /pulsar/bin/*
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-RUN echo networkaddress.cache.ttl=1 >> $JAVA_HOME/conf/security/java.security
+RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security
 
 WORKDIR /pulsar
 


### PR DESCRIPTION
### Motivation

- Pulsar docker images currently use openjdk:11-jdk-slim as the base image.

- openjdk:11-jdk-slim/openjdk:11-jdk images are based on Debian 10 which contains a lot of unfixed vulnerabilities.
    - this causes the Pulsar docker images to get flagged in Docker image vulnerability
      scanning with docker image vulnerability scanning tools such as Clair

### Modifications

- Switch the base image to `ubuntu:20.04`. Install OpenJDK with apt-get.
- Ubuntu fixes all critical and high severity security vulnerabilities. New security vulnerabilities get quickly patched in Ubuntu.
- Python version is 3.8 in adoptopenjdk:11-jdk base image and that's why the switch requires changes to the Python & Pulsar Python client installation.