### PR TITLE
[Issue 11340] Fix concurrency issues in NarUnpacker

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -69,7 +69,11 @@ public class NarUnpacker {
             throws IOException {
         File parentDirectory = new File(baseWorkingDirectory, nar.getName() + "-unpacked");
         if (!parentDirectory.exists()) {
-            parentDirectory.mkdirs();
+            if (parentDirectory.mkdirs()) {
+                log.info("Created directory {}", parentDirectory);
+            } else if (!parentDirectory.exists()) {
+                throw new IOException("Cannot create " + parentDirectory);
+            }
         }
         String sha256Sum = Base64.getUrlEncoder().withoutPadding().encodeToString(calculateSha256Sum(nar));
         // ensure that one process can extract the files

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.nar;
+
+import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class NarUnpackerTest {
+    File sampleZipFile;
+    File extractDirectory;
+
+    @BeforeMethod
+    public void createSampleZipFile() throws IOException {
+        sampleZipFile = Files.createTempFile("sample", ".zip").toFile();
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(sampleZipFile))) {
+            for (int i = 0; i < 10000; i++) {
+                ZipEntry e = new ZipEntry("hello" + i + ".txt");
+                out.putNextEntry(e);
+                byte[] msg = "hello world!".getBytes(StandardCharsets.UTF_8);
+                out.write(msg, 0, msg.length);
+                out.closeEntry();
+            }
+        }
+        extractDirectory = Files.createTempDirectory("nar_unpack_dir").toFile();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void deleteSampleZipFile() throws IOException {
+        if (sampleZipFile != null) {
+            sampleZipFile.delete();
+        }
+        if (extractDirectory != null) {
+            FileUtils.deleteFile(extractDirectory, true);
+        }
+    }
+
+    @Test
+    void shouldExtractFilesOnceInSameProcess() throws InterruptedException {
+        int threads = 20;
+        CountDownLatch countDownLatch = new CountDownLatch(threads);
+        AtomicInteger exceptionCounter = new AtomicInteger();
+        AtomicInteger extractCounter = new AtomicInteger();
+        for (int i = 0; i < threads; i++) {
+            new Thread(() -> {
+                try {
+                    NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    exceptionCounter.incrementAndGet();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        assertEquals(exceptionCounter.get(), 0);
+        assertEquals(extractCounter.get(), 1);
+    }
+
+    public static class NarUnpackerWorker {
+        public static void main(String[] args) {
+            File sampleZipFile = new File(args[0]);
+            File extractDirectory = new File(args[1]);
+            AtomicInteger extractCounter = new AtomicInteger();
+            try {
+                NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
+                if (extractCounter.get() == 1) {
+                    System.exit(101);
+                } else if (extractCounter.get() == 0) {
+                    System.exit(100);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.exit(99);
+            }
+        }
+    }
+
+    @Test
+    void shouldExtractFilesOnceInDifferentProcess() throws InterruptedException {
+        int processes = 10;
+        String javaExePath = findJavaExe().getAbsolutePath();
+        CountDownLatch countDownLatch = new CountDownLatch(processes);
+        AtomicInteger exceptionCounter = new AtomicInteger();
+        AtomicInteger extractCounter = new AtomicInteger();
+        for (int i = 0; i < processes; i++) {
+            new Thread(() -> {
+                try {
+                    // fork a new process with the same classpath
+                    Process process = new ProcessBuilder()
+                            .command(javaExePath,
+                                    "-Xmx64m",
+                                    "-cp",
+                                    System.getProperty("java.class.path"),
+                                    // use NarUnpackerWorker as the main class
+                                    NarUnpackerWorker.class.getName(),
+                                    // pass arguments to use for testing
+                                    sampleZipFile.getAbsolutePath(),
+                                    extractDirectory.getAbsolutePath())
+                            .start();
+                    String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+                    int retval = process.waitFor();
+                    log.info("Process retval {} output {}", retval, output);
+                    if (retval == 101) {
+                        extractCounter.incrementAndGet();
+                    } else if (retval != 100) {
+                        exceptionCounter.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    exceptionCounter.incrementAndGet();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        assertEquals(exceptionCounter.get(), 0);
+        assertEquals(extractCounter.get(), 1);
+    }
+
+    File findJavaExe() {
+        File javaHome = new File(System.getProperty("java.home"));
+        File javaExe = new File(javaHome, "bin/java" + (SystemUtils.IS_OS_WINDOWS ? ".exe" : ""));
+        return javaExe;
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -78,7 +78,7 @@ public class NarUnpackerTest {
                 try {
                     NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.error("Unpacking failed", e);
                     exceptionCounter.incrementAndGet();
                 } finally {
                     countDownLatch.countDown();
@@ -103,7 +103,7 @@ public class NarUnpackerTest {
                     System.exit(100);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                log.error("Unpacking failed", e);
                 System.exit(99);
             }
         }
@@ -140,7 +140,7 @@ public class NarUnpackerTest {
                         exceptionCounter.incrementAndGet();
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.error("Unpacking in a separate process failed", e);
                     exceptionCounter.incrementAndGet();
                 } finally {
                     countDownLatch.countDown();


### PR DESCRIPTION
Fixes #11340
Fixes #11379 

### Motivation

NarUnpacker used to extract Pulsar Functions jar files and Pulsar IO connector nar files has concurrency and file corruption issues.

When multiple processes start at once, the files in the extracted directory might get corrupted.
There are also cases where the same extraction directory is used for different versions of the functions jar file therefore creating file corruption issues.

### Modifications

- Calculate MD5 hash of the file content and use the Base64 encoded hash as the directory name
- Prevent concurrent extraction of the file content across multiple JVMs on the same host machine by using a OS level file lock. This solution is necessary since Nar file extraction happens in separate JVMs, the Java function instance processes.
- Prevent concurrent extraction of the file content in the same JVM with a object monitor based on the file path. 
  - Java's file locking solution throws OverlappingFileLockException if the same JVM acquires the file lock twice. Therefore it's necessary to have 2 solutions: one for preventing concurrent access within the JVM and the other to prevent concurrent access across JVMs.