### PR TITLE
Remove unused listener to reduce creating executor pool

### DIFF
--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -203,8 +203,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                     semaphore.acquire();
                     countDownLatch = new CountDownLatch(1);
                     assignmentScheduler.chooseThread(ledgerId).submit(FileSystemWriter.create(ledgerEntriesOnce, dataWriter, semaphore,
-                            countDownLatch, haveOffloadEntryNumber, this)).addListener(() -> {
-                    }, Executors.newSingleThreadExecutor());
+                            countDownLatch, haveOffloadEntryNumber, this));
                     needToOffloadFirstEntryNumber = end + 1;
                 } while (needToOffloadFirstEntryNumber - 1 != readHandle.getLastAddConfirmed() && fileSystemWriteException == null);
                 countDownLatch.await();


### PR DESCRIPTION
### Motivation
As LedgerReader read entries from ReadHandle, and then dispatch OrderedScheduler to execute write.
```java
assignmentScheduler.chooseThread(ledgerId).submit(FileSystemWriter.create(ledgerEntriesOnce, dataWriter, semaphore,
                            countDownLatch, haveOffloadEntryNumber, this)).addListener(() -> {
                    }, Executors.newSingleThreadExecutor());
```
I think it's no need to add listener but do nothing, and create executor pool every time.


