### PR TITLE
[C++] Fix boost download link in Dockerfile

### DIFF
--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -35,7 +35,7 @@ RUN apk update \
 ####################################
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz && \
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz && \
     tar xfz boost_1_72_0.tar.gz && \
     cd /boost_1_72_0 && \
     ./bootstrap.sh --with-libraries=program_options,regex,system,python --with-python=/usr/bin/python3 && \

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -35,7 +35,7 @@ RUN apk update \
 ####################################
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz && \
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz && \
     tar xfz boost_1_72_0.tar.gz && \
     cd /boost_1_72_0 && \
     ./bootstrap.sh --with-libraries=program_options,regex,system,python --with-python=/usr/bin/python3 && \

--- a/pulsar-client-cpp/pkg/deb/Dockerfile
+++ b/pulsar-client-cpp/pkg/deb/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -y && \
                 libxml2-utils git
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz && \
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.gz && \
     tar xvfz boost_1_64_0.tar.gz && \
     cd /boost_1_64_0 && \
     ./bootstrap.sh --with-libraries=program_options,filesystem,regex,thread,system,python && \

--- a/pulsar-client-cpp/pkg/rpm/Dockerfile
+++ b/pulsar-client-cpp/pkg/rpm/Dockerfile
@@ -26,7 +26,7 @@ RUN yum update -y && \
                 python-devel createrepo libstdc++-static.x86_64
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz && \
+RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.gz && \
     tar xvfz boost_1_64_0.tar.gz && \
     cd /boost_1_64_0 && \
     ./bootstrap.sh --with-libraries=program_options,filesystem,regex,thread,system,python && \


### PR DESCRIPTION
### Motivation

C++ library, boost moved to JFrog.Arifactory from Bintray.com

https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html

### Modifications

Fix download link in Dockerfiles

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. yes

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature?  no