### PR TITLE
fix: python client docs consumer example code missing client object

### DIFF
--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -88,6 +88,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.1.1-incubating/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.2.0/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.0/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.3.1/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.0/client-libraries-python.md
@@ -70,6 +70,8 @@ This example creates a consumer with the `my-subscription` subscription on the `
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.1/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.4.2/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.0/client-libraries-python.md
@@ -70,6 +70,8 @@ This creates a consumer with the `my-subscription` subscription on the `my-topic
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.1/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.5.2/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.0/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.1/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.2/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.3/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.6.4/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.0/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.1/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.2/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.7.3/client-libraries-python.md
@@ -74,6 +74,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.8.0/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.0/client-libraries-python.md
@@ -89,6 +89,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:

--- a/site2/website/versioned_docs/version-2.8.1/client-libraries-python.md
+++ b/site2/website/versioned_docs/version-2.8.1/client-libraries-python.md
@@ -89,6 +89,8 @@ The following example creates a consumer with the `my-subscription` subscription
 ```python
 import pulsar
 
+client = pulsar.Client('pulsar://localhost:6650')
+
 consumer = client.subscribe('my-topic', 'my-subscription')
 
 while True:


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

In the [client-libraries-python](https://pulsar.apache.org/docs/en/client-libraries-python/#consumer-example), the sample code of Consumer missing to create the client object which consumer object relies. 

```
import pulsar

consumer = client.subscribe('my-topic', 'my-subscription')
```

### Modifications

I added the client object code to the sample like below

```
import pulsar

client = pulsar.Client('pulsar://localhost:6650')

consumer = client.subscribe('my-topic', 'my-subscription')
```

### Impact

No code change
