### PR TITLE
[ Tests ] Fixed Wrong TimeUnit

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -160,9 +160,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
         TxnID txnID = pulsar.getTransactionMetadataStoreService().getStores()
                 .get(transactionCoordinatorIDOne).newTransaction(1000).get();
 
-        Awaitility.await().atMost(2000, TimeUnit.SECONDS).until(() -> {
+        Awaitility.await().atMost(2000, TimeUnit.MILLISECONDS).until(() -> {
             try {
-                TxnMeta txnMeta = pulsar.getTransactionMetadataStoreService()
+               pulsar.getTransactionMetadataStoreService()
                         .getStores().get(transactionCoordinatorIDOne).getTxnMeta(txnID).get();
             } catch (Exception e) {
                 return true;


### PR DESCRIPTION
### Motivation

I think it is wrong time unit .
```java
  Awaitility.await().atMost(2000, TimeUnit.SECONDS).until(() -> {
            try {
                TxnMeta txnMeta = pulsar.getTransactionMetadataStoreService()
                        .getStores().get(transactionCoordinatorIDOne).getTxnMeta(txnID).get();
            } catch (Exception e) {
                return true;
            }
            return false;
        });
```

### Modifications

- Change `timeUnit` SECONDS to MILLISECONDS