### PR TITLE
remove duplicated configuration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -123,7 +123,6 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setStickyReadsEnabled(conf.isBookkeeperEnableStickyReads());
         bkConf.setNettyMaxFrameSizeBytes(conf.getMaxMessageSize() + Commands.MESSAGE_SIZE_FRAME_PADDING);
         bkConf.setDiskWeightBasedPlacementEnabled(conf.isBookkeeperDiskWeightBasedPlacementEnabled());
-        bkConf.setNumWorkerThreads(1);
 
         if (StringUtils.isNotBlank(conf.getBookkeeperMetadataServiceUri())) {
             bkConf.setMetadataServiceUri(conf.getBookkeeperMetadataServiceUri());


### PR DESCRIPTION
### Motivation
Remove duplicated configuration when `createBkClientConfiguration` 

Currently, the configuration for BookKeeper client's `NumWorkerThreads` was duplicated in 
https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java?#L115
and 
https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java?#L126

So `NumWorkerThreads` is  set to 1 finally which is not expected.
### Modifications

remove the duplicated hardcode for `setNumWorkerThreads` to make `NumWorkerThreads` configurable

### Verifying this change

This change is a code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
