### PR TITLE
Add a usage example for redis sink

### DIFF
--- a/site2/docs/io-redis-sink.md
+++ b/site2/docs/io-redis-sink.md
@@ -42,11 +42,11 @@ Before using the Redis sink connector, you need to create a configuration file t
     ```json
     {
         "redisHosts": "localhost:6379",
-        "redisPassword": "fake@123",
-        "redisDatabase": "1",
+        "redisPassword": "mypassword",
+        "redisDatabase": "0",
         "clientMode": "Standalone",
         "operationTimeout": "2000",
-        "batchSize": "100",
+        "batchSize": "1",
         "batchTimeMs": "1000",
         "connectTimeout": "3000"
     }
@@ -55,15 +55,81 @@ Before using the Redis sink connector, you need to create a configuration file t
 * YAML
 
     ```yaml
-    {
+    configs:
         redisHosts: "localhost:6379"
-        redisPassword: "fake@123"
-        redisDatabase: 1
+        redisPassword: "mypassword"
+        redisDatabase: 0
         clientMode: "Standalone"
         operationTimeout: 2000
-        batchSize: 100
+        batchSize: 1
         batchTimeMs: 1000
         connectTimeout: 3000
-    }
+    ```
+  
+### Usage
+
+This example shows how to write records to a Redis database using the Pulsar Redis connector.
+
+1. Start a Redis server.
+
+    ```bash
+    $ docker pull redis:5.0.5
+    $ docker run -d -p 6379:6379 --name my-redis redis:5.0.5 --requirepass "mypassword"
     ```
 
+2. Start a Pulsar service locally in standalone mode.
+
+    ```bash
+    $ bin/pulsar standalone
+    ```
+    Make sure the nar file is available at `connectors/pulsar-io-redis-{{pulsar:version}}.nar`.
+   
+3. Start the Pulsar Redis connector in local run mode using one of the following methods.
+
+   * Use the **JSON** configuration file as shown previously. 
+     
+        ```bash
+        $ bin/pulsar-admin sinks localrun \
+        --archive connectors/pulsar-io-redis-{{pulsar:version}}.nar \
+        --tenant public \
+        --namespace default \
+        --name my-redis-sink \
+        --sink-config '{"redisHosts": "localhost:6379","redisPassword": "mypassword","redisDatabase": "0","clientMode": "Standalone","operationTimeout": "3000","batchSize": "1"}' \
+        --inputs my-redis-topic
+        ```
+   
+   * Use the **YAML** configuration file as shown previously.
+      
+        ```bash
+        $ bin/pulsar-admin sinks localrun \
+        --archive connectors/pulsar-io-redis-{{pulsar:version}}.nar \
+        --tenant public \
+        --namespace default \
+        --name my-redis-sink \
+        --sink-config-file redis-sink-config.yaml \
+        --inputs my-redis-topic
+        ```
+     
+4. Publish records to the topic.
+
+    ```bash
+    $ bin/pulsar-client produce \
+        persistent://public/default/my-redis-topic \
+        -k "streaming" \
+        -m "Pulsar"
+    ```     
+
+5. Start a Redis client in docker.
+   
+    ```bash
+    $ docker exec -it my-redis redis-cli -a "mypassword"
+    ```
+   
+6. Check the key/value in Redis.
+
+    ```
+    127.0.0.1:6379> keys *
+    1) "streaming"
+    127.0.0.1:6379> get "streaming"
+    "Pulsar"
+    ```

--- a/site2/docs/io-redis-sink.md
+++ b/site2/docs/io-redis-sink.md
@@ -35,7 +35,7 @@ The configuration of the Redis sink connector has the following properties.
 
 ### Example
 
-Before using the Redis sink connector, you need to create a configuration file through one of the following methods.
+Before using the Redis sink connector, you need to create a configuration file in the path you will start Pulsar service (i.e. `PULSAR_HOME`) through one of the following methods.
 
 * JSON
 
@@ -82,7 +82,7 @@ This example shows how to write records to a Redis database using the Pulsar Red
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-redis-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-redis-{{pulsar:version}}.nar`.
    
 3. Start the Pulsar Redis connector in local run mode using one of the following methods.
 
@@ -119,7 +119,7 @@ This example shows how to write records to a Redis database using the Pulsar Red
         -m "Pulsar"
     ```     
 
-5. Start a Redis client in docker.
+5. Start a Redis client in Docker.
    
     ```bash
     $ docker exec -it my-redis redis-cli -a "mypassword"


### PR DESCRIPTION
### Motivation

There is currently no usage example of sink redis, we should support this for better guidance.

### Modifications

- Add a usage example for redis sink using `docker`.
