### PR TITLE
[broker] Fix race on pendingPublishAcks

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -263,11 +263,8 @@ public class Producer {
     }
 
     private void publishOperationCompleted() {
-        long newPendingPublishAcks = this.pendingPublishAcks - 1;
-        pendingPublishAcksUpdater.lazySet(this, newPendingPublishAcks);
-
         // Check the close future to avoid grabbing the mutex every time the pending acks goes down to 0
-        if (newPendingPublishAcks == 0 && !closeFuture.isDone()) {
+        if (pendingPublishAcksUpdater.getAndDecrement(this) <= 1 && !closeFuture.isDone()) {
             synchronized (this) {
                 if (isClosed && !closeFuture.isDone()) {
                     closeNow(true);


### PR DESCRIPTION
It looks like different threads are able to concurrently increment and decrement the value of pendingPublishAcks in an unsafe way in a code path applicable to #6054 
This PR improves the safety of that. 