### PR TITLE
[website][pulsar] supported auto generate html docs for pulsar command

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -377,6 +377,8 @@ elif [ $COMMAND == "tokens" ]; then
     exec $JAVA $OPTS org.apache.pulsar.utils.auth.tokens.TokensCliUtils $@
 elif [ $COMMAND == "version" ]; then
     exec $JAVA $OPTS org.apache.pulsar.PulsarVersionStarter $@
+elif [ $COMMAND == "gen-doc" ]; then
+    exec $JAVA $OPTS org.apache.pulsar.PulsarTool $@
 elif [ $COMMAND == "help" -o $COMMAND == "--help" -o $COMMAND == "-h" ]; then
     pulsar_help;
 else

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -26,6 +26,7 @@ import static org.apache.pulsar.common.configuration.PulsarConfigurationLoader.c
 import static org.apache.pulsar.common.configuration.PulsarConfigurationLoader.isComplete;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileInputStream;
@@ -72,7 +73,8 @@ public class PulsarBrokerStarter {
     }
 
     @VisibleForTesting
-    private static class StarterArguments {
+    @Parameters(commandDescription = "Options")
+    protected static class StarterArguments {
         @Parameter(names = {"-c", "--broker-conf"}, description = "Configuration file for Broker")
         private String brokerConfigFile =
                 Paths.get("").toAbsolutePath().normalize().toString() + "/conf/broker.conf";

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarTool.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar;
+
+import com.beust.jcommander.JCommander;
+import java.util.Arrays;
+import org.apache.pulsar.broker.tools.LoadReportCommand;
+import org.apache.pulsar.common.util.CmdGenerateDocumentation;
+
+public class PulsarTool {
+    private static void genBroker(String[] args) {
+        CmdGenerateDocumentation cmd = new CmdGenerateDocumentation("pulsar");
+        cmd.jcommander.addCommand("broker", new PulsarBrokerStarter.StarterArguments());
+        cmd.run(args);
+    }
+
+    private static void genBrokerTool(String[] args) {
+        CmdGenerateDocumentation cmd = new CmdGenerateDocumentation("pulsar");
+        JCommander commander = new JCommander();
+        commander.addCommand("load-report", new LoadReportCommand.Flags());
+        cmd.jcommander.addCommand("broker-tool", commander);
+        cmd.run(args);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String subCmdName = args[0];
+        String[] subArgs = Arrays.copyOfRange(args, 1, args.length);
+        if ("broker".equals(subCmdName)) {
+            genBroker(subArgs);
+        } else {
+            genBrokerTool(subArgs);
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
@@ -28,15 +28,17 @@ import org.apache.bookkeeper.tools.framework.CliSpec;
 public class BrokerTool {
 
     public static final String NAME = "broker-tool";
+    public static final String DESC = NAME + " is used for operations on a specific broker";
 
     public static void main(String[] args) {
         CliSpec.Builder<CliFlags> specBuilder = CliSpec.newBuilder()
             .withName(NAME)
             .withUsage(NAME + " [flags] [commands]")
-            .withDescription(NAME + " is used for operations on a specific broker")
+            .withDescription(DESC)
             .withFlags(new CliFlags())
             .withConsole(System.out)
-            .addCommand(new LoadReportCommand());
+            .addCommand(new LoadReportCommand())
+            .addCommand(new GenDocCommand());
 
         CliSpec<CliFlags> spec = specBuilder.build();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenDocCommand.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenDocCommand.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tools;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import java.util.List;
+import org.apache.bookkeeper.tools.framework.Cli;
+import org.apache.bookkeeper.tools.framework.CliCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+
+/**
+ * The command to generate documents of broker-tool.
+ */
+public class GenDocCommand extends CliCommand<CliFlags, GenDocCommand.GenDocFlags> {
+
+    private static final String NAME = "gen-doc";
+    private static final String DESC = "Generate documents of broker-tool";
+
+    /**
+     * The CLI flags of gen docs command.
+     */
+    protected static class GenDocFlags extends CliFlags {
+    }
+
+    public GenDocCommand() {
+        super(CliSpec.<GenDocFlags>newBuilder()
+                .withName(NAME)
+                .withDescription(DESC)
+                .withFlags(new GenDocFlags())
+                .build());
+    }
+
+    @Override
+    public Boolean apply(CliFlags globalFlags, String[] args) {
+        CliSpec<GenDocFlags> newSpec = CliSpec.newBuilder(spec)
+                .withRunFunc(cmdFlags -> apply(cmdFlags))
+                .build();
+        return 0 == Cli.runCli(newSpec, args);
+    }
+
+    private boolean apply(GenDocFlags flags) {
+        JCommander commander = new JCommander();
+        commander.setProgramName("broker-tool");
+        commander.addCommand("load-report", new LoadReportCommand.Flags());
+        generateDocument(commander);
+        return true;
+    }
+
+    private void generateDocument(JCommander obj) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("------------\n\n");
+        sb.append("# ").append(BrokerTool.NAME).append("\n\n");
+        sb.append("### Usage\n\n");
+        sb.append("`$").append(BrokerTool.NAME).append("`\n\n");
+        sb.append("------------\n\n");
+        sb.append(BrokerTool.DESC).append("\n");
+        sb.append("\n\n```bdocs-tab:example_shell\n")
+                .append("$ pulsar ").append(BrokerTool.NAME).append(" subcommand")
+                .append("\n```");
+        sb.append("\n\n");
+        for (String s : obj.getCommands().keySet()) {
+            sb.append("* `").append(s).append("`\n");
+        }
+        obj.getCommands().forEach((subK, subV) -> {
+            sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
+            String subDesc = obj.getUsageFormatter().getCommandDescription(subK);
+            if (null != subDesc && !subDesc.isEmpty()) {
+                sb.append(subDesc).append("\n");
+            }
+            sb.append("### Usage\n\n");
+            sb.append("------------\n\n\n");
+            sb.append("```bdocs-tab:example_shell\n$ pulsar ").append(BrokerTool.NAME).append(" ")
+                    .append(subK).append(" options").append("\n```\n\n");
+            List<ParameterDescription> options = obj.getCommands().get(subK).getParameters();
+            if (options.size() > 0) {
+                sb.append("Options\n\n\n");
+                sb.append("|Flag|Description|Default|\n");
+                sb.append("|---|---|---|\n");
+            }
+            options.forEach((option) ->
+                    sb.append("| `").append(option.getNames())
+                            .append("` | ").append(option.getDescription().replace("\n", " "))
+                            .append("|").append(option.getDefault()).append("|\n")
+            );
+        });
+        System.out.println(sb.toString());
+    }
+
+    public static void main(String[] args) {
+        CliSpec.Builder<CliFlags> specBuilder = CliSpec.newBuilder()
+                .withName(NAME)
+                .withUsage("pulsar" + NAME + " [flags] [commands]")
+                .withDescription(NAME + " is used for generate documents of pulsar commands")
+                .withFlags(new CliFlags())
+                .withConsole(System.out)
+                .addCommand(new GenDocCommand());
+
+        CliSpec<CliFlags> spec = specBuilder.build();
+
+        int retCode = Cli.runCli(spec, args);
+        Runtime.getRuntime().exit(retCode);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenDocCommand.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenDocCommand.java
@@ -103,19 +103,4 @@ public class GenDocCommand extends CliCommand<CliFlags, GenDocCommand.GenDocFlag
         });
         System.out.println(sb.toString());
     }
-
-    public static void main(String[] args) {
-        CliSpec.Builder<CliFlags> specBuilder = CliSpec.newBuilder()
-                .withName(NAME)
-                .withUsage("pulsar" + NAME + " [flags] [commands]")
-                .withDescription(NAME + " is used for generate documents of pulsar commands")
-                .withFlags(new CliFlags())
-                .withConsole(System.out)
-                .addCommand(new GenDocCommand());
-
-        CliSpec<CliFlags> spec = specBuilder.build();
-
-        int retCode = Cli.runCli(spec, args);
-        Runtime.getRuntime().exit(retCode);
-    }
 }

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -188,6 +188,10 @@
           <artifactId>gson</artifactId>
       </dependency>
 
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdBase.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdBase.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.IUsageFormatter;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class CmdBase {
+    public final JCommander jcommander;
+    public IUsageFormatter usageFormatter;
+
+    @Parameter(names = {"-h", "--help"}, help = true, hidden = true)
+    private boolean help;
+
+    public CmdBase(String cmdName) {
+        jcommander = new JCommander();
+        usageFormatter = getUsageFormatter();
+        jcommander.setProgramName(cmdName);
+        jcommander.setUsageFormatter(usageFormatter);
+    }
+
+    protected IUsageFormatter getUsageFormatter() {
+        if (usageFormatter == null) {
+            usageFormatter = new DefaultUsageFormatter(jcommander);
+        }
+        return usageFormatter;
+    }
+
+    private void tryShowCommandUsage() {
+        try {
+            String chosenCommand = jcommander.getParsedCommand();
+            getUsageFormatter().usage(chosenCommand);
+        } catch (Exception e) {
+            // it is caused by an invalid command, the invalid command can not be parsed
+            System.err.println(
+                    "Invalid command, please use " + jcommander.getProgramName() + "` --help` to check out how to use");
+        }
+    }
+
+    public boolean run(String[] args) {
+        try {
+            jcommander.parse(args);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.err.println();
+            tryShowCommandUsage();
+            return false;
+        }
+
+        String cmd = jcommander.getParsedCommand();
+        if (cmd == null) {
+            jcommander.usage();
+            return false;
+        } else {
+            try {
+                apply(args);
+                return true;
+            } catch (Exception e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+    }
+
+    protected abstract boolean apply(String[] args);
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocumentation.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocumentation.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import java.util.ArrayList;
+import java.util.List;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Parameters(commandDescription = "Generate documentation automatically.")
+public class CmdGenerateDocumentation extends CmdBase {
+
+    @Parameter(
+            names = {"-n", "--command-names"},
+            description = "List of command names"
+    )
+    private List<String> commandNames = new ArrayList<>();
+
+    public String parentCmdName;
+
+    public CmdGenerateDocumentation(String parentCmdName) {
+        super("gen-doc");
+        this.parentCmdName = parentCmdName;
+    }
+
+    @Override
+    public boolean run(String[] args) {
+        return apply(args);
+    }
+
+    @Override
+    protected boolean apply(String[] args) {
+        if (commandNames.size() == 0) {
+            for (Map.Entry<String, JCommander> cmd : super.jcommander.getCommands().entrySet()) {
+                System.out.println(generateDocument(cmd.getKey(), super.jcommander));
+            }
+        } else {
+            for (String commandName : commandNames) {
+                System.out.println(generateDocument(commandName, super.jcommander));
+            }
+        }
+        return true;
+    }
+
+    private String generateDocument(String module, JCommander commander) {
+        JCommander cmd = commander.getCommands().get(module);
+        StringBuilder sb = new StringBuilder();
+        sb.append("------------\n\n");
+        sb.append("# ").append(module).append("\n\n");
+        sb.append("### Usage\n\n");
+        sb.append("`$").append(module).append("`\n\n");
+        sb.append("------------\n\n");
+        String desc = commander.getUsageFormatter().getCommandDescription(module);
+        if (null != desc && !desc.isEmpty()) {
+            sb.append(desc).append("\n");
+        }
+        sb.append("\n\n```bdocs-tab:example_shell\n")
+                .append("$ ");
+        if (null != parentCmdName && !parentCmdName.isEmpty()) {
+            sb.append(parentCmdName).append(" ");
+        }
+        sb.append(module);
+        if (cmd.getObjects().size() > 0 && cmd.getObjects().get(0).getClass().getName() == "com.beust.jcommander.JCommander") {
+            JCommander cmdObj = (JCommander) cmd.getObjects().get(0);
+            sb.append(" subcommand").append("\n```").append("\n\n");
+            for (String s : cmdObj.getCommands().keySet()) {
+                sb.append("* `").append(s).append("`\n");
+            }
+            cmdObj.getCommands().forEach((subK, subV) -> {
+                sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
+                String subDesc = cmdObj.getUsageFormatter().getCommandDescription(subK);
+                if (null != subDesc && !subDesc.isEmpty()) {
+                    sb.append(subDesc).append("\n");
+                }
+                sb.append("### Usage\n\n");
+                sb.append("------------\n\n\n");
+                sb.append("```bdocs-tab:example_shell\n$ ");
+                if (null != parentCmdName && !parentCmdName.isEmpty()) {
+                    sb.append(parentCmdName).append(" ");
+                }
+                sb.append(module).append(" ").append(subK).append(" options").append("\n```\n\n");
+                List<ParameterDescription> options = cmdObj.getCommands().get(subK).getParameters();
+                if (options.size() > 0) {
+                    sb.append("Options\n\n\n");
+                    sb.append("|Flag|Description|Default|\n");
+                    sb.append("|---|---|---|\n");
+                }
+                options.forEach((option) ->
+                        sb.append("| `").append(option.getNames())
+                                .append("` | ").append(option.getDescription().replace("\n", " "))
+                                .append("|").append(option.getDefault()).append("|\n")
+                );
+            });
+        } else {
+            sb.append(" options").append("\n```").append("\n\n");
+            sb.append("|Flag|Description|Default|\n");
+            sb.append("|---|---|---|\n");
+            List<ParameterDescription> options = cmd.getParameters();
+            options.forEach((option) ->
+                    sb.append("| `").append(option.getNames())
+                            .append("` | ").append(option.getDescription().replace("\n", " "))
+                            .append("|").append(option.getDefault()).append("|\n")
+            );
+        }
+        return sb.toString();
+    }
+}

--- a/site2/tools/pulsar-doc-gen.sh
+++ b/site2/tools/pulsar-doc-gen.sh
@@ -28,7 +28,10 @@ mkdir -p $DEST_DIR/tools/pulsar/${VERSION}
 mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules
 mkdir -p $ROOT_DIR/site2/website/brodocs/documents
 
-$ROOT_DIR/bin/pulsar broker-tool gen-doc > $ROOT_DIR/site2/website/brodocs/documents/broker-tool.md
+#$ROOT_DIR/bin/pulsar broker-tool gen-doc > $ROOT_DIR/site2/website/brodocs/documents/broker-tool.md
+echo $ROOT_DIR/bin/pulsar
+$ROOT_DIR/bin/pulsar gen-doc broker > $ROOT_DIR/site2/website/brodocs/documents/broker.md
+$ROOT_DIR/bin/pulsar gen-doc broker-tool > $ROOT_DIR/site2/website/brodocs/documents/broker-tool.md
 
 cd $ROOT_DIR/site2/website/brodocs
 cp pulsar-manifest.json manifest.json

--- a/site2/tools/pulsar-doc-gen.sh
+++ b/site2/tools/pulsar-doc-gen.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION=`${ROOT_DIR}/src/get-project-version.py`
+DEST_DIR=$ROOT_DIR/generated-site
+
+cd $ROOT_DIR
+
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules
+mkdir -p $ROOT_DIR/site2/website/brodocs/documents
+
+$ROOT_DIR/bin/pulsar broker-tool gen-doc > $ROOT_DIR/site2/website/brodocs/documents/broker-tool.md
+
+cd $ROOT_DIR/site2/website/brodocs
+cp pulsar-manifest.json manifest.json
+node brodoc.js
+
+cp index.html $DEST_DIR/tools/pulsar/${VERSION}/
+cp navData.js stylesheet.css $DEST_DIR/tools/pulsar/${VERSION}/
+cp scroll.js tabvisibility.js $DEST_DIR/tools/pulsar/${VERSION}/
+cp favicon.ico $DEST_DIR/tools/pulsar/${VERSION}/
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/bootstrap/dist/css
+cp -r $ROOT_DIR/site2/website/node_modules/bootstrap/dist/css/bootstrap.min.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/bootstrap/dist/css
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/font-awesome/css
+cp -r $ROOT_DIR/site2/website/node_modules/font-awesome/css/font-awesome.min.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/font-awesome/css
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/highlight.js/styles
+cp -r $ROOT_DIR/site2/website/node_modules/highlight.js/styles/default.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/highlight.js/styles
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery/dist
+cp -r $ROOT_DIR/site2/website/node_modules/jquery/dist/jquery.min.js $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery/dist/
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery.scrollto
+cp -r $ROOT_DIR/site2/website/node_modules/jquery.scrollto/jquery.scrollTo.min.js $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery.scrollto
+
+

--- a/site2/website/brodocs/pulsar-manifest.json
+++ b/site2/website/brodocs/pulsar-manifest.json
@@ -1,6 +1,9 @@
 {
   "docs": [
     {
+      "filename": "broker.md"
+    },
+    {
       "filename": "broker-tool.md"
     }
   ],

--- a/site2/website/brodocs/pulsar-manifest.json
+++ b/site2/website/brodocs/pulsar-manifest.json
@@ -1,0 +1,9 @@
+{
+  "docs": [
+    {
+      "filename": "broker-tool.md"
+    }
+  ],
+  "title": "Docs",
+  "copyright": "<a href='http://pulsar.apache.org/'>Apache Pulsar</a>"
+}


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
- [X] Add auto generate docs for pulsar subcommand: `broker-tool`
- [x] Add auto generate docs for pulsar subcommand: `broker`
- [ ] Add auto generate docs for pulsar subcommand: `bookie`
- [ ] Add auto generate docs for pulsar subcommand: `zookeeper`
- [ ] Add auto generate docs for pulsar subcommand: `global-zookeeper`
- [ ] Add auto generate docs for pulsar subcommand: `configuration-store`
- [ ] Add auto generate docs for pulsar subcommand: `discovery`
- [ ] Add auto generate docs for pulsar subcommand: `proxy`
- [ ] Add auto generate docs for pulsar subcommand: `websocket`
- [ ] Add auto generate docs for pulsar subcommand: `functions-worker`
- [ ] Add auto generate docs for pulsar subcommand: `sql-worker`
- [ ] Add auto generate docs for pulsar subcommand: `sql`
- [ ] Add auto generate docs for pulsar subcommand: `standalone`
- [ ] Add auto generate docs for pulsar subcommand: `initialize-cluster-metadata`
- [ ] Add auto generate docs for pulsar subcommand: `delete-cluster-metadata`
- [ ] Add auto generate docs for pulsar subcommand: `initialize-transaction-coordinator-metadata`
- [ ] Add auto generate docs for pulsar subcommand: `initialize-namespace`
- [ ] Add auto generate docs for pulsar subcommand: `compact-topic`
- [ ] Add auto generate docs for pulsar subcommand: `zookeeper-shell`
- [ ] Add auto generate docs for pulsar subcommand: `broker-tool`
- [ ] Add auto generate docs for pulsar subcommand: `tokens`
- [ ] Add auto generate docs for pulsar subcommand: `version`

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation