### PR TITLE
Admin Tool: fix batch size < 0 erro when peekmessage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2495,6 +2495,7 @@ public class PersistentTopicsBase extends AdminResource {
         PositionImpl pos = (PositionImpl) entry.getPosition();
         ByteBuf metadataAndPayload = entry.getDataBuffer();
 
+        long totalSize = metadataAndPayload.readableBytes();
         BrokerEntryMetadata brokerEntryMetadata = Commands.peekBrokerEntryMetadataIfExist(metadataAndPayload);
         MessageMetadata metadata = Commands.parseMessageMetadata(metadataAndPayload);
 
@@ -2523,7 +2524,7 @@ public class PersistentTopicsBase extends AdminResource {
         }
         if (metadata.hasNumMessagesInBatch()) {
             responseBuilder.header("X-Pulsar-num-batch-message", metadata.getNumMessagesInBatch());
-            responseBuilder.header("X-Pulsar-batch-size", metadataAndPayload.readableBytes()
+            responseBuilder.header("X-Pulsar-batch-size", totalSize
                     - metadata.getSerializedSize());
         }
         if (metadata.hasNullValue()) {


### PR DESCRIPTION
Fixes #11300 
### Motivation
This pull request fix the error of `X-Pulsar-batch-size` < 0

### Modifications

1. fix the logic of caculate `X-Pulsar-batch-size`  to make sure it's the right size of batch message
2. expose more attribute to Admin Tool command of getMessageById and examineMessage
3. add test code for these changes

### Verifying this change

This change added tests in `BrokerEntryMetadataE2ETest.testBatchMessage`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
