### PR TITLE
Fix NPE when builtin connector does not exist.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -427,6 +427,12 @@ public class PulsarSinkE2ETest extends AbstractPulsarE2ETest {
         testPulsarSinkStats(jarFilePathUrl);
     }
 
+    @Test(timeOut = 20000, groups = "builtin", expectedExceptions = {PulsarAdminException.class}, expectedExceptionsMessageRegExp = "Built-in sink is not available")
+    public void testPulsarSinkStatsBuiltinDoesNotExist() throws Exception {
+        String jarFilePathUrl = String.format("%s://foo", Utils.BUILTIN);
+        testPulsarSinkStats(jarFilePathUrl);
+    }
+
     @Test(timeOut = 20000)
     public void testPulsarSinkStatsWithFile() throws Exception {
         String jarFilePathUrl = getPulsarIODataGeneratorNar().toURI().toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSourceE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSourceE2ETest.java
@@ -184,6 +184,12 @@ public class PulsarSourceE2ETest extends AbstractPulsarE2ETest {
         testPulsarSourceStats(jarFilePathUrl);
     }
 
+    @Test(timeOut = 20000, groups = "builtin", expectedExceptions = {PulsarAdminException.class}, expectedExceptionsMessageRegExp = "Built-in source is not available")
+    public void testPulsarSourceStatsBuiltinDoesNotExist() throws Exception {
+        String jarFilePathUrl = String.format("%s://foo", Utils.BUILTIN);
+        testPulsarSourceStats(jarFilePathUrl);
+    }
+
     @Test(timeOut = 20000)
     public void testPulsarSourceStatsWithFile() throws Exception {
         String jarFilePathUrl = getPulsarIODataGeneratorNar().toURI().toString();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.utils.ComponentTypeUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.SinkConfigUtils;
+import org.apache.pulsar.functions.utils.io.Connector;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
@@ -723,7 +724,13 @@ public class SinksImpl extends ComponentImpl implements Sinks<PulsarWorkerServic
             String archive = sinkConfig.getArchive();
             if (archive.startsWith(org.apache.pulsar.common.functions.Utils.BUILTIN)) {
                 archive = archive.replaceFirst("^builtin://", "");
-                classLoader = this.worker().getConnectorsManager().getConnector(archive).getClassLoader();
+
+                Connector connector = worker().getConnectorsManager().getConnector(archive);
+                // check if builtin connector exists
+                if (connector == null) {
+                    throw new IllegalArgumentException("Built-in sink is not available");
+                }
+                classLoader = connector.getClassLoader();
             }
         }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.utils.ComponentTypeUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.SourceConfigUtils;
+import org.apache.pulsar.functions.utils.io.Connector;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
@@ -719,7 +720,13 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
             String archive = sourceConfig.getArchive();
             if (archive.startsWith(org.apache.pulsar.common.functions.Utils.BUILTIN)) {
                 archive = archive.replaceFirst("^builtin://", "");
-                classLoader = this.worker().getConnectorsManager().getConnector(archive).getClassLoader();
+
+                Connector connector = worker().getConnectorsManager().getConnector(archive);
+                // check if builtin connector exists
+                if (connector == null) {
+                    throw new IllegalArgumentException("Built-in source is not available");
+                }
+                classLoader = connector.getClassLoader();
             }
         }
 


### PR DESCRIPTION

### Motivation

Currently, if a user attempts to submit a built-in connector that does not exist, a NPE is occurs.


### Modifications

Add logic to check if builtin connector requested actually is available.  If not, return a meaningful message
### Verifying this change

Added tests

