### PR TITLE
[Doc + Website] Support Google Analytics

### DIFF
--- a/site2/website/brodocs/brodoc.js
+++ b/site2/website/brodocs/brodoc.js
@@ -182,6 +182,13 @@ function generateDoc(navContent, bodyContent, codeTabContent) {
 `<!DOCTYPE html>
 <html>
 <head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NRV2PFT');</script>
+<!-- End Google Tag Manager -->
 <meta charset="UTF-8">
 <title>${config.title}</title>
 <link rel="shortcut icon" href="favicon.ico" type="image/vnd.microsoft.icon">
@@ -192,6 +199,10 @@ function generateDoc(navContent, bodyContent, codeTabContent) {
 <link rel="stylesheet" href="stylesheet.css" type="text/css">
 </head>
 <body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NRV2PFT"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 <div id="sidebar-wrapper" class="side-nav side-bar-nav">${navContent}<br/><div class="copyright">${config.copyright}</div></div>
 <div id="wrapper">
 <div id="code-tabs-wrapper" class="code-tabs"><ul class="code-tab-list">${codeTabContent}</ul></div>


### PR DESCRIPTION
Currently, the structure of Pulsar docs is not user-friendly. To improve the UX, we want to upgrade the Pulsar website (Docusuraus) and re-architecture the doc structure.

Based on some metrics (for example, page view, number of users and sessions, average session duration, average pages per session, ratio of new to returning visitors, bounce rate, etc) collected from users, we can adjust the doc architecture and improve the contents accordingly (for example, show most frequently visited contents rather than all contents on the landing page).

Google Analytics (GA) is one of the most used free tools to measure the behaviors of websites. It helps us better understand our users. To use GA, we need to insert the code to the Pulsar website pages (https://developers.google.com/tag-manager/quickstart).

