### PR TITLE
[Issue 10975][config]add 'brokerDeleteInactivePartitionedTopicMetadataEnabled' in conf/standalone.conf

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -105,6 +105,11 @@ brokerDeleteInactiveTopicsEnabled=true
 # How often to check for inactive topics
 brokerDeleteInactiveTopicsFrequencySeconds=60
 
+# Metadata of inactive partitioned topic will not be cleaned up automatically by default.
+# Note: If `allowAutoTopicCreation` and this option are enabled at the same time,
+# it may appear that a partitioned topic has just been deleted but is automatically created as a non-partitioned topic.
+brokerDeleteInactivePartitionedTopicMetadataEnabled=false
+
 # Max pending publish requests per connection to avoid keeping large number of pending
 # requests in memory. Default: 1000
 maxPendingPublishRequestsPerConnection=1000


### PR DESCRIPTION

Fixes #10975


### Motivation


*conf/stanalone.conf  is missing the configuration of  brokerDeleteInactivePartitionedTopicMetadataEnabled*
### Modifications

*Add brokerDeleteInactivePartitionedTopicMetadataEnabled in conf/stanalone.conf*
### Verifying this change

- [X] Make sure that the change passes the CI checks.

