### PR TITLE
[PIP-82] [pulsar-broker] updates to resource-group stats:

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupPublishLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupPublishLimiter.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCount;
 import org.apache.pulsar.broker.service.PublishRateLimiter;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
@@ -72,6 +73,18 @@ public class ResourceGroupPublishLimiter implements PublishRateLimiter, RateLimi
     @Override
     public void update(PublishRate maxPublishRate) {
       // No-op
+    }
+
+    public void update(BytesAndMessagesCount maxPublishRate) {
+        this.publishMaxMessageRate = (int) maxPublishRate.messages;
+        this.publishMaxByteRate = maxPublishRate.bytes;
+    }
+
+    public BytesAndMessagesCount getResourceGroupPublishValues() {
+        BytesAndMessagesCount bmc = new BytesAndMessagesCount();
+        bmc.bytes = this.publishMaxByteRate;
+        bmc.messages = this.publishMaxMessageRate;
+        return bmc;
     }
 
     public void update(ResourceGroup resourceGroup) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
@@ -36,9 +36,16 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
             totalUsage += usage;
         }
 
-        if (confUsage < 0 || myUsage < 0 || totalUsage < 0) {
-            String errMesg = String.format("Configured usage (%d), or local usage (%d) or total usage (%d) is negative",
-                    confUsage, myUsage, totalUsage);
+        if (confUsage < 0) {
+            // This can happen if the RG is not configured with this particular limit (message or byte count) yet.
+            // It is safe to return a high value (so we don't limit) for the quota.
+            log.debug("Configured usage (%d) is not set; returning a high calculated quota", confUsage);
+            return Long.MAX_VALUE;
+        }
+
+        if (myUsage < 0 || totalUsage < 0) {
+            String errMesg = String.format("Local usage (%d) or total usage (%d) is negative",
+                    myUsage, totalUsage);
             log.error(errMesg);
             throw new PulsarAdminException(errMesg);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -204,13 +204,17 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
 
                 if (sentNumMsgs > 0 || recvdNumMsgs > 0) {
                     rgs.aggregateResourceGroupLocalUsages();  // hack to ensure aggregator calculation without waiting
-                    BytesAndMessagesCount prodCounts = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Publish);
-                    BytesAndMessagesCount consCounts = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Dispatch);
+                    BytesAndMessagesCount prodCounts = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Publish,
+                                                         true);
+                    BytesAndMessagesCount consCounts = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Dispatch,
+                                                         true);
 
                     // Re-do the getRGUsage.
                     // The counts should be equal, since there wasn't any intervening traffic on TEST_PRODUCE_CONSUME_TOPIC.
-                    BytesAndMessagesCount prodCounts1 = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Publish);
-                    BytesAndMessagesCount consCounts1 = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Dispatch);
+                    BytesAndMessagesCount prodCounts1 = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Publish,
+                                                          true);
+                    BytesAndMessagesCount consCounts1 = rgs.getRGUsage(rgName, ResourceGroupMonitoringClass.Dispatch,
+                                                          true);
 
                     Assert.assertTrue(prodCounts.bytes == prodCounts1.bytes);
                     Assert.assertTrue(prodCounts.messages == prodCounts1.messages);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImplTest.java
@@ -43,9 +43,10 @@ public class ResourceQuotaCalculatorImplTest extends MockedPulsarServiceBaseTest
     }
 
     @Test
-    public void testRQCalcNegativeConfTest() {
+    public void testRQCalcNegativeConfTest() throws PulsarAdminException {
         final long[] allUsage = { 0 };
-        Assert.assertThrows(PulsarAdminException.class, () -> this.rqCalc.computeLocalQuota(-1, 0, allUsage));
+        long calculatedQuota = this.rqCalc.computeLocalQuota(-1, 0, allUsage);
+        Assert.assertEquals(calculatedQuota, Long.MAX_VALUE);
     }
 
     @Test


### PR DESCRIPTION
  * use the new (get*) APIs to pull local usage stats from the broker service
  * use both directions (publish/dispatch)
  * workaround for regression in subscribe() (see https://github.com/apache/pulsar/issues/11289)
  * handle the case of not-yet-configured quota value on a resource group
  * cumulative vs. 'since last reported' stats
  * adjust publish rate-limit quote at update, and after new quota calculations
  * rename class RGUsageMTAggrWaitForAllMesgs, so it is picked up in CI runs

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
 
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications
  *Describe the modifications you've done.*

  * use the new (get*) APIs, instead of reading fields to get local usage stats (both publish and dispatch) from the broker service
  * handle the case of not-yet-configured quota value on a resource group (was throwing exception earlier)
  * cumulative vs. 'since last reported' stats; useful in the UTs
  * adjust publish rate-limit quote at update, and after new quota calculations
  * rename class RGUsageMTAggrWaitForAllMesgs to RGUsageMTAggrWaitForAllMesgsTest; the missing "Test" was resulting in this UT not being picked up in CI runs for "-Dgroups=other" of pulsar-broker 
  

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.

mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceGroupServiceTest -pl pulsar-broker
mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceGroupUsageAggregationTest -pl pulsar-broker
mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceQuotaCalculatorImplTest -pl pulsar-broker
mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.RGUsageMTAggrWaitForAllMesgsTest  -pl pulsar-broker


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?
No.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

