### PR TITLE
[ Issues 10786 ] Fixed flaky test testTransactionMetaStoreAssignAndFailover (#10786)

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -178,7 +178,6 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         Thread.sleep(2_000);
         Awaitility.await()
                 .untilAsserted(()-> assertEquals(le1.getState(),LeaderElectionState.Leading));
-        assertEquals(le1.getState(),LeaderElectionState.Leading);
         assertTrue(store.get(path).join().isPresent());
     }
 }


### PR DESCRIPTION

Fixes #10786 

Master Issue: #10786

### Motivation

Fixed flaky test.

### Modifications

- Replaced check after sleep to `untilAsserted` and extended `atMost` time to 10 seconds(default of `Awaitility`)