### PR TITLE
fix compaction entry read exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -109,6 +109,7 @@ public class CompactedTopicImpl implements CompactedTopic {
                                 if (startPoint == NEWER_THAN_COMPACTED) {
                                     cursor.seek(compactionHorizon.getNext());
                                     callback.readEntriesComplete(Collections.emptyList(), ctx);
+                                    return CompletableFuture.completedFuture(null);
                                 }
                                 return readEntries(context.ledger, startPoint, endPoint)
                                     .thenAccept((entries) -> {


### PR DESCRIPTION
### Motivation
When read entry from compacted ledger, it will get the following exception when read the end of compacted ledger
```
12:04:11.193 [broker-topic-workers-OrderedScheduler-7-0] ERROR org.apache.bookkeeper.client.LedgerHandle - IncorrectParameterException on ledgerId:3753 firstEntry:-4276948922 lastEntry:-4276948822
12:04:11.194 [broker-topic-workers-OrderedScheduler-7-0] ERROR org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer - [persistent://public/default/__change_events-partition-0 / multiTopicsReader-5358dc9a38-Consumer{subscription=PersistentSubscription{topic=persistent://public/default/__change_events-partition-0, name=multiTopicsReader-5358dc9a38}, consumerId=3, consumerName=fd550, address=/202.168.117.36:45676}] Error reading entries at 3837:0 : java.util.concurrent.CompletionException: org.apache.bookkeeper.client.BKException$BKIncorrectParameterException: Incorrect parameter input - Retrying to read in 15.0 seconds
```

The reason is when `startPoint == NEWER_THAN_COMPACTED` it will set cursor to normal ledger to read the following entry and should just complete the read cycle and return.
https://github.com/apache/pulsar/blob/e9c54769adc54942265b9cdb32a452b08b0eddf3/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java#L109-L118

### Modification
1. When read the end of compacted ledger, just return this read cycle.