### PR TITLE
[C++] fix regex namespace to avoid core dump

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -32,11 +32,18 @@
 #include <lib/HTTPLookupService.h>
 #include <lib/TopicName.h>
 #include <algorithm>
-#include <regex>
 #include <random>
 #include <mutex>
 #ifdef USE_LOG4CXX
 #include "Log4CxxLogger.h"
+#endif
+
+#ifdef PULSAR_USE_BOOST_REGEX
+#include <boost/regex.hpp>
+#define PULSAR_REGEX_NAMESPACE boost
+#else
+#include <regex>
+#define PULSAR_REGEX_NAMESPACE std
 #endif
 
 DECLARE_LOG_OBJECT()
@@ -267,7 +274,7 @@ void ClientImpl::createPatternMultiTopicsConsumer(const Result result, const Nam
     if (result == ResultOk) {
         ConsumerImplBasePtr consumer;
 
-        std::regex pattern(regexPattern);
+        PULSAR_REGEX_NAMESPACE::regex pattern(regexPattern);
 
         NamespaceTopicsPtr matchTopics =
             PatternMultiTopicsConsumerImpl::topicsPatternFilter(*topics, pattern);

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
@@ -31,13 +31,13 @@ PatternMultiTopicsConsumerImpl::PatternMultiTopicsConsumerImpl(ClientImplPtr cli
     : MultiTopicsConsumerImpl(client, topics, subscriptionName, TopicName::get(pattern), conf,
                               lookupServicePtr_),
       patternString_(pattern),
-      pattern_(std::regex(pattern)),
+      pattern_(PULSAR_REGEX_NAMESPACE::regex(pattern)),
       autoDiscoveryTimer_(),
       autoDiscoveryRunning_(false) {
     namespaceName_ = TopicName::get(pattern)->getNamespaceName();
 }
 
-const std::regex PatternMultiTopicsConsumerImpl::getPattern() { return pattern_; }
+const PULSAR_REGEX_NAMESPACE::regex PatternMultiTopicsConsumerImpl::getPattern() { return pattern_; }
 
 void PatternMultiTopicsConsumerImpl::resetAutoDiscoveryTimer() {
     autoDiscoveryRunning_ = false;
@@ -188,12 +188,12 @@ void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedT
     }
 }
 
-NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(const std::vector<std::string>& topics,
-                                                                       const std::regex& pattern) {
+NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(
+    const std::vector<std::string>& topics, const PULSAR_REGEX_NAMESPACE::regex& pattern) {
     NamespaceTopicsPtr topicsResultPtr = std::make_shared<std::vector<std::string>>();
 
     for (std::vector<std::string>::const_iterator itr = topics.begin(); itr != topics.end(); itr++) {
-        if (std::regex_match(*itr, pattern)) {
+        if (PULSAR_REGEX_NAMESPACE::regex_match(*itr, pattern)) {
             topicsResultPtr->push_back(*itr);
         }
     }

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
@@ -20,11 +20,18 @@
 #define PULSAR_PATTERN_MULTI_TOPICS_CONSUMER_HEADER
 #include "ConsumerImpl.h"
 #include "ClientImpl.h"
-#include <regex>
 #include <lib/TopicName.h>
 #include <lib/NamespaceName.h>
 #include "MultiTopicsConsumerImpl.h"
 #include <memory>
+
+#ifdef PULSAR_USE_BOOST_REGEX
+#include <boost/regex.hpp>
+#define PULSAR_REGEX_NAMESPACE boost
+#else
+#include <regex>
+#define PULSAR_REGEX_NAMESPACE std
+#endif
 
 namespace pulsar {
 
@@ -41,13 +48,13 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
                                    const std::string& subscriptionName, const ConsumerConfiguration& conf,
                                    const LookupServicePtr lookupServicePtr_);
 
-    const std::regex getPattern();
+    const PULSAR_REGEX_NAMESPACE::regex getPattern();
 
     void autoDiscoveryTimerTask(const boost::system::error_code& err);
 
     // filter input `topics` with given `pattern`, return matched topics
     static NamespaceTopicsPtr topicsPatternFilter(const std::vector<std::string>& topics,
-                                                  const std::regex& pattern);
+                                                  const PULSAR_REGEX_NAMESPACE::regex& pattern);
 
     // Find out topics, which are in `list1` but not in `list2`.
     static NamespaceTopicsPtr topicsListsMinus(std::vector<std::string>& list1,
@@ -59,7 +66,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
 
    private:
     const std::string patternString_;
-    const std::regex pattern_;
+    const PULSAR_REGEX_NAMESPACE::regex pattern_;
     typedef std::shared_ptr<boost::asio::deadline_timer> TimerPtr;
     TimerPtr autoDiscoveryTimer_;
     bool autoDiscoveryRunning_;


### PR DESCRIPTION
### Motivation

remove usages of `std::regex`, which causes core dump with some lower versions of GCC.

### Modifications

replace `std::regex` and `boost::regex` with `PULSAR_REGEX_NAMESPACE::regex` whose value the version of GCC determines.
similar PR: #9533

### Verifying this change

- [x] Make sure that the change passes the CI checks.