### PR TITLE
[fix master build] use `entryTimestamp` for expiry checking in `internalGetMessageIdByTimestamp`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2355,17 +2355,13 @@ public class PersistentTopicsBase extends AdminResource {
 
             ManagedLedger ledger = ((PersistentTopic) topic).getManagedLedger();
             return ledger.asyncFindPosition(entry -> {
-                MessageImpl<byte[]> msg = null;
                 try {
-                    msg = MessageImpl.deserializeBrokerEntryMetaDataFirst(entry.getDataBuffer());
-                    return msg.publishedEarlierThan(timestamp);
+                    long entryTimestamp = MessageImpl.getEntryTimestamp(entry.getDataBuffer());
+                    return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
                 } catch (Exception e) {
                     log.error("[{}] Error deserializing message for message position find", topicName, e);
                 } finally {
                     entry.release();
-                    if (msg != null) {
-                        msg.recycle();
-                    }
                 }
                 return false;
             }).thenApply(position -> {


### PR DESCRIPTION
### Motivation

#11014 introduced `getEntryTimestamp` and removed `deserializeBrokerEntryMetaDataFirst`, but #11139 is still using `deserializeBrokerEntryMetaDataFirst`, and it breaks master branch.

### Modifications

use `entryTimestamp` for expiry checking in `internalGetMessageIdByTimestamp`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
