### PR TITLE
[broker] Fixed Replicated Subscription isn't replicate new subscription when remote producer is closed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.pulsar.broker.service.Producer;
+import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.ClusterMessageId;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
@@ -127,6 +128,12 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     }
 
     private void receivedSnapshotRequest(ReplicatedSubscriptionsSnapshotRequest request) {
+        // if replicator producer is already closed, restart it to send snapshot response
+        Replicator replicator = topic.getReplicators().get(request.getSourceCluster());
+        if (!replicator.isConnected()) {
+            topic.startReplProducers();
+        }
+
         // Send response containing the current last written message id. The response
         // marker we're publishing locally and then replicating will have a higher
         // message id.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -514,9 +514,7 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
             for (int i = 0; i < numMessages; i++) {
                 String body = "message" + i;
                 producer.send(body.getBytes(StandardCharsets.UTF_8));
-                Thread.sleep(config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
             }
-            producer.close();
         }
 
         // consume 6 messages in r1
@@ -524,9 +522,8 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
         assertEquals(readMessages(consumer1, receivedMessages, numMessages, false), numMessages);
 
         // wait for subscription to be replicated
-        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
-        assertTrue(topic2.getReplicators().get("r1").isConnected());
-        assertNotNull(topic2.getSubscription(subscriptionName));
+        Awaitility.await().untilAsserted(() -> assertTrue(topic2.getReplicators().get("r1").isConnected()));
+        Awaitility.await().untilAsserted(() -> assertNotNull(topic2.getSubscription(subscriptionName)));
     }
 
     void publishMessages(Producer<byte[]> producer, int startIndex, int numMessages, Set<String> sentMessages)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -21,12 +21,16 @@ package org.apache.pulsar.broker.service;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Position;
@@ -456,6 +460,73 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
                 String.format("numReceivedMessages1 (%d) should be less than %d", numReceivedMessages1, numMessages));
         assertTrue(numReceivedMessages2 < numMessages,
                 String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
+    }
+
+    /**
+     * Tests replicated subscriptions when replicator producer is closed
+     */
+    @Test
+    public void testReplicatedSubscriptionWhenReplicatorProducerIsClosed() throws Exception {
+        String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
+        String topicName = "persistent://" + namespace + "/when-replicator-producer-is-closed";
+        String subscriptionName = "sub";
+
+        admin1.namespaces().createNamespace(namespace);
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        // create consumer in r1
+        @Cleanup
+        Consumer<byte[]> consumer1 = client1.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subscriptionName)
+                .replicateSubscriptionState(true)
+                .subscribe();
+
+        // waiting to replicate topic/subscription to r1->r2
+        Awaitility.await().until(() -> pulsar2.getBrokerService().getTopics().containsKey(topicName));
+        final PersistentTopic topic2 = (PersistentTopic) pulsar2.getBrokerService().getTopic(topicName, false).join().get();
+        Awaitility.await().untilAsserted(() -> assertTrue(topic2.getReplicators().get("r1").isConnected()));
+        Awaitility.await().untilAsserted(() -> assertNotNull(topic2.getSubscription(subscriptionName)));
+
+        // unsubscribe replicated subscription in r2
+        admin2.topics().deleteSubscription(topicName, subscriptionName);
+        assertNull(topic2.getSubscription(subscriptionName));
+
+        // close replicator producer in r2
+        final Method closeReplProducersIfNoBacklog = PersistentTopic.class.getDeclaredMethod("closeReplProducersIfNoBacklog", null);
+        closeReplProducersIfNoBacklog.setAccessible(true);
+        ((CompletableFuture<Void>) closeReplProducersIfNoBacklog.invoke(topic2, null)).join();
+        assertFalse(topic2.getReplicators().get("r1").isConnected());
+
+        // send messages in r1
+        int numMessages = 6;
+        {
+            @Cleanup
+            Producer<byte[]> producer = client1.newProducer().topic(topicName)
+                    .enableBatching(false)
+                    .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                    .create();
+            for (int i = 0; i < numMessages; i++) {
+                String body = "message" + i;
+                producer.send(body.getBytes(StandardCharsets.UTF_8));
+                Thread.sleep(config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+            }
+            producer.close();
+        }
+
+        // consume 6 messages in r1
+        Set<String> receivedMessages = new LinkedHashSet<>();
+        assertEquals(readMessages(consumer1, receivedMessages, numMessages, false), numMessages);
+
+        // wait for subscription to be replicated
+        Thread.sleep(2 * config1.getReplicatedSubscriptionsSnapshotFrequencyMillis());
+        assertTrue(topic2.getReplicators().get("r1").isConnected());
+        assertNotNull(topic2.getSubscription(subscriptionName));
     }
 
     void publishMessages(Producer<byte[]> producer, int startIndex, int numMessages, Set<String> sentMessages)


### PR DESCRIPTION
### Motivation

If replicated subscription is enabled, broker will create new subscription in remote cluster.
https://github.com/apache/pulsar/blob/a14f1c5940fe656348b6d7d326596358f43dcbc9/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java#L188-L189

This step is started when update marker message is received in remote cluster. This message is created from local cluster. It requires snapshot cache(and snapshot marker message as well).
https://github.com/apache/pulsar/blob/a14f1c5940fe656348b6d7d326596358f43dcbc9/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java#L405-L413

Snapshot marker message is created in local cluster when snapshot response marker message is received from remote cluster. Snapshot response marker message is published from replicator producer in remote cluster.
https://github.com/apache/pulsar/blob/a14f1c5940fe656348b6d7d326596358f43dcbc9/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java#L158

Therefore, when remote cluster's replicator producer is closed, then local cluster will not be able to create update message in the corner case. It causes that no new subscription will be created in remote cluster.

For example, if unsubscribe the subscription and checkGC is started in remote cluster, broker will close replicator producer.

### Modifications

* Restart replicator producer when snapshot request is received

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Added test for replicated subscription
  - Local cluster will replicate subscription to remote clusters correctly even if remote cluster's replicator producer is already closed.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?

No. Because this is one of the bug fixes.

#### For committer

For this PR, do we need to update docs?

- If yes,
  - if you update docs in this PR, label this PR with the `doc` label.
  - if you plan to update docs later, label this PR with the `doc-required` label.
  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
- If no, label this PR with the `no-need-doc` label and explain why.

