### PR TITLE
fix: pulsar admin/client cli docs jump incorrect

### DIFF
--- a/site2/website/static/js/getCliByVersion.js
+++ b/site2/website/static/js/getCliByVersion.js
@@ -25,23 +25,18 @@ function getCliByVersion(){
     var minMinorVersion = 5
     var referenceLink = "/pulsar-admin"
     if (clientModule === "pulsar-client") {
-        minMinorVersion = 7
+        minMinorVersion = 8
         referenceLink = "/reference-cli-tools/#pulsar-client"
     }
-    if (clientModule === "pulsar-admin") {
-        if ((majorVersion == 2 && minorVersion <= minMinorVersion) || majorVersion === 1) {
-            if (version === latestVersion) {
-                window.location.href = "/docs/en" + referenceLink
-                return
-            } else {
-                window.location.href = "/docs/en/" + version + referenceLink
-                return
-            }
+    if ((majorVersion > 1 && minorVersion <= minMinorVersion) || majorVersion === 1) {
+        if (version === latestVersion) {
+            window.location.href = "/docs/en" + referenceLink
         } else {
-            version = parseInt(versions[0]) + "." + parseInt(versions[1]) + ".0"
-            window.location.href = "http://pulsar.apache.org/tools/ + " + clientModule + "/" + version + "-SNAPSHOT"
-            return
+            window.location.href = "/docs/en/" + version + referenceLink
         }
+    } else {
+        version = parseInt(versions[0]) + "." + parseInt(versions[1]) + ".0"
+        window.location.href = "http://pulsar.apache.org/tools/" + clientModule + "/" + version + "-SNAPSHOT"
     }
 }
 window.onload=getCliByVersion


### PR DESCRIPTION
Master Issue: #10040

Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

Modifications
Fix pulsar-admin and pulsar-client jump

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure
Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)
Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation