### PR TITLE
Add annotations for ClientConfigurationData

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -70,7 +70,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private Authentication authentication;
 
     @ApiModelProperty(
-            name = "authentication",
+            name = "authPluginClassName",
             value = "Class name of authentication plugin of the client."
     )
     private String authPluginClassName;
@@ -144,7 +144,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean tlsAllowInsecureConnection = false;
 
     @ApiModelProperty(
-            name = "tlsAllowInsecureConnection",
+            name = "tlsHostnameVerificationEnable",
             value = "Whether the hostname is validated when the proxy creates a TLS connection with brokers."
     )
     private boolean tlsHostnameVerificationEnable = false;
@@ -214,7 +214,9 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "listenerName",
-            value = "Listener name for lookup."
+            value = "Listener name for lookup. Clients can use listenerName to choose one of the listeners "
+                    + "as the service URL to create a connection to the broker as long as the network is accessible."
+                    + "\"advertisedListeners\" must enabled in broker side."
     )
     private String listenerName;
 
@@ -224,14 +226,14 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     )
     private boolean useKeyStoreTls = false;
     @ApiModelProperty(
-            name = "useKeyStoreTls",
+            name = "sslProvider",
             value = "The TLS provider used by an internal client to authenticate with other Pulsar brokers."
     )
     private String sslProvider = null;
 
     @ApiModelProperty(
             name = "tlsTrustStoreType",
-            value = "TLS TrustStore type configuration. You need to set this configurationn when client authentication is required."
+            value = "TLS TrustStore type configuration. You need to set this configuration when client authentication is required."
     )
     private String tlsTrustStoreType = "JKS";
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -267,7 +267,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "proxyServiceUrl",
-            value = "Url of proxy Service, proxyServiceUrl and proxyProtocol must be mutually inclusive."
+            value = "URL of proxy service. proxyServiceUrl and proxyProtocol must be mutually inclusive."
     )
     private String proxyServiceUrl;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -157,8 +157,8 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "maxLookupRequest",
-            value = "The maximum number of lookup requests allowed on "
-                    + "each broker connection to prevent overload on broker."
+            value = "Maximum number of lookup requests allowed on "
+                    + "each broker connection to prevent overloading a broker."
     )
     private int maxLookupRequest = 50000;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -151,7 +151,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     @ApiModelProperty(
             name = "concurrentLookupRequest",
             value = "The number of concurrent lookup requests that can be sent on each broker connection. "
-                    + "Setting a maximum helps to keep from overloading brokers."
+                    + "Setting a maximum prevents overloading a broker."
     )
     private int concurrentLookupRequest = 5000;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -115,7 +115,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "connectionsPerBroker",
-            value = "The number of connections established between the client and each Broker."
+            value = "Number of connections established between the client and each Broker."
     )
     private int connectionsPerBroker = 1;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -202,7 +202,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "maxBackoffIntervalNanos",
-            value = "Max backoff interval, the unit is nanos."
+            value = "Max backoff interval (in nanosecond)."
     )
     private long maxBackoffIntervalNanos = TimeUnit.SECONDS.toNanos(60);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -52,7 +52,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "serviceUrl",
-            value = "Pulsar cluster http url to connect to broker."
+            value = "Pulsar cluster HTTP URL to connect to a broker."
     )
     private String serviceUrl;
     @ApiModelProperty(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -196,7 +196,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "initialBackoffIntervalNanos",
-            value = "Initial backoff interval, the unit is nanos."
+            value = "Initial backoff interval (in nanosecond)."
     )
     private long initialBackoffIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -214,7 +214,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "listenerName",
-            value = "ListenerName for lookup."
+            value = "Listener name for lookup."
     )
     private String listenerName;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -77,7 +77,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "authParams",
-            value = "Authentication params of the client."
+            value = "Authentication parameter of the client."
     )
     @Secret
     private String authParams;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -57,7 +57,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private String serviceUrl;
     @ApiModelProperty(
             name = "serviceUrlProvider",
-            value = "The implementation class of ServiceUrlProvider, used to generate ServiceUrl."
+            value = "The implementation class of ServiceUrlProvider used to generate ServiceUrl."
     )
     @JsonIgnore
     private transient ServiceUrlProvider serviceUrlProvider;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -289,7 +289,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     // socks5
     @ApiModelProperty(
             name = "socks5ProxyAddress",
-            value = "Address of socks5 proxy."
+            value = "Address of SOCKS5 proxy."
     )
     private InetSocketAddress socks5ProxyAddress;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -71,7 +71,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "authentication",
-            value = "Class name od authentication plugin of the client."
+            value = "Class name of authentication plugin of the client."
     )
     private String authPluginClassName;
 
@@ -295,7 +295,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "socks5ProxyUsername",
-            value = "User name of socks5 proxy."
+            value = "User name of SOCKS5 proxy."
     )
     private String socks5ProxyUsername;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -170,9 +170,9 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "maxNumberOfRejectedRequestPerConnection",
-            value = "The maximum number of rejected requests of a broker in a certain time frame (30 seconds) "
+            value = "Maximum number of rejected requests of a broker in a certain time frame (30 seconds) "
                     + "after the current connection is closed and the client "
-                    + "creates a new connection to connect to a different broker."
+                    + "creating a new connection to connect to a different broker."
     )
     private int maxNumberOfRejectedRequestPerConnection = 50;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -231,7 +231,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "tlsTrustStoreType",
-            value = "TLS TrustStore type configuration. Needed when client auth is required."
+            value = "TLS TrustStore type configuration. You need to set this configurationn when client authentication is required."
     )
     private String tlsTrustStoreType = "JKS";
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -301,7 +301,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "socks5ProxyUsername",
-            value = "password of socks5 proxy."
+            value = "Password of SOCKS5 proxy."
     )
     private String socks5ProxyPassword;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -121,7 +121,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "useTcpNoDelay",
-            value = "Whether to use Tcp NoDelay option."
+            value = "Whether to use TCP NoDelay option."
     )
     private boolean useTcpNoDelay = true;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -164,7 +164,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "maxLookupRedirects",
-            value = "Limit the number of times lookup requests are redirected."
+            value = "Maximum times of redirected lookup requests."
     )
     private int maxLookupRedirects = 20;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -91,7 +91,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "operationTimeoutMs",
-            value = "Client operation timeout, the unit is milliseconds."
+            value = "Client operation timeout (in millisecond)."
     )
     private long operationTimeoutMs = 30000;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.conf;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Sets;
 
+import io.swagger.annotations.ApiModelProperty;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Clock;
@@ -49,70 +50,259 @@ import org.apache.pulsar.client.util.Secret;
 public class ClientConfigurationData implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
+    @ApiModelProperty(
+            name = "serviceUrl",
+            value = "Pulsar cluster http url to connect to broker."
+    )
     private String serviceUrl;
+    @ApiModelProperty(
+            name = "serviceUrlProvider",
+            value = "The implementation class of ServiceUrlProvider, used to generate ServiceUrl."
+    )
     @JsonIgnore
     private transient ServiceUrlProvider serviceUrlProvider;
 
+    @ApiModelProperty(
+            name = "authentication",
+            value = "Authentication settings of the client."
+    )
     @JsonIgnore
     private Authentication authentication;
+
+    @ApiModelProperty(
+            name = "authentication",
+            value = "Class name od authentication plugin of the client."
+    )
     private String authPluginClassName;
 
+    @ApiModelProperty(
+            name = "authParams",
+            value = "Authentication params of the client."
+    )
     @Secret
     private String authParams;
+
+    @ApiModelProperty(
+            name = "authParamMap",
+            value = "Authentication map of the client."
+    )
     @Secret
     private Map<String, String> authParamMap;
 
+    @ApiModelProperty(
+            name = "operationTimeoutMs",
+            value = "Client operation timeout, the unit is milliseconds."
+    )
     private long operationTimeoutMs = 30000;
+
+    @ApiModelProperty(
+            name = "statsIntervalSeconds",
+            value = "The Interval to print client stats, the unit is seconds."
+    )
     private long statsIntervalSeconds = 60;
 
+    @ApiModelProperty(
+            name = "numIoThreads",
+            value = "Number of IO threads."
+    )
     private int numIoThreads = 1;
+
+    @ApiModelProperty(
+            name = "numListenerThreads",
+            value = "Number of consumer listener threads."
+    )
     private int numListenerThreads = 1;
+
+    @ApiModelProperty(
+            name = "connectionsPerBroker",
+            value = "The number of connections established between the client and each Broker."
+    )
     private int connectionsPerBroker = 1;
 
+    @ApiModelProperty(
+            name = "useTcpNoDelay",
+            value = "Whether to use Tcp NoDelay option."
+    )
     private boolean useTcpNoDelay = true;
 
+    @ApiModelProperty(
+            name = "useTls",
+            value = "Whether to use TLS."
+    )
     private boolean useTls = false;
+
+    @ApiModelProperty(
+            name = "tlsTrustCertsFilePath",
+            value = "Path to the trusted TLS certificate file."
+    )
     private String tlsTrustCertsFilePath = "";
+
+    @ApiModelProperty(
+            name = "tlsAllowInsecureConnection",
+            value = "Whether the client accepts untrusted TLS certificates from the broker."
+    )
     private boolean tlsAllowInsecureConnection = false;
+
+    @ApiModelProperty(
+            name = "tlsAllowInsecureConnection",
+            value = "Whether the hostname is validated when the proxy creates a TLS connection with brokers."
+    )
     private boolean tlsHostnameVerificationEnable = false;
+    @ApiModelProperty(
+            name = "concurrentLookupRequest",
+            value = "The number of concurrent lookup requests that can be sent on each broker connection. "
+                    + "Setting a maximum helps to keep from overloading brokers."
+    )
     private int concurrentLookupRequest = 5000;
+
+    @ApiModelProperty(
+            name = "maxLookupRequest",
+            value = "The maximum number of lookup requests allowed on "
+                    + "each broker connection to prevent overload on broker."
+    )
     private int maxLookupRequest = 50000;
+
+    @ApiModelProperty(
+            name = "maxLookupRedirects",
+            value = "Limit the number of times lookup requests are redirected."
+    )
     private int maxLookupRedirects = 20;
+
+    @ApiModelProperty(
+            name = "maxNumberOfRejectedRequestPerConnection",
+            value = "The maximum number of rejected requests of a broker in a certain time frame (30 seconds) "
+                    + "after the current connection is closed and the client "
+                    + "creates a new connection to connect to a different broker."
+    )
     private int maxNumberOfRejectedRequestPerConnection = 50;
+
+    @ApiModelProperty(
+            name = "keepAliveIntervalSeconds",
+            value = "Seconds of keeping alive interval for each client broker connection."
+    )
     private int keepAliveIntervalSeconds = 30;
+
+    @ApiModelProperty(
+            name = "connectionTimeoutMs",
+            value = "Duration of waiting for a connection to a broker to be established."
+                    + "If the duration passes without a response from a broker, the connection attempt is dropped."
+    )
     private int connectionTimeoutMs = 10000;
+    @ApiModelProperty(
+            name = "requestTimeoutMs",
+            value = "Maximum duration for completing a request."
+    )
     private int requestTimeoutMs = 60000;
+
+    @ApiModelProperty(
+            name = "initialBackoffIntervalNanos",
+            value = "Initial backoff interval, the unit is nanos."
+    )
     private long initialBackoffIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
+
+    @ApiModelProperty(
+            name = "maxBackoffIntervalNanos",
+            value = "Max backoff interval, the unit is nanos."
+    )
     private long maxBackoffIntervalNanos = TimeUnit.SECONDS.toNanos(60);
+
+    @ApiModelProperty(
+            name = "enableBusyWait",
+            value = "Whether to enable BusyWait for EpollEventLoopGroup."
+    )
     private boolean enableBusyWait = false;
-    //
+
+    @ApiModelProperty(
+            name = "listenerName",
+            value = "ListenerName for lookup."
+    )
     private String listenerName;
 
-    // set TLS using KeyStore way.
+    @ApiModelProperty(
+            name = "useKeyStoreTls",
+            value = "Set TLS using KeyStore way."
+    )
     private boolean useKeyStoreTls = false;
+    @ApiModelProperty(
+            name = "useKeyStoreTls",
+            value = "The TLS Provider used by internal client to authenticate with other Pulsar brokers."
+    )
     private String sslProvider = null;
-    // needed when client auth is required
+
+    @ApiModelProperty(
+            name = "tlsTrustStoreType",
+            value = "TLS TrustStore type configuration. Needed when client auth is required."
+    )
     private String tlsTrustStoreType = "JKS";
+
+    @ApiModelProperty(
+            name = "tlsTrustStorePath",
+            value = "Path of TLS TrustStore."
+    )
     private String tlsTrustStorePath = null;
+
+    @ApiModelProperty(
+            name = "tlsTrustStorePassword",
+            value = "Password of TLS TrustStore."
+    )
     private String tlsTrustStorePassword = null;
+
+    @ApiModelProperty(
+            name = "tlsCiphers",
+            value = "Set of TLS Ciphers."
+    )
     private Set<String> tlsCiphers = Sets.newTreeSet();
+
+    @ApiModelProperty(
+            name = "tlsProtocols",
+            value = "Protocols of TLS."
+    )
     private Set<String> tlsProtocols = Sets.newTreeSet();
 
+    @ApiModelProperty(
+            name = "memoryLimitBytes",
+            value = "Limit the memory usage of client, the unit is Bytes."
+    )
     private long memoryLimitBytes = 0;
 
-    /** proxyServiceUrl and proxyProtocol must be mutually inclusive **/
+    @ApiModelProperty(
+            name = "proxyServiceUrl",
+            value = "Url of proxy Service, proxyServiceUrl and proxyProtocol must be mutually inclusive."
+    )
     private String proxyServiceUrl;
+
+    @ApiModelProperty(
+            name = "proxyProtocol",
+            value = "Protocol of proxy Service, proxyServiceUrl and proxyProtocol must be mutually inclusive."
+    )
     private ProxyProtocol proxyProtocol;
 
-    // transaction
+    @ApiModelProperty(
+            name = "enableTransaction",
+            value = "Whether to enable transaction."
+    )
     private boolean enableTransaction = false;
 
     @JsonIgnore
     private Clock clock = Clock.systemDefaultZone();
 
     // socks5
+    @ApiModelProperty(
+            name = "socks5ProxyAddress",
+            value = "Address of socks5 proxy."
+    )
     private InetSocketAddress socks5ProxyAddress;
+
+    @ApiModelProperty(
+            name = "socks5ProxyUsername",
+            value = "User name of socks5 proxy."
+    )
     private String socks5ProxyUsername;
+
+    @ApiModelProperty(
+            name = "socks5ProxyUsername",
+            value = "password of socks5 proxy."
+    )
     private String socks5ProxyPassword;
 
     public Authentication getAuthentication() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -97,7 +97,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "statsIntervalSeconds",
-            value = "The Interval to print client stats, the unit is seconds."
+            value = " Interval to print client stats (in second)."
     )
     private long statsIntervalSeconds = 60;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -225,7 +225,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean useKeyStoreTls = false;
     @ApiModelProperty(
             name = "useKeyStoreTls",
-            value = "The TLS Provider used by internal client to authenticate with other Pulsar brokers."
+            value = "The TLS provider used by an internal client to authenticate with other Pulsar brokers."
     )
     private String sslProvider = null;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -273,7 +273,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "proxyProtocol",
-            value = "Protocol of proxy Service, proxyServiceUrl and proxyProtocol must be mutually inclusive."
+            value = "Protocol of proxy service. proxyServiceUrl and proxyProtocol must be mutually inclusive."
     )
     private ProxyProtocol proxyProtocol;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -261,7 +261,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "memoryLimitBytes",
-            value = "Limit the memory usage of client, the unit is Bytes."
+            value = "Limit of client memory usage (in byte)."
     )
     private long memoryLimitBytes = 0;
 


### PR DESCRIPTION

Master Issue: #10041

### Motivation
In order to automatically generate documents, we need to add annotations to the code first

### Modifications
Since FieldContext is in the broker-common module, we can only use ApiModelProperty.
