### PR TITLE
[docs] Fix 'Community' dropdown menu symbols

### DIFF
--- a/site2/website/core/Footer.js
+++ b/site2/website/core/Footer.js
@@ -138,11 +138,10 @@ class Footer extends React.Component {
             '<li><a href="${contributingUrl}">Contributing</a></li>' +
             '<li><a href="${codingUrl}">Coding guide</a></li>' +
             '<li><a href="${eventsUrl}">Events</a></li>' +
-            '<li><a href="${twitterUrl}" target="_blank">Twitter &#x2750</a></li>' +
-            '<li><a href="${wikiUrl}" target="_blank">Wiki &#x2750</a></li>' +
-            '<li><a href="${issuesUrl}" target="_blank">Issue tracking &#x2750</a></li>' +
-            '<li><a href="${summitUrl}" target="_blank">Pulsar Summit &#x2750</a></li>' +
-            '<li>&nbsp;</li>' +
+            '<li><a href="${twitterUrl}" target="_blank">Twitter</a></li>' +
+            '<li><a href="${wikiUrl}" target="_blank">Wiki</a></li>' +
+            '<li><a href="${issuesUrl}" target="_blank">Issue tracking</a></li>' +
+            '<li><a href="${summitUrl}" target="_blank">Pulsar Summit</a></li>' +
             '<li><a href="${resourcesUrl}">Resources</a></li>' +
             '<li><a href="${teamUrl}">Team</a></li>' +
             '<li><a href="${poweredByUrl}">Powered By</a></li>' +


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

In the navigation bar of the docs 'Community' dropdown menu has some symbols displayed incorrectly (❐),  and has an empty item in the list

### Modifications

Removed the symbols and the empty list item as well

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
![before](https://user-images.githubusercontent.com/44555427/124310183-a597e900-db8d-11eb-8415-09a8a58a570c.png)
![after](https://user-images.githubusercontent.com/44555427/124310177-a466bc00-db8d-11eb-9378-9768911c880a.png)

