### PR TITLE
[Transaction] Fix transaction problem when sub delete.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1930,7 +1930,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("[{}] handleEndTxnOnPartition txnId: [{}], txnAction: [{}]", topic,
                     txnID, txnAction);
         }
-        CompletableFuture<Optional<Topic>> topicFuture = service.getTopics().get(TopicName.get(topic).toString());
+        CompletableFuture<Optional<Topic>> topicFuture = service.getTopic(topic, true);
         if (topicFuture != null) {
             topicFuture.whenComplete((optionalTopic, t) -> {
                 if (!optionalTopic.isPresent()) {
@@ -1978,7 +1978,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     new TxnID(txnidMostBits, txnidLeastBits), txnAction);
         }
 
-        CompletableFuture<Optional<Topic>> topicFuture = service.getTopics().get(TopicName.get(topic).toString());
+        CompletableFuture<Optional<Topic>> topicFuture = service.getTopic(topic, true);
         if (topicFuture != null) {
             topicFuture.thenAccept(optionalTopic -> {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1995,12 +1995,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                 Subscription subscription = optionalTopic.get().getSubscription(subName);
                 if (subscription == null) {
-                    log.error("Topic {} subscription {} is not exist.", optionalTopic.get().getName(), subName);
-                    ctx.writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(
-                            requestId, txnidLeastBits, txnidMostBits,
-                            ServerError.ServiceNotReady,
-                            "Topic " + optionalTopic.get().getName()
-                                    + " subscription " + subName + " is not exist."));
+                    log.warn("Topic {} subscription {} is not exist.", optionalTopic.get().getName(), subName);
+                    ctx.writeAndFlush(
+                            Commands.newEndTxnOnSubscriptionResponse(requestId, txnidLeastBits, txnidMostBits));
                     return;
                 }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -18,34 +18,22 @@
  */
 package org.apache.pulsar.broker.transaction.buffer;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-
 import com.google.common.collect.Sets;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.Cleanup;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.pulsar.broker.intercept.MockBrokerInterceptor;
-import org.apache.pulsar.broker.service.BrokerService;
-import org.apache.pulsar.broker.service.Subscription;
-import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl;
-import org.apache.pulsar.broker.transaction.coordinator.TransactionMetaStoreTestBase;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClient;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClientException;
@@ -53,15 +41,17 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.api.proto.TxnAction;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -73,74 +63,44 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 @Test(groups = "broker")
-public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
+public class TransactionBufferClientTest extends TransactionTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(TransactionBufferClientTest.class);
     private TransactionBufferClient tbClient;
     TopicName partitionedTopicName = TopicName.get("persistent", "public", "test", "tb-client");
     int partitions = 10;
-    BrokerService[] brokerServices;
     private static final String namespace = "public/test";
 
-    private EventLoopGroup eventLoopGroup;
-
     @Override
-    protected void afterSetup() throws Exception {
-        pulsarAdmins[0].clusters().createCluster("my-cluster", ClusterData.builder().serviceUrl(pulsarServices[0].getWebServiceAddress()).build());
-        pulsarAdmins[0].tenants().createTenant("public", new TenantInfoImpl(Sets.newHashSet(), Sets.newHashSet("my-cluster")));
-        pulsarAdmins[0].namespaces().createNamespace(namespace, 10);
-        pulsarAdmins[0].topics().createPartitionedTopic(partitionedTopicName.getPartitionedTopicName(), partitions);
+    @BeforeClass(alwaysRun = true)
+    protected void setup() throws Exception {
+        setBrokerCount(3);
+        internalSetup();
+        String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
+        String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort).build());
+
+        admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
+                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), 16);
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
+        admin.namespaces().createNamespace(namespace, 10);
+        admin.topics().createPartitionedTopic(partitionedTopicName.getPartitionedTopicName(), partitions);
+
         pulsarClient.newConsumer()
                 .topic(partitionedTopicName.getPartitionedTopicName())
                 .subscriptionName("test").subscribe();
-        tbClient = TransactionBufferClientImpl.create(
-                ((PulsarClientImpl) pulsarClient),
+        tbClient = TransactionBufferClientImpl.create(pulsarClient,
                 new HashedWheelTimer(new DefaultThreadFactory("transaction-buffer")));
     }
 
     @Override
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
-        if (tbClient != null) {
-            tbClient.close();
-        }
-        if (brokerServices != null) {
-            for (BrokerService bs : brokerServices) {
-                bs.close();
-            }
-            brokerServices = null;
-        }
-        super.cleanup();
-        eventLoopGroup.shutdownGracefully().get();
-    }
-
-    @Override
-    protected void afterPulsarStart() throws Exception {
-        eventLoopGroup = new NioEventLoopGroup();
-        brokerServices = new BrokerService[pulsarServices.length];
-        AtomicLong atomicLong = new AtomicLong(0);
-        for (int i = 0; i < pulsarServices.length; i++) {
-            Subscription mockSubscription = mock(Subscription.class);
-            Mockito.when(mockSubscription.endTxn(Mockito.anyLong(),
-                    Mockito.anyLong(), Mockito.anyInt(), Mockito.anyLong()))
-                    .thenReturn(CompletableFuture.completedFuture(null));
-
-            Topic mockTopic = mock(Topic.class);
-            Mockito.when(mockTopic.endTxn(any(), Mockito.anyInt(), anyLong()))
-                    .thenReturn(CompletableFuture.completedFuture(null));
-            Mockito.when(mockTopic.getSubscription(any())).thenReturn(mockSubscription);
-
-            ConcurrentOpenHashMap<String, CompletableFuture<Optional<Topic>>> topicMap =
-                    mock(ConcurrentOpenHashMap.class);
-            Mockito.when(topicMap.get(Mockito.anyString())).thenReturn(
-                    CompletableFuture.completedFuture(Optional.of(mockTopic)));
-
-            BrokerService brokerService = Mockito.spy(new BrokerService(pulsarServices[i], eventLoopGroup));
-            doReturn(new MockBrokerInterceptor()).when(brokerService).getInterceptor();
-            doReturn(atomicLong.getAndIncrement() + "").when(brokerService).generateUniqueProducerName();
-            brokerServices[i] = brokerService;
-            Mockito.when(brokerService.getTopics()).thenReturn(topicMap);
-            Mockito.when(pulsarServices[i].getBrokerService()).thenReturn(brokerService);
-        }
+        tbClient.close();
+        super.internalCleanup();
     }
 
     @Test
@@ -193,43 +153,6 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
             assertEquals(futures.get(i).get().getMostSigBits(), 1L);
             assertEquals(futures.get(i).get().getLeastSigBits(), i);
         }
-    }
-
-    @Test
-    public void testTransactionBufferOpFail() throws InterruptedException, ExecutionException {
-        ConcurrentOpenHashMap<String, CompletableFuture<Optional<Topic>>>[] originalMaps =
-                new ConcurrentOpenHashMap[brokerServices.length];
-        ConcurrentOpenHashMap<String, CompletableFuture<Optional<Topic>>> topicMap = new ConcurrentOpenHashMap<>();
-        for (int i = 0; i < brokerServices.length; i++) {
-            originalMaps[i] = brokerServices[i].getTopics();
-            when(brokerServices[i].getTopics()).thenReturn(topicMap);
-        }
-
-        try {
-            tbClient.abortTxnOnSubscription(
-                    partitionedTopicName.getPartition(0).toString(), "test", 1L, 1, -1L).get();
-            fail();
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof PulsarClientException.LookupException);
-        }
-
-        try {
-            tbClient.abortTxnOnTopic(
-                    partitionedTopicName.getPartition(0).toString(), 1L, 1, -1L).get();
-            fail();
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof PulsarClientException.LookupException);
-        }
-
-        for (int i = 0; i < brokerServices.length; i++) {
-            when(brokerServices[i].getTopics()).thenReturn(originalMaps[i]);
-        }
-
-        tbClient.abortTxnOnSubscription(
-                partitionedTopicName.getPartition(0).toString(), "test", 1L, 1, -1L).get();
-
-        tbClient.abortTxnOnTopic(
-                partitionedTopicName.getPartition(0).toString(), 1L, 1, -1L).get();
     }
 
     @Test
@@ -311,10 +234,32 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
     }
 
     @Test
-    public void testTransactionBufferLookUp() throws ExecutionException, InterruptedException {
+    public void testTransactionBufferLookUp() throws Exception {
         String topic = "persistent://" + namespace + "/testTransactionBufferLookUp";
-        tbClient.abortTxnOnSubscription(topic + "_abort_sub", "test", 1L, 1L, -1L).get();
-        tbClient.commitTxnOnSubscription(topic + "_commit_sub", "test", 1L, 1L, -1L).get();
+        String subName = "test";
+        admin.topics().createNonPartitionedTopic(topic + "_abort_sub");
+        admin.topics().createSubscription(topic + "_abort_sub", subName, MessageId.earliest);
+
+        admin.topics().createNonPartitionedTopic(topic + "_commit_sub");
+        admin.topics().createSubscription(topic + "_commit_sub", subName, MessageId.earliest);
+
+        Awaitility.await().until(() -> {
+            try {
+                tbClient.abortTxnOnSubscription(topic + "_abort_sub", "test", 1L, 1L, -1L).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
+        Awaitility.await().until(() -> {
+            try {
+                tbClient.commitTxnOnSubscription(topic + "_commit_sub", "test", 1L, 1L, -1L).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
         tbClient.abortTxnOnTopic(topic + "_abort_topic", 1L, 1L, -1L).get();
         tbClient.commitTxnOnTopic(topic + "_commit_topic", 1L, 1L, -1L).get();
     }
@@ -330,10 +275,35 @@ public class TransactionBufferClientTest extends TransactionMetaStoreTestBase {
         field.setAccessible(true);
         field.set(transactionBufferHandler, new Semaphore(2));
 
-        String topic = "persistent://" + namespace + "/testTransactionBufferLookUp";
-        tbClient.abortTxnOnSubscription(topic + "_abort_sub", "test", 1L, 1L, -1L).get();
+
+        String topic = "persistent://" + namespace + "/testTransactionBufferHandlerSemaphore";
+        String subName = "test";
+
+        admin.topics().createNonPartitionedTopic(topic + "_abort_sub");
+        admin.topics().createSubscription(topic + "_abort_sub", subName, MessageId.earliest);
+
+        admin.topics().createNonPartitionedTopic(topic + "_commit_sub");
+        admin.topics().createSubscription(topic + "_commit_sub", subName, MessageId.earliest);
+
+
+        Awaitility.await().until(() -> {
+            try {
+                tbClient.abortTxnOnSubscription(topic + "_abort_sub", "test", 1L, 1L, -1L).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+
+        Awaitility.await().until(() -> {
+            try {
+                tbClient.commitTxnOnSubscription(topic + "_commit_sub", "test", 1L, 1L, -1L).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
         tbClient.abortTxnOnTopic(topic + "_abort_topic", 1L, 1L, -1L).get();
-        tbClient.commitTxnOnSubscription(topic + "_commit_sub", "test", 1L, 1L, -1L).get();
         tbClient.commitTxnOnTopic(topic + "_commit_topic", 1L, 1L, -1L).get();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Semaphore;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClient;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClientException;
@@ -49,9 +48,7 @@ import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -236,12 +233,6 @@ public class TransactionBufferClientTest extends TransactionTestBase {
     @Test
     public void testTransactionBufferLookUp() throws Exception {
         String topic = "persistent://" + namespace + "/testTransactionBufferLookUp";
-        String subName = "test";
-        admin.topics().createNonPartitionedTopic(topic + "_abort_sub");
-        admin.topics().createSubscription(topic + "_abort_sub", subName, MessageId.earliest);
-
-        admin.topics().createNonPartitionedTopic(topic + "_commit_sub");
-        admin.topics().createSubscription(topic + "_commit_sub", subName, MessageId.earliest);
 
         Awaitility.await().until(() -> {
             try {
@@ -277,14 +268,6 @@ public class TransactionBufferClientTest extends TransactionTestBase {
 
 
         String topic = "persistent://" + namespace + "/testTransactionBufferHandlerSemaphore";
-        String subName = "test";
-
-        admin.topics().createNonPartitionedTopic(topic + "_abort_sub");
-        admin.topics().createSubscription(topic + "_abort_sub", subName, MessageId.earliest);
-
-        admin.topics().createNonPartitionedTopic(topic + "_commit_sub");
-        admin.topics().createSubscription(topic + "_commit_sub", subName, MessageId.earliest);
-
 
         Awaitility.await().until(() -> {
             try {


### PR DESCRIPTION
## Motivation
now, when sub has been deleted the end txn sub will fail.

## implement
when the sub has been deleted the end txn sub op will success.

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

