### PR TITLE
[docs] Capitalize cli menu item

### DIFF
--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -110,7 +110,7 @@ window.addEventListener('load', function () {
     const cli = document.querySelector("a[href='#cli']").parentNode;
     const cliMenu =
         '<li>' +
-        '<a id="cli-menu" href="#">Cli <span style="font-size: 0.75em">&nbsp;▼</span></a>' +
+        '<a id="cli-menu" href="#">CLI <span style="font-size: 0.75em">&nbsp;▼</span></a>' +
         '<div id="cli-dropdown" class="hide">' +
         '<ul id="cli-dropdown-items">' +
         '<li><a href="/pulsar-admin-cli?version=' + version + '">Pulsar Admin</a></li>' +


### PR DESCRIPTION
### Motivation

Improve documentation by fixing improperly capitalized acronym.

### Modifications

Change menu item from "Cli" to "CLI".