### PR TITLE
[Issue 11007]  add a version of AUTO_PRODUCE_BYTES that doesn't validate the message in `encode`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -72,6 +73,7 @@ import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.apache.avro.Schema.Parser;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.mledger.impl.EntryCacheImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
@@ -88,6 +90,7 @@ import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.TopicMessageImpl;
 import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
+import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.EncryptionContext.EncryptionKey;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -4016,8 +4019,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // now we send with a schema, but we have enabled compression and batching
         // the producer will have to setup the schema and resume the send
-        Schema<MyBean> schema = Schema.AVRO(MyBean.class);
-        byte[] schemaBytes = schema.getSchemaInfo().getSchema();
+        Schema<MyBean> myBeanSchema = Schema.AVRO(MyBean.class);
+        byte[] schemaBytes = myBeanSchema.getSchemaInfo().getSchema();
         org.apache.avro.Schema schemaAvroNative = new Parser().parse(new ByteArrayInputStream(schemaBytes));
         AvroWriter<MyBean> writer = new AvroWriter<>(schemaAvroNative);
         byte[] content = writer.write(payload);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -344,7 +344,6 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
              Consumer<V2Data> c = pulsarClient.newConsumer(v2Schema)
                      .topic(topic)
                      .subscriptionName("sub1").subscribe()) {
-            Assert.expectThrows(SchemaSerializationException.class, () -> p.send(contentV1));
 
             p.newMessage(Schema.NATIVE_AVRO(v1SchemaAvroNative))
                     .value(contentV1).send();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -339,7 +339,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 .topic(topic).create()) {
             p.send(contentV2);
         }
-        try (Producer<byte[]> p = pulsarClient.newProducer()
+        try (Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative))
                 .topic(topic).create();
              Consumer<V2Data> c = pulsarClient.newConsumer(v2Schema)
                      .topic(topic)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -553,7 +553,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         Consumer<byte[]> c = pulsarClient.newConsumer(Schema.NATIVE_AVRO(v2SchemaAvroNative))
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
-        Producer<byte[]> p = pulsarClient.newProducer(NATSchema.NATIVE_AVRO(v1SchemaAvroNative))
+        Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative))
                 .topic(topic)
                 .enableBatching(true)
                 .batchingMaxPublishDelay(10, TimeUnit.SECONDS).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -242,6 +242,17 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         } catch (PulsarClientException e) {
             assertTrue(e.getCause() instanceof SchemaSerializationException);
         }
+
+        Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
+        byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
+        // if using NATIVE_AVRO, producer can connect but the publish will fail
+        try (Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative)).topic(topic).create()) {
+            p.send("junkdata".getBytes(UTF_8));
+        } catch (PulsarClientException e) {
+            assertTrue(e.getCause() instanceof SchemaSerializationException);
+        }
+   
     }
 
     @Test
@@ -276,6 +287,68 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
             p.newMessage(Schema.AUTO_PRODUCE_BYTES(Schema.AVRO(V1Data.class)))
                     .value(contentV1).send();
             p.send(contentV2);
+            Message<V2Data> msg1 = c.receive();
+            V2Data msg1Value = msg1.getValue();
+            Assert.assertEquals(dataV1.i, msg1Value.i);
+            assertNull(msg1Value.j);
+            Assert.assertEquals(msg1.getSchemaVersion(), new LongSchemaVersion(0).bytes());
+
+            Message<V2Data> msg2 = c.receive();
+            Assert.assertEquals(dataV2, msg2.getValue());
+            Assert.assertEquals(msg2.getSchemaVersion(), new LongSchemaVersion(1).bytes());
+
+            try {
+                p.newMessage(Schema.BYTES).value(contentV1).send();
+                if (schemaValidationEnforced) {
+                    Assert.fail("Shouldn't be able to send to a schema'd topic with no schema"
+                            + " if SchemaValidationEnabled is enabled");
+                }
+                Message<V2Data> msg3 = c.receive();
+                Assert.assertEquals(msg3.getSchemaVersion(), SchemaVersion.Empty.bytes());
+            } catch (PulsarClientException e) {
+                if (schemaValidationEnforced) {
+                    Assert.assertTrue(e instanceof IncompatibleSchemaException);
+                } else {
+                    Assert.fail("Shouldn't throw IncompatibleSchemaException"
+                            + " if SchemaValidationEnforced is disabled");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newNativeAvroProducerForMessageSchemaOnTopicWithMultiVersionSchema() throws Exception {
+        String topic = "my-property/my-ns/schema-test";
+        Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
+        byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
+        AvroWriter<V1Data> v1Writer = new AvroWriter<>(v1SchemaAvroNative);
+        Schema<V2Data> v2Schema = Schema.AVRO(V2Data.class);
+        byte[] v2SchemaBytes = v2Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v2SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v2SchemaBytes));
+        AvroWriter<V2Data> v2Writer = new AvroWriter<>(v2SchemaAvroNative);
+        V1Data dataV1 = new V1Data(2);
+        V2Data dataV2 = new V2Data(3, 5);
+        byte[] contentV1 = v1Writer.write(dataV1);
+        byte[] contentV2 = v2Writer.write(dataV2);
+        try (Producer<byte[]> ignored = pulsarClient.newProducer(Schema.NATIVE_AVRO(v1SchemaAvroNative))
+                .topic(topic).create()) {
+        }
+        try (Producer<byte[]> p = pulsarClient.newProducer(Schema.NATIVE_AVRO(v2SchemaAvroNative))
+                .topic(topic).create()) {
+            p.send(contentV2);
+        }
+        try (Producer<byte[]> p = pulsarClient.newProducer()
+                .topic(topic).create();
+             Consumer<V2Data> c = pulsarClient.newConsumer(v2Schema)
+                     .topic(topic)
+                     .subscriptionName("sub1").subscribe()) {
+            Assert.expectThrows(SchemaSerializationException.class, () -> p.send(contentV1));
+
+            p.newMessage(Schema.NATIVE_AVRO(v1SchemaAvroNative))
+                    .value(contentV1).send();
+            p.newMessage(Schema.NATIVE_AVRO(v2SchemaAvroNative))
+                    .value(contentV2).send();
             Message<V2Data> msg1 = c.receive();
             V2Data msg1Value = msg1.getValue();
             Assert.assertEquals(dataV1.i, msg1Value.i);
@@ -375,6 +448,44 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
     }
 
     @Test
+    public void newNativeAvroProducerForMessageSchemaOnTopicInitialWithNoSchema() throws Exception {
+        String topic = "my-property/my-ns/schema-test";
+        Schema<V1Data> v1Schema = Schema.AVRO(V1Data.class);
+        byte[] v1SchemaBytes = v1Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v1SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v1SchemaBytes));
+        AvroWriter<V1Data> v1Writer = new AvroWriter<>(v1SchemaAvroNative);
+        Schema<V2Data> v2Schema = Schema.AVRO(V2Data.class);
+        byte[] v2SchemaBytes = v2Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v2SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v2SchemaBytes));
+        AvroWriter<V2Data> v2Writer = new AvroWriter<>(v2SchemaAvroNative);
+
+        try (Producer<byte[]> p = pulsarClient.newProducer()
+                .topic(topic).create();
+             Consumer<byte[]> c = pulsarClient.newConsumer()
+                     .topic(topic)
+                     .subscriptionName("sub1").subscribe()) {
+            for (int i = 0; i < 2; ++i) {
+                V1Data dataV1 = new V1Data(i);
+                V2Data dataV2 = new V2Data(i, -i);
+                byte[] contentV1 = v1Writer.write(dataV1);
+                byte[] contentV2 = v2Writer.write(dataV2);
+                p.newMessage(Schema.NATIVE_AVRO(v1SchemaAvroNative)).value(contentV1).send();
+                Message<byte[]> msg1 = c.receive();
+                Assert.assertEquals(msg1.getSchemaVersion(), new LongSchemaVersion(0).bytes());
+                Assert.assertEquals(msg1.getData(), contentV1);
+                p.newMessage(Schema.NATIVE_AVRO(v2SchemaAvroNative)).value(contentV2).send();
+                Message<byte[]> msg2 = c.receive();
+                Assert.assertEquals(msg2.getSchemaVersion(), new LongSchemaVersion(1).bytes());
+                Assert.assertEquals(msg2.getData(), contentV2);
+            }
+        }
+
+        List<SchemaInfo> allSchemas = admin.schemas().getAllSchemas(topic);
+        Assert.assertEquals(allSchemas, Arrays.asList(v1Schema.getSchemaInfo(),
+                v2Schema.getSchemaInfo()));
+    }
+
+    @Test
     public void newProducerForMessageSchemaWithBatch() throws Exception {
         String topic = "my-property/my-ns/schema-test";
         Consumer<V2Data> c = pulsarClient.newConsumer(Schema.AVRO(V2Data.class))
@@ -407,6 +518,66 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 byte[] content = incompatibleDataAvroWriter.write(new IncompatibleData(-i, -i));
                 try {
                     p.newMessage(Schema.AUTO_PRODUCE_BYTES(Schema.AVRO(IncompatibleData.class)))
+                            .value(content).send();
+                } catch (Exception e) {
+                    Assert.assertTrue(e instanceof IncompatibleSchemaException, e.getMessage());
+                }
+            }
+        }
+        p.flush();
+        for (int i = 0; i < total; ++i) {
+            V2Data value = c.receive().getValue();
+            if (i / batch % 2 == 0) {
+                assertNull(value.j);
+                Assert.assertEquals(value.i, i);
+            } else {
+                Assert.assertEquals(value, new V2Data(i, i + total));
+            }
+        }
+        c.close();
+    }
+
+
+    @Test
+    public void newNativeAvroProducerForMessageSchemaWithBatch() throws Exception {
+        String topic = "my-property/my-ns/schema-test";
+        Schema<V2Data> v2Schema = Schema.AVRO(V2Data.class);
+        byte[] v2SchemaBytes = v2Schema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema v2SchemaAvroNative = new Parser().parse(new ByteArrayInputStream(v2SchemaBytes));
+
+        Consumer<V2Data> c = pulsarClient.newConsumer(Schema.NATIVE_AVRO(v2SchemaAvroNative))
+                .topic(topic)
+                .subscriptionName("sub1").subscribe();
+        Producer<byte[]> p = pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(true)
+                .batchingMaxPublishDelay(10, TimeUnit.SECONDS).create();
+        AvroWriter<V1Data> v1DataAvroWriter = new AvroWriter<>(
+                ReflectData.AllowNull.get().getSchema(V1Data.class));
+        AvroWriter<V2Data> v2DataAvroWriter = new AvroWriter<>(
+                ReflectData.AllowNull.get().getSchema(V2Data.class));
+        AvroWriter<IncompatibleData> incompatibleDataAvroWriter = new AvroWriter<>(
+                ReflectData.AllowNull.get().getSchema(IncompatibleData.class));
+        int total = 20;
+        int batch = 5;
+        int incompatible = 3;
+        for (int i = 0; i < total; ++i) {
+            if (i / batch % 2 == 0) {
+                byte[] content = v1DataAvroWriter.write(new V1Data(i));
+                p.newMessage(Schema.NATIVE_AVRO(v1SchemaAvroNative))
+                        .value(content).sendAsync();
+            } else {
+                byte[] content = v2DataAvroWriter.write(new V2Data(i, i + total));
+                p.newMessage(Schema.NATIVE_AVRO(v2SchemaAvroNative))
+                        .value(content).sendAsync();
+            }
+            if ((i + 1) % incompatible == 0) {
+                Schema<IncompatibleData> incompatibleSchema = Schema.AVRO(IncompatibleData.class);
+                byte[] incompatibleSchemaBytes = incompatibleSchema.getSchemaInfo().getSchema();
+                org.apache.avro.Schema incompatibleSchemaAvroNative = new Parser().parse(new ByteArrayInputStream(incompatibleSchemaBytes));
+                byte[] content = incompatibleDataAvroWriter.write(new IncompatibleData(-i, -i));
+                try {
+                    p.newMessage(Schema.NATIVE_AVRO(incompatibleSchemaAvroNative))
                             .value(content).send();
                 } catch (Exception e) {
                     Assert.assertTrue(e instanceof IncompatibleSchemaException, e.getMessage());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -553,7 +553,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         Consumer<byte[]> c = pulsarClient.newConsumer(Schema.NATIVE_AVRO(v2SchemaAvroNative))
                 .topic(topic)
                 .subscriptionName("sub1").subscribe();
-        Producer<byte[]> p = pulsarClient.newProducer()
+        Producer<byte[]> p = pulsarClient.newProducer(NATSchema.NATIVE_AVRO(v1SchemaAvroNative))
                 .topic(topic)
                 .enableBatching(true)
                 .batchingMaxPublishDelay(10, TimeUnit.SECONDS).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -29,9 +29,12 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
+import org.apache.avro.Schema.Parser;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,6 +66,7 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
+import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -745,7 +749,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         producer.newMessage(Schema.BYTES).value("test".getBytes(StandardCharsets.UTF_8)).send();
         producer.newMessage(Schema.BOOL).value(true).send();
         
-        Schema<MyBean> personThreeSchema = Schema.AVRO(Schemas.PersonThree.class);
+        Schema<Schemas.PersonThree> personThreeSchema = Schema.AVRO(Schemas.PersonThree.class);
         byte[] personThreeSchemaBytes = personThreeSchema.getSchemaInfo().getSchema();
         org.apache.avro.Schema personThreeSchemaAvroNative = new Parser().parse(new ByteArrayInputStream(personThreeSchemaBytes));
         AvroWriter<Schemas.PersonThree> writer = new AvroWriter<>(personThreeSchemaAvroNative);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -763,7 +763,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(allSchemas.get(2), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(3), Schema.AVRO(Schemas.PersonOne.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(4), Schema.BOOL.getSchemaInfo());
-        Assert.assertEquals(allSchemas.get(5), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -763,7 +763,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(allSchemas.get(2), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(3), Schema.AVRO(Schemas.PersonOne.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(4), Schema.BOOL.getSchemaInfo());
-        Assert.assertEquals(allSchemas.get(4), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(5), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -744,6 +744,13 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         producer.newMessage(Schema.BYTES).value("test".getBytes(StandardCharsets.UTF_8)).send();
         producer.newMessage(Schema.BYTES).value("test".getBytes(StandardCharsets.UTF_8)).send();
         producer.newMessage(Schema.BOOL).value(true).send();
+        
+        Schema<MyBean> personThreeSchema = Schema.AVRO(Schemas.PersonThree.class);
+        byte[] personThreeSchemaBytes = personThreeSchema.getSchemaInfo().getSchema();
+        org.apache.avro.Schema personThreeSchemaAvroNative = new Parser().parse(new ByteArrayInputStream(personThreeSchemaBytes));
+        AvroWriter<Schemas.PersonThree> writer = new AvroWriter<>(personThreeSchemaAvroNative);
+        byte[] content = writer.write(new Schemas.PersonThree(0, "ran"));
+        producer.newMessage(Schema.NATIVE_AVRO(personThreeSchemaAvroNative)).value(content).send();
 
         List<SchemaInfo> allSchemas = admin.schemas().getAllSchemas(topic);
         Assert.assertEquals(allSchemas.size(), 5);
@@ -752,6 +759,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(allSchemas.get(2), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(3), Schema.AVRO(Schemas.PersonOne.class).getSchemaInfo());
         Assert.assertEquals(allSchemas.get(4), Schema.BOOL.getSchemaInfo());
+        Assert.assertEquals(allSchemas.get(4), Schema.AVRO(Schemas.PersonThree.class).getSchemaInfo());
     }
 
     @Test

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -435,7 +435,7 @@ public interface Schema<T> extends Cloneable{
      * @since 2.9.0
      * @see #AUTO_PRODUCE_BYTES()
      */
-    static Schema<byte[]> AUTO_PRODUCE_VALIDATED_AVRO_BYTES(Schema<?> schema) {
+    static Schema<byte[]> NATIVE_AVRO(Object schema) {
         return DefaultImplementation.newAutoProduceValidatedAvroSchema(schema);
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -433,7 +433,6 @@ public interface Schema<T> extends Cloneable{
      *
      * @return the auto schema instance
      * @since 2.9.0
-     * @see #AUTO_PRODUCE_BYTES()
      */
     static Schema<byte[]> NATIVE_AVRO(Object schema) {
         return DefaultImplementation.newAutoProduceValidatedAvroSchema(schema);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -426,6 +426,19 @@ public interface Schema<T> extends Cloneable{
         return DefaultImplementation.newAutoProduceSchema(schema);
     }
 
+    /**
+     * Create a schema instance that accepts a serialized Avro payload
+     * without validating it against the schema specified. 
+     * It can be useful when migrating data from existing event or message stores.
+     *
+     * @return the auto schema instance
+     * @since 2.9.0
+     * @see #AUTO_PRODUCE_BYTES()
+     */
+    static Schema<byte[]> AUTO_PRODUCE_VALIDATED_AVRO_BYTES(Schema<?> schema) {
+        return DefaultImplementation.newAutoProduceValidatedAvroSchema(schema);
+    }
+
     // CHECKSTYLE.ON: MethodName
 
     static Schema<?> getSchema(SchemaInfo schemaInfo) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -301,7 +301,7 @@ public class DefaultImplementation {
     public static Schema<byte[]> newAutoProduceValidatedAvroSchema(Object schema) {
         return catchExceptions(
                 () -> (Schema<byte[]>) getConstructor(
-                    "org.apache.pulsar.client.impl.schema.AutoProduceValidatedAvroBytesSchema", Object.class)
+                    "org.apache.pulsar.client.impl.schema.NativeAvroBytesSchema", Object.class)
                         .newInstance(schema));
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -298,6 +298,13 @@ public class DefaultImplementation {
                         .newInstance(schema));
     }
 
+    public static Schema<byte[]> newAutoProduceValidatedAvroSchema(Schema<?> schema) {
+        return catchExceptions(
+                () -> (Schema<byte[]>) getConstructor(
+                    "org.apache.pulsar.client.impl.schema.AutoProduceValidatedAvroBytesSchema", Schema.class)
+                        .newInstance(schema));
+    }
+
     public static Schema<KeyValue<byte[], byte[]>> newKeyValueBytesSchema() {
         return catchExceptions(
                 () -> (Schema<KeyValue<byte[], byte[]>>) getStaticMethod(

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/internal/DefaultImplementation.java
@@ -298,10 +298,10 @@ public class DefaultImplementation {
                         .newInstance(schema));
     }
 
-    public static Schema<byte[]> newAutoProduceValidatedAvroSchema(Schema<?> schema) {
+    public static Schema<byte[]> newAutoProduceValidatedAvroSchema(Object schema) {
         return catchExceptions(
                 () -> (Schema<byte[]>) getConstructor(
-                    "org.apache.pulsar.client.impl.schema.AutoProduceValidatedAvroBytesSchema", Schema.class)
+                    "org.apache.pulsar.client.impl.schema.AutoProduceValidatedAvroBytesSchema", Object.class)
                         .newInstance(schema));
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
@@ -33,10 +33,9 @@ import java.util.Optional;
  * For this reason, it will not perform bytes validation against the schema in encoding and decoding, which are just identify functions.
  * This class also makes it possible for users to bring in their own Avro serializer/deserializer. 
  */
-public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSchema<T> {
+public class AutoProduceValidatedAvroBytesSchema<T> implements Schema<byte[]> {
 
     private Schema<T> schema;
-
     
     public AutoProduceValidatedAvroBytesSchema(org.apache.avro.Schema schema) {
         SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
@@ -54,11 +53,14 @@ public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSche
         this.schema = schema;
     }
 
+    public boolean schemaInitialized() {
+        return schema != null;
+    }
+
     private static org.apache.avro.Schema validateSchema (Object schema) {
         if (! (schema instanceof org.apache.avro.Schema)) throw new IllegalArgumentException("The input schema is not of type 'org.apache.avro.Schema'.");
         return (org.apache.avro.Schema) schema;
     }
-        
 
     private void ensureSchemaInitialized() {
         checkState(schemaInitialized(), "Schema is not initialized before used");
@@ -76,6 +78,23 @@ public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSche
         ensureSchemaInitialized();
         
         return bytes;
+    }
+
+    @Override
+    public SchemaInfo getSchemaInfo() {
+        ensureSchemaInitialized();
+
+        return schema.getSchemaInfo();
+    }
+
+    @Override
+    public Optional<Object> getNativeSchema() {
+        return Optional.ofNullable(schema);
+    }
+
+    @Override
+    public Schema<byte[]> clone() {
+        return new AutoProduceBytesSchema<>(schema.clone());
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
-import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
@@ -38,21 +37,25 @@ public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSche
     
     public AutoProduceValidatedAvroBytesSchema(org.apache.avro.Schema schema) {
         SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
-        
-        setSchema(DefaultImplementation.newAvroSchema(schemaDefinition));
+        this.schema = AvroSchema.of(schemaDefinition);
     }
 
-    public AutoProduceValidatedAvroBytesSchema(Schema<T> schema) {
-        this.schema = null;
-        setSchema(schema);
+    public AutoProduceValidatedAvroBytesSchema(Object schema) {
+        this(validateSchema(schema));
     }
 
     public void setSchema(Schema<T> schema) {
         if (SchemaType.AVRO != schema.getSchemaInfo().getType()) {
-            throw new IllegalArgumentException("Provided schema is not an Avro type.");
+            throw new IllegalArgumentException("The type of input schema is not 'SchemaType.AVRO'.");
         }
         this.schema = schema;
     }
+
+    private static org.apache.avro.Schema validateSchema (Object schema) {
+        if (! (schema instanceof org.apache.avro.Schema)) throw new IllegalArgumentException("The input schema is not of type 'org.apache.avro.Schema'.");
+        return (org.apache.avro.Schema) schema;
+    }
+        
 
     private void ensureSchemaInitialized() {
         checkState(schemaInitialized(), "Schema is not initialized before used");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.internal.DefaultImplementation;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Optional;
+
+/**
+ * Auto detect schema.
+ */
+public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSchema<T> {
+
+    private Schema<T> schema;
+
+    
+    public AutoProduceValidatedAvroBytesSchema(org.apache.avro.Schema schema) {
+        SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
+        
+        setSchema(DefaultImplementation.newAvroSchema(schemaDefinition));
+    }
+
+    public AutoProduceValidatedAvroBytesSchema(Schema<T> schema) {
+        setSchema(schema);
+    }
+
+    public void setSchema(Schema<T> schema) {
+        if (SchemaType.AVRO != schema.getSchemaInfo().getType()) {
+            throw new IllegalArgumentException("Provided schema is not an Avro type.");
+        }
+        this.schema = schema;
+    }
+
+    private void ensureSchemaInitialized() {
+        checkState(schemaInitialized(), "Schema is not initialized before used");
+    }
+
+    @Override
+    public byte[] encode(byte[] message) {
+        ensureSchemaInitialized();
+
+        return message;
+    }
+
+    @Override
+    public byte[] decode(byte[] bytes, byte[] schemaVersion) {
+        ensureSchemaInitialized();
+        
+        return bytes;
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
@@ -28,7 +28,10 @@ import org.apache.pulsar.common.schema.SchemaType;
 import java.util.Optional;
 
 /**
- * Auto detect schema.
+ * Schema from a native Apache Avro schema.
+ * This class is supposed to be used for working with existing data serialized in Avro, possibly stored in another system like Kafka.
+ * For this reason, it will not perform bytes validation against the schema in encoding and decoding, which are just identify functions.
+ * This class also makes it possible for users to bring in their own Avro serializer/deserializer. 
  */
 public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSchema<T> {
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceValidatedAvroBytesSchema.java
@@ -43,6 +43,7 @@ public class AutoProduceValidatedAvroBytesSchema<T> extends AutoProduceBytesSche
     }
 
     public AutoProduceValidatedAvroBytesSchema(Schema<T> schema) {
+        this.schema = null;
         setSchema(schema);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
@@ -33,16 +33,16 @@ import java.util.Optional;
  * For this reason, it will not perform bytes validation against the schema in encoding and decoding, which are just identify functions.
  * This class also makes it possible for users to bring in their own Avro serializer/deserializer. 
  */
-public class AutoProduceValidatedAvroBytesSchema<T> implements Schema<byte[]> {
+public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
 
     private Schema<T> schema;
     
-    public AutoProduceValidatedAvroBytesSchema(org.apache.avro.Schema schema) {
+    public NativeAvroBytesSchema(org.apache.avro.Schema schema) {
         SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
         this.schema = AvroSchema.of(schemaDefinition);
     }
 
-    public AutoProduceValidatedAvroBytesSchema(Object schema) {
+    public NativeAvroBytesSchema(Object schema) {
         this(validateSchema(schema));
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
@@ -36,21 +36,20 @@ import java.util.Optional;
 public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
 
     private Schema<T> schema;
+    private org.apache.avro.Schema nativeSchema;
     
     public NativeAvroBytesSchema(org.apache.avro.Schema schema) {
-        SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
-        this.schema = AvroSchema.of(schemaDefinition);
+        setSchema(schema);
     }
 
     public NativeAvroBytesSchema(Object schema) {
         this(validateSchema(schema));
     }
 
-    public void setSchema(Schema<T> schema) {
-        if (SchemaType.AVRO != schema.getSchemaInfo().getType()) {
-            throw new IllegalArgumentException("The type of input schema is not 'SchemaType.AVRO'.");
-        }
-        this.schema = schema;
+    public void setSchema(org.apache.avro.Schema schema) {
+        SchemaDefinition schemaDefinition = SchemaDefinition.builder().withJsonDef(schema.toString(false)).build();
+        this.nativeSchema = schema;
+        this.schema = AvroSchema.of(schemaDefinition);
     }
 
     public boolean schemaInitialized() {
@@ -58,7 +57,8 @@ public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
     }
 
     private static org.apache.avro.Schema validateSchema (Object schema) {
-        if (! (schema instanceof org.apache.avro.Schema)) throw new IllegalArgumentException("The input schema is not of type 'org.apache.avro.Schema'.");
+        if (! (schema instanceof org.apache.avro.Schema)) 
+            throw new IllegalArgumentException("The input schema is not of type 'org.apache.avro.Schema'.");
         return (org.apache.avro.Schema) schema;
     }
 
@@ -89,7 +89,7 @@ public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
 
     @Override
     public Optional<Object> getNativeSchema() {
-        return Optional.ofNullable(schema);
+        return Optional.ofNullable(this.nativeSchema);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/NativeAvroBytesSchema.java
@@ -29,9 +29,11 @@ import java.util.Optional;
 
 /**
  * Schema from a native Apache Avro schema.
- * This class is supposed to be used for working with existing data serialized in Avro, possibly stored in another system like Kafka.
- * For this reason, it will not perform bytes validation against the schema in encoding and decoding, which are just identify functions.
- * This class also makes it possible for users to bring in their own Avro serializer/deserializer. 
+ * This class is supposed to be used on the producer side for working with existing data serialized in Avro, 
+ * possibly stored in another system like Kafka.
+ * For this reason, it will not perform bytes validation against the schema in encoding and decoding, 
+ * which are just identify functions.
+ * This class also makes it possible for users to bring in their own Avro serialization method. 
  */
 public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
 
@@ -73,11 +75,10 @@ public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
         return message;
     }
 
+    /* decode should not be used because this is a Schema to be used on the Producer side */
     @Override
     public byte[] decode(byte[] bytes, byte[] schemaVersion) {
-        ensureSchemaInitialized();
-        
-        return bytes;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -89,12 +90,12 @@ public class NativeAvroBytesSchema<T> implements Schema<byte[]> {
 
     @Override
     public Optional<Object> getNativeSchema() {
-        return Optional.ofNullable(this.nativeSchema);
+        return Optional.of(this.nativeSchema);
     }
 
     @Override
     public Schema<byte[]> clone() {
-        return new AutoProduceBytesSchema<>(schema.clone());
+        return new NativeAvroBytesSchema(nativeSchema);
     }
 
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #11007

### Motivation

When ingesting event/message data from external systems such as Kafka and Cassandra, the events very often are already serialized with Avro with the schemas also available. In such cases, a Pulsar producer doesn't need to perform the validation step again when sending the events to a topic.

### Modifications

Introduce a new class `AutoProduceValidatedAvroBytesSchema` that ~~extends `AutoProduceBytesSchema`~~ implements `Schema<byte[]>`.

~~TODO: make the `public AutoProduceValidatedAvroBytesSchema(org.apache.avro.Schema schema)` constructor accessible to the client.~~

Add `NATIVE_AVRO` method to `org.apache.pulsar.client.api.Schema` which calls `AutoProduceValidatedAvroBytesSchema`'s constructor via reflection. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
