### PR TITLE
Added missing configuration entries

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -105,6 +105,12 @@ brokerDeleteInactiveTopicsEnabled=true
 # How often to check for inactive topics
 brokerDeleteInactiveTopicsFrequencySeconds=60
 
+# Allow you to delete a tenant forcefully.
+forceDeleteTenantAllowed=false
+
+# Allow you to delete a namespace forcefully.
+forceDeleteNamespaceAllowed=false
+
 # Max pending publish requests per connection to avoid keeping large number of pending
 # requests in memory. Default: 1000
 maxPendingPublishRequestsPerConnection=1000


### PR DESCRIPTION
The two configuration entries forceDeleteTenantAllowed and forceDeleteNamespaceAllowed exist in broker.conf, but they were missing in standalone.conf, so they were not able to be configured by environment variables.
