### PR TITLE
expose producer name to getMessageById for Admin API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2515,6 +2515,9 @@ public class PersistentTopicsBase extends AdminResource {
         if (metadata.hasPublishTime()) {
             responseBuilder.header("X-Pulsar-publish-time", DateFormatter.format(metadata.getPublishTime()));
         }
+        if (metadata.hasProducerName()) {
+            responseBuilder.header("X-Pulsar-producer-name", metadata.getProducerName());
+        }
         if (metadata.hasEventTime()) {
             responseBuilder.header("X-Pulsar-event-time", DateFormatter.format(metadata.getEventTime()));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -139,6 +139,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
+                .producerName("my-producer")
                 .topic(topic)
                 .create();
 
@@ -154,6 +155,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
                 .getMessageById(topic, messageId.getLedgerId(), messageId.getEntryId());
         Assert.assertEquals(message.getData(), "hello".getBytes());
         Assert.assertEquals(message.getEventTime(), eventTime);
+        Assert.assertEquals(message.getProducerName(), "my-producer");
         Assert.assertEquals(message.getDeliverAtTime(), deliverAtTime);
         Assert.assertTrue(message.getPublishTime() >= sendTime);
 
@@ -172,6 +174,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
 
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer()
+                .producerName("my-producer")
                 .topic(topic)
                 .create();
 
@@ -188,6 +191,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
         Assert.assertEquals(message.getData(), "hello".getBytes());
         Assert.assertEquals(message.getEventTime(), eventTime);
         Assert.assertEquals(message.getDeliverAtTime(), deliverAtTime);
+        Assert.assertEquals(message.getProducerName(), "my-producer");
         Assert.assertTrue(message.getPublishTime() >= sendTime);
 
         BrokerEntryMetadata entryMetadata = message.getBrokerEntryMetadata();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -101,7 +101,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     private static final String DELIVER_AT_TIME = "X-Pulsar-deliver-at-time";
     private static final String BROKER_ENTRY_TIMESTAMP = "X-Pulsar-Broker-Entry-METADATA-timestamp";
     private static final String BROKER_ENTRY_INDEX =  "X-Pulsar-Broker-Entry-METADATA-index";
-    static private final String PRODUCER_NAME = "X-Pulsar-producer-name";
+    private static final String PRODUCER_NAME = "X-Pulsar-producer-name";
     // CHECKSTYLE.ON: MemberName
 
     public TopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -101,6 +101,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     private static final String DELIVER_AT_TIME = "X-Pulsar-deliver-at-time";
     private static final String BROKER_ENTRY_TIMESTAMP = "X-Pulsar-Broker-Entry-METADATA-timestamp";
     private static final String BROKER_ENTRY_INDEX =  "X-Pulsar-Broker-Entry-METADATA-index";
+    static private final String PRODUCER_NAME = "X-Pulsar-producer-name";
     // CHECKSTYLE.ON: MemberName
 
     public TopicsImpl(WebTarget web, Authentication auth, long readTimeoutMs) {
@@ -1558,6 +1559,11 @@ public class TopicsImpl extends BaseResource implements Topics {
             tmp = headers.getFirst(BATCH_SIZE_HEADER);
             if (tmp != null) {
                 properties.put(BATCH_SIZE_HEADER, (String) tmp);
+            }
+
+            tmp = headers.getFirst(PRODUCER_NAME);
+            if (tmp != null) {
+                messageMetadata.setProducerName((String) tmp);
             }
 
             for (Entry<String, List<Object>> entry : headers.entrySet()) {


### PR DESCRIPTION
### Motivation

Current we can get `Message` from Pulsar Admin API like `getMessageById` or `examineMessage`, but `Message.getProducerName()` return null. In some case we may need to known the producer name of the message.

### Modifications

expose producer name to `MessageMetadata` in `Message` for Pulsar Admin API.
