### PR TITLE
Fix pulsar-io main profile activation by default

### DIFF
--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -35,7 +35,11 @@
     <profile>
       <id>main</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>disableIoMainProfile</name>
+          <!-- always active unless true is passed as a value -->
+          <value>!true</value>
+        </property>
       </activation>
       <modules>
         <module>core</module>


### PR DESCRIPTION
### Motivation

`pulsar-io` modules build failed due to the falg `activeByDefault` fail to activate the profile if any other profile is activated.

![image](https://user-images.githubusercontent.com/31875453/124209594-65e4e900-db1c-11eb-91d7-0b02579a0a17.png)

### Modifications

- Use a better solution to activate the `main` profile by default by using a property value with inversion (`!`) rule.