### PR TITLE
[feat][website] add local debugging tools shell for website

### DIFF
--- a/site2/README.md
+++ b/site2/README.md
@@ -35,6 +35,16 @@ cd pulsar/site2/website
 yarn test
 ```
 
+If you want to tests the **complete website** (including api docs and cli tools docs)
+
+**At first**, you should do one full-website-building with running `sh docker-build-site`, and then
+```bash
+cd pulsar/site2/tools
+sh debug-site.sh
+```
+Access local website: [http://localhost](http://localhost)
+> `sh docker-build-site` is a very time-consuming process. After the first complete build is executed, if there are new modifications, it is recommended to only do the necessary, instead of performing the complete build again, and finally execute `sh debug-site.sh`
+
 ### Check
 
 Before submitting a pull request, run the following command to make sure no broken links exist.

--- a/site2/README.md
+++ b/site2/README.md
@@ -35,16 +35,6 @@ cd pulsar/site2/website
 yarn test
 ```
 
-If you want to tests the **complete website** (including api docs and cli tools docs)
-
-**At first**, you should do one full-website-building with running `sh docker-build-site`, and then
-```bash
-cd pulsar/site2/tools
-sh debug-site.sh
-```
-Access local website: [http://localhost](http://localhost)
-> `sh docker-build-site` is a very time-consuming process. After the first complete build is executed, if there are new modifications, it is recommended to only do the necessary, instead of performing the complete build again, and finally execute `sh debug-site.sh`
-
 ### Check
 
 Before submitting a pull request, run the following command to make sure no broken links exist.

--- a/site2/tools/debug-site.sh
+++ b/site2/tools/debug-site.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+container_id=$(docker ps | grep pulsar-website-nginx | awk '{print $1}')
+
+if [ -n "$container_id" ]
+then
+docker rm -f $container_id
+fi
+
+docker run --name pulsar-website-nginx -p 80:80 -v $ROOT_DIR/generated-site/content:/usr/share/nginx/html:ro -d nginx
+
+echo "Website is running: http://localhost"


### PR DESCRIPTION
Currently, website construction test is not very convenient, you need to merge branches to see the effect, in order to facilitate local testing, I added this tool script, after building the website, you can execute `sh debug-site.sh` locally, you can access the latest build locally Website

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

### Documentation
Does this pull request introduce a new feature? (no)