### PR TITLE
[C++][Python] Add connection timeout configuration

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ClientConfiguration.h
@@ -244,6 +244,22 @@ class PULSAR_PUBLIC ClientConfiguration {
      */
     unsigned int getPartitionsUpdateInterval() const;
 
+    /**
+     * Set the duration of time to wait for a connection to a broker to be established. If the duration passes
+     * without a response from the broker, the connection attempt is dropped.
+     *
+     * Default: 10000
+     *
+     * @param timeoutMs the duration in milliseconds
+     * @return
+     */
+    ClientConfiguration& setConnectionTimeout(int timeoutMs);
+
+    /**
+     * The getter associated with setConnectionTimeout().
+     */
+    int getConnectionTimeout() const;
+
     friend class ClientImpl;
     friend class PulsarWrapper;
 

--- a/pulsar-client-cpp/lib/ClientConfiguration.cc
+++ b/pulsar-client-cpp/lib/ClientConfiguration.cc
@@ -140,4 +140,12 @@ ClientConfiguration& ClientConfiguration::setListenerName(const std::string& lis
 }
 
 const std::string& ClientConfiguration::getListenerName() const { return impl_->listenerName; }
+
+ClientConfiguration& ClientConfiguration::setConnectionTimeout(int timeoutMs) {
+    impl_->connectionTimeoutMs = timeoutMs;
+    return *this;
+}
+
+int ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -39,6 +39,7 @@ struct ClientConfigurationImpl {
     bool validateHostName{false};
     unsigned int partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
+    int connectionTimeoutMs{10000};  // 10 seconds
 
     std::unique_ptr<LoggerFactory> takeLogger() { return std::move(loggerFactory); }
 };

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -418,6 +418,8 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
     } else if (endpointIterator != tcp::resolver::iterator()) {
         // The connection failed. Try the next endpoint in the list.
         socket_->close();
+        connectTimeoutTask_->stop();
+        connectTimeoutTask_->start();
         tcp::endpoint endpoint = *endpointIterator;
         socket_->async_connect(endpoint, std::bind(&ClientConnection::handleTcpConnected, shared_from_this(),
                                                    std::placeholders::_1, ++endpointIterator));

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -45,6 +45,7 @@
 #include <pulsar/Client.h>
 #include <set>
 #include <lib/BrokerConsumerStatsImpl.h>
+#include "lib/PeriodicTask.h"
 
 using namespace pulsar;
 
@@ -283,6 +284,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     proto::BaseCommand incomingCmd_;
 
     Promise<Result, ClientConnectionWeakPtr> connectPromise_;
+    std::shared_ptr<PeriodicTask> connectTimeoutTask_;
 
     typedef std::map<long, PendingRequestData> PendingRequestsMap;
     PendingRequestsMap pendingRequests_;

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -480,8 +480,9 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     state_ = Closing;
     lock.unlock();
 
-    LOG_INFO("Closing Pulsar client");
     SharedInt numberOfOpenHandlers = std::make_shared<int>(producers.size() + consumers.size());
+    LOG_INFO("Closing Pulsar client with " << producers.size() << " producers and " << consumers.size()
+                                           << " consumers");
 
     for (ProducersList::iterator it = producers.begin(); it != producers.end(); ++it) {
         ProducerImplBasePtr producer = it->lock();

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -47,6 +47,8 @@ class PULSAR_PUBLIC ExecutorService : private boost::noncopyable {
     void postWork(std::function<void(void)> task);
     void close();
 
+    boost::asio::io_service &getIOService() { return *io_service_; }
+
    private:
     /*
      *  only called once and within lock so no need to worry about thread-safety

--- a/pulsar-client-cpp/lib/PeriodicTask.cc
+++ b/pulsar-client-cpp/lib/PeriodicTask.cc
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "lib/PeriodicTask.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace pulsar {
+
+PeriodicTask::PeriodicTask(boost::asio::io_service& ioService, int periodMs)
+    : timer_(ioService), periodMs_(periodMs) {}
+
+void PeriodicTask::start() {
+    if (state_ != Pending) {
+        return;
+    }
+    state_ = Ready;
+    if (periodMs_ >= 0) {
+        auto self = shared_from_this();
+        timer_.expires_from_now(boost::posix_time::millisec(periodMs_));
+        timer_.async_wait([this, self](const ErrorCode& ec) { handleTimeout(ec); });
+    }
+}
+
+void PeriodicTask::stop() {
+    State state = Ready;
+    if (!state_.compare_exchange_strong(state, Closing)) {
+        return;
+    }
+    timer_.cancel();
+    state_ = Pending;
+}
+
+void PeriodicTask::handleTimeout(const ErrorCode& ec) {
+    if (state_ != Ready) {
+        return;
+    }
+
+    callback(ec);
+
+    // state_ may be changed in handleTimeout, so we check state_ again
+    if (state_ == Ready) {
+        auto self = shared_from_this();
+        timer_.expires_from_now(boost::posix_time::millisec(periodMs_));
+        timer_.async_wait([this, self](const ErrorCode& ec) { handleTimeout(ec); });
+    }
+}
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/PeriodicTask.cc
+++ b/pulsar-client-cpp/lib/PeriodicTask.cc
@@ -21,9 +21,6 @@
 
 namespace pulsar {
 
-PeriodicTask::PeriodicTask(boost::asio::io_service& ioService, int periodMs)
-    : timer_(ioService), periodMs_(periodMs) {}
-
 void PeriodicTask::start() {
     if (state_ != Pending) {
         return;

--- a/pulsar-client-cpp/lib/PeriodicTask.cc
+++ b/pulsar-client-cpp/lib/PeriodicTask.cc
@@ -47,7 +47,7 @@ void PeriodicTask::handleTimeout(const ErrorCode& ec) {
         return;
     }
 
-    callback(ec);
+    callback_(ec);
 
     // state_ may be changed in handleTimeout, so we check state_ again
     if (state_ == Ready) {

--- a/pulsar-client-cpp/lib/PeriodicTask.h
+++ b/pulsar-client-cpp/lib/PeriodicTask.h
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+#include <boost/asio.hpp>
+
+namespace pulsar {
+
+/**
+ * A task that is executed periodically.
+ */
+class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
+   public:
+    using ErrorCode = boost::system::error_code;
+
+    enum State : std::uint8_t
+    {
+        Pending,
+        Ready,
+        Closing
+    };
+
+    PeriodicTask(boost::asio::io_service& ioService, int periodMs);
+
+    void start();
+
+    void stop();
+
+    virtual void callback(const ErrorCode& ec) = 0;
+
+    State getState() const noexcept { return state_; }
+
+   private:
+    std::atomic<State> state_{Pending};
+    boost::asio::deadline_timer timer_;
+    const int periodMs_;
+
+    void handleTimeout(const ErrorCode& ec);
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/PeriodicTask.h
+++ b/pulsar-client-cpp/lib/PeriodicTask.h
@@ -28,6 +28,15 @@ namespace pulsar {
 
 /**
  * A task that is executed periodically.
+ *
+ * After the `start()` method is called, it will trigger `callback()` method periodically whose interval is
+ * `periodMs` in the constructor. After the `stop()` method is called, the timer will be cancelled and
+ * `callback()` will never be called again unless `start()` was called again.
+ *
+ * If you don't want to execute the task infinitely, you can call `stop()` in the implementation of
+ * `callback()` method.
+ *
+ * NOTE: If the `periodMs` is negative, the `callback()` will never be called.
  */
 class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
    public:
@@ -40,7 +49,7 @@ class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
         Closing
     };
 
-    PeriodicTask(boost::asio::io_service& ioService, int periodMs);
+    PeriodicTask(boost::asio::io_service& ioService, int periodMs) : timer_(ioService), periodMs_(periodMs) {}
 
     void start();
 

--- a/pulsar-client-cpp/lib/PeriodicTask.h
+++ b/pulsar-client-cpp/lib/PeriodicTask.h
@@ -60,6 +60,7 @@ class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
     void setCallback(CallbackType callback) noexcept { callback_ = callback; }
 
     State getState() const noexcept { return state_; }
+    int getPeriodMs() const noexcept { return periodMs_; }
 
    private:
     std::atomic<State> state_{Pending};

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -355,6 +355,7 @@ class Client:
     def __init__(self, service_url,
                  authentication=None,
                  operation_timeout_seconds=30,
+                 connection_timeout_ms=10000,
                  io_threads=1,
                  message_listener_threads=1,
                  concurrent_lookup_requests=50000,
@@ -380,6 +381,8 @@ class Client:
         * `operation_timeout_seconds`:
           Set timeout on client operations (subscribe, create producer, close,
           unsubscribe).
+        * `connection_timeout_ms`:
+          Set timeout in milliseconds on TCP connections.
         * `io_threads`:
           Set the number of IO threads to be used by the Pulsar client.
         * `message_listener_threads`:
@@ -413,6 +416,7 @@ class Client:
         _check_type(str, service_url, 'service_url')
         _check_type_or_none(Authentication, authentication, 'authentication')
         _check_type(int, operation_timeout_seconds, 'operation_timeout_seconds')
+        _check_type(int, connection_timeout_ms, 'connection_timeout_ms')
         _check_type(int, io_threads, 'io_threads')
         _check_type(int, message_listener_threads, 'message_listener_threads')
         _check_type(int, concurrent_lookup_requests, 'concurrent_lookup_requests')
@@ -427,6 +431,7 @@ class Client:
         if authentication:
             conf.authentication(authentication.auth)
         conf.operation_timeout_seconds(operation_timeout_seconds)
+        conf.connection_timeout(connection_timeout_ms)
         conf.io_threads(io_threads)
         conf.message_listener_threads(message_listener_threads)
         conf.concurrent_lookup_requests(concurrent_lookup_requests)

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -355,7 +355,6 @@ class Client:
     def __init__(self, service_url,
                  authentication=None,
                  operation_timeout_seconds=30,
-                 connection_timeout_ms=10000,
                  io_threads=1,
                  message_listener_threads=1,
                  concurrent_lookup_requests=50000,
@@ -364,7 +363,8 @@ class Client:
                  tls_trust_certs_file_path=None,
                  tls_allow_insecure_connection=False,
                  tls_validate_hostname=False,
-                 logger=None
+                 logger=None,
+                 connection_timeout_ms=10000,
                  ):
         """
         Create a new Pulsar client instance.
@@ -381,8 +381,6 @@ class Client:
         * `operation_timeout_seconds`:
           Set timeout on client operations (subscribe, create producer, close,
           unsubscribe).
-        * `connection_timeout_ms`:
-          Set timeout in milliseconds on TCP connections.
         * `io_threads`:
           Set the number of IO threads to be used by the Pulsar client.
         * `message_listener_threads`:
@@ -412,6 +410,8 @@ class Client:
           the endpoint.
         * `logger`:
           Set a Python logger for this Pulsar client. Should be an instance of `logging.Logger`.
+        * `connection_timeout_ms`:
+          Set timeout in milliseconds on TCP connections.
         """
         _check_type(str, service_url, 'service_url')
         _check_type_or_none(Authentication, authentication, 'authentication')

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -195,6 +195,8 @@ void export_config() {
             .def("authentication", &ClientConfiguration_setAuthentication, return_self<>())
             .def("operation_timeout_seconds", &ClientConfiguration::getOperationTimeoutSeconds)
             .def("operation_timeout_seconds", &ClientConfiguration::setOperationTimeoutSeconds, return_self<>())
+            .def("connection_timeout", &ClientConfiguration::getConnectionTimeout)
+            .def("connection_timeout", &ClientConfiguration::setConnectionTimeout, return_self<>())
             .def("io_threads", &ClientConfiguration::getIOThreads)
             .def("io_threads", &ClientConfiguration::setIOThreads, return_self<>())
             .def("message_listener_threads", &ClientConfiguration::getMessageListenerThreads)

--- a/pulsar-client-cpp/tests/PeriodicTaskTest.cc
+++ b/pulsar-client-cpp/tests/PeriodicTaskTest.cc
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include "lib/ExecutorService.h"
+#include "lib/LogUtils.h"
+#include "lib/PeriodicTask.h"
+
+DECLARE_LOG_OBJECT()
+
+using namespace pulsar;
+
+class CountdownTask : public PeriodicTask {
+   public:
+    CountdownTask(boost::asio::io_service& ioService, int periodMs, int initialCount)
+        : PeriodicTask(ioService, periodMs), count_(initialCount) {}
+
+    void callback(const ErrorCode& ec) override {
+        if (--count_ <= 0) {
+            stop();
+        }
+        LOG_INFO("Now count is " << count_ << ", error code: " << ec.message());
+    }
+
+    int getCount() const noexcept { return count_; }
+
+   private:
+    std::atomic_int count_;
+};
+
+TEST(PeriodicTaskTest, testCountdownTask) {
+    ExecutorService executor;
+
+    auto task = std::make_shared<CountdownTask>(executor.getIOService(), 200, 5);
+
+    // Wait for 3 seconds to verify callback won't be triggered after 1 second (200 ms * 5)
+    task->start();
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    LOG_INFO("Now count is " << task->getCount());
+    ASSERT_EQ(task->getCount(), 0);
+
+    task->stop();  // it's redundant, just to verify multiple stop() is idempotent
+
+    executor.close();
+}


### PR DESCRIPTION
Fixes #10747 

### Motivation

This PR is a catchup of https://github.com/apache/pulsar/pull/2852 and adds connection timeout configuration to C++ and Python client.

### Modifications

- Add a `PeriodicTask` class to execute tasks periodically and the relate unit tests: `PeriodicTastTest`.
- Use `PeriodicTask` to register a timer before connecting to broker asynchronously, if the connection was not established when the timer is triggered, close the socket so that `handleTcpConnected` can be triggered immediately with a failure.
- Add connection timeout (in milliseconds) to both C++ and Python clients.
- Add `ClientTest.testConnectTimeout` (C++) and `test_connect_timeout` (Python) and  to verify the connection timeout works.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- PeriodicTaskTest
- ClientTest.testConnectTimeout
- test_connect_timeout

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (**yes**)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)