### PR TITLE
[Security] Upgrade commons-compress to 1.21

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -349,7 +349,7 @@ The Apache Software License, Version 2.0
     - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.1.jar
-    - org.apache.commons-commons-compress-1.19.jar
+    - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
     - io.netty-netty-buffer-4.1.63.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ flexible messaging model and an intuitive client API.</description>
     <narPluginPhase>package</narPluginPhase>
 
     <!-- apache commons -->
-    <commons-compress.version>1.19</commons-compress.version>
+    <commons-compress.version>1.21</commons-compress.version>
 
     <bookkeeper.version>4.14.1</bookkeeper.version>
     <zookeeper.version>3.6.3</zookeeper.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -229,7 +229,7 @@ The Apache Software License, Version 2.0
     - guice-multibindings-4.2.0.jar
  * Apache Commons
     - commons-math3-3.6.1.jar
-    - commons-compress-1.19.jar
+    - commons-compress-1.21.jar
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar


### PR DESCRIPTION
### Motivation

- addresses CVE-2021-35515, CVE-2021-35516, CVE-2021-35517
  and CVE-2021-36090
- these are DoS type of vulnerabilities which don't impact Pulsar
- main benefit is that it clears the security scanning report.

### Modifications

- Bump commons-compress from 1.19 to 1.21