### PR TITLE
fix authorization not working when subscription permission is empty

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -120,7 +120,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         // list is empty)
                         Set<String> roles = policies.get().auth_policies
                                 .getSubscriptionAuthentication().get(subscription);
-                        if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
+                        if (roles == null || roles.isEmpty() || !roles.contains(role)) {
                             log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
                             permissionFuture.complete(false);
                             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -653,7 +653,7 @@ public class Consumer {
                     return;
                 }
             } catch (Exception e) {
-                log.warn("[{}] Get unexpected error while autorizing [{}]  {}", appId, subscription.getTopicName(),
+                log.warn("[{}] Get unexpected error while authorizing [{}]  {}", appId, subscription.getTopicName(),
                         e.getMessage(), e);
             }
             log.info("[{}] is not allowed to consume from topic [{}] anymore", appId, subscription.getTopicName());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -202,6 +202,11 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
         // tests for subscription auth mode
         admin.namespaces().grantPermissionOnNamespace("p1/c1/ns1", "*", EnumSet.of(AuthAction.consume));
         admin.namespaces().setSubscriptionAuthMode("p1/c1/ns1", SubscriptionAuthMode.Prefix);
+
+        admin.namespaces().grantPermissionOnSubscription("p1/c1/ns1", "sub1", Sets.newHashSet("role1"));
+        admin.namespaces().grantPermissionOnSubscription("p1/c1/ns1", "sub2", Sets.newHashSet("role2"));
+        admin.namespaces().grantPermissionOnSubscription("p1/c1/ns1", "role1-sub1", Sets.newHashSet("role1"));
+        admin.namespaces().grantPermissionOnSubscription("p1/c1/ns1", "role2-sub2", Sets.newHashSet("role2"));
         waitForChange();
 
         assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -98,6 +98,8 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, subscriptionName,
+                Sets.newHashSet("proxy", "client"));
 
         // Step 2: Run Pulsar Proxy without forwarding authData - expect Exception
         ProxyConfiguration proxyConfig = new ProxyConfiguration();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
@@ -193,6 +193,8 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, subscriptionName,
+                Sets.newHashSet("proxy", "client"));
 
         // Step 2: Try to use proxy Client as a normal Client - expect exception
         PulsarClient proxyClient = createPulsarClient(pulsar.getBrokerServiceUrl(), proxyAuthParams);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
@@ -178,6 +178,8 @@ public class ProxyWithAuthorizationNegTest extends ProducerConsumerBase {
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Proxy", Sets.newHashSet(AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                Sets.newHashSet("Proxy", "Client"));
 
         Consumer<byte[]> consumer;
         try {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -251,6 +251,8 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                Sets.newHashSet("Proxy", "Client"));
 
         Consumer<byte[]> consumer = proxyClient.newConsumer()
                 .topic("persistent://my-property/proxy-authorization/my-ns/my-topic1")
@@ -305,6 +307,8 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                Sets.newHashSet("Proxy", "Client"));
 
         try {
             proxyClient.newConsumer().topic("persistent://my-property/proxy-authorization/my-ns/my-topic1")
@@ -357,6 +361,8 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                Sets.newHashSet("Proxy", "Client"));
 
         try {
             proxyClient.newConsumer().topic("persistent://my-property/proxy-authorization/my-ns/my-topic1")
@@ -394,6 +400,8 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                Sets.newHashSet("Proxy", "Client"));
 
         ProxyConfiguration proxyConfig = new ProxyConfiguration();
         proxyConfig.setAuthenticationEnabled(true);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -234,6 +234,8 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         admin.topics().createPartitionedTopic(topicName, 2);
         admin.topics().grantPermission(topicName, CLIENT_ROLE,
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnSubscription(namespaceName, subscriptionName,
+                Sets.newHashSet(CLIENT_ROLE));
 
         Consumer<byte[]> consumer = proxyClient.newConsumer()
                 .topic(topicName)
@@ -335,9 +337,12 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
             Assert.fail("should have failed with authorization error");
         } catch (Exception ex) {
             // excepted
+            String sub = CLIENT_ROLE + "-sub1";
+            admin.namespaces().grantPermissionOnSubscription(namespaceName, sub,
+                    Sets.newHashSet(CLIENT_ROLE));
             consumer = proxyClient.newConsumer()
                     .topic("persistent://my-property/proxy-authorization/my-ns/my-topic1")
-                    .subscriptionName(CLIENT_ROLE + "-sub1").subscribe();
+                    .subscriptionName(sub).subscribe();
         }
 
         Producer<byte[]> producer = proxyClient.newProducer(Schema.BYTES)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -159,6 +159,8 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
             // excepted
             admin.namespaces().grantPermissionOnNamespace(namespaceName, CLIENT_ROLE,
                     Sets.newHashSet(AuthAction.consume));
+            admin.namespaces().grantPermissionOnSubscription(namespaceName, "my-subscriber-name",
+                    Sets.newHashSet(CLIENT_ROLE));
             log.info("-- Admin permissions {} ---", admin.namespaces().getPermissions(namespaceName));
             consumer = proxyClient.newConsumer()
                     .topic("persistent://my-property/proxy-authorization/my-ns/my-topic1")


### PR DESCRIPTION
### Motivation

This PR fixed the problem that `org.apache.pulsar.broker.authorization.AuthorizationProvider#canConsumeAsync` returned `true` when `org.apache.pulsar.common.policies.data.AuthPolicies#getSubscriptionAuthentication` was empty (i.e. the set of `subscription_auth_roles` in admin policies is empty). This is equivalent to allowing `subscription permissions` not to be checked during authorization.

### Modifications

- modifies `canConsumeAsync` of `PulsarAuthorizationProvider` and its relative test case.