### PR TITLE
fix subscription permission not working in reset cursor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1934,7 +1934,7 @@ public class PersistentTopicsBase extends AdminResource {
                                        boolean authoritative) {
         try {
             validateTopicOwnership(topicName, authoritative);
-            validateTopicOperation(topicName, TopicOperation.RESET_CURSOR);
+            validateTopicOperation(topicName, TopicOperation.RESET_CURSOR, subName);
 
             log.info("[{}] [{}] Received reset cursor on subscription {} to time {}",
                     clientAppId(), topicName, subName, timestamp);
@@ -2157,7 +2157,7 @@ public class PersistentTopicsBase extends AdminResource {
             return;
         } else {
             validateTopicOwnership(topicName, authoritative);
-            validateTopicOperation(topicName, TopicOperation.RESET_CURSOR);
+            validateTopicOperation(topicName, TopicOperation.RESET_CURSOR, subName);
 
             PersistentTopic topic = (PersistentTopic) getTopicReference(topicName);
             if (topic == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -247,6 +247,14 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
             // Ok
         }
 
+        // reset on position
+        try {
+            sub1Admin.topics().resetCursor(topicName, subscriptionName, MessageId.earliest);
+            fail("should have fail with authorization exception");
+        } catch (org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException e) {
+            // Ok
+        }
+
         // now, grant subscription-access to subscriptionRole as well
         superAdmin.namespaces().grantPermissionOnSubscription(namespace, subscriptionName,
                 Sets.newHashSet(otherPrincipal, subscriptionRole));


### PR DESCRIPTION
### Motivation

Some `internalResetCursorXX` methods do not pass in the `subscriptionName` parameter when verifying permissions, which causes the `subscription` check to be skipped during the permission check of `AuthorizationProvider#canConsumeAsync` and leads an error validation result. This PR will fix this problem.

### Modifications

Refine the parameters of `validateTopicOperation` and supplement a relative test case.