### PR TITLE
[Transaction] Transaction coordinator fence mechanism.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -770,7 +770,6 @@ public class PulsarService implements AutoCloseable {
                 transactionMetadataStoreService = new TransactionMetadataStoreService(TransactionMetadataStoreProvider
                         .newProvider(config.getTransactionMetadataStoreProviderClassName()), this,
                         transactionBufferClient, transactionTimer);
-                transactionMetadataStoreService.start();
 
                 transactionBufferProvider = TransactionBufferProvider
                         .newProvider(config.getTransactionBufferProviderClassName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -25,13 +25,16 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
+import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.transaction.buffer.exceptions.UnsupportedTxnActionException;
 import org.apache.pulsar.broker.transaction.recover.TransactionRecoverTrackerImpl;
 import org.apache.pulsar.broker.transaction.timeout.TransactionTimeoutTrackerFactoryImpl;
@@ -43,10 +46,9 @@ import org.apache.pulsar.client.api.transaction.TransactionBufferClientException
 import org.apache.pulsar.client.api.transaction.TransactionBufferClientException.RequestTimeoutException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.TxnAction;
-import org.apache.pulsar.common.naming.NamespaceBundle;
-import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreProvider;
@@ -74,6 +76,11 @@ public class TransactionMetadataStoreService {
     private final TransactionTimeoutTrackerFactory timeoutTrackerFactory;
     private static final long endTransactionRetryIntervalTime = 1000;
     private final Timer transactionOpRetryTimer;
+    // this semaphore for loading one transaction coordinator with the same tc id on the same time
+    private final ConcurrentLongHashMap<Semaphore> tcLoadSemaphores;
+    // one connect request open the transactionMetaStore the other request will add to the queue, when the open op
+    // finished the request will be poll and complete the future
+    private final ConcurrentLongHashMap<ConcurrentLinkedDeque<CompletableFuture<Void>>> pendingConnectRequests;
 
     public TransactionMetadataStoreService(TransactionMetadataStoreProvider transactionMetadataStoreProvider,
                                            PulsarService pulsarService, TransactionBufferClient tbClient,
@@ -84,91 +91,108 @@ public class TransactionMetadataStoreService {
         this.tbClient = tbClient;
         this.timeoutTrackerFactory = new TransactionTimeoutTrackerFactoryImpl(this, timer);
         this.transactionOpRetryTimer = timer;
+        this.tcLoadSemaphores = new ConcurrentLongHashMap<>();
+        this.pendingConnectRequests = new ConcurrentLongHashMap<>();
     }
 
-    public void start() {
-        pulsarService.getNamespaceService().addNamespaceBundleOwnershipListener(new NamespaceBundleOwnershipListener() {
-            @Override
-            public void onLoad(NamespaceBundle bundle) {
-                pulsarService.getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                    .whenComplete((topics, ex) -> {
-                        if (ex == null) {
-                            for (String topic : topics) {
-                                TopicName name = TopicName.get(topic);
-                                if (TopicName.TRANSACTION_COORDINATOR_ASSIGN.getLocalName()
-                                        .equals(TopicName.get(name.getPartitionedTopicName()).getLocalName())
-                                        && name.isPartitioned()) {
-                                    addTransactionMetadataStore(TransactionCoordinatorID.get(name.getPartitionIndex()));
-                                }
-                            }
-                        } else {
-                            LOG.error("Failed to get owned topic list when triggering on-loading bundle {}.",
-                                    bundle, ex);
-                        }
-                    });
-            }
-            @Override
-            public void unLoad(NamespaceBundle bundle) {
-                pulsarService.getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                    .whenComplete((topics, ex) -> {
-                        if (ex == null) {
-                            for (String topic : topics) {
-                                TopicName name = TopicName.get(topic);
-                                if (TopicName.TRANSACTION_COORDINATOR_ASSIGN.getLocalName()
-                                        .equals(TopicName.get(name.getPartitionedTopicName()).getLocalName())
-                                        && name.isPartitioned()) {
-                                    removeTransactionMetadataStore(
-                                            TransactionCoordinatorID.get(name.getPartitionIndex()));
-                                }
-                            }
-                        } else {
-                            LOG.error("Failed to get owned topic list error when triggering un-loading bundle {}.",
-                                    bundle, ex);
-                        }
-                     });
-            }
-            @Override
-            public boolean test(NamespaceBundle namespaceBundle) {
-                return namespaceBundle.getNamespaceObject().equals(NamespaceName.SYSTEM_NAMESPACE);
-            }
-        });
-    }
-
-    public void addTransactionMetadataStore(TransactionCoordinatorID tcId) {
-        pulsarService.getBrokerService()
-                .getManagedLedgerConfig(TopicName.get(MLTransactionLogImpl.TRANSACTION_LOG_PREFIX + tcId))
-                .whenComplete((v, e) -> {
-                    if (e != null) {
-                        LOG.error("Add transaction metadata store with id {} error", tcId.getId(), e);
-                    } else {
-                        TransactionTimeoutTracker timeoutTracker = timeoutTrackerFactory.newTracker(tcId);
-                        TransactionRecoverTracker recoverTracker =
-                                new TransactionRecoverTrackerImpl(TransactionMetadataStoreService.this,
-                                        timeoutTracker, tcId.getId());
-                        transactionMetadataStoreProvider.openStore(tcId, pulsarService.getManagedLedgerFactory(), v,
-                                timeoutTracker, recoverTracker)
-                                .whenComplete((store, ex) -> {
-                                    if (ex != null) {
-                                        LOG.error("Add transaction metadata store with id {} error", tcId.getId(), ex);
-                                    } else {
-                                        stores.put(tcId, store);
-                                        LOG.info("Added new transaction meta store {}", tcId);
-                                    }
-                                });
+    public CompletableFuture<Void> handleTcClientConnect(TransactionCoordinatorID tcId) {
+        if (stores.get(tcId) != null) {
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return pulsarService.getBrokerService().checkTopicNsOwnership(TopicName
+                    .TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) tcId.getId()).toString()).thenCompose(v -> {
+                        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+                final Semaphore tcLoadSemaphore = this.tcLoadSemaphores
+                        .computeIfAbsent(tcId.getId(), (id) -> new Semaphore(1));
+                Deque<CompletableFuture<Void>> deque = pendingConnectRequests
+                        .computeIfAbsent(tcId.getId(), (id) -> new ConcurrentLinkedDeque<>());
+                if (tcLoadSemaphore.tryAcquire()) {
+                    // when tcLoadSemaphore.release(), this command will acquire semaphore, so we should jude the store
+                    // exist again.
+                    if (stores.get(tcId) != null) {
+                        return CompletableFuture.completedFuture(null);
                     }
-        });
+
+                    openTransactionMetadataStore(tcId).thenAccept((store) -> {
+                        stores.put(tcId, store);
+                        LOG.info("Added new transaction meta store {}", tcId);
+                        while (true) {
+                            CompletableFuture<Void> future = deque.poll();
+                            if (future != null) {
+                                // complete queue request future
+                                future.complete(null);
+                            } else {
+                                break;
+                            }
+                        }
+
+                        completableFuture.complete(null);
+                        tcLoadSemaphore.release();
+                    }).exceptionally(e -> {
+                        completableFuture.completeExceptionally(e.getCause());
+                        // release before handle request queue, in order to client reconnect infinite loop
+                        tcLoadSemaphore.release();
+
+                        while (true) {
+                            CompletableFuture<Void> future = deque.poll();
+                            if (future != null) {
+                                // this means that this tc client connection connect fail
+                                future.completeExceptionally(e);
+                            } else {
+                                break;
+                            }
+                        }
+                        LOG.error("Add transaction metadata store with id {} error", tcId.getId(), e);
+                        return null;
+                    });
+                } else {
+                    // only one command can open transaction metadata store,
+                    // other will be added to the deque, when the op of openTransactionMetadataStore finished
+                    // then handle the requests witch in the queue
+                    deque.add(completableFuture);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Handle tc client connect added into pending queue! tcId : {}", tcId.toString());
+                    }
+                }
+                return completableFuture;
+            });
+        }
     }
 
-    public void removeTransactionMetadataStore(TransactionCoordinatorID tcId) {
-        TransactionMetadataStore metadataStore = stores.remove(tcId);
-        if (metadataStore != null) {
-            metadataStore.closeAsync().whenComplete((v, ex) -> {
-                if (ex != null) {
-                    LOG.error("Close transaction metadata store with id " + tcId, ex);
-                } else {
-                    LOG.info("Removed and closed transaction meta store {}", tcId);
-                }
-            });
+    public CompletableFuture<TransactionMetadataStore> openTransactionMetadataStore(TransactionCoordinatorID tcId) {
+        return pulsarService.getBrokerService()
+                .getManagedLedgerConfig(TopicName.get(MLTransactionLogImpl
+                        .TRANSACTION_LOG_PREFIX + tcId)).thenCompose(v -> {
+                            TransactionTimeoutTracker timeoutTracker = timeoutTrackerFactory.newTracker(tcId);
+                            TransactionRecoverTracker recoverTracker =
+                                    new TransactionRecoverTrackerImpl(TransactionMetadataStoreService.this,
+                                    timeoutTracker, tcId.getId());
+                            return transactionMetadataStoreProvider
+                                    .openStore(tcId, pulsarService.getManagedLedgerFactory(), v,
+                                            timeoutTracker, recoverTracker);
+                });
+    }
+
+    public CompletableFuture<Void> removeTransactionMetadataStore(TransactionCoordinatorID tcId) {
+        final Semaphore tcLoadSemaphore = this.tcLoadSemaphores
+                .computeIfAbsent(tcId.getId(), (id) -> new Semaphore(1));
+        if (tcLoadSemaphore.tryAcquire()) {
+            TransactionMetadataStore metadataStore = stores.remove(tcId);
+            if (metadataStore != null) {
+                metadataStore.closeAsync().whenComplete((v, ex) -> {
+                    if (ex != null) {
+                        LOG.error("Close transaction metadata store with id " + tcId, ex);
+                    } else {
+                        LOG.info("Removed and closed transaction meta store {}", tcId);
+                    }
+                });
+            }
+            tcLoadSemaphore.release();
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return FutureUtil.failedFuture(
+                    new ServiceUnitNotReadyException("Could not remove " +
+                            "TransactionMetadataStore, it is doing other operations!"));
         }
     }
 
@@ -323,6 +347,14 @@ public class TransactionMetadataStoreService {
         return completableFuture;
     }
 
+    // when managedLedger fence will remove this tc and reload
+    public void handleOpFail(Throwable e, TransactionCoordinatorID tcId) {
+        if (e.getCause() instanceof ManagedLedgerException.ManagedLedgerFencedException
+                || e instanceof ManagedLedgerException.ManagedLedgerFencedException) {
+            removeTransactionMetadataStore(tcId);
+        }
+    }
+
     public void endTransactionForTimeout(TxnID txnID) {
         getTxnMeta(txnID).thenCompose(txnMeta -> {
             if (txnMeta.status() == TxnStatus.OPEN) {
@@ -400,13 +432,14 @@ public class TransactionMetadataStoreService {
     }
 
     private static boolean isRetryableException(Throwable e) {
-        return e instanceof TransactionMetadataStoreStateException
+        return (e instanceof TransactionMetadataStoreStateException
                 || e instanceof RequestTimeoutException
                 || e instanceof ManagedLedgerException
                 || e instanceof BrokerPersistenceException
                 || e instanceof LookupException
                 || e instanceof ReachMaxPendingOpsException
-                || e instanceof ConnectException;
+                || e instanceof ConnectException)
+                && !(e instanceof ManagedLedgerException.ManagedLedgerFencedException);
     }
 
     private CompletableFuture<Void> endTxnInTransactionMetadataStore(TxnID txnID, int txnAction) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -112,6 +112,7 @@ import org.apache.pulsar.common.api.proto.CommandSend;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.CommandTcClientConnect;
 import org.apache.pulsar.common.api.proto.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.FeatureFlags;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
@@ -1838,6 +1839,40 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     @Override
+    protected void handleTcClientConnect(CommandTcClientConnect command) {
+        final long requestId = command.getRequestId();
+        final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
+        if (log.isDebugEnabled()) {
+            log.debug("Receive tc client connect request {} to transaction meta store {} from {}.",
+                    requestId, tcId, remoteAddress);
+        }
+
+        if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+            BrokerServiceException.NotAllowedException ex =
+                    new BrokerServiceException.NotAllowedException(
+                            "Transaction manager is not not enabled");
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
+            return;
+        }
+
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                service.pulsar().getTransactionMetadataStoreService();
+
+        transactionMetadataStoreService.handleTcClientConnect(tcId).thenAccept(connection -> {
+            if (log.isDebugEnabled()) {
+                log.debug("Handle tc client connect request {} to transaction meta store {} from {} success.",
+                        requestId, tcId, remoteAddress);
+            }
+            commandSender.sendSuccessResponse(requestId);
+        }).exceptionally(e -> {
+            log.error("Handle tc client connect request {} to transaction meta store {} from {} fail.",
+                    requestId, tcId, remoteAddress, e.getCause());
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(e), e.getMessage());
+            return null;
+        });
+    }
+
+    @Override
     protected void handleNewTxn(CommandNewTxn command) {
         final long requestId = command.getRequestId();
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
@@ -1845,16 +1880,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("Receive new txn request {} to transaction meta store {} from {}.",
                     requestId, tcId, remoteAddress);
         }
-        TransactionMetadataStoreService transactionMetadataStoreService =
-                service.pulsar().getTransactionMetadataStoreService();
-        if (transactionMetadataStoreService == null) {
-            CoordinatorException.CoordinatorNotFoundException ex =
-                    new CoordinatorException.CoordinatorNotFoundException(
-                                               "Transaction manager is not started or not enabled");
-            ctx.writeAndFlush(Commands.newTxnResponse(requestId, tcId.getId(),
-                    BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
+
+        if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+            BrokerServiceException.NotAllowedException ex =
+                    new BrokerServiceException.NotAllowedException(
+                            "Transaction manager is not not enabled");
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
             return;
         }
+
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                service.pulsar().getTransactionMetadataStoreService();
         transactionMetadataStoreService.newTransaction(tcId, command.getTxnTtlSeconds())
             .whenComplete(((txnID, ex) -> {
                 if (ex == null) {
@@ -1867,8 +1903,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     if (log.isDebugEnabled()) {
                         log.debug("Send response error for new txn request {}", requestId, ex);
                     }
+
                     ctx.writeAndFlush(Commands.newTxnResponse(requestId, tcId.getId(),
                             BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
+                    transactionMetadataStoreService.handleOpFail(ex, tcId);
                 }
             }));
     }
@@ -1876,12 +1914,23 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleAddPartitionToTxn(CommandAddPartitionToTxn command) {
         final TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
+        final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
         final long requestId = command.getRequestId();
         if (log.isDebugEnabled()) {
             command.getPartitionsList().forEach(partion ->
                     log.debug("Receive add published partition to txn request {} "
                             + "from {} with txnId {}, topic: [{}]", requestId, remoteAddress, txnID, partion));
         }
+
+        if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+            BrokerServiceException.NotAllowedException ex =
+                    new BrokerServiceException.NotAllowedException(
+                            "Transaction manager is not not enabled");
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
+            return;
+        }
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                service.pulsar().getTransactionMetadataStoreService();
         service.pulsar().getTransactionMetadataStoreService().addProducedPartitionToTxn(txnID,
                 command.getPartitionsList())
                 .whenComplete(((v, ex) -> {
@@ -1895,10 +1944,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         if (log.isDebugEnabled()) {
                             log.debug("Send response error for add published partition to txn request {}", requestId,
                                     ex);
+                        }
+
+                        if (ex instanceof CoordinatorException.CoordinatorNotFoundException) {
+                            ctx.writeAndFlush(Commands.newAddPartitionToTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
+                        } else {
+                            ctx.writeAndFlush(Commands.newAddPartitionToTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex.getCause()),
+                                    ex.getCause().getMessage()));
+                        }
+                        transactionMetadataStoreService.handleOpFail(ex, tcId);
                     }
-                    ctx.writeAndFlush(Commands.newAddPartitionToTxnResponse(requestId, txnID.getMostSigBits(),
-                            BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
-                }
             }));
     }
 
@@ -1907,16 +1964,38 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final long requestId = command.getRequestId();
         final int txnAction = command.getTxnAction().getValue();
         TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
+        final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
 
-        service.pulsar().getTransactionMetadataStoreService()
+        if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+            BrokerServiceException.NotAllowedException ex =
+                    new BrokerServiceException.NotAllowedException(
+                            "Transaction manager is not not enabled");
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
+            return;
+        }
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                service.pulsar().getTransactionMetadataStoreService();
+
+        transactionMetadataStoreService
                 .endTransaction(txnID, txnAction, false)
-                .thenRun(() -> ctx.writeAndFlush(Commands.newEndTxnResponse(requestId,
-                        txnID.getLeastSigBits(), txnID.getMostSigBits())))
-                .exceptionally(throwable -> {
-                    log.error("Send response error for end txn request.", throwable);
-                    ctx.writeAndFlush(Commands.newEndTxnResponse(requestId, txnID.getMostSigBits(),
-                            BrokerServiceException.getClientErrorCode(throwable.getCause()), throwable.getMessage()));
-                    return null; });
+                .whenComplete((v ,ex) -> {
+                    if (ex == null) {
+                        ctx.writeAndFlush(Commands.newEndTxnResponse(requestId,
+                                txnID.getLeastSigBits(), txnID.getMostSigBits()));
+                    } else {
+                        log.error("Send response error for end txn request.", ex);
+
+                        if (ex instanceof CoordinatorException.CoordinatorNotFoundException) {
+                            ctx.writeAndFlush(Commands.newEndTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
+                        } else {
+                            ctx.writeAndFlush(Commands.newEndTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex.getCause()),
+                                    ex.getCause().getMessage()));
+                        }
+                        transactionMetadataStoreService.handleOpFail(ex, tcId);
+                    }
+                });
     }
 
     @Override
@@ -2066,7 +2145,19 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     requestId, remoteAddress, txnID);
         }
 
-        service.pulsar().getTransactionMetadataStoreService().addAckedPartitionToTxn(txnID,
+        final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
+
+        if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
+            BrokerServiceException.NotAllowedException ex =
+                    new BrokerServiceException.NotAllowedException(
+                            "Transaction manager is not not enabled");
+            commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
+            return;
+        }
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                service.pulsar().getTransactionMetadataStoreService();
+
+        transactionMetadataStoreService.addAckedPartitionToTxn(txnID,
                 MLTransactionMetadataStore.subscriptionToTxnSubscription(command.getSubscriptionsList()))
                 .whenComplete(((v, ex) -> {
                     if (ex == null) {
@@ -2082,9 +2173,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             log.debug("Send response error for add published partition to txn request {}",
                                     requestId, ex);
                         }
-                        ctx.writeAndFlush(Commands.newAddSubscriptionToTxnResponse(requestId,
-                                txnID.getMostSigBits(), BrokerServiceException.getClientErrorCode(ex),
-                                ex.getMessage()));
+
+                        if (ex instanceof CoordinatorException.CoordinatorNotFoundException) {
+                            ctx.writeAndFlush(Commands.newAddSubscriptionToTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex), ex.getMessage()));
+                        } else {
+                            ctx.writeAndFlush(Commands.newAddSubscriptionToTxnResponse(requestId, txnID.getMostSigBits(),
+                                    BrokerServiceException.getClientErrorCode(ex.getCause()),
+                                    ex.getCause().getMessage()));
+                        }
+                        transactionMetadataStoreService.handleOpFail(ex, tcId);
                     }
                 }));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.stats.prometheus;
 
+import static org.apache.pulsar.common.events.EventsTopicNames.checkTopicIsEventsNames;
 import io.netty.util.concurrent.FastThreadLocal;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -26,6 +27,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
@@ -62,10 +64,12 @@ public class TransactionAggregator {
                             topic.getSubscriptions().values().forEach(subscription -> {
                                 try {
                                     localManageLedgerStats.get().reset();
-                                    ManagedLedger managedLedger =
-                                            ((PersistentSubscription) subscription).getPendingAckManageLedger().get();
-                                    generateManageLedgerStats(managedLedger,
-                                            stream, cluster, namespace, name, subscription.getName());
+                                    if (!checkTopicIsEventsNames(TopicName.get(subscription.getTopic().getName()))) {
+                                        ManagedLedger managedLedger =
+                                                ((PersistentSubscription) subscription).getPendingAckManageLedger().get();
+                                        generateManageLedgerStats(managedLedger,
+                                                stream, cluster, namespace, name, subscription.getName());
+                                    }
                                 } catch (Exception e) {
                                     log.warn("Transaction pending ack generate managedLedgerStats fail!", e);
                                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -28,12 +28,17 @@ import java.util.List;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.TxnAction;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreState;
 import org.apache.pulsar.transaction.coordinator.TransactionSubscription;
@@ -57,6 +62,10 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         ServiceConfiguration configuration = getDefaultConf();
         configuration.setTransactionCoordinatorEnabled(true);
         super.baseSetup(configuration);
+        admin.tenants().createTenant("pulsar", new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), 16);
+        admin.lookups().lookupPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString());
     }
 
     @AfterMethod(alwaysRun = true)
@@ -66,11 +75,17 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     }
 
     @Test
-    public void testAddAndRemoveTransactionMetadataStore() {
+    public void testCloseLock() {
+
+    }
+
+    @Test
+    public void testAddAndRemoveTransactionMetadataStore() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
         Assert.assertNotNull(transactionMetadataStoreService);
 
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        admin.lookups().lookupTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.getPartition(0).toString());
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
@@ -82,9 +97,9 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void testNewTransaction() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(1));
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(2));
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(0));
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(1));
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(2));
         Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 3);
         checkTransactionMetadataStoreReady((MLTransactionMetadataStore) pulsar.getTransactionMetadataStoreService()
@@ -108,7 +123,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void testAddProducedPartitionToTxn() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
@@ -132,7 +147,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void testAddAckedPartitionToTxn() throws Exception {
         TransactionMetadataStoreService transactionMetadataStoreService = pulsar.getTransactionMetadataStoreService();
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        transactionMetadataStoreService.handleTcClientConnect(TransactionCoordinatorID.get(0)).get();
         Awaitility.await().until(() ->
                 transactionMetadataStoreService.getStores().size() == 1);
 
@@ -154,7 +169,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
     @Test
     public void testTimeoutTracker() throws Exception {
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
@@ -183,7 +198,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
     @Test
     public void testTimeoutTrackerExpired() throws Exception {
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await().until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
         MLTransactionMetadataStore transactionMetadataStore =
@@ -213,7 +228,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
     @Test
     public void testTimeoutTrackerMultiThreading() throws Exception {
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
@@ -284,7 +299,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test
     public void transactionTimeoutRecoverTest() throws Exception {
         int timeout = 2000;
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
@@ -298,7 +313,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         pulsar.getTransactionMetadataStoreService()
                 .removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
 
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);
@@ -324,7 +339,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
     @Test(dataProvider = "txnStatus")
     public void testEndTransactionOpRetry(TxnStatus txnStatus) throws Exception {
         int timeOut = 3000;
-        pulsar.getTransactionMetadataStoreService().addTransactionMetadataStore(TransactionCoordinatorID.get(0));
+        pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
                         .getStores().get(TransactionCoordinatorID.get(0)) != null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionClientReconnectTest.java
@@ -19,27 +19,31 @@
 package org.apache.pulsar.broker.transaction;
 
 import com.google.common.collect.Sets;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.client.impl.transaction.TransactionImpl;
+import org.apache.pulsar.client.impl.transaction.TransactionCoordinatorClientImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
+import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.FileAssert.fail;
 
@@ -78,26 +82,10 @@ public class TransactionClientReconnectTest extends TransactionTestBase {
     }
 
     @Test
-    public void testTransactionClientReconnectTest() throws PulsarClientException, ExecutionException, InterruptedException {
+    public void testTransactionNewReconnect() throws Exception {
+        start();
 
-        ((PulsarClientImpl) pulsarClient).getLookup()
-                .getPartitionedTopicMetadata(TopicName.TRANSACTION_COORDINATOR_ASSIGN).get();
-
-        Awaitility.await().until(() -> {
-            pulsarClient.newTransaction()
-                    .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
-            return true;
-        });
-
-        TransactionImpl transaction = (TransactionImpl) pulsarClient.newTransaction()
-                .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
-
-        TransactionMetadataStoreService transactionMetadataStoreService =
-                getPulsarServiceList().get(0).getTransactionMetadataStoreService();
-
-        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0));
-
-        // transaction client will reconnect
+        // when throw CoordinatorNotFoundException client will reconnect tc
         try {
             pulsarClient.newTransaction()
                     .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
@@ -105,40 +93,172 @@ public class TransactionClientReconnectTest extends TransactionTestBase {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
         }
+        reconnect();
 
+        fence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());
+
+        // tc fence will remove this tc and reopen
         try {
-            transaction.registerProducedTopic(RECONNECT_TOPIC).get();
-            fail();
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException);
-        }
-
-        try {
-            transaction.registerAckedTopic(RECONNECT_TOPIC, "test").get();
-            fail();
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException);
-        }
-
-        try {
-            transaction.commit().get();
-            fail();
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.MetaStoreHandlerNotReadyException);
-        }
-
-        transactionMetadataStoreService.addTransactionMetadataStore(TransactionCoordinatorID.get(0));
-
-        // wait transaction coordinator init success
-        Awaitility.await().until(() -> {
             pulsarClient.newTransaction()
                     .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
+            fail();
+        } catch (ExecutionException e) {
+            assertEquals(e.getCause().getMessage(),
+                    "org.apache.bookkeeper.mledger.ManagedLedgerException$ManagedLedgerFencedException: " +
+                            "java.lang.Exception: Attempted to use a fenced managed ledger");
+        }
+
+        reconnect();
+    }
+
+    @Test
+    public void testTransactionAddSubscriptionToTxnAsyncReconnect() throws Exception {
+        TransactionCoordinatorClientImpl transactionCoordinatorClient = ((PulsarClientImpl) pulsarClient).getTcClient();
+        start();
+
+        try {
+            transactionCoordinatorClient.addSubscriptionToTxnAsync(new TxnID(0, 0), "test", "test").get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+        }
+
+        reconnect();
+        fence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());
+        try {
+            transactionCoordinatorClient.addSubscriptionToTxnAsync(new TxnID(0, 0), "test", "test").get();
+            fail();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException) {
+                assertEquals(e.getCause().getMessage(), "The transaction with this txdID `(0,0)`not found ");
+            } else {
+                assertEquals(e.getCause().getMessage(), "java.lang.Exception: Attempted to use a fenced managed ledger");
+            }
+        }
+        reconnect();
+    }
+
+    @Test
+    public void testTransactionAbortToTxnAsyncReconnect() throws Exception {
+        TransactionCoordinatorClientImpl transactionCoordinatorClient = ((PulsarClientImpl) pulsarClient).getTcClient();
+        start();
+
+        try {
+            transactionCoordinatorClient.abortAsync(new TxnID(0, 0)).get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+        }
+
+        reconnect();
+        fence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());
+        try {
+            transactionCoordinatorClient.abortAsync(new TxnID(0, 0)).get();
+            fail();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException) {
+                assertEquals(e.getCause().getMessage(), "The transaction with this txdID `(0,0)`not found ");
+            } else {
+                assertEquals(e.getCause().getMessage(), "java.lang.Exception: Attempted to use a fenced managed ledger");
+            }
+        }
+        reconnect();
+    }
+
+    @Test
+    public void testTransactionCommitToTxnAsyncReconnect() throws Exception {
+        TransactionCoordinatorClientImpl transactionCoordinatorClient = ((PulsarClientImpl) pulsarClient).getTcClient();
+        start();
+
+        try {
+            transactionCoordinatorClient.commitAsync(new TxnID(0, 0)).get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+        }
+
+        reconnect();
+        fence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());
+        try {
+            transactionCoordinatorClient.commitAsync(new TxnID(0, 0)).get();
+            fail();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException) {
+                assertEquals(e.getCause().getMessage(), "The transaction with this txdID `(0,0)`not found ");
+            } else {
+                assertEquals(e.getCause().getMessage(), "java.lang.Exception: Attempted to use a fenced managed ledger");
+            }
+        }
+        reconnect();
+    }
+
+    @Test
+    public void testTransactionAddPublishPartitionToTxnReconnect() throws Exception {
+        TransactionCoordinatorClientImpl transactionCoordinatorClient = ((PulsarClientImpl) pulsarClient).getTcClient();
+        start();
+
+        try {
+            transactionCoordinatorClient.addPublishPartitionToTxnAsync(new TxnID(0, 0),
+                    Collections.singletonList("test")).get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.CoordinatorNotFoundException);
+        }
+
+        reconnect();
+        fence(getPulsarServiceList().get(0).getTransactionMetadataStoreService());
+        try {
+            transactionCoordinatorClient.addPublishPartitionToTxnAsync(new TxnID(0, 0),
+                    Collections.singletonList("test")).get();
+            fail();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException) {
+                assertEquals(e.getCause().getMessage(), "The transaction with this txdID `(0,0)`not found ");
+            } else {
+                assertEquals(e.getCause().getMessage(), "java.lang.Exception: Attempted to use a fenced managed ledger");
+            }
+        }
+        reconnect();
+    }
+
+    public void start() throws Exception {
+        // wait transaction coordinator init success
+        Awaitility.await().until(() -> {
+            try {
+                pulsarClient.newTransaction()
+                        .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
+            } catch (Exception e) {
+                return false;
+            }
             return true;
         });
-        transaction = (TransactionImpl) pulsarClient.newTransaction()
+        pulsarClient.newTransaction()
                 .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
-        transaction.registerProducedTopic(RECONNECT_TOPIC).get();
-        transaction.registerAckedTopic(RECONNECT_TOPIC, "test").get();
-        transaction.commit().get();
+
+        TransactionMetadataStoreService transactionMetadataStoreService =
+                getPulsarServiceList().get(0).getTransactionMetadataStoreService();
+        // remove transaction metadata store
+        transactionMetadataStoreService.removeTransactionMetadataStore(TransactionCoordinatorID.get(0)).get();
+
+    }
+
+    public void fence(TransactionMetadataStoreService transactionMetadataStoreService) throws Exception {
+        Field field = ManagedLedgerImpl.class.getDeclaredField("state");
+        field.setAccessible(true);
+        field.set(((MLTransactionMetadataStore) transactionMetadataStoreService.getStores()
+                .get(TransactionCoordinatorID.get(0))).getManagedLedger(), ManagedLedgerImpl.State.Fenced);
+    }
+
+    public void reconnect() {
+        //reconnect
+        Awaitility.await().until(() -> {
+            try {
+                pulsarClient.newTransaction()
+                        .withTransactionTimeout(200, TimeUnit.MILLISECONDS).build().get();
+            } catch (Exception e) {
+                return false;
+            }
+            return true;
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -73,7 +73,7 @@ public abstract class TransactionTestBase extends TestRetrySupport {
     @Getter
     private final List<ServiceConfiguration> serviceConfigurationList = new ArrayList<>();
     @Getter
-    private final List<PulsarService> pulsarServiceList = new ArrayList<>();
+    protected final List<PulsarService> pulsarServiceList = new ArrayList<>();
 
     protected PulsarAdmin admin;
     protected PulsarClient pulsarClient;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.api.proto.AuthMethod;
 import org.apache.pulsar.common.api.proto.BaseCommand;
@@ -586,6 +587,12 @@ public class Commands {
             convertSchema(schemaInfo, subscribe.setSchema());
         }
 
+        return serializeWithSize(cmd);
+    }
+
+    public static ByteBuf newTcClientConnect(long tcId, long requestId) {
+        BaseCommand cmd = localCmd(Type.TC_CLIENT_CONNECT);
+        cmd.setTcClientConnect().setTcId(tcId).setRequestId(requestId);
         return serializeWithSize(cmd);
     }
 
@@ -1222,10 +1229,14 @@ public class Commands {
     public static ByteBuf newAddPartitionToTxnResponse(long requestId, long txnIdMostBits, ServerError error,
            String errorMsg) {
         BaseCommand cmd = localCmd(Type.ADD_PARTITION_TO_TXN_RESPONSE);
-        cmd.setAddPartitionToTxnResponse()
+        CommandAddPartitionToTxnResponse response = cmd.setAddPartitionToTxnResponse()
                 .setRequestId(requestId)
                 .setError(error)
                 .setTxnidMostBits(txnIdMostBits);
+
+        if (errorMsg != null) {
+            response.setMessage(errorMsg);
+        }
         return serializeWithSize(cmd);
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -23,7 +23,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
-
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandAckResponse;
@@ -75,6 +74,7 @@ import org.apache.pulsar.common.api.proto.CommandSendError;
 import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
+import org.apache.pulsar.common.api.proto.CommandTcClientConnect;
 import org.apache.pulsar.common.api.proto.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.intercept.InterceptException;
@@ -361,6 +361,11 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 handleAuthResponse(cmd.getAuthResponse());
                 break;
 
+            case TC_CLIENT_CONNECT:
+                checkArgument(cmd.hasTcClientConnect());
+                handleTcClientConnect(cmd.getTcClientConnect());
+                break;
+
             case NEW_TXN:
                 checkArgument(cmd.hasNewTxn());
                 handleNewTxn(cmd.getNewTxn());
@@ -599,6 +604,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleAuthChallenge(CommandAuthChallenge commandAuthChallenge) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleTcClientConnect(CommandTcClientConnect tcClientConnect) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -758,6 +758,11 @@ enum TxnAction {
     ABORT = 1;
 }
 
+message CommandTcClientConnect {
+    required uint64 request_id = 1;
+    required uint64 tc_id = 2 [default = 0];
+}
+
 message CommandNewTxn {
     required uint64 request_id = 1;
     optional uint64 txn_ttl_seconds = 2 [default = 0];
@@ -937,6 +942,7 @@ message BaseCommand {
 
         END_TXN_ON_SUBSCRIPTION = 60;
         END_TXN_ON_SUBSCRIPTION_RESPONSE = 61;
+        TC_CLIENT_CONNECT = 62;
 
     }
 
@@ -1012,4 +1018,5 @@ message BaseCommand {
     optional CommandEndTxnOnPartitionResponse endTxnOnPartitionResponse = 59;
     optional CommandEndTxnOnSubscription endTxnOnSubscription = 60;
     optional CommandEndTxnOnSubscriptionResponse endTxnOnSubscriptionResponse = 61;
+    optional CommandTcClientConnect tcClientConnect = 62;
 }


### PR DESCRIPTION
## Motivation
now transaction coordinator init use `addNamespaceBundleOwnershipListener`, but it will not ensure transaction coordinator has been loaded correctly.

![image](https://user-images.githubusercontent.com/39078850/126097255-2dd005bc-7e10-415a-873d-7ea54914ab6e.png)
As shown in this picture, when add transaction coordinator fail, this coordinator will not init again. Client do transaction op will all get `CoordinatorNotFoundException`.

## implement
when client do transaction op, we don't have corresponding coordinator, we also can init again, but every transaction client op will init transaction again. so should add a comman `TcClientConnect`. The client must connect to tc successfully then we can do transaction op. when client in `CONNECTING` state, client will return fail.
```
message CommandTcClientConnect {
    required uint64 request_id = 1;
    required uint64 tc_id = 2 [default = 0];
}
```

This command mainly responsible for loading tc. when client op get `CoordinatorNotFoundException`, client will do lookup and reconnect tc. and in the one broker, only one tc will initing with the same tcId. When tc append log get `ManagedLedgerFencedException` broker will remove this tc. if client send `CommandTcClientConnect` to this broker, broker will check the ownerShip, then decide whether to load this tc.
 

### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

