### PR TITLE
Fix GetListInBundle return all Topics in bundle

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -57,6 +58,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -352,13 +354,20 @@ public class NonPersistentTopics extends PersistentTopics {
                     return;
                 }
                 try {
+                    ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>> bundleTopics =
+                            pulsar().getBrokerService().getMultiLayerTopicsMap().get(namespaceName.toString());
+                    if (bundleTopics == null || bundleTopics.isEmpty()) {
+                        asyncResponse.resume(Collections.emptyList());
+                        return;
+                    }
                     final List<String> topicList = Lists.newArrayList();
-                    pulsar().getBrokerService().forEachTopic(topic -> {
-                        TopicName topicName = TopicName.get(topic.getName());
-                        if (nsBundle.includes(topicName)) {
-                            topicList.add(topic.getName());
-                        }
-                    });
+                    String bundleKey = namespaceName.toString() + "/" + nsBundle.getBundleRange();
+                    ConcurrentOpenHashMap<String, Topic> topicMap = bundleTopics.get(bundleKey);
+                    if (topicMap != null) {
+                        topicList.addAll(topicMap.keys().stream()
+                                .filter(name -> !TopicName.get(name).isPersistent())
+                                .collect(Collectors.toList()));
+                    }
                     asyncResponse.resume(topicList);
                 } catch (Exception e) {
                     log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -82,6 +82,7 @@ import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
+import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.FailureDomain;
@@ -2045,6 +2046,34 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         assertEquals(admin.namespaces().getProperties(namespace), properties);
         admin.namespaces().clearProperties(namespace);
         assertEquals(admin.namespaces().getProperties(namespace).size(), 0);
+    }
+
+    @Test
+    public void testGetListInBundle() throws Exception {
+        final String namespace = "prop-xyz/ns11";
+        admin.namespaces().createNamespace(namespace, 3);
+
+        final String persistentTopicName = TopicName.get(
+                "persistent", NamespaceName.get(namespace),
+                "get_topics_mode_" + UUID.randomUUID()).toString();
+
+        final String nonPersistentTopicName = TopicName.get(
+                "non-persistent", NamespaceName.get(namespace),
+                "get_topics_mode_" + UUID.randomUUID()).toString();
+        admin.topics().createPartitionedTopic(persistentTopicName, 3);
+        admin.topics().createPartitionedTopic(nonPersistentTopicName, 3);
+        pulsarClient.newProducer().topic(persistentTopicName).create().close();
+        pulsarClient.newProducer().topic(nonPersistentTopicName).create().close();
+
+        BundlesData bundlesData = admin.namespaces().getBundles(namespace);
+        List<String> boundaries = bundlesData.getBoundaries();
+        int topicNum = 0;
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
+            List<String> topic = admin.topics().getListInBundle(namespace, bundle);
+            topicNum += topic.size();
+        }
+        assertEquals(topicNum, 3);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -2071,7 +2071,13 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         for (int i = 0; i < boundaries.size() - 1; i++) {
             String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
             List<String> topic = admin.topics().getListInBundle(namespace, bundle);
+            if (topic == null) {
+                continue;
+            }
             topicNum += topic.size();
+            for (String s : topic) {
+                assertFalse(TopicName.get(s).isPersistent());
+            }
         }
         assertEquals(topicNum, 3);
     }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/blob/7824325efc822307f60b38e9d24bdb189e415a06/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java#L310-L313

1)
`getListFromBundle` in NonPersistentTopics should only return the list of non-persistent topics under a namespace bundle.
But now it returns all the topics.
2)
Now it will traverse all topics on Broker. When there are a lot of topics, timeouts often occur.
![image](https://user-images.githubusercontent.com/9758905/123505745-67815d80-d693-11eb-87bb-ef3287668155.png)

### Modifications
1) Filter out persistent topics
2) Only traverse the topics under the corresponding bundle 

### Verifying this change
