### PR TITLE
fix retention size policy delete too much ledgers

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2383,13 +2383,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             for (LedgerInfo ls : ledgers.headMap(slowestReaderLedgerId, false).values()) {
                 // currentLedger can not be deleted
                 if (ls.getLedgerId() == currentLedger.getId()) {
-                    log.debug("[{}] Ledger {} skipped for deletion as it is currently being written to", name,
-                            ls.getLedgerId());
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Ledger {} skipped for deletion as it is currently being written to", name,
+                                ls.getLedgerId());
+                    }
                     break;
                 }
                 // if truncate, all ledgers besides currentLedger are going to be deleted
                 if (isTruncate){
-                    log.debug("[{}] Ledger {} has been truncated, , ts {}", name, ls.getLedgerId(), ls.getTimestamp());
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Ledger {} has been truncated with ts {}", name, ls.getLedgerId(), ls.getTimestamp());
+                    }
                     ledgersToDelete.add(ls);
                     continue;
                 }
@@ -2401,7 +2405,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     boolean overRetentionQuotaAfterDelete = isLedgerRetentionOverSizeQuotaAfterDelete(totalSizeToDelete);
                     if (overRetentionQuota) {
                         if (overRetentionQuotaAfterDelete) {
-                            log.debug("[{}] Ledger {} is over quota", name, ls.getLedgerId());
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] Ledger {} is over quota", name, ls.getLedgerId());
+                            }
                             ledgersToDelete.add(ls);
                             continue;
                         } else {
@@ -2415,9 +2421,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
 
                 if (hasLedgerRetentionExpired(ls.getTimestamp())) {
-                    log.debug("[{}] Ledger {} has expired, expired is {}, ts {}", name, ls.getLedgerId(), ls.getTimestamp());
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Ledger {} has expired, expired is {}, ts {}", name, ls.getLedgerId(), ls.getTimestamp());
+                    }
                     ledgersToDelete.add(ls);
                     continue;
+                } else {
+                    // once retention constraint has been met, skip check
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Ledger {} not deleted. Neither expired nor over-quota", name, ls.getLedgerId());
+                    }
+                    break;
                 }
             }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -44,6 +44,7 @@ import java.nio.ReadOnlyBufferException;
 import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1968,6 +1969,46 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ml.close();
         assertTrue(ml.getLedgersInfoAsList().size() > 1);
         assertTrue(ml.getTotalSize() > "shortmessage".getBytes().length);
+    }
+
+    @Test
+    public void testRetentionSize() throws Exception {
+        final int retentionSizeInMB = 5;
+        final int totalMessage = 10;
+
+        // message size is 1MB
+        final int messageSize = 1048576;
+        char[] data = new char[messageSize];
+        Arrays.fill(data, 'a');
+        byte [] message = new String(data).getBytes(Encoding);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setRetentionSizeInMB(retentionSizeInMB);
+        config.setMaxEntriesPerLedger(1);
+        config.setRetentionTime(1, TimeUnit.HOURS);
+
+
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("retention_size_ledger", config);
+        ManagedCursor c1 = ml.openCursor("c1");
+        Position position = null;
+        for (int i = 0; i < totalMessage; i++) {
+            position = ml.addEntry(message);
+        }
+        List<Entry> entryList = c1.readEntries(totalMessage);
+        if (null != position) {
+            c1.markDelete(position);
+        }
+        entryList.forEach(entry -> {
+            log.info("Read entry position {}:{}", entry.getLedgerId(), entry.getEntryId());
+            entry.release();
+        });
+
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(ml.getTotalSize() <= retentionSizeInMB * 1024 * 1024);
+            assertEquals(ml.getLedgersInfoAsList().size(), 5);
+        });
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1996,7 +1996,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < totalMessage; i++) {
             position = ml.addEntry(message);
         }
-        // all ledgers are not delete yet since not entry has been acked for c1
+        // all ledgers are not delete yet since no entry has been acked for c1
         assertEquals(ml.getLedgersInfoAsList().size(), totalMessage);
 
         List<Entry> entryList = c1.readEntries(totalMessage);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1996,6 +1996,9 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < totalMessage; i++) {
             position = ml.addEntry(message);
         }
+        // all ledgers are not delete yet since not entry has been acked for c1
+        assertEquals(ml.getLedgersInfoAsList().size(), totalMessage);
+
         List<Entry> entryList = c1.readEntries(totalMessage);
         if (null != position) {
             c1.markDelete(position);


### PR DESCRIPTION

Fixes #11241
### Motivation
This pull request fix the error that retention size policy delete too much ledgers when all cursors has no backlog

### Modifications

1.  generate `ledgersToDelete` by checking ledger size one by one instead of `TOTAL_SIZE_UPDATER`
2. refactor the logic of generate `ledgersToDelete`
3. add test code

### Verifying this change
This change added tests and can be verified as follows:
- add test in `ManagedLedgerTest.testRetentionSize()`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
