### PR TITLE
fix: python client docs missing pular pkg import code 

### DIFF
--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -86,6 +86,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This example creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listens for incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
@@ -68,6 +68,8 @@ client.close()
 This creates a consumer with the `my-subscription` subscription on the `my-topic` topic, listen for incoming messages, print the content and ID of messages that arrive, and acknowledge each message to the Pulsar broker:
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
@@ -72,6 +72,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.8.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.0/client-libraries-python.md
@@ -87,6 +87,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.8.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.1/client-libraries-python.md
@@ -87,6 +87,8 @@ client.close()
 The following example creates a consumer with the `my-subscription` subscription name on the `my-topic` topic, receives incoming messages, prints the content and ID of messages that arrive, and acknowledges each message to the Pulsar broker.
 
 ```python
+import pulsar
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:


### PR DESCRIPTION
### Motivation

In the [client-libraries-python](https://pulsar.apache.org/docs/en/client-libraries-python/) docs, the [Consumer example](https://pulsar.apache.org/docs/en/client-libraries-python/#consumer-example) missing pkg import code of `import pulsar`. 

### Modifications

Added the pkg import code to the docs. 

### Impact
No code change. 
