### PR TITLE
Update the instructions for building individual modules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Compile and install:
 $ mvn install -DskipTests
 ```
 
+Compile and install individual module
+```bash
+$ mvn -pl module-name (e.g: pulsar-broker) install -DskipTests
+```
+
 ## Minimal build (This skips most of external connectors and tiered storage handlers)
 ```
 mvn install -Pcore-modules,-main
@@ -109,8 +114,7 @@ $ mvn test
 Run Individual Unit Test:
 
 ```bash
-$ cd module-name (e.g: pulsar-client)
-$ mvn test -Dtest=unit-test-name (e.g: ConsumerBuilderImplTest)
+$ mvn -pl module-name (e.g: pulsar-client) test -Dtest=unit-test-name (e.g: ConsumerBuilderImplTest)
 ```
 
 Run Selected Test packages:

--- a/pulsar-broker/src/main/proto/TransactionPendingAck.proto
+++ b/pulsar-broker/src/main/proto/TransactionPendingAck.proto
@@ -18,7 +18,7 @@
  */
 syntax = "proto2";
 
-import "../pulsar-common/src/main/proto/PulsarApi.proto";
+import "pulsar-common/src/main/proto/PulsarApi.proto";
 package pulsar.proto;
 option java_package = "org.apache.pulsar.broker.transaction.pendingack.proto";
 option optimize_for = LITE_RUNTIME;

--- a/pulsar-broker/src/main/proto/TransactionPendingAck.proto
+++ b/pulsar-broker/src/main/proto/TransactionPendingAck.proto
@@ -18,7 +18,7 @@
  */
 syntax = "proto2";
 
-import "pulsar-common/src/main/proto/PulsarApi.proto";
+import "../pulsar-common/src/main/proto/PulsarApi.proto";
 package pulsar.proto;
 option java_package = "org.apache.pulsar.broker.transaction.pendingack.proto";
 option optimize_for = LITE_RUNTIME;


### PR DESCRIPTION
### Motivation
When build pulsar-broker individual module as the folllowing step.
```bash
cd pulsar-broker
mvn clean install -DskipTests
```
It will get the following exceptions.
```
[ERROR] Failed to generate lightproto code for [/home/hangc/Downloads/tmp/pulsar/pulsar-broker/src/main/proto/TransactionPendingAck.proto, /home/hangc/Downloads/tmp/pulsar/pulsar-broker/src/main/proto/ResourceUsage.proto]: java.lang.IllegalStateException: Imported proto pulsar-common/src/main/proto/PulsarApi.proto not found. (null)
java.lang.RuntimeException: java.lang.IllegalStateException: Imported proto pulsar-common/src/main/proto/PulsarApi.proto not found. (null)
    at io.protostuff.parser.Proto.importProto (Proto.java:316)
    at io.protostuff.parser.ProtoParser.header_import (ProtoParser.java:1431)
    at io.protostuff.parser.ProtoParser.statement (ProtoParser.java:336)
    at io.protostuff.parser.ProtoParser.parse (ProtoParser.java:165)
    at io.protostuff.parser.ProtoUtil.loadFrom (ProtoUtil.java:52)
    at io.protostuff.parser.ProtoUtil.loadFrom (ProtoUtil.java:60)
    at io.protostuff.parser.ProtoUtil.loadFrom (ProtoUtil.java:90)
    at com.github.splunk.lightproto.generator.LightProtoGenerator.generate (LightProtoGenerator.java:42)
    at com.github.splunk.lightproto.maven.plugin.LightProtoMojo.generate (LightProtoMojo.java:62)
    at com.github.splunk.lightproto.maven.plugin.LightProtoMojo.execute (LightProtoMojo.java:94)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
```
The reason is `TransactionPendingAck.proto` uses project base dir to import `PulsarApi.proto`, which will lead to `PulsarApi.proto` not found when build in pulsar-broker module.

### Modification
1. Update the README.md doc guide for individual module build and run individual test.