### PR TITLE
[website][common]common util for generate docs

### DIFF
--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -188,6 +188,10 @@
           <artifactId>gson</artifactId>
       </dependency>
 
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Parameters(commandDescription = "Generate documentation automatically.")
+public class CmdGenerateDocs {
+
+    @Parameter(
+            names = {"-h", "--help"},
+            description = "Display help information"
+    )
+    public boolean help;
+
+    @Parameter(
+            names = {"-n", "--command-names"},
+            description = "List of command names"
+    )
+    private List<String> commandNames = new ArrayList<>();
+
+    private static final String name = "gen-doc";
+    private final JCommander jcommander;
+
+    public CmdGenerateDocs(String cmdName) {
+        jcommander = new JCommander(this);
+        jcommander.setProgramName(cmdName);
+    }
+
+    public CmdGenerateDocs addCommand(String name, Object command) {
+        jcommander.addCommand(name, command);
+        return this;
+    }
+
+    public boolean run(String[] args) {
+        JCommander tmpCmd = new JCommander(this);
+        tmpCmd.setProgramName(jcommander.getProgramName() + " " + name);
+        try {
+            if (args == null) {
+                args = new String[]{};
+            }
+            tmpCmd.parse(args);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.err.println();
+            tmpCmd.usage();
+            return false;
+        }
+        if (help) {
+            tmpCmd.usage();
+            return true;
+        }
+
+        if (commandNames.size() == 0) {
+            for (Map.Entry<String, JCommander> cmd : jcommander.getCommands().entrySet()) {
+                if (cmd.getKey().equals(name)) {
+                    continue;
+                }
+                System.out.println(generateDocument(cmd.getKey(), jcommander));
+            }
+        } else {
+            for (String commandName : commandNames) {
+                if (commandName.equals(name)) {
+                    continue;
+                }
+                if (!jcommander.getCommands().keySet().contains(commandName)) {
+                    continue;
+                }
+                System.out.println(generateDocument(commandName, jcommander));
+            }
+        }
+        return true;
+    }
+
+    private String generateDocument(String module, JCommander commander) {
+        JCommander cmd = commander.getCommands().get(module);
+        StringBuilder sb = new StringBuilder();
+        sb.append("------------\n\n");
+        sb.append("# ").append(module).append("\n\n");
+        sb.append("### Usage\n\n");
+        sb.append("`$").append(module).append("`\n\n");
+        sb.append("------------\n\n");
+        String desc = commander.getUsageFormatter().getCommandDescription(module);
+        if (null != desc && !desc.isEmpty()) {
+            sb.append(desc).append("\n");
+        }
+        sb.append("\n\n```bdocs-tab:example_shell\n")
+                .append("$ ");
+        if (null != jcommander.getProgramName() && !jcommander.getProgramName().isEmpty()) {
+            sb.append(jcommander.getProgramName()).append(" ");
+        }
+        sb.append(module);
+        if (cmd.getObjects().size() > 0
+                && cmd.getObjects().get(0).getClass().getName() == "com.beust.jcommander.JCommander") {
+            JCommander cmdObj = (JCommander) cmd.getObjects().get(0);
+            sb.append(" subcommand").append("\n```").append("\n\n");
+            for (String s : cmdObj.getCommands().keySet()) {
+                if (s.equals(name)) {
+                    continue;
+                }
+                sb.append("* `").append(s).append("`\n");
+            }
+            cmdObj.getCommands().forEach((subK, subV) -> {
+                if (!subK.equals(name)) {
+                    sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
+                    String subDesc = cmdObj.getUsageFormatter().getCommandDescription(subK);
+                    if (null != subDesc && !subDesc.isEmpty()) {
+                        sb.append(subDesc).append("\n");
+                    }
+                    sb.append("### Usage\n\n");
+                    sb.append("------------\n\n\n");
+                    sb.append("```bdocs-tab:example_shell\n$ ");
+                    if (null != jcommander.getProgramName() && !jcommander.getProgramName().isEmpty()) {
+                        sb.append(jcommander.getProgramName()).append(" ");
+                    }
+                    sb.append(module).append(" ").append(subK).append(" options").append("\n```\n\n");
+                    List<ParameterDescription> options = cmdObj.getCommands().get(subK).getParameters();
+                    if (options.size() > 0) {
+                        sb.append("Options\n\n\n");
+                        sb.append("|Flag|Description|Default|\n");
+                        sb.append("|---|---|---|\n");
+                    }
+                    options.forEach((option) ->
+                            sb.append("| `").append(option.getNames())
+                                    .append("` | ").append(option.getDescription().replace("\n", " "))
+                                    .append("|").append(option.getDefault()).append("|\n")
+                    );
+                }
+            });
+        } else {
+            sb.append(" options").append("\n```").append("\n\n");
+            sb.append("|Flag|Description|Default|\n");
+            sb.append("|---|---|---|\n");
+            List<ParameterDescription> options = cmd.getParameters();
+            options.forEach((option) ->
+                    sb.append("| `").append(option.getNames())
+                            .append("` | ").append(option.getDescription().replace("\n", " "))
+                            .append("|").append(option.getDefault()).append("|\n")
+            );
+        }
+        return sb.toString();
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import static org.testng.Assert.assertEquals;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.testng.annotations.Test;
+
+public class CmdGenerateDocsTest {
+
+    @Parameters(commandDescription = "Options")
+    public class Arguments {
+        @Parameter(names = {"-h", "--help"}, description = "Show this help message")
+        private boolean help = false;
+
+        @Parameter(names = {"-n", "--name"}, description = "Name")
+        private String name;
+    }
+
+    @Test
+    public void testHelp() {
+        PrintStream oldStream = System.out;
+        try {
+            ByteArrayOutputStream baoStream = new ByteArrayOutputStream(2048);
+            PrintStream cacheStream = new PrintStream(baoStream);
+            System.setOut(cacheStream);
+
+            CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
+            cmd.addCommand("test", new Arguments());
+            cmd.run(new String[]{"-h"});
+
+            String message = baoStream.toString();
+            String rightMsg = "Usage: pulsar gen-doc [options]\n"
+                    + "  Options:\n"
+                    + "    -n, --command-names\n"
+                    + "      List of command names\n"
+                    + "      Default: []\n"
+                    + "    -h, --help\n"
+                    + "      Display help information\n"
+                    + "      Default: false\n"
+                    + "\n";
+            assertEquals(rightMsg, message);
+        } finally {
+            System.setOut(oldStream);
+        }
+    }
+
+    @Test
+    public void testGenerateDocs() {
+        PrintStream oldStream = System.out;
+        try {
+            ByteArrayOutputStream baoStream = new ByteArrayOutputStream(2048);
+            PrintStream cacheStream = new PrintStream(baoStream);
+            System.setOut(cacheStream);
+
+            CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
+            cmd.addCommand("test", new Arguments());
+            cmd.run(null);
+
+            String message = baoStream.toString();
+            String rightMsg = "------------\n"
+                    + "\n"
+                    + "# test\n"
+                    + "\n"
+                    + "### Usage\n"
+                    + "\n"
+                    + "`$test`\n"
+                    + "\n"
+                    + "------------\n"
+                    + "\n"
+                    + "Options\n"
+                    + "\n"
+                    + "\n"
+                    + "```bdocs-tab:example_shell\n"
+                    + "$ pulsar test options\n"
+                    + "```\n"
+                    + "\n"
+                    + "|Flag|Description|Default|\n"
+                    + "|---|---|---|\n"
+                    + "| `-n, --name` | Name|null|\n"
+                    + "| `-h, --help` | Show this help message|false|\n"
+                    + "\n";
+            assertEquals(rightMsg, message);
+        } finally {
+            System.setOut(oldStream);
+        }
+    }
+}


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
common util for generate docs

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation