### PR TITLE
[pulsar-io] Refine the key in redis sink when key is null

### DIFF
--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
@@ -121,9 +121,10 @@ public class RedisSink implements Sink<byte[]> {
         if (CollectionUtils.isNotEmpty(recordsToFlush)) {
             for (Record<byte[]> record: recordsToFlush) {
                 try {
-                    // use the value of record as key when its key is null
+                    // use an empty string as key when the key is null
+                    String recordKey = record.getKey().isPresent() ? record.getKey().get() : "";
+                    byte[] key = recordKey.getBytes(StandardCharsets.UTF_8);
                     byte[] value = record.getValue();
-                    byte[] key = record.getKey().isPresent() ? record.getKey().get().getBytes(StandardCharsets.UTF_8) : value;
                     recordsToSet.put(key, value);
                 } catch (Exception e) {
                     record.fail();

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
@@ -121,9 +121,9 @@ public class RedisSink implements Sink<byte[]> {
         if (CollectionUtils.isNotEmpty(recordsToFlush)) {
             for (Record<byte[]> record: recordsToFlush) {
                 try {
-                    // records with null keys or values will be ignored
-                    byte[] key = record.getKey().isPresent() ? record.getKey().get().getBytes(StandardCharsets.UTF_8) : null;
+                    // use the value of record as key when its key is null
                     byte[] value = record.getValue();
+                    byte[] key = record.getKey().isPresent() ? record.getKey().get().getBytes(StandardCharsets.UTF_8) : value;
                     recordsToSet.put(key, value);
                 } catch (Exception e) {
                     record.fail();


### PR DESCRIPTION
### Motivation

When the record has a null key, someone maybe confused by a NPE warn as below:

```
11:26:22.730 [pool-5-thread-1] WARN  org.apache.pulsar.io.redis.sink.RedisSink - Record flush thread was exception
java.lang.NullPointerException: null
        at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011) ~[?:1.8.0_291]
        at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006) ~[?:1.8.0_291]
        at org.apache.pulsar.io.redis.sink.RedisSink.flush(RedisSink.java:127) ~[pulsar-io-redis-2.8.0.nar-unpacked/:?]
        at org.apache.pulsar.io.redis.sink.RedisSink.lambda$write$1(RedisSink.java:94) ~[pulsar-io-redis-2.8.0.nar-unpacked/:?]
```

We can use an empty string as key when its key is null as other sinks do.

### Modifications

- Use an empty string as key when its key is null.