### PR TITLE
Generate documentation of ServiceDiscovery automatically

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -111,7 +111,7 @@ public abstract class BaseGenerateDocumentation {
 
         sb.append("# ").append(type).append("\n");
         sb.append("|Name|Description|Default|\n");
-        sb.append("|---|---|---|---|---|\n");
+        sb.append("|---|---|---|\n");
         for (Field field : fields) {
             ApiModelProperty fieldContext = field.getAnnotation(ApiModelProperty.class);
             if (fieldContext == null) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import io.swagger.annotations.ApiModelProperty;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +29,7 @@ import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.configuration.FieldContext;
 
 @Data
@@ -97,6 +99,29 @@ public abstract class BaseGenerateDocumentation {
             sb.append(field.get(obj)).append(" | ");
             sb.append(fieldContext.dynamic()).append(" | ");
             sb.append(fieldContext.category()).append(" | ");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    protected String generateDocByApiModelProperty(String className, String type, StringBuilder sb) throws Exception {
+        Class<?> clazz = Class.forName(className);
+        Object obj = clazz.getDeclaredConstructor().newInstance();
+        Field[] fields = clazz.getDeclaredFields();
+
+        sb.append("# ").append(type).append("\n");
+        sb.append("|Name|Description|Default|\n");
+        sb.append("|---|---|---|---|---|\n");
+        for (Field field : fields) {
+            ApiModelProperty fieldContext = field.getAnnotation(ApiModelProperty.class);
+            if (fieldContext == null) {
+                continue;
+            }
+            field.setAccessible(true);
+            String name = StringUtils.isBlank(fieldContext.name()) ? field.getName() : fieldContext.name();
+            sb.append("| ").append(name).append(" | ");
+            sb.append(fieldContext.value().replace("\n", "<br>")).append(" | ");
+            sb.append(field.get(obj)).append(" | ");
             sb.append("\n");
         }
         return sb.toString();

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/BaseGenerateDocumentation.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.common.configuration.FieldContext;
+
+@Data
+@Parameters(commandDescription = "Generate documentation automatically.")
+@Slf4j
+public abstract class BaseGenerateDocumentation {
+
+    JCommander jcommander;
+
+    @Parameter(names = {"-c", "--class-names"}, description =
+            "List of class names, generate documentation based on the annotations in the Class")
+    private List<String> classNames = new ArrayList<>();
+
+    @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
+    boolean help;
+
+    public BaseGenerateDocumentation() {
+        jcommander = new JCommander();
+        jcommander.setProgramName("pulsar-generateDocumentation");
+        jcommander.addObject(this);
+    }
+
+    public boolean run(String[] args) throws Exception {
+        if (args.length == 0) {
+            jcommander.usage();
+            return false;
+        }
+
+        if (help) {
+            jcommander.usage();
+            return true;
+        }
+
+        try {
+            jcommander.parse(Arrays.copyOfRange(args, 0, args.length));
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            jcommander.usage();
+            return false;
+        }
+        if (!CollectionUtils.isEmpty(classNames)) {
+            for (String className : classNames) {
+                System.out.println(generateDocumentByClassName(className));
+            }
+        }
+        return true;
+    }
+
+    protected abstract String generateDocumentByClassName(String className) throws Exception;
+
+    protected String generateDocByFieldContext(String className, String type, StringBuilder sb) throws Exception {
+        Class<?> clazz = Class.forName(className);
+        Object obj = clazz.getDeclaredConstructor().newInstance();
+        Field[] fields = clazz.getDeclaredFields();
+
+        sb.append("# ").append(type).append("\n");
+        sb.append("|Name|Description|Default|Dynamic|Category|\n");
+        sb.append("|---|---|---|---|---|\n");
+        for (Field field : fields) {
+            FieldContext fieldContext = field.getAnnotation(FieldContext.class);
+            if (fieldContext == null) {
+                continue;
+            }
+            field.setAccessible(true);
+            sb.append("| ").append(field.getName()).append(" | ");
+            sb.append(fieldContext.doc().replace("\n", "<br>")).append(" | ");
+            sb.append(field.get(obj)).append(" | ");
+            sb.append(fieldContext.dynamic()).append(" | ");
+            sb.append(fieldContext.category()).append(" | ");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.discovery.service.server;
 
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -36,91 +37,209 @@ import com.google.common.collect.Sets;
 @Data
 public class ServiceConfig implements PulsarConfiguration {
 
-    // Local-Zookeeper quorum connection string
+    @ApiModelProperty(
+            name = "zookeeperServers",
+            value = "Local-Zookeeper quorum connection string"
+    )
     private String zookeeperServers;
     // Global-Zookeeper quorum connection string
     @Deprecated
     private String globalZookeeperServers;
-    // Configuration Store connection string
+
+    @ApiModelProperty(
+            name = "configurationStoreServers",
+            value = "Configuration Store connection string"
+    )
     private String configurationStoreServers;
 
-    // ZooKeeper session timeout
+    @ApiModelProperty(
+            name = "zookeeperSessionTimeoutMs",
+            value = "ZooKeeper session timeout in ms"
+    )
     private int zookeeperSessionTimeoutMs = 30_000;
 
-    // ZooKeeper cache expiry time in seconds
+    @ApiModelProperty(
+            name = "zooKeeperCacheExpirySeconds",
+            value = "ZooKeeper cache expiry time in seconds"
+    )
     private int zooKeeperCacheExpirySeconds=300;
 
-    // Port to use to server binary-proto request
+    @ApiModelProperty(
+            name = "servicePort",
+            value = "Port to use to server binary-proto request"
+    )
     private Optional<Integer> servicePort = Optional.ofNullable(5000);
-    // Port to use to server binary-proto-tls request
+
+    @ApiModelProperty(
+            name = "servicePortTls",
+            value = "Port to use to server binary-proto-tls request"
+    )
     private Optional<Integer> servicePortTls = Optional.empty();
-    // Port to use to server HTTP request
+
+    @ApiModelProperty(
+            name = "webServicePort",
+            value = "Port to use to server HTTP request"
+    )
     private Optional<Integer> webServicePort = Optional.ofNullable(8080);
-    // Port to use to server HTTPS request
+
+    @ApiModelProperty(
+            name = "webServicePortTls",
+            value = "Port to use to server HTTPS request"
+    )
     private Optional<Integer> webServicePortTls = Optional.empty();
-    // Control whether to bind directly on localhost rather than on normal
-    // hostname
+
+    @ApiModelProperty(
+            name = "bindOnLocalhost",
+            value = "Control whether to bind directly on localhost rather than on normal hostname"
+    )
     private boolean bindOnLocalhost = false;
 
-    // Role names that are treated as "super-user", meaning they will be able to
-    // do all admin operations and publish/consume from all topics
+    @ApiModelProperty(
+            name = "superUserRoles",
+            value = "Role names that are treated as \"super-user\", meaning they will be able to "
+                    + "do all admin operations and publish/consume from all topics"
+    )
     private Set<String> superUserRoles = Sets.newTreeSet();
 
-    // Allow wildcard matching in authorization
-    // (wildcard matching only applicable if wildcard-char:
-    // * presents at first or last position eg: *.pulsar.service, pulsar.service.*)
+    @ApiModelProperty(
+            name = "authorizationAllowWildcardsMatching",
+            value = "Allow wildcard matching in authorization (wildcard matching only applicable "
+                    + "if wildcard-char: * presents at first or last position eg: *.pulsar.service, pulsar.service.*"
+    )
     private boolean authorizationAllowWildcardsMatching = false;
 
-    // Enable authentication
+    @ApiModelProperty(
+            name = "authenticationEnabled",
+            value = "Whether enable authentication"
+    )
     private boolean authenticationEnabled = false;
-    // Authentication provider name list, which is a list of class names
+
+    @ApiModelProperty(
+            name = "authenticationProviders",
+            value = "Authentication provider name list, which is a list of class names"
+    )
     private Set<String> authenticationProviders = Sets.newTreeSet();
-    // Enforce authorization
+
+    @ApiModelProperty(
+            name = "authorizationEnabled",
+            value = "Whether Enforce authorization"
+    )
     private boolean authorizationEnabled = false;
-    // Authorization provider fully qualified class-name
+
+    @ApiModelProperty(
+            name = "authorizationProvider",
+            value = "Authorization provider fully qualified class-name"
+    )
     private String authorizationProvider = PulsarAuthorizationProvider.class.getName();
 
     /***** --- TLS --- ****/
     @Deprecated
     private boolean tlsEnabled = false;
-    // Tls cert refresh duration in seconds (set 0 to check on every new connection)
+
+    @ApiModelProperty(
+            name = "tlsCertRefreshCheckDurationSec",
+            value = "Tls cert refresh duration in seconds (set 0 to check on every new connection)"
+    )
     private long tlsCertRefreshCheckDurationSec = 300;
-    // Path for the TLS certificate file
+
+    @ApiModelProperty(
+            name = "tlsCertificateFilePath",
+            value = "Path for the TLS certificate file"
+    )
     private String tlsCertificateFilePath;
-    // Path for the TLS private key file
+
+    @ApiModelProperty(
+            name = "tlsKeyFilePath",
+            value = "Path for the TLS private key file"
+    )
     private String tlsKeyFilePath;
-    // Path for the trusted TLS certificate file
+
+    @ApiModelProperty(
+            name = "tlsTrustCertsFilePath",
+            value = "Path for the trusted TLS certificate file"
+    )
     private String tlsTrustCertsFilePath = "";
-    // Accept untrusted TLS certificate from client
+
+    @ApiModelProperty(
+            name = "tlsAllowInsecureConnection",
+            value = "Accept untrusted TLS certificate from client"
+    )
     private boolean tlsAllowInsecureConnection = false;
-    // Specify the tls protocols the broker will use to negotiate during TLS Handshake.
-    // Example:- [TLSv1.3, TLSv1.2]
+
+    @ApiModelProperty(
+            name = "tlsProtocols",
+            value = "Specify the tls protocols the broker will use to negotiate during TLS Handshake. "
+                    + "Example:- [TLSv1.3, TLSv1.2]"
+    )
     private Set<String> tlsProtocols = Sets.newTreeSet();
-    // Specify the tls cipher the broker will use to negotiate during TLS Handshake.
-    // Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+
+    @ApiModelProperty(
+            name = "tlsCiphers",
+            value = "Specify the tls cipher the broker will use to negotiate during TLS Handshake. "
+                    + "Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]"
+    )
     private Set<String> tlsCiphers = Sets.newTreeSet();
-    // Specify whether Client certificates are required for TLS
-    // Reject the Connection if the Client Certificate is not trusted.
+
+    @ApiModelProperty(
+            name = "tlsRequireTrustedClientCertOnConnect",
+            value = "Specify whether Client certificates are required for TLS. "
+                    + "Reject the Connection if the Client Certificate is not trusted."
+    )
     private boolean tlsRequireTrustedClientCertOnConnect = false;
 
     /***** --- TLS with KeyStore--- ****/
-    // Enable TLS with KeyStore type configuration in broker
+    @ApiModelProperty(
+            name = "tlsEnabledWithKeyStore",
+            value = "Enable TLS with KeyStore type configuration in broker"
+    )
     private boolean tlsEnabledWithKeyStore = false;
-    // TLS Provider
+
+    @ApiModelProperty(
+            name = "tlsProvider",
+            value = "Full class name of TLS Provider"
+    )
     private String tlsProvider = null;
-    // TLS KeyStore type configuration in broker: JKS, PKCS12
+
+    @ApiModelProperty(
+            name = "tlsKeyStoreType",
+            value = "TLS KeyStore type configuration in broker: JKS, PKCS12"
+    )
     private String tlsKeyStoreType = "JKS";
-    // TLS KeyStore path in broker
+
+    @ApiModelProperty(
+            name = "tlsKeyStore",
+            value = "TLS KeyStore path in broker"
+    )
     private String tlsKeyStore = null;
-    // TLS KeyStore password in broker
+
+    @ApiModelProperty(
+            name = "tlsKeyStorePassword",
+            value = "TLS KeyStore password in broker"
+    )
     private String tlsKeyStorePassword = null;
-    // TLS TrustStore type configuration in broker: JKS, PKCS12
+
+    @ApiModelProperty(
+            name = "tlsTrustStoreType",
+            value = "TLS TrustStore type configuration in broker: JKS, PKCS12"
+    )
     private String tlsTrustStoreType = "JKS";
-    // TLS TrustStore path in broker
+
+    @ApiModelProperty(
+            name = "tlsTrustStore",
+            value = "TLS TrustStore path in broker"
+    )
     private String tlsTrustStore = null;
-    // TLS TrustStore password in broker"
+
+    @ApiModelProperty(
+            name = "tlsTrustStorePassword",
+            value = "TLS TrustStore password in broker"
+    )
     private String tlsTrustStorePassword = null;
 
+    @ApiModelProperty(
+            name = "properties",
+            value = "Can store string in key-value format"
+    )
     private Properties properties = new Properties();
 
     public String getConfigurationStoreServers() {

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -39,7 +39,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "zookeeperServers",
-            value = "Local-Zookeeper quorum connection string"
+            value = "Local ZooKeeper quorum connection string"
     )
     private String zookeeperServers;
     // Global-Zookeeper quorum connection string
@@ -48,43 +48,43 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "configurationStoreServers",
-            value = "Configuration Store connection string"
+            value = "Configuration store connection string"
     )
     private String configurationStoreServers;
 
     @ApiModelProperty(
             name = "zookeeperSessionTimeoutMs",
-            value = "ZooKeeper session timeout in ms"
+            value = "ZooKeeper session timeout (in million seconds)"
     )
     private int zookeeperSessionTimeoutMs = 30_000;
 
     @ApiModelProperty(
             name = "zooKeeperCacheExpirySeconds",
-            value = "ZooKeeper cache expiry time in seconds"
+            value = "ZooKeeper cache expiry time (in seconds)"
     )
     private int zooKeeperCacheExpirySeconds=300;
 
     @ApiModelProperty(
             name = "servicePort",
-            value = "Port to use to server binary-proto request"
+            value = "Port used to server binary-proto request"
     )
     private Optional<Integer> servicePort = Optional.ofNullable(5000);
 
     @ApiModelProperty(
             name = "servicePortTls",
-            value = "Port to use to server binary-proto-tls request"
+            value = "Port used to server binary-proto-tls request"
     )
     private Optional<Integer> servicePortTls = Optional.empty();
 
     @ApiModelProperty(
             name = "webServicePort",
-            value = "Port to use to server HTTP request"
+            value = "Port used to server HTTP request"
     )
     private Optional<Integer> webServicePort = Optional.ofNullable(8080);
 
     @ApiModelProperty(
             name = "webServicePortTls",
-            value = "Port to use to server HTTPS request"
+            value = "Port used to server HTTPS request"
     )
     private Optional<Integer> webServicePortTls = Optional.empty();
 
@@ -96,15 +96,16 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "superUserRoles",
-            value = "Role names that are treated as \"super-user\", meaning they will be able to "
-                    + "do all admin operations and publish/consume from all topics"
+            value = "Role names that are treated as \"super-user\", meaning they are able to "
+                    + "do all admin operations and publish to or consume from all topics"
     )
     private Set<String> superUserRoles = Sets.newTreeSet();
 
     @ApiModelProperty(
             name = "authorizationAllowWildcardsMatching",
             value = "Allow wildcard matching in authorization (wildcard matching only applicable "
-                    + "if wildcard-char: * presents at first or last position eg: *.pulsar.service, pulsar.service.*"
+                    + "if wildcard char * presents at first or last position. "
+                    + "For example, *.pulsar.service, pulsar.service.*"
     )
     private boolean authorizationAllowWildcardsMatching = false;
 
@@ -122,7 +123,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "authorizationEnabled",
-            value = "Whether Enforce authorization"
+            value = "Whether enforce authorization"
     )
     private boolean authorizationEnabled = false;
 
@@ -138,7 +139,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "tlsCertRefreshCheckDurationSec",
-            value = "Tls cert refresh duration in seconds (set 0 to check on every new connection)"
+            value = "TLS cert refresh duration (in seconds). 0 means checking every new connection."
     )
     private long tlsCertRefreshCheckDurationSec = 300;
 
@@ -168,22 +169,22 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "tlsProtocols",
-            value = "Specify the tls protocols the broker will use to negotiate during TLS Handshake. "
-                    + "Example:- [TLSv1.3, TLSv1.2]"
+            value = "Specify the TLS protocols the broker uses to negotiate during TLS Handshake. "
+                    + "Example: [TLSv1.3, TLSv1.2]"
     )
     private Set<String> tlsProtocols = Sets.newTreeSet();
 
     @ApiModelProperty(
             name = "tlsCiphers",
             value = "Specify the tls cipher the broker will use to negotiate during TLS Handshake. "
-                    + "Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]"
+                    + "Example: [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]"
     )
     private Set<String> tlsCiphers = Sets.newTreeSet();
 
     @ApiModelProperty(
             name = "tlsRequireTrustedClientCertOnConnect",
-            value = "Specify whether Client certificates are required for TLS. "
-                    + "Reject the Connection if the Client Certificate is not trusted."
+            value = "Specify whether client certificates are required for TLS. "
+                    + "Reject the connection if the client certificate is not trusted."
     )
     private boolean tlsRequireTrustedClientCertOnConnect = false;
 
@@ -202,7 +203,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "tlsKeyStoreType",
-            value = "TLS KeyStore type configuration in broker: JKS, PKCS12"
+            value = "TLS KeyStore type configurations in broker are JKS or PKCS12"
     )
     private String tlsKeyStoreType = "JKS";
 
@@ -220,7 +221,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "tlsTrustStoreType",
-            value = "TLS TrustStore type configuration in broker: JKS, PKCS12"
+            value = "TLS TrustStore type configuration in broker are JKS or PKCS12"
     )
     private String tlsTrustStoreType = "JKS";
 
@@ -238,7 +239,7 @@ public class ServiceConfig implements PulsarConfiguration {
 
     @ApiModelProperty(
             name = "properties",
-            value = "Can store string in key-value format"
+            value = "You can store string in key-value format"
     )
     private Properties properties = new Properties();
 

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/util/CmdGenerateDocumentation.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/util/CmdGenerateDocumentation.java
@@ -33,7 +33,7 @@ public class CmdGenerateDocumentation extends BaseGenerateDocumentation {
     public String generateDocumentByClassName(String className) throws Exception {
         StringBuilder sb = new StringBuilder();
         if (ServiceConfig.class.getName().equals(className)) {
-            return generateDocByFieldContext(className, "Service discovery", sb);
+            return generateDocByApiModelProperty(className, "Service discovery", sb);
         }
         return "Class [" + className + "] not found";
     }

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/util/CmdGenerateDocumentation.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/util/CmdGenerateDocumentation.java
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.utils;
+package org.apache.pulsar.discovery.service.util;
 
 import com.beust.jcommander.Parameters;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BaseGenerateDocumentation;
-import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
+import org.apache.pulsar.discovery.service.server.ServiceConfig;
 
 @Data
 @Parameters(commandDescription = "Generate documentation automatically.")
@@ -33,11 +32,8 @@ public class CmdGenerateDocumentation extends BaseGenerateDocumentation {
     @Override
     public String generateDocumentByClassName(String className) throws Exception {
         StringBuilder sb = new StringBuilder();
-        if (ServiceConfiguration.class.getName().equals(className)) {
-            return generateDocByFieldContext(className, "Broker", sb);
-        }
-        if (WebSocketProxyConfiguration.class.getName().equals(className)) {
-            return generateDocByFieldContext(className, "WebSocket", sb);
+        if (ServiceConfig.class.getName().equals(className)) {
+            return generateDocByFieldContext(className, "Service discovery", sb);
         }
         return "Class [" + className + "] not found";
     }

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/CmdTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/CmdTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.discovery.service;
+
+import static org.testng.Assert.assertTrue;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import org.apache.pulsar.common.configuration.FieldContext;
+import org.apache.pulsar.discovery.service.util.CmdGenerateDocumentation;
+import org.testng.annotations.Test;
+
+public class CmdTest {
+
+    @Test
+    public void cmdParserServiceConfigTest() throws Exception {
+        String value = generateDoc("org.apache.pulsar.discovery.service.server.ServiceConfig");
+        assertTrue(value.contains("Service discovery"));
+    }
+
+    private String generateDoc(String clazz) throws Exception {
+        PrintStream oldStream = System.out;
+        try (ByteArrayOutputStream baoStream = new ByteArrayOutputStream(2048);
+             PrintStream cacheStream = new PrintStream(baoStream);) {
+            System.setOut(cacheStream);
+            CmdGenerateDocumentation.main(("-c " + clazz).split(" "));
+            String message = baoStream.toString();
+            Class cls = Class.forName(clazz);
+            Field[] fields = cls.getDeclaredFields();
+            for (Field field : fields) {
+                field.setAccessible(true);
+                FieldContext fieldContext = field.getAnnotation(FieldContext.class);
+                if (fieldContext == null) {
+                    continue;
+                }
+                assertTrue(message.indexOf(field.getName()) > 0);
+            }
+            return message;
+        } finally {
+            System.setOut(oldStream);
+        }
+    }
+}


### PR DESCRIPTION
Master Issue: #10041

### Motivation
The config object in the Service Discovery module has been annotated.
So the document can be automatically generated.
But this module and Pulsar proxy module both depend on broker-common, so we need to move the common CMD to the common module, otherwise we need to copy the code.

### Modifications
1) Move common CMD to broker-common
2) Add unit test for  Service Discovery

### Verifying this change

