### PR TITLE
[website][pulsar-client/pulsar-perf] pulsar-client and pulsar-perf cli doc command flag duplicated

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdGenerateDocumentation.java
@@ -79,17 +79,12 @@ public class CmdGenerateDocumentation {
         }
         sb.append("|Flag|Description|Default|\n");
         sb.append("|---|---|---|\n");
-        // IKey is an internal interface and cannot be accessed directly,
-        // so the type needs to be erased and force cast to a subclass
-        Map descriptionMap = cmd.getDescriptions();
-        descriptionMap.forEach((k, v) -> {
-            StringKey key = (StringKey) k;
-            ParameterDescription description = (ParameterDescription) v;
-            sb.append("| `").append(key.getName())
-                    .append("` | ").append(description.getDescription().replace("\n", " "))
-                    .append("|").append(description.getDefault()).append("|\n");
-
-        });
+        List<ParameterDescription> options = cmd.getParameters();
+        options.forEach((option) ->
+                sb.append("| `").append(option.getNames())
+                        .append("` | ").append(option.getDescription().replace("\n", " "))
+                        .append("|").append(option.getDefault()).append("|\n")
+        );
         System.out.println(sb.toString());
         return sb.toString();
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/CmdGenerateDocumentation.java
@@ -109,17 +109,12 @@ public class CmdGenerateDocumentation {
         }
         sb.append("|Flag|Description|Default|\n");
         sb.append("|---|---|---|\n");
-        // IKey is an internal interface and cannot be accessed directly,
-        // so the type needs to be erased and force cast to a subclass
-        Map descriptionMap = cmd.getDescriptions();
-        descriptionMap.forEach((k, v) -> {
-            StringKey key = (StringKey) k;
-            ParameterDescription description = (ParameterDescription) v;
-            sb.append("| `").append(key.getName())
-                    .append("` | ").append(description.getDescription().replace("\n", " "))
-                    .append("|").append(description.getDefault()).append("|\n");
-
-        });
+        List<ParameterDescription> options = cmd.getParameters();
+        options.forEach((option) ->
+                sb.append("| `").append(option.getNames())
+                        .append("` | ").append(option.getDescription().replace("\n", " "))
+                        .append("|").append(option.getDefault()).append("|\n")
+        );
         System.out.println(sb.toString());
         return sb.toString();
     }


### PR DESCRIPTION
### Master Issue: #10040

### Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
fix duplicated long and short command line parameter names for pulsar-client cli docs
fix duplicated long and short command line parameter names for pulsar-perf cli docs

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation