### PR TITLE
[website][pulsar]generate docs for pulsar subcommand: tokens

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.common.util.CmdGenerateDocs;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 
 public class TokensCliUtils {
@@ -303,6 +304,8 @@ public class TokensCliUtils {
         CommandValidateToken commandValidateToken = new CommandValidateToken();
         jcommander.addCommand("validate", commandValidateToken);
 
+        jcommander.addCommand("gen-doc", new Object());
+
         try {
             jcommander.parse(args);
 
@@ -329,6 +332,10 @@ public class TokensCliUtils {
             commandShowToken.run();
         } else if (cmd.equals("validate")) {
             commandValidateToken.run();
+        } else if (cmd.equals("gen-doc")) {
+            CmdGenerateDocs genDocCmd = new CmdGenerateDocs("pulsar");
+            genDocCmd.addCommand("tokens", jcommander);
+            genDocCmd.run(null);
         } else {
             System.err.println("Invalid command: " + cmd);
             System.exit(1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.utils.auth.tokens;
+
+import static org.testng.Assert.assertTrue;
+import com.beust.jcommander.Parameter;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.testng.annotations.Test;
+
+/**
+ * TokensCliUtils Tests.
+ */
+public class TokensCliUtilsTest {
+
+    /**
+     * Test tokens generate docs.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGenerateDocs() throws Exception {
+        PrintStream oldStream = System.out;
+        try {
+            ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(baoStream));
+
+            TokensCliUtils.main(new String[]{"gen-doc"});
+
+            String message = baoStream.toString();
+
+            String[] innerClassList = {
+                    TokensCliUtils.CommandCreateSecretKey.class.getName(),
+                    TokensCliUtils.CommandCreateKeyPair.class.getName(),
+                    TokensCliUtils.CommandCreateToken.class.getName(),
+                    TokensCliUtils.CommandShowToken.class.getName(),
+                    TokensCliUtils.CommandValidateToken.class.getName()
+            };
+
+            for (String name : innerClassList) {
+                assertInnerClass(name, message);
+            }
+
+        } finally {
+            System.setOut(oldStream);
+        }
+    }
+
+    private void assertInnerClass(String className, String message) throws Exception {
+        Class argumentsClass = Class.forName(className);
+        Field[] fields = argumentsClass.getDeclaredFields();
+        for (Field field : fields) {
+            boolean fieldHasAnno = field.isAnnotationPresent(Parameter.class);
+            if (fieldHasAnno) {
+                Parameter fieldAnno = field.getAnnotation(Parameter.class);
+                String[] names = fieldAnno.names();
+                if (names.length < 1) {
+                    continue;
+                }
+                String nameStr = Arrays.asList(names).toString();
+                nameStr = nameStr.substring(1, nameStr.length() - 1);
+                assertTrue(message.indexOf(nameStr) > 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
generate docs for pulsar subcommand - tokens

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation