### PR TITLE
Added count to OpReadEntry.recycle()

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -190,6 +190,7 @@ class OpReadEntry implements ReadEntriesCallback {
         nextReadPosition = null;
         maxPosition = null;
         recyclerHandle.recycle(this);
+        count = 0;
     }
 
     private static final Logger log = LoggerFactory.getLogger(OpReadEntry.class);


### PR DESCRIPTION
While exploring a heap dump, I noticed that recycled OpReadEntry instances still had > 0 count values. 
This PR adds the count to recycle() to ensure the count gets reset to 0. It's not clear what the impact may be at this time.  