### PR TITLE
[Websocket] Support cumulative acknowledge for Pulsar Websocket consumer.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -31,8 +31,10 @@ import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +57,7 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.TopicType;
@@ -70,6 +73,7 @@ import org.apache.pulsar.websocket.stats.ProxyTopicStat.ProducerStats;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeException;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.glassfish.jersey.client.ClientConfig;
@@ -826,16 +830,110 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
 
             Thread.sleep(500);
 
-            //assertEquals(consumeSocket1.getReceivedMessagesCount(), 1);
             assertTrue(consumeSocket1.getReceivedMessagesCount() > 0);
 
             Thread.sleep(500);
 
-            //assertEquals(consumeSocket2.getReceivedMessagesCount(), 1);
             assertTrue(consumeSocket1.getReceivedMessagesCount() > 0);
 
         } finally {
             stopWebSocketClient(consumeClient1, consumeClient2, produceClient);
+        }
+    }
+
+    @WebSocket(maxTextMessageSize = 64 * 1024)
+    private class CumulativeAckConsumerSocket extends SimpleConsumerSocket {
+        @Override
+        public synchronized void onMessage(String msg) throws JsonParseException, IOException {
+            JsonObject message = new Gson().fromJson(msg, JsonObject.class);
+            if (message.get(X_PULSAR_MESSAGE_ID) != null) {
+                String messageId = message.get(X_PULSAR_MESSAGE_ID).getAsString();
+                consumerBuffer.add(messageId);
+                JsonObject ack = new JsonObject();
+                if (receivedMessages.get() % 20 == 0) {
+                    // cumulative acking
+                    ack.add("messageId", new JsonPrimitive(messageId));
+                    ack.add("ackType", new JsonPrimitive("cumulative"));
+                    this.getRemote().sendString(ack.toString());
+                } else if (receivedMessages.get() % 2 == 0) {
+                    // ack half of messages by individual ack
+                    ack.add("messageId", new JsonPrimitive(messageId));
+                    this.getRemote().sendString(ack.toString());
+                }
+            } else {
+                consumerBuffer.add(message.toString());
+            }
+        }
+    }
+
+    @Test(timeOut = 10000)
+    public void cumulativeAckMessageTest() throws Exception {
+        final String subscription = "my-sub";
+        final String consumerTopic = "my-property/my-ns/my-topic11";
+
+        final String consumerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get() +
+                "/ws/v2/consumer/persistent/" +
+                consumerTopic + "/" + subscription +
+                "?allowCumulativeAck=true";
+
+        final String producerUri = "ws://localhost:" + proxyServer.getListenPortHTTP().get() +
+                "/ws/v2/producer/persistent/" + consumerTopic;
+
+        WebSocketClient consumeClient1 = new WebSocketClient();
+        SimpleConsumerSocket consumeSocket1 = new CumulativeAckConsumerSocket();
+        WebSocketClient produceClient = new WebSocketClient();
+        SimpleProducerSocket produceSocket = new SimpleProducerSocket();
+
+        try {
+            consumeClient1.start();
+            ClientUpgradeRequest consumeRequest1 = new ClientUpgradeRequest();
+            Future<Session> consumerFuture1 = consumeClient1.connect(consumeSocket1, URI.create(consumerUri), consumeRequest1);
+
+            assertTrue(consumerFuture1.get().isOpen());
+
+            ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
+            produceClient.start();
+            Future<Session> producerFuture = produceClient.connect(produceSocket, URI.create(producerUri), produceRequest);
+            assertTrue(producerFuture.get().isOpen());
+
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(consumeSocket1.getReceivedMessagesCount(), 10));
+
+            // only half message acked by individual ack
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getMsgBacklogNoDelayed(), 5));
+
+            produceSocket.sendMessage(10);
+
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(consumeSocket1.getReceivedMessagesCount(), 20));
+
+            // all messages acked by cumulative ack
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getMsgBacklogNoDelayed(), 0));
+
+            produceSocket.sendMessage(10);
+
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(consumeSocket1.getReceivedMessagesCount(), 30));
+
+            assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getConsumers().get(0).getMsgOutCounter(), 30);
+            // only half message acked by individual ack
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getMsgBacklogNoDelayed(), 5));
+
+            produceSocket.sendMessage(10);
+
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(consumeSocket1.getReceivedMessagesCount(), 40));
+
+            assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getConsumers().get(0).getMsgOutCounter(), 40);
+            // all messages acked by cumulative ack
+            Awaitility.await().atMost(1000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> assertEquals(admin.topics().getStats(TopicDomain.persistent + "://" + consumerTopic, true, true).getSubscriptions().get(subscription).getMsgBacklogNoDelayed(), 0));
+
+        } finally {
+            stopWebSocketClient(consumeClient1, produceClient);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleConsumerSocket.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleConsumerSocket.java
@@ -40,11 +40,11 @@ import org.slf4j.LoggerFactory;
 
 @WebSocket(maxTextMessageSize = 64 * 1024)
 public class SimpleConsumerSocket {
-    private static final String X_PULSAR_MESSAGE_ID = "messageId";
+    protected static final String X_PULSAR_MESSAGE_ID = "messageId";
     private final CountDownLatch closeLatch;
     private Session session;
-    private final ArrayList<String> consumerBuffer;
-    private final AtomicInteger receivedMessages = new AtomicInteger();
+    protected final ArrayList<String> consumerBuffer;
+    protected final AtomicInteger receivedMessages = new AtomicInteger();
     // Custom message handler to override standard message processing, if it's needed
     private SimpleConsumerMessageHandler customMessageHandler;
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -31,10 +31,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -46,6 +49,7 @@ import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -78,7 +82,9 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
 
     private int maxPendingMessages = 0;
     private final AtomicInteger pendingMessages = new AtomicInteger();
+    private final ReadWriteLock pendingMessagesLock = new ReentrantReadWriteLock();
     private final boolean pullMode;
+    private final boolean allowCumulativeAck;
 
     private final LongAdder numMsgsDelivered;
     private final LongAdder numBytesDelivered;
@@ -96,6 +102,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         this.numBytesDelivered = new LongAdder();
         this.numMsgsAcked = new LongAdder();
         this.pullMode = Boolean.valueOf(queryParams.get("pullMode"));
+        this.allowCumulativeAck = Boolean.valueOf(queryParams.get("allowCumulativeAck"));
 
         try {
             // checkAuth() and getConsumerConfiguration() should be called after assigning a value to this.subscription
@@ -276,8 +283,61 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         // We should have received an ack
         MessageId msgId = MessageId.fromByteArrayWithTopic(Base64.getDecoder().decode(command.messageId),
                 topic.toString());
-        consumer.acknowledgeAsync(msgId).thenAccept(consumer -> numMsgsAcked.increment());
-        checkResumeReceive();
+        if ("cumulative".equals(command.ackType)) {
+            if (allowCumulativeAck) {
+                // If not pull mode, then we need to calculate how many messages have been acked in a cumulative ack request
+                // to properly calculate how many more messages we should dispatch to consumer. Use precise backlog size before
+                // and after the cumulative ack for the calculation.
+                // Use a writelock to prevent individual ack during the process which might cause incorrect result.
+                if (!this.pullMode) {
+                    try {
+                        pendingMessagesLock.writeLock().lock();
+                        TopicStats stats = service.getAdminClient().topics().getStats(topic.toString(), true, true);
+                        Long backlogBefore = stats.getSubscriptions().get(subscription).getMsgBacklogNoDelayed();
+                        consumer.acknowledgeCumulative(msgId);
+                        stats = service.getAdminClient().topics().getStats(topic.toString(), true, true);
+                        Long backlogAfter = stats.getSubscriptions().get(subscription).getMsgBacklogNoDelayed();
+                        int ack = (int) (backlogBefore - backlogAfter) > pendingMessages.get() ? pendingMessages.get() : (int) (backlogBefore - backlogAfter);
+                        int pending = pendingMessages.getAndAdd(-ack);
+                        if (pending >= maxPendingMessages) {
+                            // Resume delivery
+                            receiveMessage();
+                        }                    } catch (PulsarAdminException e) {
+                        log.warn("[{}] Fail to handle websocket consumer cumulative ack request: {}", consumer.getTopic(), e.getMessage());
+                    } finally {
+                        pendingMessagesLock.writeLock().unlock();
+                    }
+                } else {
+                    // for pull mode no need to keep track of how many messages to dispatch, so simply do cumulative ack.
+                    consumer.acknowledgeCumulativeAsync(msgId).exceptionally(exception -> {
+                        log.warn("[{}] Fail to handle websocket consumer cumulative ack request: {}", consumer.getTopic(), exception.getMessage());
+                        return null;
+                    });
+                }
+            } else {
+                log.warn("[{}] Websocket consumer cumulative ack request not enabled", consumer.getTopic());
+            }
+        } else {
+            if (allowCumulativeAck) {
+                // multiple individual acks can happen at the same time, but individual ack and cumulative ack can't
+                // happen at the same time, as it'll interfere calculation of pending message, hence use a readlock.
+                try {
+                    pendingMessagesLock.readLock().lock();
+                    consumer.acknowledge(msgId);
+                    checkResumeReceive();
+                } finally {
+                    pendingMessagesLock.readLock().unlock();
+                }
+            } else {
+                consumer.acknowledgeAsync(msgId)
+                        .thenAccept(consumer -> numMsgsAcked.increment())
+                        .exceptionally(exception -> {
+                            log.warn("[{}] Fail to handle websocket consumer ack request: {}", consumer.getTopic(), exception.getMessage());
+                            return null;
+                        });
+                checkResumeReceive();
+            }
+        }
     }
 
     private void handleNack(ConsumerCommand command) throws IOException {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ConsumerCommand.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/data/ConsumerCommand.java
@@ -22,4 +22,5 @@ public class ConsumerCommand {
     public String type;
     public String messageId;
     public Integer permitMessages;
+    public String ackType;
 }


### PR DESCRIPTION
Fixes #5979

### Motivation
Support cumulative acknowledge for Websocket consumer.

### Modifications
For non-pull mode, use Admin API topics.getStats to calculate message backlog difference before and after cumulative ack to properly track how many message need to send to consumer. As individual ack will also change backlog count, use a readwrite lock to prevent individual ack when doing cumulative ack.
For pull mode simply do cumulative ack.

### Verifying this change
This change added tests and can be verified as follows:
  - *Added unit test to verify cumulative ack works.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no
