### PR TITLE
[Issue #11348][pulsar-broker] Fix can not get leader broker in follower brokers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -111,14 +111,8 @@ public class BrokersBase extends PulsarWebResource {
         validateSuperUserAccess();
 
         try {
-            LeaderBroker leaderBroker;
-            if (pulsar().getLeaderElectionService().isLeader()) {
-                leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
-                        .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
-            } else {
-                leaderBroker = pulsar().getLeaderElectionService().readCurrentLeader().get()
-                        .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
-            }
+            LeaderBroker leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
             return BrokerInfo.builder().serviceUrl(leaderBroker.getServiceUrl()).build();
         } catch (Exception e) {
             LOG.error("[{}] Failed to get the information of the leader broker.", clientAppId(), e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -111,8 +111,14 @@ public class BrokersBase extends PulsarWebResource {
         validateSuperUserAccess();
 
         try {
-            LeaderBroker leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
-                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
+            LeaderBroker leaderBroker;
+            if (pulsar().getLeaderElectionService().isLeader()) {
+                leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader()
+                        .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
+            } else {
+                leaderBroker = pulsar().getLeaderElectionService().readCurrentLeader().get()
+                        .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Couldn't find leader broker"));
+            }
             return BrokerInfo.builder().serviceUrl(leaderBroker.getServiceUrl()).build();
         } catch (Exception e) {
             LOG.error("[{}] Failed to get the information of the leader broker.", clientAppId(), e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.LeaderBroker;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.testng.annotations.Test;
+
+/**
+ * Test multi-broker admin api.
+ */
+@Slf4j
+@Test(groups = "broker-admin")
+public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
+    @Override
+    protected int numberOfAdditionalBrokers() {
+        return 3;
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+    }
+
+    @Override
+    protected void onCleanup() {
+        super.onCleanup();
+    }
+
+    @Test(timeOut = 30 * 1000)
+    public void testGetLeaderBroker()
+            throws ExecutionException, InterruptedException, PulsarAdminException {
+        List<PulsarService> allBrokers = getAllBrokers();
+        Optional<LeaderBroker> leaderBroker =
+                allBrokers.get(0).getLeaderElectionService().readCurrentLeader().get();
+        assertTrue(leaderBroker.isPresent());
+        log.info("Leader broker is {}", leaderBroker);
+        for (PulsarAdmin admin : getAllAdmins()) {
+            String serviceUrl = admin.brokers().getLeaderBroker().getServiceUrl();
+            log.info("Pulsar admin get leader broker is {}", serviceUrl);
+            assertEquals(leaderBroker.get().getServiceUrl(), serviceUrl);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #11348 

### Motivation

The follower broker use pulsar-admin should be able to get leader-broker

### Verifying this change

A new test was added for verifying the follower broker to get leader-broker

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

This is a bug fix, no need documentation.

