### PR TITLE
remove legacy znode when delete namespace or tenant forcefully

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -80,7 +80,7 @@ public abstract class AdminResource extends PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
     public static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
     public static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
-    private static final String MANAGED_LEDGER_PATH_ZNODE = "/managed-ledgers";
+    public static final String MANAGED_LEDGER_PATH_ZNODE = "/managed-ledgers";
 
     protected BookKeeper bookKeeper() {
         return pulsar().getBookKeeperClient();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -105,6 +105,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.zookeeper.LocalZooKeeperConnectionService;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -456,6 +457,23 @@ public abstract class NamespacesBase extends AdminResource {
                 // check whether partitioned topics znode exist
                 if (namespaceResources().exists(globalPartitionedPath)) {
                     deleteRecursive(namespaceResources(), globalPartitionedPath);
+                }
+
+                final String managedLedgerPath = joinPath(MANAGED_LEDGER_PATH_ZNODE, namespaceName.toString());
+                final String persistentDomain = managedLedgerPath + "/" + TopicDomain.persistent.value();
+                final String nonPersistentDomain = managedLedgerPath +  "/" + TopicDomain.non_persistent.value();
+
+                try {
+                    LocalZooKeeperConnectionService.deleteIfExists(
+                            pulsar().getLocalZkCache().getZooKeeper(), persistentDomain, -1 );
+                    LocalZooKeeperConnectionService.deleteIfExists(
+                            pulsar().getLocalZkCache().getZooKeeper(), nonPersistentDomain, -1 );
+                    LocalZooKeeperConnectionService.deleteIfExists(
+                            pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1 );
+                } catch (KeeperException | InterruptedException e) {
+                    // warn level log here since this failure has no side effect besides left a un-used metadata
+                    // and also will not affect the re-creation of namespace
+                    log.warn("[{}] Failed to remove managed-ledger for {}", clientAppId(), namespaceName, e);
                 }
 
                 // we have successfully removed all the ownership for the namespace, the policies znode can be deleted

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -465,11 +465,11 @@ public abstract class NamespacesBase extends AdminResource {
 
                 try {
                     LocalZooKeeperConnectionService.deleteIfExists(
-                            pulsar().getLocalZkCache().getZooKeeper(), persistentDomain, -1 );
+                            pulsar().getLocalZkCache().getZooKeeper(), persistentDomain, -1);
                     LocalZooKeeperConnectionService.deleteIfExists(
-                            pulsar().getLocalZkCache().getZooKeeper(), nonPersistentDomain, -1 );
+                            pulsar().getLocalZkCache().getZooKeeper(), nonPersistentDomain, -1);
                     LocalZooKeeperConnectionService.deleteIfExists(
-                            pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1 );
+                            pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1);
                 } catch (KeeperException | InterruptedException e) {
                     // warn level log here since this failure has no side effect besides left a un-used metadata
                     // and also will not affect the re-creation of namespace

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -333,7 +333,7 @@ public class TenantsBase extends PulsarWebResource {
             final String managedLedgerPath = joinPath(MANAGED_LEDGER_PATH_ZNODE, tenant);
             try {
                 LocalZooKeeperConnectionService.deleteIfExists(
-                        pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1 );
+                        pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1);
             } catch (KeeperException | InterruptedException e) {
                 // warn level log here since this failure has no side effect besides left a un-used metadata
                 // and also will not affect the re-creation of tenant

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
+import static org.apache.pulsar.broker.admin.AdminResource.MANAGED_LEDGER_PATH_ZNODE;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import com.google.common.collect.Lists;
 import io.swagger.annotations.ApiOperation;
@@ -50,6 +51,8 @@ import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.zookeeper.LocalZooKeeperConnectionService;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -326,6 +329,15 @@ public class TenantsBase extends PulsarWebResource {
                     asyncResponse.resume(new RestException(exception.getCause()));
                 }
                 return null;
+            }
+            final String managedLedgerPath = joinPath(MANAGED_LEDGER_PATH_ZNODE, tenant);
+            try {
+                LocalZooKeeperConnectionService.deleteIfExists(
+                        pulsar().getLocalZkCache().getZooKeeper(), managedLedgerPath, -1 );
+            } catch (KeeperException | InterruptedException e) {
+                // warn level log here since this failure has no side effect besides left a un-used metadata
+                // and also will not affect the re-creation of tenant
+                log.warn("[{}] Failed to remove managed-ledger for {}", clientAppId(), tenant, e);
             }
             // delete tenant normally
             internalDeleteTenant(asyncResponse, tenant);


### PR DESCRIPTION
Fixes #11195

### Motivation

Fix metadata not cleaned after delete namespace or tenant forcefully.

### Modifications
**For force delete of namespace**
Add delete for znode  `/managed-ledger/tenant/namespaces/persistent` , `/managed-ledger/tenant/namespaces/non-persistent` and  `/managed-ledger/tenant/namespaces`  if exist.

**For force delete of tenant**
Add delete for znode  `/managed-ledger/tenant` if exist.

### Verifying this change

This change added tests and can be verified as follows:

Add new test for force delete of namespace in `AdminApiTest.testDeleteNamespaceForcefully`
Extended test for force delete of tenant.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)