### PR TITLE
PIP-85: [pulsar-io] pass pulsar client via context to connector

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
@@ -198,5 +198,7 @@ public interface BaseContext {
      *
      * @return the instance of pulsar client
      */
-    PulsarClient getPulsarClient();
+    default PulsarClient getPulsarClient() {
+        throw new UnsupportedOperationException("not implemented");
+    }
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/BaseContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.api;
 
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 import org.slf4j.Logger;
@@ -191,4 +192,11 @@ public interface BaseContext {
      * @param value The value of the metric
      */
     void recordMetric(String metricName, double value);
+
+    /**
+     * Get the pulsar client.
+     *
+     * @return the instance of pulsar client
+     */
+    PulsarClient getPulsarClient();
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -487,6 +487,11 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         }
     }
 
+    @Override
+    public PulsarClient getPulsarClient() {
+        return client;
+    }
+
     private <O> Producer<O> getProducer(String topicName, Schema<O> schema) throws PulsarClientException {
         Producer<O> producer;
         if (tlPublishProducers != null) {

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.common;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -203,6 +204,11 @@ public class IOConfigUtilsTest {
         public <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) throws PulsarClientException {
             return null;
         }
+
+        @Override
+        public PulsarClient getPulsarClient() {
+            return null;
+        }
     }
 
     @Test
@@ -350,6 +356,11 @@ public class IOConfigUtilsTest {
         @Override
         public CompletableFuture<Void> deleteStateAsync(String key) {
         	return null;
+        }
+
+        @Override
+        public PulsarClient getPulsarClient() {
+            return null;
         }
     }
 

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -78,13 +78,6 @@ public abstract class DebeziumSource extends KafkaConnectSource {
         // database.history : implementation class for database history.
         setConfigIfNull(config, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name(), DEFAULT_HISTORY);
 
-        // database.history.pulsar.service.url, this is set as the value of pulsar.service.url if null.
-        String serviceUrl = (String) config.get(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG);
-        if (serviceUrl == null) {
-            throw new IllegalArgumentException("Pulsar service URL not provided.");
-        }
-        setConfigIfNull(config, PulsarDatabaseHistory.SERVICE_URL.name(), serviceUrl);
-
         String topicNamespace = topicNamespace(sourceContext);
         // topic.namespace
         setConfigIfNull(config, PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG, topicNamespace);

--- a/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
+++ b/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
@@ -33,6 +33,3 @@ configs:
   mongodb.password: "dbz"
   mongodb.task.id: "1"
   database.whitelist: "inventory"
-
-  ## PULSAR_SERVICE_URL_CONFIG
-  pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
+++ b/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
@@ -35,8 +35,6 @@ configs:
   database.server.name: "dbserver1"
   database.whitelist: "inventory"
 
-  ## PULSAR_SERVICE_URL_CONFIG
-  pulsar.service.url: "pulsar://127.0.0.1:6650"
   database.history.pulsar.topic: "mysql-history-topic"
   offset.storage.topic: "mysql-offset-topic"
 

--- a/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
+++ b/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
@@ -35,7 +35,5 @@ configs:
   database.server.name: "dbserver1"
   schema.whitelist: "inventory"
 
-  ## PULSAR_SERVICE_URL_CONFIG
-  pulsar.service.url: "pulsar://127.0.0.1:6650"
 
 

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -117,7 +117,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
         offsetStore = new PulsarOffsetBackingStore();
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(stringConfig);
-        offsetStore.configure(pulsarKafkaWorkerConfig);
+        offsetStore.configure(pulsarKafkaWorkerConfig, sourceContext.getPulsarClient());
         offsetStore.start();
 
         offsetReader = new OffsetStorageReaderImpl(

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -115,9 +115,9 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         keyConverter.configure(config, true);
         valueConverter.configure(config, false);
 
-        offsetStore = new PulsarOffsetBackingStore();
+        offsetStore = new PulsarOffsetBackingStore(sourceContext.getPulsarClient());
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(stringConfig);
-        offsetStore.configure(pulsarKafkaWorkerConfig, sourceContext.getPulsarClient());
+        offsetStore.configure(pulsarKafkaWorkerConfig);
         offsetStore.start();
 
         offsetReader = new OffsetStorageReaderImpl(

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -55,7 +55,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.pulsar.io.kafka.connect.PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG;
-import static org.apache.pulsar.io.kafka.connect.PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG;
 
 @Slf4j
 public class KafkaConnectSink implements Sink<GenericObject> {
@@ -156,7 +155,6 @@ public class KafkaConnectSink implements Sink<GenericObject> {
 
         configs.forEach(x -> {
             x.put(OFFSET_STORAGE_TOPIC_CONFIG, kafkaSinkConfig.getOffsetStorageTopic());
-            x.put(PULSAR_SERVICE_URL_CONFIG, kafkaSinkConfig.getPulsarServiceUrl());
         });
         task = (SinkTask) taskClass.getConstructor().newInstance();
         taskContext =

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaConnectSinkConfig.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaConnectSinkConfig.java
@@ -69,16 +69,6 @@ public class PulsarKafkaConnectSinkConfig implements Serializable {
             help = "Pulsar topic to store offsets at.")
     private String offsetStorageTopic;
 
-    /*
-    This is used to configure PulsarOffsetBackingStore.
-    It will become unnecessary after the PulsarClient is exposed to the context.
-    */
-    @FieldDoc(
-            required = true,
-            defaultValue = "",
-            help = "Pulsar service URL to use for the offset store.")
-    private String pulsarServiceUrl;
-
     @FieldDoc(
             defaultValue = "true",
             help = "In case of Record<KeyValue<>> data use key from KeyValue<> instead of one from Record.")

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
@@ -69,7 +69,7 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
 
         offsetStore = new PulsarOffsetBackingStore();
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(config);
-        offsetStore.configure(pulsarKafkaWorkerConfig);
+        offsetStore.configure(pulsarKafkaWorkerConfig, ctx.getPulsarClient());
         offsetStore.start();
 
         this.onPartitionChange = onPartitionChange;

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
@@ -67,9 +67,9 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
         this.config = config;
         this.ctx = ctx;
 
-        offsetStore = new PulsarOffsetBackingStore();
+        offsetStore = new PulsarOffsetBackingStore(ctx.getPulsarClient());
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(config);
-        offsetStore.configure(pulsarKafkaWorkerConfig, ctx.getPulsarClient());
+        offsetStore.configure(pulsarKafkaWorkerConfig);
         offsetStore.start();
 
         this.onPartitionChange = onPartitionChange;

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaWorkerConfig.java
@@ -37,13 +37,6 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
     public static final String OFFSET_STORAGE_TOPIC_CONFIG = "offset.storage.topic";
     private static final String OFFSET_STORAGE_TOPIC_CONFIG_DOC = "pulsar topic to store kafka connector offsets in";
 
-
-    /**
-     * <code>pulsar.service.url</code>
-     */
-    public static final String PULSAR_SERVICE_URL_CONFIG = "pulsar.service.url";
-    private static final String PULSAR_SERVICE_URL_CONFIG_DOC = "pulsar service url";
-
     /**
      * <code>topic.namespace</code>
      */
@@ -56,10 +49,6 @@ public class PulsarKafkaWorkerConfig extends WorkerConfig {
                 Type.STRING,
                 Importance.HIGH,
                 OFFSET_STORAGE_TOPIC_CONFIG_DOC)
-            .define(PULSAR_SERVICE_URL_CONFIG,
-                Type.STRING,
-                Importance.HIGH,
-                PULSAR_SERVICE_URL_CONFIG_DOC)
             .define(TOPIC_NAMESPACE_CONFIG,
                 Type.STRING,
                 "public/default",

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -58,6 +58,7 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     private volatile CompletableFuture<Void> outstandingReadToEnd = null;
 
     public PulsarOffsetBackingStore(PulsarClient client) {
+        checkArgument(client != null, "Pulsar Client must be provided");
         this.client = client;
     }
 

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -57,16 +57,18 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     private Reader<byte[]> reader;
     private volatile CompletableFuture<Void> outstandingReadToEnd = null;
 
+    public PulsarOffsetBackingStore(PulsarClient client) {
+        this.client = client;
+    }
+
     @Override
-    public void configure(WorkerConfig workerConfig, PulsarClient client) {
+    public void configure(WorkerConfig workerConfig) {
         this.topic = workerConfig.getString(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG);
         checkArgument(!isBlank(topic), "Offset storage topic must be specified");
         this.serviceUrl = workerConfig.getString(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG);
         checkArgument(!isBlank(serviceUrl), "Pulsar service url must be specified at `"
             + WorkerConfig.BOOTSTRAP_SERVERS_CONFIG + "`");
         this.data = new HashMap<>();
-
-        this.client = client;
 
         log.info("Configure offset backing store on pulsar topic {} at cluster {}",
             topic, serviceUrl);

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -141,22 +141,23 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     @Override
     public void start() {
         try {
-            log.info("Successfully created pulsar client to {}", serviceUrl);
             producer = client.newProducer(Schema.BYTES)
                 .topic(topic)
                 .create();
             log.info("Successfully created producer to produce updates to topic {}", topic);
+
             reader = client.newReader(Schema.BYTES)
                     .topic(topic)
                     .startMessageId(MessageId.earliest)
                 .create();
             log.info("Successfully created reader to replay updates from topic {}", topic);
+
             CompletableFuture<Void> endFuture = new CompletableFuture<>();
             readToEnd(endFuture);
             endFuture.join();
         } catch (PulsarClientException e) {
-            log.error("Failed to create pulsar client to cluster at {}", serviceUrl, e);
-            throw new RuntimeException("Failed to create pulsar client to cluster at " + serviceUrl, e);
+            log.error("Failed to setup pulsar producer/reader to cluster at {}", serviceUrl, e);
+            throw new RuntimeException("Failed to setup pulsar producer/reader to cluster at " + serviceUrl, e);
         }
     }
 

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -174,13 +174,6 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
                 log.warn("Failed to close reader", e);
             }
         }
-        if (null != client) {
-            try {
-                client.close();
-            } catch (IOException e) {
-                log.warn("Failed to close client", e);
-            }
-        }
     }
 
     @Override

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -66,9 +66,6 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
     public void configure(WorkerConfig workerConfig) {
         this.topic = workerConfig.getString(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG);
         checkArgument(!isBlank(topic), "Offset storage topic must be specified");
-        this.serviceUrl = workerConfig.getString(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG);
-        checkArgument(!isBlank(serviceUrl), "Pulsar service url must be specified at `"
-            + WorkerConfig.BOOTSTRAP_SERVERS_CONFIG + "`");
         this.data = new HashMap<>();
 
         log.info("Configure offset backing store on pulsar topic {} at cluster {}",

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -99,8 +99,8 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         this.client = PulsarClient.builder()
                 .serviceUrl(brokerUrl.toString())
                 .build();
-        when(mockCtx.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
-        when(mockCtx.getPulsarClient()).thenReturn(client);
+        when(context.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
+        when(context.getPulsarClient()).thenReturn(client);
     }
 
     @AfterMethod(alwaysRun = true)
@@ -177,13 +177,13 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         assertEquals(MessageIdUtils.getOffset(msgId), sink.currentOffset(tp.topic(), tp.partition()));
 
         sink.taskContext.offset(tp, 0);
-        verify(mockCtx, times(1)).seek(Mockito.anyString(), Mockito.anyInt(), any());
+        verify(context, times(1)).seek(Mockito.anyString(), Mockito.anyInt(), any());
         assertEquals(0, sink.currentOffset(tp.topic(), tp.partition()));
 
         sink.taskContext.pause(tp);
-        verify(mockCtx, times(1)).pause(tp.topic(), tp.partition());
+        verify(context, times(1)).pause(tp.topic(), tp.partition());
         sink.taskContext.resume(tp);
-        verify(mockCtx, times(1)).resume(tp.topic(), tp.partition());
+        verify(context, times(1)).resume(tp.topic(), tp.partition());
 
         sink.close();
     }
@@ -416,7 +416,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         KafkaConnectSink sink = new KafkaConnectSink();
         when(context.getSubscriptionType()).thenReturn(SubscriptionType.Exclusive);
-        sink.open(props, mockCtx);
+        sink.open(props, context);
 
         // offset is -1 before any data is written (aka no offset)
         assertEquals(-1L, sink.currentOffset(topicName, partition));
@@ -436,7 +436,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         // close the producer, open again
         sink = new KafkaConnectSink();
-        sink.open(props, mockCtx);
+        sink.open(props, context);
 
         // offset is 1 after reopening the producer
         assertEquals(1, sink.currentOffset(topicName, partition));

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -87,7 +87,6 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         props = Maps.newHashMap();
         props.put("topic", "test-topic");
-        props.put("pulsarServiceUrl", brokerUrl.toString());
         props.put("offsetStorageTopic", offsetTopicName);
         props.put("kafkaConnectorSinkClass", "org.apache.kafka.connect.file.FileStreamSinkConnector");
 

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -436,6 +436,9 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         // close the producer, open again
         sink = new KafkaConnectSink();
+        when(context.getPulsarClient()).then(PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .build());
         sink.open(props, context);
 
         // offset is 1 after reopening the producer

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -436,7 +436,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         // close the producer, open again
         sink = new KafkaConnectSink();
-        when(context.getPulsarClient()).then(PulsarClient.builder()
+        when(context.getPulsarClient()).thenReturn(PulsarClient.builder()
                 .serviceUrl(brokerUrl.toString())
                 .build());
         sink.open(props, context);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -97,7 +97,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
         this.context = mock(SinkContext.class);
         this.client = PulsarClient.builder()
-                .serviceUrl(brokerUrl)
+                .serviceUrl(brokerUrl.toString())
                 .build();
         when(mockCtx.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
         when(mockCtx.getPulsarClient()).thenReturn(client);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.file.FileStreamSourceConnector;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SourceContext;

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -67,7 +67,6 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
         config.put(PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
 
         this.offsetTopicName = "persistent://my-property/my-ns/kafka-connect-source-offset";
-        config.put(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG, brokerUrl.toString());
         config.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, offsetTopicName);
 
         this.topicName = "persistent://my-property/my-ns/kafka-connect-source";

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -78,7 +78,7 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
 
         this.context = mock(SourceContext.class);
         this.client = PulsarClient.builder()
-                .serviceUrl(brokerUrl)
+                .serviceUrl(brokerUrl.toString())
                 .build();
         when(context.getPulsarClient()).thenReturn(this.client);
     }

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
@@ -53,6 +53,7 @@ public class PulsarOffsetBackingStoreTest extends ProducerConsumerBase {
     private PulsarKafkaWorkerConfig distributedConfig;
     private String topicName;
     private PulsarOffsetBackingStore offsetBackingStore;
+    private PulsarClient client;
 
     @BeforeMethod
     @Override
@@ -64,7 +65,9 @@ public class PulsarOffsetBackingStoreTest extends ProducerConsumerBase {
         this.defaultProps.put(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG, brokerUrl.toString());
         this.defaultProps.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, topicName);
         this.distributedConfig = new PulsarKafkaWorkerConfig(this.defaultProps);
-        PulsarClient client = mock(PulsarClient.class);
+        this.client = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .build();
         this.offsetBackingStore = new PulsarOffsetBackingStore(client);
         this.offsetBackingStore.configure(distributedConfig);
         this.offsetBackingStore.start();

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
@@ -36,9 +36,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Test the implementation of {@link PulsarOffsetBackingStore}.
@@ -61,7 +64,8 @@ public class PulsarOffsetBackingStoreTest extends ProducerConsumerBase {
         this.defaultProps.put(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG, brokerUrl.toString());
         this.defaultProps.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, topicName);
         this.distributedConfig = new PulsarKafkaWorkerConfig(this.defaultProps);
-        this.offsetBackingStore = new PulsarOffsetBackingStore();
+        PulsarClient client = mock(PulsarClient.class);
+        this.offsetBackingStore = new PulsarOffsetBackingStore(client);
         this.offsetBackingStore.configure(distributedConfig);
         this.offsetBackingStore.start();
     }

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStoreTest.java
@@ -62,7 +62,6 @@ public class PulsarOffsetBackingStoreTest extends ProducerConsumerBase {
         super.producerBaseSetup();
 
         this.topicName = "persistent://my-property/my-ns/offset-topic";
-        this.defaultProps.put(PulsarKafkaWorkerConfig.PULSAR_SERVICE_URL_CONFIG, brokerUrl.toString());
         this.defaultProps.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, topicName);
         this.distributedConfig = new PulsarKafkaWorkerConfig(this.defaultProps);
         this.client = PulsarClient.builder()

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.kafka.sink;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.SinkContext;
@@ -166,6 +167,11 @@ public class KafkaAbstractSinkTest {
             @Override
             public CompletableFuture<Void> deleteStateAsync(String key) {
             	return null;
+            }
+
+            @Override
+            public PulsarClient getPulsarClient() {
+                return null;
             }
         };
         ThrowingRunnable openAndClose = ()->{


### PR DESCRIPTION
### Motivation

Fixes #8668

### Modifications

Expose `PulsarClient` via `BaseContext`, and allow connectors to use the inherited pulsar client from function worker to produce/consume messages.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:
- PulsarOffsetBackingStoreTest
- KafkaConnectSourceTest
- KafkaConnectSinkTest

### Does this pull request potentially affect one of the following parts:


  - The public API: `SourceContext` and `SinkContext` need to implement the `getPulsarClient` method

