### PR TITLE
[Broker/Bookie] Set -Dio.netty.tryReflectionSetAccessible=true for pulsar processes

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -163,6 +163,9 @@ BOOKIE_CLASSPATH="$BOOKIE_JAR:$BOOKIE_CLASSPATH:$BOOKIE_EXTRA_CLASSPATH"
 BOOKIE_CLASSPATH="`dirname $BOOKIE_LOG_CONF`:$BOOKIE_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $BOOKIE_LOG_CONF`"
 
+# Allow Netty to use reflection access
+OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"
 
 OPTS="$OPTS $BOOKIE_EXTRA_OPTS"

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -86,6 +86,9 @@ PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 
+# Allow Netty to use reflection access
+OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+
 # Ensure we can read bigger content from ZK. (It might be
 # rarely needed when trying to list many z-nodes under a
 # directory)

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -276,7 +276,7 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 # directory)
 OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
 
-# Enables Netty to use UnpooledUnsafeNoCleanerDirectByteBuf on JDK 11
+# Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -276,6 +276,9 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 # directory)
 OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
 
+# Enables Netty to use UnpooledUnsafeNoCleanerDirectByteBuf on JDK 11
+OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 
 if [ $COMMAND == "bookie" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -1315,6 +1315,7 @@ flexible messaging model and an intuitive client API.</description>
             -Dpulsar.allocator.pooled=false
             -Dpulsar.allocator.leak_detection=Advanced
             -Dpulsar.allocator.exit_on_oom=false
+            -Dio.netty.tryReflectionSetAccessible=true
             ${test.additional.args}
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>


### PR DESCRIPTION
### Motivation

- allows Netty to use reflection access on JDK9+ 
- fixes `jvm_memory_direct_bytes_used` Prometheus metric for Bookkeeper (Bookie). The direct memory usage metrics are disabled in Bookie on JDK11 unless `-Dio.netty.tryReflectionSetAccessible=true` is used.
- enables Netty to use more efficient byte buffer implementation such as UnpooledUnsafeNoCleanerDirectByteBuf in JDK9+ (JDK 11 in this case). This is already used in JDK8. In JDK9+, it is necessary to set `-Dio.netty.tryReflectionSetAccessible=true` to use UnpooledUnsafeNoCleanerDirectByteBuf. This is necessary for preventing performance regressions in this area.


### Modifications

- pass `-Dio.netty.tryReflectionSetAccessible=true` JVM option by default to all pulsar process started with `bin/pulsar` script.