### PR TITLE
[C++] Use same regex code at ZTSClient

### DIFF
--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -46,8 +46,10 @@ namespace ptree = boost::property_tree;
 
 #ifdef PULSAR_USE_BOOST_REGEX
 #include <boost/regex.hpp>
+#define PULSAR_REGEX_NAMESPACE boost
 #else
 #include <regex>
+#define PULSAR_REGEX_NAMESPACE std
 #endif
 
 DECLARE_LOG_OBJECT()
@@ -365,27 +367,15 @@ const std::string ZTSClient::getHeader() const { return roleHeader_; }
 PrivateKeyUri ZTSClient::parseUri(const char *uri) {
     PrivateKeyUri uriSt;
     // scheme mediatype[;base64] path file
-
-#ifdef PULSAR_USE_BOOST_REGEX
-    static const boost::regex expression(
-        "^(\?:([^:/\?#]+):)(\?:([;/\\-\\w]*),)\?(/\?(\?:[^\?#/]*/)*)\?([^\?#]*)");
-    boost::cmatch groups;
-    if (boost::regex_match(uri, groups, expression)) {
-        uriSt.scheme = groups.str(1);
-        uriSt.mediaTypeAndEncodingType = groups.str(2);
-        uriSt.data = groups.str(4);
-    }
-#else   // !PULSAR_USE_BOOST_REGEX
-    static const std::regex expression(
-        R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?(\/[^?#]+)?)");
-    std::cmatch groups;
-    if (std::regex_match(uri, groups, expression)) {
+    static const PULSAR_REGEX_NAMESPACE::regex expression(
+        R"(^(?:([A-Za-z]+):)(?:([/\w\-]+;\w+),([=\w]+))?(?:\/\/)?([^?#]+)?)");
+    PULSAR_REGEX_NAMESPACE::cmatch groups;
+    if (PULSAR_REGEX_NAMESPACE::regex_match(uri, groups, expression)) {
         uriSt.scheme = groups.str(1);
         uriSt.mediaTypeAndEncodingType = groups.str(2);
         uriSt.data = groups.str(3);
         uriSt.path = groups.str(4);
     }
-#endif  // PULSAR_USE_BOOST_REGEX
     return uriSt;
 }
 }  // namespace pulsar

--- a/pulsar-client-cpp/tests/ZTSClientTest.cc
+++ b/pulsar-client-cpp/tests/ZTSClientTest.cc
@@ -43,6 +43,18 @@ TEST(ZTSClientTest, testZTSClient) {
     }
 
     {
+        PrivateKeyUri uri = ZTSClientWrapper::parseUri("file:./path/to/private.key");
+        ASSERT_EQ("file", uri.scheme);
+        ASSERT_EQ("./path/to/private.key", uri.path);
+    }
+
+    {
+        PrivateKeyUri uri = ZTSClientWrapper::parseUri("file://./path/to/private.key");
+        ASSERT_EQ("file", uri.scheme);
+        ASSERT_EQ("./path/to/private.key", uri.path);
+    }
+
+    {
         PrivateKeyUri uri = ZTSClientWrapper::parseUri("data:application/x-pem-file;base64,SGVsbG8gV29ybGQK");
         ASSERT_EQ("data", uri.scheme);
         ASSERT_EQ("application/x-pem-file;base64", uri.mediaTypeAndEncodingType);


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar/pull/9533 causes some degraded behaviors at [ZTSClient](https://github.com/apache/pulsar/pull/9533/files#diff-41a90a5ec7937b5e2151752843621d6acfe8963077dc04c285842a09a4e45ecc).

1. when using boost::regex
   - can't set `path` at file scheme
2. when using std::regex
   - can't set relative path like `file:./path/to/private.key`

I'd like to fix this issue.

### Modifications

* Use same regex code between boost and std like [this](https://github.com/apache/pulsar/pull/9533/files#diff-a67e917f5f42f3337507a69a4e0f13e286238dc759b4048cb5141290cf445b38)
* Fix regex to be able to capture relative path like `file:./`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Add unit tests for `ZTSClientWrapper::parseUri` with relative path

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?

No. Because this is one of the bug fixes.

#### For committer

For this PR, do we need to update docs?

- If yes,
  - if you update docs in this PR, label this PR with the `doc` label.
  - if you plan to update docs later, label this PR with the `doc-required` label.
  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
- If no, label this PR with the `no-need-doc` label and explain why.
