### PR TITLE
[admin] Enable peeking encrypted batch messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2519,6 +2519,7 @@ public class PersistentTopicsBase extends AdminResource {
             responseBuilder.header("X-Pulsar-PROPERTY-TOTAL-CHUNKS", Integer.toString(metadata.getNumChunksFromMsg()));
             responseBuilder.header("X-Pulsar-PROPERTY-CHUNK-ID", Integer.toString(metadata.getChunkId()));
         }
+        responseBuilder.header("X-Pulsar-Is-Encrypted", metadata.getEncryptionKeysCount() > 0);
 
         // Decode if needed
         CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(metadata.getCompression());

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1535,8 +1535,17 @@ public class TopicsImpl extends BaseResource implements Topics {
             }
 
             tmp = headers.getFirst(BATCH_HEADER);
-            if (response.getHeaderString(BATCH_HEADER) != null) {
+            if (tmp != null) {
                 properties.put(BATCH_HEADER, (String) tmp);
+            }
+
+            boolean isEncrypted = false;
+            tmp = headers.getFirst("X-Pulsar-Is-Encrypted");
+            if (tmp != null) {
+                isEncrypted = Boolean.parseBoolean(tmp.toString());
+            }
+
+            if (!isEncrypted && response.getHeaderString(BATCH_HEADER) != null) {
                 return getIndividualMsgsFromBatch(topic, msgId, data, properties, messageMetadata);
             }
 


### PR DESCRIPTION
### Motivation

We can peek non-batched messages successfully, even if they are encrypted:
```sh
$ ./bin/pulsar-admin topics peek-messages -s sub1 persistent://public/default/non-batch

Message ID: 2:0
Tenants:
"publish-time    2021-07-07T13:43:07.621+09:00"
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| f5 ac 6c 84 87 21 ec 67 8c 84 62 1c d5 ff 1f e0 |..l..!.g..b.....|
|00000010| 6a 87 be 62 10                                  |j..b.           |
+--------+-------------------------------------------------+----------------+
```

On the other hand, if batched messages are encrypted, an exception will be thrown when peeking:
```
$ ./bin/pulsar-admin topics peek-messages -s sub1 persistent://public/default/batch

13:48:29.578 [AsyncHttpClient-7-1] ERROR org.apache.pulsar.client.admin.internal.TopicsImpl - Exception occurred while trying to get BatchMsgId: 0:0:0
java.lang.IllegalArgumentException: Invalid unknonwn tag type: 6
        at org.apache.pulsar.common.api.proto.LightProtoCodec.skipUnknownField(LightProtoCodec.java:270) ~[pulsar-common.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.common.api.proto.SingleMessageMetadata.parseFrom(SingleMessageMetadata.java:470) ~[pulsar-common.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.common.protocol.Commands.deSerializeSingleMessageInBatch(Commands.java:1624) ~[pulsar-common.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.client.admin.internal.TopicsImpl.getIndividualMsgsFromBatch(TopicsImpl.java:1558) ~[pulsar-client-admin-original.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.client.admin.internal.TopicsImpl.getMessagesFromHttpResponse(TopicsImpl.java:1540) ~[pulsar-client-admin-original.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.client.admin.internal.TopicsImpl.access$100(TopicsImpl.java:90) ~[pulsar-client-admin-original.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.client.admin.internal.TopicsImpl$15.completed(TopicsImpl.java:1027) ~[pulsar-client-admin-original.jar:2.9.0-SNAPSHOT]
        at org.apache.pulsar.client.admin.internal.TopicsImpl$15.completed(TopicsImpl.java:1022) ~[pulsar-client-admin-original.jar:2.9.0-SNAPSHOT]
        ...
```

This is probably because the payload of the batch message is encrypted and it fails to retrieve the individual payloads from it.

### Modifications

When an encrypted message is peeked, the broker returns a response with the value of the `X-Pulsar-Is-Encrypted` header set to true. Then, admin client treats it as a non-batch message and creates a `MessageImpl` instance. This fix enables us to peek the message without throwing an exception.
```sh
$ ./bin/pulsar-admin topics peek-messages -s sub1 persistent://public/default/batch

Message ID: 17:0
Tenants:
"X-Pulsar-batch-size    -292"
"X-Pulsar-num-batch-message    1"
"publish-time    2021-07-07T16:10:45.014+09:00"
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 73 3c bf c9 d9 c7 bd 56 6f ac 71 e8 8d 7b fa 33 |s<.....Vo.q..{.3|
|00000010| 2a 46 1e 9e 30 bb e2 7e ff 8c 41 9e a2          |*F..0..~..A..   |
+--------+-------------------------------------------------+----------------+
```