### PR TITLE
[Issue 11036][client] Producer BatcherBuilder configuration property

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -19,12 +19,13 @@
 package org.apache.pulsar.client.impl.conf;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.google.common.collect.ImmutableList;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -38,7 +39,9 @@ import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -188,8 +188,8 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     }
 
     public enum BatcherBuilderType {
-        DEFAULT(BatcherBuilder.DEFAULT),
-        KEY_BASED(BatcherBuilder.KEY_BASED);
+        Default(BatcherBuilder.DEFAULT),
+        Key_Based(BatcherBuilder.KEY_BASED);
 
         private final BatcherBuilder batcherBuilder;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -19,12 +19,12 @@
 package org.apache.pulsar.client.impl.conf;
 
 import java.io.Serializable;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.google.common.collect.ImmutableList;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -149,6 +149,16 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
         this.batchingMaxBytes = batchingMaxBytes;
     }
 
+    @JsonSetter
+    public void setBatcherBuilderType(BatcherBuilderType batcherBuilderType) {
+        this.batcherBuilder = batcherBuilderType.batcherBuilder;
+    }
+
+    @JsonGetter
+    public BatcherBuilderType getBatcherBuilderType() {
+        return BatcherBuilderType.fromBatcherBuilder(this.batcherBuilder);
+    }
+
     public void setSendTimeoutMs(int sendTimeout, TimeUnit timeUnit) {
         checkArgument(sendTimeout >= 0, "sendTimeout needs to be >= 0");
         this.sendTimeoutMs = timeUnit.toMillis(sendTimeout);
@@ -172,5 +182,23 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     public void setAutoUpdatePartitionsIntervalSeconds(int interval, TimeUnit timeUnit) {
         checkArgument(interval > 0, "interval needs to be > 0");
         this.autoUpdatePartitionsIntervalSeconds = timeUnit.toSeconds(interval);
+    }
+
+    public enum BatcherBuilderType {
+        DEFAULT(BatcherBuilder.DEFAULT),
+        KEY_BASED(BatcherBuilder.KEY_BASED);
+
+        private final BatcherBuilder batcherBuilder;
+
+        BatcherBuilderType(BatcherBuilder batcherBuilder) {
+            this.batcherBuilder = batcherBuilder;
+        }
+
+        public static BatcherBuilderType fromBatcherBuilder(BatcherBuilder batcherBuilder) {
+            return Arrays.stream(values())
+                    .filter(t->t.batcherBuilder==batcherBuilder)
+                    .findFirst()
+                    .orElse(null);
+        }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -76,14 +76,16 @@ public class ConfigurationDataUtilsTest {
         confData.setProducerName("unset");
         confData.setBatchingEnabled(true);
         confData.setBatchingMaxMessages(1234);
+        confData.setBatcherBuilderType(ProducerConfigurationData.BatcherBuilderType.DEFAULT);
         confData.setAutoUpdatePartitionsIntervalSeconds(1, TimeUnit.MINUTES);
         Map<String, Object> config = new HashMap<>();
         config.put("producerName", "test-producer");
         config.put("batchingEnabled", false);
-        confData.setBatcherBuilder(BatcherBuilder.DEFAULT);
+        config.put("batcherBuilderType", "KEY_BASED");
         confData = ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class);
         assertEquals("test-producer", confData.getProducerName());
         assertFalse(confData.isBatchingEnabled());
+        assertEquals(BatcherBuilder.KEY_BASED, confData.getBatcherBuilder());
         assertEquals(1234, confData.getBatchingMaxMessages());
         assertEquals(60,confData.getAutoUpdatePartitionsIntervalSeconds());
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -76,12 +76,12 @@ public class ConfigurationDataUtilsTest {
         confData.setProducerName("unset");
         confData.setBatchingEnabled(true);
         confData.setBatchingMaxMessages(1234);
-        confData.setBatcherBuilderType(ProducerConfigurationData.BatcherBuilderType.DEFAULT);
+        confData.setBatcherBuilderType(ProducerConfigurationData.BatcherBuilderType.Default);
         confData.setAutoUpdatePartitionsIntervalSeconds(1, TimeUnit.MINUTES);
         Map<String, Object> config = new HashMap<>();
         config.put("producerName", "test-producer");
         config.put("batchingEnabled", false);
-        config.put("batcherBuilderType", "KEY_BASED");
+        config.put("batcherBuilderType", "Key_Based");
         confData = ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class);
         assertEquals("test-producer", confData.getProducerName());
         assertFalse(confData.isBatchingEnabled());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
@@ -29,7 +29,7 @@ public class ProducerConfigurationDataTest {
     }
 
     @Test
-    public void testLoadBatcherBuilderDefaultCase() throws JsonProcessingException {
+    public void testLoadBatcherBuilderDefaultCase() {
         assertEquals(BatcherBuilder.DEFAULT, confData.getBatcherBuilder());
     }
 
@@ -58,7 +58,7 @@ public class ProducerConfigurationDataTest {
     }
 
     @Test
-    public void testLoadBatcherBuilderTypeUnknown() throws JsonProcessingException {
+    public void testLoadBatcherBuilderTypeUnknown() {
         Map<String, Object> config = new HashMap<>();
         config.put("batcherBuilderType", "UNKNOWN");
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
@@ -1,6 +1,5 @@
 package org.apache.pulsar.client.impl.conf;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.pulsar.client.api.BatcherBuilder;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationDataTest.java
@@ -1,0 +1,67 @@
+package org.apache.pulsar.client.impl.conf;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class ProducerConfigurationDataTest {
+    private static final String PRODUCER_NAME = "test-producer";
+
+    private ProducerConfigurationData confData;
+
+    @BeforeTest
+    public void setUp() {
+        confData = new ProducerConfigurationData();
+        confData.setProducerName(PRODUCER_NAME);
+    }
+
+    @AfterTest
+    public void ensurePreserveOtherProperties() {
+        assertEquals(PRODUCER_NAME, confData.getProducerName());
+    }
+
+    @Test
+    public void testLoadBatcherBuilderDefaultCase() throws JsonProcessingException {
+        assertEquals(BatcherBuilder.DEFAULT, confData.getBatcherBuilder());
+    }
+
+    @Test
+    public void testLoadChangeBatcherBuilderTypeToKeyBased() {
+        confData.setBatcherBuilderType(ProducerConfigurationData.BatcherBuilderType.Default);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("batcherBuilderType", "Key_Based");
+
+        confData = ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class);
+
+        assertEquals(BatcherBuilder.KEY_BASED, confData.getBatcherBuilder());
+    }
+
+    @Test
+    public void testLoadChangeBatcherBuilderTypeToDefault() {
+        confData.setBatcherBuilderType(ProducerConfigurationData.BatcherBuilderType.Key_Based);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("batcherBuilderType", "Default");
+
+        confData = ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class);
+
+        assertEquals(BatcherBuilder.DEFAULT, confData.getBatcherBuilder());
+    }
+
+    @Test
+    public void testLoadBatcherBuilderTypeUnknown() throws JsonProcessingException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("batcherBuilderType", "UNKNOWN");
+
+        assertThrows(RuntimeException.class, () -> ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class));
+    }
+}

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -185,6 +185,7 @@ ProducerCryptoFailureAction|`cryptoFailureAction`|Producer should take action wh
 long|`batchingMaxPublishDelayMicros`|Batching time period of sending messages.|TimeUnit.MILLISECONDS.toMicros(1)
 int|batchingMaxMessages|The maximum number of messages permitted in a batch.|1000
 boolean|`batchingEnabled`|Enable batching of messages. |true
+BatcherBuilderType| `batcherBuilderType`| BatcherBuilder type <br/><br/>Two types are available:<li>Default</li><li>Key_Based</li>|BatcherBuilderType.Default
 CompressionType|`compressionType`|Message data compression type used by a producer. <br/><br/>Available options:<li>[`LZ4`](https://github.com/lz4/lz4)<br/><li>[`ZLIB`](https://zlib.net/)<br/><li>[`ZSTD`](https://facebook.github.io/zstd/)<br/><li>[`SNAPPY`](https://google.github.io/snappy/)| No compression
 
 You can configure parameters if you do not want to use the default configuration.

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
@@ -186,6 +186,7 @@ ProducerCryptoFailureAction|`cryptoFailureAction`|Producer should take action wh
 long|`batchingMaxPublishDelayMicros`|Batching time period of sending messages.|TimeUnit.MILLISECONDS.toMicros(1)
 int|batchingMaxMessages|The maximum number of messages permitted in a batch.|1000
 boolean|`batchingEnabled`|Enable batching of messages. |true
+BatcherBuilderType| `batcherBuilderType`| BatcherBuilder type <br/><br/>Two types are available:<li>Default</li><li>Key_Based</li>|BatcherBuilderType.Default
 CompressionType|`compressionType`|Message data compression type used by a producer. <br/><br/>Available options:<li>[`LZ4`](https://github.com/lz4/lz4)<br/><li>[`ZLIB`](https://zlib.net/)<br/><li>[`ZSTD`](https://facebook.github.io/zstd/)<br/><li>[`SNAPPY`](https://google.github.io/snappy/)| No compression
 
 You can configure parameters if you do not want to use the default configuration.

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-java.md
@@ -186,7 +186,6 @@ ProducerCryptoFailureAction|`cryptoFailureAction`|Producer should take action wh
 long|`batchingMaxPublishDelayMicros`|Batching time period of sending messages.|TimeUnit.MILLISECONDS.toMicros(1)
 int|batchingMaxMessages|The maximum number of messages permitted in a batch.|1000
 boolean|`batchingEnabled`|Enable batching of messages. |true
-BatcherBuilderType| `batcherBuilderType`| BatcherBuilder type <br/><br/>Two types are available:<li>Default</li><li>Key_Based</li>|BatcherBuilderType.Default
 CompressionType|`compressionType`|Message data compression type used by a producer. <br/><br/>Available options:<li>[`LZ4`](https://github.com/lz4/lz4)<br/><li>[`ZLIB`](https://zlib.net/)<br/><li>[`ZSTD`](https://facebook.github.io/zstd/)<br/><li>[`SNAPPY`](https://google.github.io/snappy/)| No compression
 
 You can configure parameters if you do not want to use the default configuration.


### PR DESCRIPTION
Fixes #11036

### Motivation

See #11036 for background on this PR

### Modifications

Added a getter/setter pair for `batcherBuilderType` on the `ProducerConfigurationData` class, which manipulate the `batcherBuilder` attribute, based on an enum. This allows for easy mapping to/from properties and json format.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended `ConfigurationDataUtilsTest::testLoadProducerConfigurationData`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no: config property added, not actual cli options)
  - Anything that affects deployment: (no: config property added, but default didn't change)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs: `client-libraries-java.md`)