### PR TITLE
[ Issue 11032 ] Fixed flaky test ZKSessionTest.. #11032

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -178,7 +178,6 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         Thread.sleep(2_000);
         Awaitility.await()
                 .untilAsserted(()-> assertEquals(le1.getState(),LeaderElectionState.Leading));
-        assertEquals(le1.getState(),LeaderElectionState.Leading);
         assertTrue(store.get(path).join().isPresent());
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -174,8 +174,6 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertEquals(e, SessionEvent.Reconnected);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
-        // ---- after 2000 millis, the le1 is also can be leader.
-        Thread.sleep(2_000);
         Awaitility.await()
                 .untilAsserted(()-> assertEquals(le1.getState(),LeaderElectionState.Leading));
         assertTrue(store.get(path).join().isPresent());


### PR DESCRIPTION
Fixes #11032 #11143

Master Issue: #11032 #11143

Motivation
In some cases, testing errors occurred due to Zookeeper's notification delay.

Modifications
Waiting async notice until timeout.