### PR TITLE
[website][pulsar]generate docs for pulsar subcommand: broker-tool

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
@@ -36,7 +36,8 @@ public class BrokerTool {
             .withDescription(NAME + " is used for operations on a specific broker")
             .withFlags(new CliFlags())
             .withConsole(System.out)
-            .addCommand(new LoadReportCommand());
+            .addCommand(new LoadReportCommand())
+            .addCommand(new GenerateDocsCommand());
 
         CliSpec<CliFlags> spec = specBuilder.build();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/BrokerTool.java
@@ -29,7 +29,7 @@ public class BrokerTool {
 
     public static final String NAME = "broker-tool";
 
-    public static void main(String[] args) {
+    public static int run(String[] args) {
         CliSpec.Builder<CliFlags> specBuilder = CliSpec.newBuilder()
             .withName(NAME)
             .withUsage(NAME + " [flags] [commands]")
@@ -41,8 +41,11 @@ public class BrokerTool {
 
         CliSpec<CliFlags> spec = specBuilder.build();
 
-        int retCode = Cli.runCli(spec, args);
-        Runtime.getRuntime().exit(retCode);
+        return Cli.runCli(spec, args);
     }
 
+    public static void main(String[] args) {
+        int retCode = run(args);
+        Runtime.getRuntime().exit(retCode);
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenerateDocsCommand.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/tools/GenerateDocsCommand.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tools;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.bookkeeper.tools.framework.Cli;
+import org.apache.bookkeeper.tools.framework.CliCommand;
+import org.apache.bookkeeper.tools.framework.CliFlags;
+import org.apache.bookkeeper.tools.framework.CliSpec;
+import org.apache.pulsar.common.util.CmdGenerateDocs;
+
+/**
+ * The command to generate documents of broker-tool.
+ */
+public class GenerateDocsCommand extends CliCommand<CliFlags, GenerateDocsCommand.GenDocFlags> {
+
+    private static final String NAME = "gen-doc";
+    private static final String DESC = "Generate documents of broker-tool";
+
+    /**
+     * The CLI flags of gen docs command.
+     */
+    protected static class GenDocFlags extends CliFlags {
+        @Parameter(
+                names = {"-n", "--command-names"},
+                description = "List of command names"
+        )
+        private List<String> commandNames = new ArrayList<>();
+    }
+
+    public GenerateDocsCommand() {
+        super(CliSpec.<GenDocFlags>newBuilder()
+                .withName(NAME)
+                .withDescription(DESC)
+                .withFlags(new GenDocFlags())
+                .build());
+    }
+
+    @Override
+    public Boolean apply(CliFlags globalFlags, String[] args) {
+        CliSpec<GenDocFlags> newSpec = CliSpec.newBuilder(spec)
+                .withRunFunc(cmdFlags -> apply(cmdFlags))
+                .build();
+        return 0 == Cli.runCli(newSpec, args);
+    }
+
+    private boolean apply(GenerateDocsCommand.GenDocFlags flags) {
+        CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
+        JCommander commander = new JCommander();
+        commander.addCommand("load-report", new LoadReportCommand.Flags());
+        cmd.addCommand("broker-tool", commander);
+        if (flags.commandNames.isEmpty()) {
+            cmd.run(null);
+        } else {
+            ArrayList<String> args = new ArrayList(flags.commandNames);
+            args.add(0, "-n");
+            cmd.run(args.toArray(new String[0]));
+        }
+        return true;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import org.testng.annotations.Test;
 
 /**
- * Holds util methods used in test.
+ * Broker Tool Tests.
  */
 public class BrokerToolTest {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.tools;
+
+import static org.testng.Assert.assertTrue;
+import com.beust.jcommander.Parameter;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.testng.annotations.Test;
+
+/**
+ * Holds util methods used in test.
+ */
+public class BrokerToolTest {
+
+    /**
+     * Test broker-tool generate docs
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGenerateDocs() throws Exception {
+        PrintStream oldStream = System.out;
+        try {
+            ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(baoStream));
+
+            BrokerTool.run(new String[]{"gen-doc"});
+
+            String message = baoStream.toString();
+
+            Class argumentsClass = Class.forName("org.apache.pulsar.broker.tools.LoadReportCommand$Flags");
+            Field[] fields = argumentsClass.getDeclaredFields();
+            for (Field field : fields) {
+                boolean fieldHasAnno = field.isAnnotationPresent(Parameter.class);
+                if (fieldHasAnno) {
+                    Parameter fieldAnno = field.getAnnotation(Parameter.class);
+                    String[] names = fieldAnno.names();
+                    String nameStr = Arrays.asList(names).toString();
+                    nameStr = nameStr.substring(1, nameStr.length() - 1);
+                    assertTrue(message.indexOf(nameStr) > 0);
+                }
+            }
+        } finally {
+            System.setOut(oldStream);
+        }
+    }
+}


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
generate docs for pulsar subcommand: broker-tool

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation