### PR TITLE
[website][pulsar]: auto generate docs for pulsar subcommand: standalone

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -20,15 +20,19 @@ package org.apache.pulsar;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.common.util.CmdGenerateDocs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PulsarStandaloneStarter extends PulsarStandalone {
+    @Parameter(names = {"-g", "--generate-docs"}, description = "Generate docs")
+    private boolean generateDocs = false;
 
     private static final Logger log = LoggerFactory.getLogger(PulsarStandaloneStarter.class);
 
@@ -41,6 +45,12 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             if (this.isHelp() || isBlank(this.getConfigFile())) {
                 jcommander.usage();
                 return;
+            }
+            if (this.generateDocs) {
+                CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
+                cmd.addCommand("standalone", this);
+                cmd.run(null);
+                System.exit(0);
             }
 
             if (this.isNoBroker() && this.isOnlyBroker()) {


### PR DESCRIPTION
### Master Issue: #10040
Motivation
Support auto generate HTML page for pulsar client cli tool, for example: https://github.com/apache/pulsar/tree/asf-site/content/tools/pulsar-admin

### Modifications
generate docs for pulsar subcommand: standalone

(Please pick either of the following options)

This change is a trivial rework / code cleanup without any test coverage.

(or)

This change is already covered by existing tests, such as (please describe tests).

(or)

This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure

### Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (yes / no)
The public API: (yes / no)
The schema: (yes / no / don't know)
The default values of configurations: (yes / no)
The wire protocol: (yes / no)
The rest endpoints: (yes / no)
The admin cli options: (yes / no)
Anything that affects deployment: (yes / no / don't know)

### Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a followup issue for adding the documentation