### PR TITLE
add parameter to control publish message check policy frequency

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -487,8 +487,8 @@ maxMessagePublishBufferSizeInMB=
 # Use 0 or negative number to disable the check
 retentionCheckIntervalInSeconds=120
 
-# Check between intervals to see if max message size in topic policies has been updated.
-# Default is 60s
+# Control the frequency of checking the max message size in the topic policy. 
+# The default interval is 60 seconds.
 maxMessageSizeCheckIntervalInSeconds=60
 
 # Max number of partitions per partitioned topic

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -487,6 +487,10 @@ maxMessagePublishBufferSizeInMB=
 # Use 0 or negative number to disable the check
 retentionCheckIntervalInSeconds=120
 
+# Check between intervals to see if max message size in topic policies has been updated.
+# Default is 60s
+maxMessageSizeCheckIntervalInSeconds=60
+
 # Max number of partitions per partitioned topic
 # Use 0 or negative number to disable the check
 maxNumPartitionsPerPartitionedTopic=0

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -118,6 +118,10 @@ maxPendingPublishRequestsPerConnection=1000
 # How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 
+# Check between intervals to see if max message size in topic policies has been updated.
+# Default is 60s
+maxMessageSizeCheckIntervalInSeconds=60
+
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -412,6 +412,10 @@ messagePublishBufferCheckIntervalInMillis=100
 # Use 0 or negative number to disable the check
 retentionCheckIntervalInSeconds=120
 
+# Check between intervals to see if max message size in topic policies has been updated.
+# Default is 60s
+maxMessageSizeCheckIntervalInSeconds=60
+
 # Max number of partitions per partitioned topic
 # Use 0 or negative number to disable the check
 maxNumPartitionsPerPartitionedTopic=0

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -918,6 +918,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
+            doc = "Check between intervals to see if max message size of topic policy has updated. default is 60s"
+    )
+    private int maxMessageSizeCheckIntervalInSeconds = 60;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
             doc = "The number of partitions per partitioned topic.\n"
                 + "If try to create or update partitioned topics by exceeded number of partitions, then fail."
     )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -56,7 +56,6 @@ import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
-import static org.mockito.Mockito.doReturn;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;


### PR DESCRIPTION
### Motivation
In current `isExceedMaximumMessageSize` implementation, it get topic policy and compare maxMessageSize value.
However, for each message to publish, it should call isExceedMaximumMessageSize once, which cost too much resources.

### Modifiction
1. add `maxMessageSizeCheckIntervalInSeconds` parameter to control maxMessageSize refresh frequency
2. reduce getTopicPolicies call frequency to reduce resources cost.
3. add test to cover this case.