### PR TITLE
[PIP 86][Function] Preload and release of external resources

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Hook.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Hook.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api;
+
+import org.apache.pulsar.common.classification.InterfaceAudience;
+
+/**
+ * An interface for hook
+ * Preload and release of external resources
+ */
+@InterfaceAudience.Public
+public interface Hook {
+
+    /**
+     * Pre-Process Function Hook
+     *
+     * @throws Exception
+     */
+    void preProcess(Context context) throws RuntimeException;
+
+
+    /**
+     * Post-Process Function Hook
+     *
+     * @throws Exception
+     */
+    void postProcess() throws RuntimeException;
+}

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/RichFunction.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/RichFunction.java
@@ -21,11 +21,12 @@ package org.apache.pulsar.functions.api;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 
 /**
- * An interface for hook
+ * An interface for richFunction
+ * Extension for Function interface
  * Initial and close of external resources
  */
 @InterfaceAudience.Public
-public interface HookFunction extends Function{
+public interface RichFunction extends Function{
 
     /**
      * InitialResource Function Hook
@@ -40,5 +41,5 @@ public interface HookFunction extends Function{
      *
      * @throws Exception
      */
-    void cleanup() throws Exception;
+    void tearDown() throws Exception;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -32,7 +32,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.functions.api.Function;
-import org.apache.pulsar.functions.api.HookFunction;
+import org.apache.pulsar.functions.api.RichFunction;
 import org.apache.pulsar.functions.api.Record;
 
 /**
@@ -76,17 +76,17 @@ public class JavaInstance implements AutoCloseable {
     }
 
     public void setup() throws Exception {
-        if (null != function && function instanceof HookFunction) {
+        if (null != function && function instanceof RichFunction) {
             try {
-                ((HookFunction) function).setup();
+                ((RichFunction) function).setup();
             } catch (Exception e) {
                 log.error("setup error:", e);
                 throw e;
             }
         }
-        if (null != javaUtilFunction && javaUtilFunction instanceof HookFunction) {
+        if (null != javaUtilFunction && javaUtilFunction instanceof RichFunction) {
             try {
-                ((HookFunction) javaUtilFunction).setup();
+                ((RichFunction) javaUtilFunction).setup();
             } catch (Exception e) {
                 log.error("setup error:", e);
                 throw e;
@@ -180,17 +180,17 @@ public class JavaInstance implements AutoCloseable {
     public void close() throws Exception {
         context.close();
         executor.shutdown();
-        if (null != function && function instanceof HookFunction) {
+        if (null != function && function instanceof RichFunction) {
             try {
-                ((HookFunction) function).cleanup();
+                ((RichFunction) function).tearDown();
             } catch (Exception e) {
                 log.error("function closeResource occurred exception", e);
                 throw e;
             }
         }
-        if (null != javaUtilFunction && javaUtilFunction instanceof HookFunction) {
+        if (null != javaUtilFunction && javaUtilFunction instanceof RichFunction) {
             try {
-                ((HookFunction) javaUtilFunction).cleanup();
+                ((RichFunction) javaUtilFunction).tearDown();
             } catch (Exception e) {
                 log.error("function closeResource occurred exception", e);
                 throw e;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -221,7 +221,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         setupLogHandler();
 
         javaInstance = new JavaInstance(contextImpl, object, instanceConfig);
-
+        javaInstance.setup();
         // to signal member variables are initialized
         isInitialized = true;
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

1. Before Function is started, some resources only need to be initialized once, and there is no need to make various judgments in the process() method of the Function interface
2. After the Function is closed, in the process of using process(), the referenced external resources need to be manually closed(), and they need to be released separately in the close() of javaInstance

### Modifications
1. Before starting, some resources only need to be loaded once
2. When Function Instance manually releases some resources, users need to implement the release method and provide support

@Slf4j
public class HelloWorldFunction implements Function<String, Void> {
	@Override
	public String process(byte[] input, Context context) {
	}
}
eg:
@Slf4j
public class HelloWorldFunction implements Function<String, Void>,Hook {
	@Override
	public String process(byte[] input, Context context) {
		
	}
	/**
		resource init
	*/
	@Override
	public void preProcess(Context context) throws Exception {
		database Connection
		other resource initialize
	}
	/**
		resource close
	*/
	@Override
	public void postProcess() {
		connection close
		call the callback function
	}
}
1. Provide an interface for initialization and unified release of external resources for users to use, easy to manage and expand
2. The order of the release of external resources is controlled by the pulsar function. Users only need to pay attention to the event processing logic. The code is clearer and more concise, and the hierarchy is clear

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:
yes

*(example:)*
  - The initialization and release functions have been applied and verified in the online project

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no) yes
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
