### PR TITLE
[ Issue 11050 ] Fixed flaky test ServerCnxTest.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -752,17 +752,15 @@ public class ServerCnxTest {
         CompletableFuture<Topic> delayFuture = new CompletableFuture<>();
         doReturn(delayFuture).when(brokerService).getOrCreateTopic(any(String.class));
         // Create subscriber first time
-        ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
+        ByteBuf clientCommand1 = Commands.newSubscribe(successTopicName, //
                 successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
                 "test" /* consumer name */, 0 /* avoid reseting cursor */);
-        channel.writeInbound(clientCommand);
-
         // Create producer second time
-        clientCommand = Commands.newSubscribe(successTopicName, //
+        ByteBuf clientCommand2 = Commands.newSubscribe(successTopicName, //
                 successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0,
                 "test" /* consumer name */, 0 /* avoid reseting cursor */);
-        channel.writeInbound(clientCommand);
-
+        channel.writeInbound(clientCommand1);
+        channel.writeInbound(clientCommand2);
         Object response = getResponse();
         assertTrue(response instanceof CommandError, "Response is not CommandError but " + response);
         CommandError error = (CommandError) response;


### PR DESCRIPTION
Fixes #11050 

Master Issue: #11050

### Motivation

Since there is a delay in creating an object in the middle of concurrent requests,
it may cause the first request to have been completed, so the second time will return success.

### Modifications

- Change the order of creating objects.

