### PR TITLE
fix testng assertEquals parameter order

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -79,13 +78,11 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
-import org.apache.pulsar.common.policies.data.AutoFailoverPolicyDataImpl;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.BrokerInfo;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
-import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -112,8 +109,6 @@ import org.slf4j.LoggerFactory;
 
 @Test(groups = "broker")
 public class AdminTest extends MockedPulsarServiceBaseTest {
-    private static final Logger log = LoggerFactory.getLogger(AdminTest.class);
-
     private final String configClusterName = "use";
     private ConfigurationCacheService configurationCache;
     private Clusters clusters;
@@ -415,9 +410,9 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                     .listenerName("listenerName")
                     .build());
             ClusterData cluster = clusters.getCluster("auth");
-            assertEquals("authenticationPlugin", cluster.getAuthenticationPlugin());
-            assertEquals("authenticationParameters", cluster.getAuthenticationParameters());
-            assertEquals("listenerName", cluster.getListenerName());
+            assertEquals(cluster.getAuthenticationPlugin(), "authenticationPlugin");
+            assertEquals(cluster.getAuthenticationParameters(), "authenticationParameters");
+            assertEquals(cluster.getListenerName(), "listenerName");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
@@ -80,7 +80,7 @@ public class ServiceUrlProviderTest extends ProducerConsumerBase {
             System.out.println(message.getValue());
             received++;
         } while (received < 200);
-        Assert.assertEquals(200, received);
+        Assert.assertEquals(received, 200);
         producer.close();
         consumer.close();
     }

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
@@ -39,19 +39,19 @@ public class RabbitMQSinkConfigTest {
         String path = yamlFile.getAbsolutePath();
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(path);
         assertNotNull(config);
-        assertEquals("localhost", config.getHost());
-        assertEquals(Integer.parseInt("5673"), config.getPort());
-        assertEquals("/", config.getVirtualHost());
-        assertEquals("guest", config.getUsername());
-        assertEquals("guest", config.getPassword());
-        assertEquals("test-connection", config.getConnectionName());
-        assertEquals(Integer.parseInt("0"), config.getRequestedChannelMax());
-        assertEquals(Integer.parseInt("0"), config.getRequestedFrameMax());
-        assertEquals(Integer.parseInt("60000"), config.getConnectionTimeout());
-        assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
-        assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
-        assertEquals("test-exchange", config.getExchangeName());
-        assertEquals("test-exchange-type", config.getExchangeType());
+        assertEquals(config.getHost(), "localhost");
+        assertEquals(config.getPort(), Integer.parseInt("5673"));
+        assertEquals(config.getVirtualHost(), "/");
+        assertEquals(config.getUsername(), "guest");
+        assertEquals(config.getPassword(), "guest");
+        assertEquals(config.getConnectionName(), "test-connection");
+        assertEquals(config.getRequestedChannelMax(), Integer.parseInt("0"));
+        assertEquals(config.getRequestedFrameMax(), Integer.parseInt("0"));
+        assertEquals(config.getConnectionTimeout(), Integer.parseInt("60000"));
+        assertEquals(config.getHandshakeTimeout(), Integer.parseInt("10000"));
+        assertEquals(config.getRequestedHeartbeat(), Integer.parseInt("60"));
+        assertEquals(config.getExchangeName(), "test-exchange");
+        assertEquals(config.getExchangeType(), "test-exchange-type");
     }
 
     @Test
@@ -73,19 +73,19 @@ public class RabbitMQSinkConfigTest {
 
         RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
         assertNotNull(config);
-        assertEquals("localhost", config.getHost());
-        assertEquals(Integer.parseInt("5673"), config.getPort());
-        assertEquals("/", config.getVirtualHost());
-        assertEquals("guest", config.getUsername());
-        assertEquals("guest", config.getPassword());
-        assertEquals("test-connection", config.getConnectionName());
-        assertEquals(Integer.parseInt("0"), config.getRequestedChannelMax());
-        assertEquals(Integer.parseInt("0"), config.getRequestedFrameMax());
-        assertEquals(Integer.parseInt("60000"), config.getConnectionTimeout());
-        assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
-        assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
-        assertEquals("test-exchange", config.getExchangeName());
-        assertEquals("test-exchange-type", config.getExchangeType());
+        assertEquals(config.getHost(), "localhost");
+        assertEquals(config.getPort(), Integer.parseInt("5673"));
+        assertEquals(config.getVirtualHost(), "/");
+        assertEquals(config.getUsername(), "guest");
+        assertEquals(config.getPassword(), "guest");
+        assertEquals(config.getConnectionName(), "test-connection");
+        assertEquals(config.getRequestedChannelMax(), Integer.parseInt("0"));
+        assertEquals(config.getRequestedFrameMax(), Integer.parseInt("0"));
+        assertEquals(config.getConnectionTimeout(), Integer.parseInt("60000"));
+        assertEquals(config.getHandshakeTimeout(), Integer.parseInt("10000"));
+        assertEquals(config.getRequestedHeartbeat(), Integer.parseInt("60"));
+        assertEquals(config.getExchangeName(), "test-exchange");
+        assertEquals(config.getExchangeType(), "test-exchange-type");
     }
 
     @Test

--- a/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
+++ b/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
@@ -40,14 +40,14 @@ public class RedisSinkConfigTest {
         String path = yamlFile.getAbsolutePath();
         RedisSinkConfig config = RedisSinkConfig.load(path);
         assertNotNull(config);
-        assertEquals("localhost:6379", config.getRedisHosts());
-        assertEquals("fake@123", config.getRedisPassword());
-        assertEquals(Integer.parseInt("1"), config.getRedisDatabase());
-        assertEquals("Standalone", config.getClientMode());
-        assertEquals(Long.parseLong("2000"), config.getOperationTimeout());
-        assertEquals(Integer.parseInt("100"), config.getBatchSize());
-        assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
-        assertEquals(Long.parseLong("3000"), config.getConnectTimeout());
+        assertEquals(config.getRedisHosts(), "localhost:6379");
+        assertEquals(config.getRedisPassword(), "fake@123");
+        assertEquals(config.getRedisDatabase(), Integer.parseInt("1"));
+        assertEquals(config.getClientMode(), "Standalone");
+        assertEquals(config.getOperationTimeout(), Long.parseLong("2000"));
+        assertEquals(config.getBatchSize(), Integer.parseInt("100"));
+        assertEquals(config.getBatchTimeMs(), Long.parseLong("1000"));
+        assertEquals(config.getConnectTimeout(), Long.parseLong("3000"));
     }
 
     @Test
@@ -64,14 +64,14 @@ public class RedisSinkConfigTest {
 
         RedisSinkConfig config = RedisSinkConfig.load(map);
         assertNotNull(config);
-        assertEquals("localhost:6379", config.getRedisHosts());
-        assertEquals("fake@123", config.getRedisPassword());
-        assertEquals(Integer.parseInt("1"), config.getRedisDatabase());
-        assertEquals("Standalone", config.getClientMode());
-        assertEquals(Long.parseLong("2000"), config.getOperationTimeout());
-        assertEquals(Integer.parseInt("100"), config.getBatchSize());
-        assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
-        assertEquals(Long.parseLong("3000"), config.getConnectTimeout());
+        assertEquals(config.getRedisHosts(), "localhost:6379");
+        assertEquals(config.getRedisPassword(), "fake@123");
+        assertEquals(config.getRedisDatabase(), Integer.parseInt("1"));
+        assertEquals(config.getClientMode(), "Standalone");
+        assertEquals(config.getOperationTimeout(), Long.parseLong("2000"));
+        assertEquals(config.getBatchSize(), Integer.parseInt("100"));
+        assertEquals(config.getBatchTimeMs(), Long.parseLong("1000"));
+        assertEquals(config.getConnectTimeout(), Long.parseLong("3000"));
     }
 
     @Test

--- a/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrSinkConfigTest.java
+++ b/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrSinkConfigTest.java
@@ -43,12 +43,12 @@ public class SolrSinkConfigTest {
         String path = yamlFile.getAbsolutePath();
         SolrSinkConfig config = SolrSinkConfig.load(path);
         assertNotNull(config);
-        assertEquals("localhost:2181,localhost:2182/chroot", config.getSolrUrl());
-        assertEquals("SolrCloud", config.getSolrMode());
-        assertEquals("techproducts", config.getSolrCollection());
-        assertEquals(Integer.parseInt("100"), config.getSolrCommitWithinMs());
-        assertEquals("fakeuser", config.getUsername());
-        assertEquals("fake@123", config.getPassword());
+        assertEquals(config.getSolrUrl(), "localhost:2181,localhost:2182/chroot");
+        assertEquals(config.getSolrMode(), "SolrCloud");
+        assertEquals(config.getSolrCollection(), "techproducts");
+        assertEquals(config.getSolrCommitWithinMs(), Integer.parseInt("100"));
+        assertEquals(config.getUsername(), "fakeuser");
+        assertEquals(config.getPassword(), "fake@123");
     }
 
     @Test
@@ -63,12 +63,12 @@ public class SolrSinkConfigTest {
 
         SolrSinkConfig config = SolrSinkConfig.load(map);
         assertNotNull(config);
-        assertEquals("localhost:2181,localhost:2182/chroot", config.getSolrUrl());
-        assertEquals("SolrCloud", config.getSolrMode());
-        assertEquals("techproducts", config.getSolrCollection());
-        assertEquals(Integer.parseInt("100"), config.getSolrCommitWithinMs());
-        assertEquals("fakeuser", config.getUsername());
-        assertEquals("fake@123", config.getPassword());
+        assertEquals(config.getSolrUrl(), "localhost:2181,localhost:2182/chroot");
+        assertEquals(config.getSolrMode(), "SolrCloud");
+        assertEquals(config.getSolrCollection(), "techproducts");
+        assertEquals(config.getSolrCommitWithinMs(), Integer.parseInt("100"));
+        assertEquals(config.getUsername(), "fakeuser");
+        assertEquals(config.getPassword(), "fake@123");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
When change from Junit to TestNG, the `assertEquals` method's parameter order has changed. However in our current test, the `assertEquals` are misorder.

### Modifications
1. Change the order of TestNG#assertEquals parameter.
