### PR TITLE
[function] set subscription name for go function runtime

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -262,6 +262,9 @@ func (gi *goInstance) setupConsumer() (chan pulsar.ConsumerMessage, error) {
 
 	funcDetails := gi.context.instanceConf.funcDetails
 	subscriptionName := funcDetails.Tenant + "/" + funcDetails.Namespace + "/" + funcDetails.Name
+	if funcDetails.Source != nil && funcDetails.Source.SubscriptionName != "" {
+		subscriptionName = funcDetails.Source.SubscriptionName
+	}
 
 	properties := getProperties(getDefaultSubscriptionName(
 		funcDetails.Tenant,


### PR DESCRIPTION
Fixes #11307 


### Motivation
Function Go runtime should use the subscription name provided to consume from pulsar instead of ignoring it and use the default one.

### Modifications

set subscription name if proviede

### Verifying this change

- [ ] Make sure that the change passes the CI checks.