### PR TITLE
Fix incorrect usage of localrun command in ES sink

### DIFF
--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -90,7 +90,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -100,7 +100,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -112,7 +111,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.5.1/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.5.1/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.5.2/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.5.2/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.6.0/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.6.1/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.6.2/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.6.3/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.6.3/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.6.4/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.6.4/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.7.0/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.7.1/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.7.1/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.7.2/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.7.2/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.7.3/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.7.3/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.8.0/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.8.0/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```

--- a/site2/website/versioned_docs/version-2.8.1/io-elasticsearch-sink.md
+++ b/site2/website/versioned_docs/version-2.8.1/io-elasticsearch-sink.md
@@ -91,7 +91,7 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
     ```bash
     $ bin/pulsar standalone
     ```
-    Make sure the nar file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
+    Make sure the NAR file is available at `connectors/pulsar-io-elastic-search-{{pulsar:version}}.nar`.
 
 3. Start the Pulsar Elasticsearch connector in local run mode using one of the following methods.
     * Use the **JSON** configuration as shown previously. 
@@ -101,7 +101,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config '{"elasticSearchUrl":"http://localhost:9200","indexName": "my_index","username": "scooby","password": "doobie"}' \
             --inputs elasticsearch_test
         ```
@@ -113,7 +112,6 @@ Before using the ElasticSearch sink connector, you need to create a configuratio
             --tenant public \
             --namespace default \
             --name elasticsearch-test-sink \
-            --sink-type elastic_search \
             --sink-config-file elasticsearch-sink.yml \
             --inputs elasticsearch_test
         ```


### PR DESCRIPTION
### Motivation

Option `--archive` and `--sink-type` cannot be specified at the same time:
```
Cannot specify both archive and sink-type
```
since
```
if (archive != null && sinkType != null) {
    throw new ParameterException("Cannot specify both archive and sink-type");
}
```

### Modifications

Remove option `--sink-type`.