### PR TITLE
[C++] Fix missed header for some compilers

### DIFF
--- a/pulsar-client-cpp/lib/KeySharedPolicy.cc
+++ b/pulsar-client-cpp/lib/KeySharedPolicy.cc
@@ -18,6 +18,7 @@
  */
 #include <lib/KeySharedPolicyImpl.h>
 
+#include <algorithm>
 #include <stdexcept>
 
 namespace pulsar {


### PR DESCRIPTION
### Motivation

Visual Studio 2017 cannot compile the code of latest master

![image](https://user-images.githubusercontent.com/18204803/123817671-ed6b0600-d92a-11eb-8616-cbdc3778cf7b.png)

It's introduced from https://github.com/apache/pulsar/pull/11088. For some compilers, `std::max` might be included implicitly, but C++ standard only requires that it's included in `<algorithm>` header, see https://en.cppreference.com/w/cpp/algorithm/max for reference.

### Modifications

Include `<algorithm>` header for `std::max` function.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.