### PR TITLE
Fix npe when unloading persistent partitioned topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -31,6 +31,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -236,5 +238,37 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertEquals(statsAfterUnsubscribe.getMsgInCounter(), statsBeforeUnsubscribe.getMsgInCounter());
         assertEquals(statsAfterUnsubscribe.getBytesOutCounter(), statsBeforeUnsubscribe.getBytesOutCounter());
         assertEquals(statsAfterUnsubscribe.getMsgOutCounter(), statsBeforeUnsubscribe.getMsgOutCounter());
+    }
+
+    @Test
+    public void testPersistentPartitionedTopicUnload() throws Exception {
+        final String topicName = "persistent://prop/ns/failedUnload";
+        final String ns = "prop/ns";
+        final int partitions = 5;
+        final int producers = 1;
+        // ensure that the number of bundle is greater than 1
+        final int bundles = 2;
+
+        admin.namespaces().createNamespace(ns, bundles);
+        admin.topics().createPartitionedTopic(topicName, partitions);
+
+        List<Producer> producerSet = new ArrayList<>();
+        for (int i = 0; i < producers; i++) {
+            producerSet.add(pulsarClient.newProducer(Schema.STRING).topic(topicName).create());
+        }
+
+        assertFalse(pulsar.getBrokerService().getTopics().containsKey(topicName));
+        pulsar.getBrokerService().getTopicIfExists(topicName).get();
+        assertTrue(pulsar.getBrokerService().getTopics().containsKey(topicName));
+
+        // ref of partitioned-topic name should be empty
+        assertFalse(pulsar.getBrokerService().getTopicReference(topicName).isPresent());
+
+        NamespaceBundle bundle = pulsar.getNamespaceService().getBundle(TopicName.get(topicName));
+        pulsar.getNamespaceService().unloadNamespaceBundle(bundle, 5, TimeUnit.SECONDS).get();
+
+        for (Producer producer : producerSet) {
+            producer.close();
+        }
     }
 }


### PR DESCRIPTION
### Motivations
When we performed pressure tests on persistent partitioned topics, we found that the `NullPointerException` would occasionally appear when executing unload bundles operations, and at the same time the producers could no longer write messages.

Some server error log
```
java.util.concurrent.ExecutionException: java.lang.NullPointerException
        at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1895)
        at org.apache.pulsar.broker.service.persistent.PersistentTopicTest.testPersistentPartitionedTopicUnload(PersistentTopicTest.java:268)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
        at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
        at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
        at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
        at org.apache.pulsar.broker.service.BrokerService.removeTopicFromCache(BrokerService.java:1729)
        at org.apache.pulsar.broker.service.BrokerService.cleanUnloadedTopicFromCache(BrokerService.java:1699)
        at org.apache.pulsar.broker.namespace.OwnedBundle.lambda$handleUnloadRequest$1(OwnedBundle.java:136)
        at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:822)
        at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:797)
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962)
```

The problem is that the cleanup logic in `org.apache.pulsar.broker.service.BrokerService#cleanUnloadedTopicFromCache` does not check wheather the topic reference is present when unloading bundles. This may cause an attempt to obtain bundle map which does not exist from `org.apache.pulsar.broker.service.BrokerService#multiLayerTopicsMap` during cache cleanup.

### Modifications
Added more safety checks to fix this issue.

### Documentation
Does this pull request introduce a new feature? (no)