### PR TITLE
[website][pulsar]generate html pages for pulsar command

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -98,6 +98,7 @@ node ./scripts/split-swagger-by-version.js
 ${ROOT_DIR}/site2/tools/pulsar-admin-doc-gen.sh
 ${ROOT_DIR}/site2/tools/pulsar-client-doc-gen.sh
 ${ROOT_DIR}/site2/tools/pulsar-perf-doc-gen.sh
+${ROOT_DIR}/site2/tools/pulsar-doc-gen.sh
 cd ${ROOT_DIR}/site2/website
 
 rm -rf ${ROOT_DIR}/generated-site/content

--- a/site2/tools/pulsar-doc-gen.sh
+++ b/site2/tools/pulsar-doc-gen.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION=`${ROOT_DIR}/src/get-project-version.py`
+DEST_DIR=$ROOT_DIR/generated-site
+
+cd $ROOT_DIR
+
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules
+mkdir -p $ROOT_DIR/site2/website/brodocs/documents
+
+$ROOT_DIR/bin/pulsar broker -g > $ROOT_DIR/site2/website/brodocs/documents/broker.md
+$ROOT_DIR/bin/pulsar broker-tool gen-doc > $ROOT_DIR/site2/website/brodocs/documents/broker-tool.md
+$ROOT_DIR/bin/pulsar compact-topic -t tmp -g > $ROOT_DIR/site2/website/brodocs/documents/compact-topic.md
+$ROOT_DIR/bin/pulsar tokens gen-doc > $ROOT_DIR/site2/website/brodocs/documents/tokens.md
+
+cd $ROOT_DIR/site2/website/brodocs
+cp pulsar-manifest.json manifest.json
+node brodoc.js
+
+cp index.html $DEST_DIR/tools/pulsar/${VERSION}/
+cp navData.js stylesheet.css $DEST_DIR/tools/pulsar/${VERSION}/
+cp scroll.js tabvisibility.js $DEST_DIR/tools/pulsar/${VERSION}/
+cp favicon.ico $DEST_DIR/tools/pulsar/${VERSION}/
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/bootstrap/dist/css
+cp -r $ROOT_DIR/site2/website/node_modules/bootstrap/dist/css/bootstrap.min.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/bootstrap/dist/css
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/font-awesome/css
+cp -r $ROOT_DIR/site2/website/node_modules/font-awesome/css/font-awesome.min.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/font-awesome/css
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/highlight.js/styles
+cp -r $ROOT_DIR/site2/website/node_modules/highlight.js/styles/default.css $DEST_DIR/tools/pulsar/${VERSION}/node_modules/highlight.js/styles
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery/dist
+cp -r $ROOT_DIR/site2/website/node_modules/jquery/dist/jquery.min.js $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery/dist/
+mkdir -p $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery.scrollto
+cp -r $ROOT_DIR/site2/website/node_modules/jquery.scrollto/jquery.scrollTo.min.js $DEST_DIR/tools/pulsar/${VERSION}/node_modules/jquery.scrollto
+
+

--- a/site2/website/brodocs/pulsar-manifest.json
+++ b/site2/website/brodocs/pulsar-manifest.json
@@ -1,0 +1,18 @@
+{
+  "docs": [
+    {
+      "filename": "broker.md"
+    },
+    {
+      "filename": "broker-tool.md"
+    },
+    {
+      "filename": "compact-topic.md"
+    },
+    {
+      "filename": "tokens.md"
+    }
+  ],
+  "title": "Docs",
+  "copyright": "<a href='http://pulsar.apache.org/'>Apache Pulsar</a>"
+}

--- a/site2/website/pages/en/pulsar-cli.js
+++ b/site2/website/pages/en/pulsar-cli.js
@@ -5,7 +5,7 @@ const Container = CompLibrary.Container;
 const CWD = process.cwd();
 const releases = require(`${CWD}/releases.json`);
 
-class PulsarPerfCli extends React.Component {
+class PulsarCli extends React.Component {
     render() {
         const latestVersion = releases[0];
         const url = "../js/getCliByVersion.js?latestVersion=" + latestVersion;
@@ -13,7 +13,7 @@ class PulsarPerfCli extends React.Component {
             <div className="pageContainer">
                 <Container className="mainContainer documentContainer postContainer" >
                     <span id="latestVersion" style={{display:'none'}}>{latestVersion}</span>
-                    <span id="clientModule" style={{display: 'none'}}>pulsar-perf</span>
+                    <span id="clientModule" style={{display: 'none'}}>pulsar</span>
                     <script src={url}></script>
                 </Container>
             </div>
@@ -21,4 +21,4 @@ class PulsarPerfCli extends React.Component {
     }
 }
 
-module.exports = PulsarPerfCli;
+module.exports = PulsarCli;

--- a/site2/website/static/js/custom.js
+++ b/site2/website/static/js/custom.js
@@ -116,6 +116,7 @@ window.addEventListener('load', function () {
         '<li><a href="/pulsar-admin-cli?version=' + version + '">Pulsar Admin</a></li>' +
         '<li><a href="/pulsar-client-cli?version=' + version + '">Pulsar Client</a></li>' +
         '<li><a href="/pulsar-perf-cli?version=' + version + '">Pulsar Perf</a></li>' +
+        '<li><a href="/pulsar-cli?version=' + version + '">Pulsar</a></li>' +
       '</ul>' +
         '</div>' +
         '</li>';

--- a/site2/website/static/js/getCliByVersion.js
+++ b/site2/website/static/js/getCliByVersion.js
@@ -30,6 +30,9 @@ function getCliByVersion(){
     } else if(clientModule === "pulsar-perf") {
         minMinorVersion = 8
         referenceLink = "/reference-cli-tools/#pulsar-perf"
+    } else if(clientModule === "pulsar") {
+        minMinorVersion = 8
+        referenceLink = "/reference-cli-tools/#pulsar"
     }
     if ((majorVersion > 1 && minorVersion <= minMinorVersion) || majorVersion === 1) {
         if (version === latestVersion) {


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
generate html pages for pulsar command

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation