### PR TITLE
[Issue 11153] [pulsar-broker] Fix for missing metadata-store watch events

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pulsar.broker.resourcegroup;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.RESOURCEGROUPS;
+import static org.apache.pulsar.common.policies.path.PolicyPath.path;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import com.google.common.collect.Sets;
 import java.util.Random;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -34,6 +38,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class ResourceGroupConfigListenerTest extends MockedPulsarServiceBaseTest {
 
     ResourceGroup testAddRg = new ResourceGroup();
@@ -164,6 +169,51 @@ public class ResourceGroupConfigListenerTest extends MockedPulsarServiceBaseTest
                 assertNull(pulsar.getResourceGroupServiceManager().resourceGroupGet(rgName));
             }
         });
+    }
+
+    @Test
+    public void testResourceGroupUpdateLoop() throws PulsarAdminException {
+
+        ResourceGroup zooRg = new ResourceGroup();
+        pulsar.getPulsarResources().getResourcegroupResources().getStore().registerListener(
+          notification -> {
+              String notifyPath = notification.getPath();
+              String rgName = notifyPath.substring(notifyPath.lastIndexOf('/') + 1);
+              if (!notifyPath.startsWith(path(RESOURCEGROUPS))) {
+                  return;
+              }
+              if (RESOURCEGROUPS.equals(rgName)) {
+                  return;
+              }
+              pulsar.getPulsarResources().getResourcegroupResources()
+                .getAsync(notifyPath).whenComplete((optionalRg, ex) -> {
+                  if (ex != null) {
+                      return;
+                  }
+                  if (optionalRg.isPresent()) {
+                      ResourceGroup resourceGroup = optionalRg.get();
+
+                      zooRg.setDispatchRateInBytes(resourceGroup.getDispatchRateInBytes());
+                      zooRg.setDispatchRateInMsgs(resourceGroup.getDispatchRateInMsgs());
+                      zooRg.setPublishRateInBytes(resourceGroup.getPublishRateInBytes());
+                      zooRg.setPublishRateInMsgs(resourceGroup.getPublishRateInMsgs());
+                  }
+              });
+          }
+        );
+        ResourceGroup rg = new ResourceGroup();
+        rg.setPublishRateInMsgs(-1);
+        rg.setPublishRateInBytes(10);
+        rg.setDispatchRateInMsgs(10);
+        rg.setDispatchRateInBytes(20);
+        createResourceGroup("myrg", rg);
+
+        for (int i = 0; i < 1000; i++) {
+            rg.setPublishRateInMsgs(i);
+            updateResourceGroup("myrg", rg);
+        }
+
+        Awaitility.await().untilAsserted(() -> assertEquals(zooRg.getPublishRateInMsgs(), rg.getPublishRateInMsgs()));
     }
 
     private void prepareData() throws PulsarAdminException {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -161,8 +161,8 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
                         // Make sure we have the value cached before the operation is completed
-                        objCache.put(path,
-                                FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
+                        //objCache.put(path,
+                        //        FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
                     }).thenApply(__ -> newValueObj);
                 }), path);
     }
@@ -192,8 +192,8 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(stat -> {
                         // Make sure we have the value cached before the operation is completed
-                        objCache.put(path,
-                                FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
+                        //objCache.put(path,
+                        //        FutureUtils.value(Optional.of(new CacheGetResult<>(newValueObj, stat))));
                     }).thenApply(__ -> newValueObj);
                 }), path);
     }


### PR DESCRIPTION
Fixes #11153

### Motivation

There is a race condition between the admin API handler updating the cache with the latest changes and the metadata-store get()/getAsync() API. If the get API hits the cache, it fails to register a watch event for future updates. This results in watch events getting missed.

### Modifications

The admin API handler should not update the cache. This results in the metadata-store get()/getAsync() API lazily populating the cache via asyncReload().

Fix is to not update the cache in admin API handler.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] Added unit test to verify change. Without the fix, the unit test would fail.


This change added tests and can be verified as follows:

Added test `org.apache.pulsar.broker.resourcegroup.ResourceGroupConfigListenerTest#testResourceGroupUpdateLoop` to verify the changes. The test can be run using mvn command:

mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceGroupConfigListenerTest#testResourceGroupUpdateLoop -pl pulsar-broker

### Documentation

  - Does this pull request introduce a new feature? (no)

this is a bug fix and has no user visible change (except that the issue is fixed). There is no documentation impact.