### PR TITLE
[DOCS] function worker docs enhancement

### DIFF
--- a/site2/docs/functions-worker.md
+++ b/site2/docs/functions-worker.md
@@ -65,7 +65,7 @@ This section illustrates how to run `functions-worker` as a separate process in 
 ![assets/functions-worker-separated.png](assets/functions-worker-separated.png)
 
 > Note    
-> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake.
+> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake. Also, while accessing the `functions-worker` to manage any of the functions, the `pulsar-admin` CLI tool or any of the clients should use the `workerHostname` and `workerPort` that you set in [Worker parameters](#worker-parameters) to generate an `--admin-url`.
 
 ### Configure Functions-worker to run separately
 
@@ -215,7 +215,13 @@ If authentication is enabled on the BookKeeper cluster, you need configure the B
 
 ### Start Functions-worker
 
-Once you have finished configuring the `functions_worker.yml` configuration file, you can use the following command to start a `functions-worker`:
+Once you have finished configuring the `functions_worker.yml` configuration file, you can start a `functions-worker` in the background by using [nohup](https://en.wikipedia.org/wiki/Nohup) with the [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool:
+
+```bash
+bin/pulsar-daemon start functions-worker
+```
+
+You can also start `functions-worker` in the foreground by using `pulsar` CLI tool:
 
 ```bash
 bin/pulsar functions-worker

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -25,8 +25,8 @@
     ],
     "Pulsar Functions": [
       "functions-overview",
-      "functions-worker",
       "functions-runtime",
+      "functions-worker",
       "functions-develop",
       "functions-package",
       "functions-debug",

--- a/site2/website/versioned_docs/version-2.8.0/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-worker.md
@@ -66,7 +66,7 @@ This section illustrates how to run `functions-worker` as a separate process in 
 ![assets/functions-worker-separated.png](assets/functions-worker-separated.png)
 
 > Note    
-> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake.
+> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake. Also, while accessing the `functions-worker` to manage any of the functions, the `pulsar-admin` CLI tool or any of the client should use the `workerHostname` and `workerPort` that you set in [Worker parameters](#worker-parameters) to generate an `--admin-url`.  
 
 ### Configure Functions-worker to run separately
 
@@ -216,7 +216,13 @@ If authentication is enabled on the BookKeeper cluster, you need configure the B
 
 ### Start Functions-worker
 
-Once you have finished configuring the `functions_worker.yml` configuration file, you can use the following command to start a `functions-worker`:
+Once you have finished configuring the `functions_worker.yml` configuration file, you can start a `functions-worker` in the background by using [nohup](https://en.wikipedia.org/wiki/Nohup) with the [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool:
+
+```bash
+bin/pulsar-daemon start functions-worker
+```
+
+You can also start `functions-worker` in the foreground by using `pulsar` CLI tool:
 
 ```bash
 bin/pulsar functions-worker

--- a/site2/website/versioned_docs/version-2.8.0/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-worker.md
@@ -66,7 +66,7 @@ This section illustrates how to run `functions-worker` as a separate process in 
 ![assets/functions-worker-separated.png](assets/functions-worker-separated.png)
 
 > Note    
-> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake. Also, while accessing the `functions-worker` to manage any of the functions, the `pulsar-admin` CLI tool or any of the client should use the `workerHostname` and `workerPort` that you set in [Worker parameters](#worker-parameters) to generate an `--admin-url`.  
+> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake. Also, while accessing the `functions-worker` to manage any of the functions, the `pulsar-admin` CLI tool or any of the clients should use the `workerHostname` and `workerPort` that you set in [Worker parameters](#worker-parameters) to generate an `--admin-url`.  
 
 ### Configure Functions-worker to run separately
 

--- a/site2/website/versioned_docs/version-2.8.1/functions-worker.md
+++ b/site2/website/versioned_docs/version-2.8.1/functions-worker.md
@@ -66,7 +66,7 @@ This section illustrates how to run `functions-worker` as a separate process in 
 ![assets/functions-worker-separated.png](assets/functions-worker-separated.png)
 
 > Note    
-> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake.
+> In this mode, make sure `functionsWorkerEnabled` is set to `false`, so you won't start `functions-worker` with brokers by mistake. Also, while accessing the `functions-worker` to manage any of the functions, the `pulsar-admin` CLI tool or any of the clients should use the `workerHostname` and `workerPort` that you set in [Worker parameters](#worker-parameters) to generate an `--admin-url`.
 
 ### Configure Functions-worker to run separately
 
@@ -216,7 +216,13 @@ If authentication is enabled on the BookKeeper cluster, you need configure the B
 
 ### Start Functions-worker
 
-Once you have finished configuring the `functions_worker.yml` configuration file, you can use the following command to start a `functions-worker`:
+Once you have finished configuring the `functions_worker.yml` configuration file, you can start a `functions-worker` in the background by using [nohup](https://en.wikipedia.org/wiki/Nohup) with the [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool:
+
+```bash
+bin/pulsar-daemon start functions-worker
+```
+
+You can also start `functions-worker` in the foreground by using `pulsar` CLI tool:
 
 ```bash
 bin/pulsar functions-worker

--- a/site2/website/versioned_sidebars/version-2.8.0-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.0-sidebars.json
@@ -25,8 +25,8 @@
     ],
     "Pulsar Functions": [
       "version-2.8.0-functions-overview",
-      "version-2.8.0-functions-worker",
       "version-2.8.0-functions-runtime",
+      "version-2.8.0-functions-worker",
       "version-2.8.0-functions-develop",
       "version-2.8.0-functions-package",
       "version-2.8.0-functions-debug",

--- a/site2/website/versioned_sidebars/version-2.8.1-sidebars.json
+++ b/site2/website/versioned_sidebars/version-2.8.1-sidebars.json
@@ -25,8 +25,8 @@
     ],
     "Pulsar Functions": [
       "version-2.8.1-functions-overview",
-      "version-2.8.1-functions-worker",
       "version-2.8.1-functions-runtime",
+      "version-2.8.1-functions-worker",
       "version-2.8.1-functions-develop",
       "version-2.8.1-functions-package",
       "version-2.8.1-functions-debug",


### PR DESCRIPTION
* updated function worker startup instructions
* updated a note to clarify on which admin-url should be used when functions-worker is run separately
* changed the order of 'Setup: Configure Functions runtime' and 'Setup: Pulsar Functions Worker' as the worker page's first line was pointing to the runtime page which is bad UX