### PR TITLE
use testng to replace junit

### DIFF
--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pulsar.io.flume.node;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import java.io.File;
 
@@ -35,7 +35,7 @@ public final class TestEnvVarResolverProperties {
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
     private PropertiesFileConfigurationProvider provider;
 
-    @BeforeMethod
+    @Before
     public void setUp() {
         provider = new PropertiesFileConfigurationProvider("a1", TESTFILE);
     }
@@ -44,7 +44,7 @@ public final class TestEnvVarResolverProperties {
     public void resolveEnvVar() {
         environmentVariables.set("VARNAME", "varvalue");
         String resolved = EnvVarResolverProperties.resolveEnvVars("padding ${VARNAME} padding");
-        Assert.assertEquals(resolved, "padding varvalue padding");
+        Assert.assertEquals( "padding varvalue padding", resolved);
     }
 
     @Test
@@ -53,7 +53,7 @@ public final class TestEnvVarResolverProperties {
         environmentVariables.set("VARNAME2", "varvalue2");
         String resolved = EnvVarResolverProperties
                 .resolveEnvVars("padding ${VARNAME1} ${VARNAME2} padding");
-        Assert.assertEquals(resolved, "padding varvalue1 varvalue2 padding");
+        Assert.assertEquals( "padding varvalue1 varvalue2 padding", resolved);
     }
 
     @Test
@@ -63,8 +63,8 @@ public final class TestEnvVarResolverProperties {
         System.setProperty("propertiesImplementation",
                 "org.apache.pulsar.io.flume.node.EnvVarResolverProperties");
 
-        Assert.assertEquals(provider.getFlumeConfiguration()
+        Assert.assertEquals(NC_PORT, provider.getFlumeConfiguration()
                 .getConfigurationFor("a1")
-                .getSourceContext().get("r1").getParameters().get("port"), NC_PORT);
+                .getSourceContext().get("r1").getParameters().get("port"));
     }
 }

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.io.flume.node;
 
+import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -30,6 +31,7 @@ public final class TestEnvVarResolverProperties {
             TestEnvVarResolverProperties.class.getClassLoader()
                     .getResource("flume-conf-with-envvars.properties").getFile());
 
+    @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
     private PropertiesFileConfigurationProvider provider;
 

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -44,7 +44,7 @@ public final class TestEnvVarResolverProperties {
     public void resolveEnvVar() {
         environmentVariables.set("VARNAME", "varvalue");
         String resolved = EnvVarResolverProperties.resolveEnvVars("padding ${VARNAME} padding");
-        Assert.assertEquals( "padding varvalue padding", resolved);
+        Assert.assertEquals("padding varvalue padding", resolved);
     }
 
     @Test
@@ -53,7 +53,7 @@ public final class TestEnvVarResolverProperties {
         environmentVariables.set("VARNAME2", "varvalue2");
         String resolved = EnvVarResolverProperties
                 .resolveEnvVars("padding ${VARNAME1} ${VARNAME2} padding");
-        Assert.assertEquals( "padding varvalue1 varvalue2 padding", resolved);
+        Assert.assertEquals("padding varvalue1 varvalue2 padding", resolved);
     }
 
     @Test

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -18,52 +18,52 @@
  */
 package org.apache.pulsar.io.flume.node;
 
-import java.io.File;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
 
 public final class TestEnvVarResolverProperties {
     private static final File TESTFILE = new File(
             TestEnvVarResolverProperties.class.getClassLoader()
                     .getResource("flume-conf-with-envvars.properties").getFile());
 
-    @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
     private PropertiesFileConfigurationProvider provider;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeMethod
+    public void setUp() {
         provider = new PropertiesFileConfigurationProvider("a1", TESTFILE);
     }
 
     @Test
-    public void resolveEnvVar() throws Exception {
+    public void resolveEnvVar() {
+        System.setProperty("VARNAME", "varvalue");
         environmentVariables.set("VARNAME", "varvalue");
         String resolved = EnvVarResolverProperties.resolveEnvVars("padding ${VARNAME} padding");
-        Assert.assertEquals("padding varvalue padding", resolved);
+        Assert.assertEquals(resolved, "padding varvalue padding");
     }
 
     @Test
-    public void resolveEnvVars() throws Exception {
+    public void resolveEnvVars() {
         environmentVariables.set("VARNAME1", "varvalue1");
         environmentVariables.set("VARNAME2", "varvalue2");
         String resolved = EnvVarResolverProperties
                 .resolveEnvVars("padding ${VARNAME1} ${VARNAME2} padding");
-        Assert.assertEquals("padding varvalue1 varvalue2 padding", resolved);
+        Assert.assertEquals(resolved, "padding varvalue1 varvalue2 padding");
     }
 
     @Test
-    public void getProperty() throws Exception {
+    public void getProperty() {
         String NC_PORT = "6667";
         environmentVariables.set("NC_PORT", NC_PORT);
         System.setProperty("propertiesImplementation",
                 "org.apache.pulsar.io.flume.node.EnvVarResolverProperties");
 
-        Assert.assertEquals(NC_PORT, provider.getFlumeConfiguration()
+        Assert.assertEquals(provider.getFlumeConfiguration()
                 .getConfigurationFor("a1")
-                .getSourceContext().get("r1").getParameters().get("port"));
+                .getSourceContext().get("r1").getParameters().get("port"), NC_PORT);
     }
 }

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -40,7 +40,6 @@ public final class TestEnvVarResolverProperties {
 
     @Test
     public void resolveEnvVar() {
-        System.setProperty("VARNAME", "varvalue");
         environmentVariables.set("VARNAME", "varvalue");
         String resolved = EnvVarResolverProperties.resolveEnvVars("padding ${VARNAME} padding");
         Assert.assertEquals(resolved, "padding varvalue padding");

--- a/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
+++ b/pulsar-io/flume/src/test/java/org/apache/pulsar/io/flume/node/TestEnvVarResolverProperties.java
@@ -18,13 +18,12 @@
  */
 package org.apache.pulsar.io.flume.node;
 
+import java.io.File;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
-
-import java.io.File;
 
 public final class TestEnvVarResolverProperties {
     private static final File TESTFILE = new File(

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -138,12 +138,12 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.write(record);
         sink.flush();
 
-        assertEquals(1, status.get());
+        assertEquals(status.get(), 1);
 
         sink.close();
 
         List<String> lines = Files.readAllLines(file, StandardCharsets.US_ASCII);
-        assertEquals("value", lines.get(0));
+        assertEquals(lines.get(0), "value");
     }
 
     @Test
@@ -169,15 +169,15 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.write(record);
         sink.flush();
 
-        assertEquals(1, status.get());
+        assertEquals(status.get(), 1);
 
         final TopicPartition tp = new TopicPartition("fake-topic", 0);
-        assertNotEquals(0, MessageIdUtils.getOffset(msgId));
-        assertEquals(MessageIdUtils.getOffset(msgId), sink.currentOffset(tp.topic(), tp.partition()));
+        assertNotEquals(MessageIdUtils.getOffset(msgId), 0);
+        assertEquals(sink.currentOffset(tp.topic(), tp.partition()), MessageIdUtils.getOffset(msgId));
 
         sink.taskContext.offset(tp, 0);
         verify(context, times(1)).seek(Mockito.anyString(), Mockito.anyInt(), any());
-        assertEquals(0, sink.currentOffset(tp.topic(), tp.partition()));
+        assertEquals(sink.currentOffset(tp.topic(), tp.partition()), 0);
 
         sink.taskContext.pause(tp);
         verify(context, times(1)).pause(tp.topic(), tp.partition());
@@ -260,7 +260,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.write(record);
         sink.flush();
 
-        assertEquals(1, status.get());
+        assertEquals(status.get(), 1);
 
         sink.close();
 
@@ -268,10 +268,10 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         ObjectMapper om = new ObjectMapper();
         Map<String, Object> result = om.readValue(lines.get(0), new TypeReference<Map<String, Object>>(){});
 
-        assertEquals(expectedKey, result.get("key"));
-        assertEquals(expected, result.get("value"));
-        assertEquals(expectedKeySchema, result.get("keySchema"));
-        assertEquals(expectedSchema, result.get("valueSchema"));
+        assertEquals(result.get("key"), expectedKey);
+        assertEquals(result.get("value"), expected);
+        assertEquals(result.get("keySchema"), expectedKeySchema);
+        assertEquals(result.get("valueSchema"), expectedSchema);
     }
 
     private GenericRecord getGenericRecord(Object value, Schema schema) {
@@ -418,18 +418,18 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.open(props, context);
 
         // offset is -1 before any data is written (aka no offset)
-        assertEquals(-1L, sink.currentOffset(topicName, partition));
+        assertEquals(sink.currentOffset(topicName, partition), -1L);
 
         sink.write(record);
         sink.flush();
 
         // offset is 0 for the first written record
-        assertEquals(0, sink.currentOffset(topicName, partition));
+        assertEquals(sink.currentOffset(topicName, partition), 0);
 
         sink.write(record);
         sink.flush();
         // offset is 1 for the second written record
-        assertEquals(1, sink.currentOffset(topicName, partition));
+        assertEquals(sink.currentOffset(topicName, partition), 1);
 
         sink.close();
 
@@ -441,12 +441,12 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.open(props, context);
 
         // offset is 1 after reopening the producer
-        assertEquals(1, sink.currentOffset(topicName, partition));
+        assertEquals(sink.currentOffset(topicName, partition), 1);
 
         sink.write(record);
         sink.flush();
         // offset is 2 for the next written record
-        assertEquals(2, sink.currentOffset(topicName, partition));
+        assertEquals(sink.currentOffset(topicName, partition), 2);
 
         sink.close();
     }

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -57,14 +57,14 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.fail;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 @Slf4j
@@ -382,7 +382,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         sink.write(record);
         sink.flush();
 
-        assertEquals("write should fail for unsupported schema",-1, status.get());
+        assertEquals(status.get(), -1, "write should fail for unsupported schema");
 
         sink.close();
     }


### PR DESCRIPTION
### Motivation
Pulsar uses TestNG, but some tests are still using junit

### Modifications
Use testng instead of junit