### PR TITLE
The broker may be starting to create a new ledger repeatedly.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1589,6 +1589,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     synchronized void createLedgerAfterClosed() {
+        if (STATE_UPDATER.get(this) == State.CreatingLedger) {
+    		return;
+    	}
         STATE_UPDATER.set(this, State.CreatingLedger);
         this.lastLedgerCreationInitiationTimestamp = System.currentTimeMillis();
         mbean.startDataLedgerCreateOp();


### PR DESCRIPTION
'createLedgerAfterClosed()' may be starting to create a new ledger repeatedly, for 'ledgerClosed' would has starting a creating  ledger job when 'pendingAddEntries' is not empty.

The related modulue is  'org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl' and the funtions are as follows:

public void rollCurrentLedgerIfFull() {
    ...
    ledgerClosed(lh);
    createLedgerAfterClosed();
    ...
}

synchronized void ledgerClosed(final LedgerHandle lh) {
    if (!pendingAddEntries.isEmpty()) {
            // Need to create a new ledger to write pending entries
            log.info("[{}] Creating a new ledger", name);
            STATE_UPDATER.set(this, State.CreatingLedger);
            this.lastLedgerCreationInitiationTimestamp = System.currentTimeMillis();
            mbean.startDataLedgerCreateOp();
            asyncCreateLedger(bookKeeper, config, digestType, this, Collections.emptyMap());
        }
}

synchronized void createLedgerAfterClosed() {
        STATE_UPDATER.set(this, State.CreatingLedger);
        this.lastLedgerCreationInitiationTimestamp = System.currentTimeMillis();
        mbean.startDataLedgerCreateOp();
        asyncCreateLedger(bookKeeper, config, digestType, this, Collections.emptyMap());
    }

