### PR TITLE
[Transaction] Transaction pending ack lazy init.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
@@ -159,5 +160,15 @@ public interface ManagedLedgerFactory {
      * @throws ManagedLedgerException
      */
     void shutdown() throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Check managed ledger store has been initialized before.
+     *
+     * @param name {@link String}
+     * @return a future represents the result of the operation.
+     *         an instance of {@link Boolean} is returned
+     *         if the operation succeeds.
+     */
+    CompletableFuture<Boolean> checkManagedLedgerInitializedBefore(String name);
 
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -525,6 +525,11 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     @Override
+    public CompletableFuture<Boolean> checkManagedLedgerInitializedBefore(String name) {
+        return store.exists(name);
+    }
+
+    @Override
     public ManagedLedgerInfo getManagedLedgerInfo(String name) throws InterruptedException, ManagedLedgerException {
         class Result {
             ManagedLedgerInfo info = null;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
@@ -19,6 +19,8 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
@@ -129,4 +131,14 @@ public interface MetaStore {
      * @throws MetaStoreException
      */
     Iterable<String> getManagedLedgers() throws MetaStoreException;
+
+    /**
+     * Check path exists.
+     *
+     * @param path {@link String}
+     * @return a future represents the result of the operation.
+     *         an instance of {@link Boolean} is returned
+     *         if the operation succeeds.
+     */
+    CompletableFuture<Boolean> exists(String path);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -23,6 +23,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -227,6 +228,11 @@ public class MetaStoreImpl implements MetaStore {
         } catch (CompletionException e) {
             throw getException(e);
         }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> exists(String path) {
+        return store.exists(PREFIX + path);
     }
 
     //

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -453,11 +453,11 @@ public class PersistentSubscription implements Subscription {
     public CompletableFuture<Void> transactionIndividualAcknowledge(
             TxnID txnId,
             List<MutablePair<PositionImpl, Integer>> positions) {
-        return pendingAckHandle.individualAcknowledgeMessage(txnId, positions);
+        return pendingAckHandle.individualAcknowledgeMessage(txnId, positions, false);
     }
 
     public CompletableFuture<Void> transactionCumulativeAcknowledge(TxnID txnId, List<PositionImpl> positions) {
-        return pendingAckHandle.cumulativeAcknowledgeMessage(txnId, positions);
+        return pendingAckHandle.cumulativeAcknowledgeMessage(txnId, positions, false);
     }
 
     private final MarkDeleteCallback markDeleteCallback = new MarkDeleteCallback() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -48,15 +48,16 @@ public interface PendingAckHandle {
      * Client will not send batch size to server, we get the batch size from consumer pending ack. When we get the Batch
      * size, we can accurate batch ack of this position.
      *
-     * @param txnID                  {@link TxnID}TransactionID of an ongoing transaction trying to sck message.
+     * @param txnID                  {@link TxnID} TransactionID of an ongoing transaction trying to sck message.
      * @param positions              {@link MutablePair} the pair of positions and these batch size.
+     * @param isInCacheRequest       {@link Boolean} the boolean of the request in cache whether or not.
      * @return the future of this operation.
      * @throws TransactionConflictException if the ack with transaction is conflict with pending ack.
      * @throws NotAllowedException if Use this method incorrectly eg. not use
      * PositionImpl or cumulative ack with a list of positions.
      */
     CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID, List<MutablePair<PositionImpl,
-            Integer>> positions);
+            Integer>> positions, boolean isInCacheRequest);
 
     /**
      * Acknowledge message(s) for an ongoing transaction.
@@ -73,14 +74,16 @@ public interface PendingAckHandle {
      * If an ongoing transaction cumulative acked a message and then try to ack single message which is
      * greater than that one it cumulative acked, it'll succeed.
      *
-     * @param txnID                  {@link TxnID}TransactionID of an ongoing transaction trying to sck message.
+     * @param txnID                  {@link TxnID} TransactionID of an ongoing transaction trying to sck message.
      * @param positions              {@link MutablePair} the pair of positions and these batch size.
+     * @param isInCacheRequest       {@link Boolean} the boolean of the request in cache whether or not.
      * @return the future of this operation.
      * @throws TransactionConflictException if the ack with transaction is conflict with pending ack.
      * @throws NotAllowedException if Use this method incorrectly eg. not use
      * PositionImpl or cumulative ack with a list of positions.
      */
-    CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions);
+    CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions,
+                                                         boolean isInCacheRequest);
 
     /**
      * Commit a transaction.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/TransactionPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/TransactionPendingAckStoreProvider.java
@@ -59,4 +59,13 @@ public interface TransactionPendingAckStoreProvider {
      */
     CompletableFuture<PendingAckStore> newPendingAckStore(PersistentSubscription subscription);
 
+    /**
+     * Check pending ack store has been initialized before.
+     *
+     * @param subscription {@link PersistentSubscription}
+     * @return a future represents the result of the operation.
+     *         an instance of {@link Boolean} is returned
+     *         if the operation succeeds.
+     */
+    CompletableFuture<Boolean> checkInitializedBefore(PersistentSubscription subscription);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/InMemoryPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/InMemoryPendingAckStoreProvider.java
@@ -29,4 +29,9 @@ public class InMemoryPendingAckStoreProvider implements TransactionPendingAckSto
     public CompletableFuture<PendingAckStore> newPendingAckStore(PersistentSubscription subscription) {
         return CompletableFuture.completedFuture(new InMemoryPendingAckStore());
     }
+
+    @Override
+    public CompletableFuture<Boolean> checkInitializedBefore(PersistentSubscription subscription) {
+        return CompletableFuture.completedFuture(true);
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckReplyCallBack.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckReplyCallBack.java
@@ -44,16 +44,19 @@ public class MLPendingAckReplyCallBack implements PendingAckReplyCallBack {
 
     @Override
     public void replayComplete() {
-        log.info("Topic name : [{}], SubName : [{}] pending ack state reply success!",
-                pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
-
-        if (pendingAckHandle.changeToReadyState()) {
-            pendingAckHandle.completeHandleFuture();
+        synchronized (pendingAckHandle) {
             log.info("Topic name : [{}], SubName : [{}] pending ack state reply success!",
                     pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
-        } else {
-            log.error("Topic name : [{}], SubName : [{}] pending ack state reply fail!",
-                    pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
+
+            if (pendingAckHandle.changeToReadyState()) {
+                pendingAckHandle.completeHandleFuture();
+                pendingAckHandle.handleCacheRequest();
+                log.info("Topic name : [{}], SubName : [{}] pending ack state reply success!",
+                        pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
+            } else {
+                log.error("Topic name : [{}], SubName : [{}] pending ack state reply fail!",
+                        pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -83,4 +83,13 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                         }, () -> true, null);
         return pendingAckStoreFuture;
     }
+
+    @Override
+    public CompletableFuture<Boolean> checkInitializedBefore(PersistentSubscription subscription) {
+        PersistentTopic originPersistentTopic = (PersistentTopic) subscription.getTopic();
+        String pendingAckTopicName = MLPendingAckStore
+                .getTransactionPendingAckStoreSuffix(originPersistentTopic.getName(), subscription.getName());
+        return originPersistentTopic.getBrokerService().getManagedLedgerFactory()
+                .checkManagedLedgerInitializedBefore(TopicName.get(pendingAckTopicName).getPersistenceNamingEncoding());
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -42,12 +42,13 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
 
     @Override
     public CompletableFuture<Void> individualAcknowledgeMessage(TxnID txnID,
-                                                                List<MutablePair<PositionImpl, Integer>> positions) {
+                                                                List<MutablePair<PositionImpl, Integer>> positions,
+                                                                boolean isInCacheRequest) {
         return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
     }
 
     @Override
-    public CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions) {
+    public CompletableFuture<Void> cumulativeAcknowledgeMessage(TxnID txnID, List<PositionImpl> positions, boolean isInCacheRequest) {
         return FutureUtil.failedFuture(new NotAllowedException("The transaction is disabled"));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleState.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleState.java
@@ -32,6 +32,7 @@ public abstract class PendingAckHandleState {
         None,
         Initializing,
         Ready,
+        Error,
         Close
     }
 
@@ -39,7 +40,7 @@ public abstract class PendingAckHandleState {
             AtomicReferenceFieldUpdater.newUpdater(PendingAckHandleState.class, State.class, "state");
 
     @SuppressWarnings("unused")
-    private volatile State state = null;
+    protected volatile State state = null;
 
     public PendingAckHandleState(State state) {
         STATE_UPDATER.set(this, state);
@@ -58,6 +59,10 @@ public abstract class PendingAckHandleState {
         return (STATE_UPDATER.compareAndSet(this, State.Ready, State.Close)
                 || STATE_UPDATER.compareAndSet(this, State.None, State.Close)
                 || STATE_UPDATER.compareAndSet(this, State.Initializing, State.Close));
+    }
+
+    protected void changeToErrorState() {
+        STATE_UPDATER.set(this, State.Error);
     }
 
     public boolean checkIfReady() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -161,6 +161,11 @@ public class PersistentSubscriptionTest {
                     }
                 });
             }
+
+            @Override
+            public CompletableFuture<Boolean> checkInitializedBefore(PersistentSubscription subscription) {
+                return CompletableFuture.completedFuture(true);
+            }
         }).when(pulsarMock).getTransactionPendingAckStoreProvider();
         doReturn(svcConfig).when(pulsarMock).getConfiguration();
         doReturn(mock(Compactor.class)).when(pulsarMock).getCompactor();


### PR DESCRIPTION
## Motivation
now, in `broker.conf` `transactionCoordinatorEnabled=true` MLPendingAck will init manageLedger, some ack will not use transaction, so don't need to init manageLedger. When this sub use transaction, we can lazy init `PendingAckHandle`.

## implement
When this sub use transaction, we can lazy init `PendingAckHandle`.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

