### PR TITLE
[ManagedLedger] Pin executor and scheduled executor threads for ManagedLedgerImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -235,7 +235,7 @@ public class EntryCacheImpl implements EntryCache {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor().chooseThread(ml.getName())).exceptionally(exception->{
+                    }, ml.getExecutor()).exceptionally(exception->{
                           ml.invalidateLedgerHandle(lh);
                           callback.readEntryFailed(createManagedLedgerException(exception), ctx);
                           return null;
@@ -334,7 +334,7 @@ public class EntryCacheImpl implements EntryCache {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor().chooseThread(ml.getName())).exceptionally(exception->{
+                    }, ml.getExecutor()).exceptionally(exception->{
                     	  if (exception instanceof BKException
                                   && ((BKException)exception).getCode() == BKException.Code.TooManyRequestsException) {
                                   callback.readEntriesFailed(createManagedLedgerException(exception), ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -235,7 +235,7 @@ public class EntryCacheImpl implements EntryCache {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor()).exceptionally(exception->{
+                    }, ml.getPinnedExecutor()).exceptionally(exception->{
                           ml.invalidateLedgerHandle(lh);
                           callback.readEntryFailed(createManagedLedgerException(exception), ctx);
                           return null;
@@ -313,7 +313,7 @@ public class EntryCacheImpl implements EntryCache {
                         }
 
                         checkNotNull(ml.getName());
-                        checkNotNull(ml.getExecutor());
+                        checkNotNull(ml.getPinnedExecutor());
 
                         try {
                             // We got the entries, we need to transform them to a List<> type
@@ -334,7 +334,7 @@ public class EntryCacheImpl implements EntryCache {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor()).exceptionally(exception->{
+                    }, ml.getPinnedExecutor()).exceptionally(exception->{
                     	  if (exception instanceof BKException
                                   && ((BKException)exception).getCode() == BKException.Code.TooManyRequestsException) {
                                   callback.readEntriesFailed(createManagedLedgerException(exception), ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -247,7 +247,7 @@ public class EntryCacheManager {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor());
+                    }, ml.getPinnedExecutor());
         }
 
         @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -247,7 +247,7 @@ public class EntryCacheManager {
                         } finally {
                             ledgerEntries.close();
                         }
-                    }, ml.getExecutor().chooseThread(ml.getName()));
+                    }, ml.getExecutor());
         }
 
         @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1137,7 +1137,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         final PositionImpl newPosition = (PositionImpl) newPos;
 
         // order trim and reset operations on a ledger
-        ledger.getExecutor().executeOrdered(ledger.getName(), safeRun(() -> {
+        ledger.getExecutor().execute(safeRun(() -> {
             PositionImpl actualPosition = newPosition;
 
             if (!ledger.isValidPosition(actualPosition) &&

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -57,6 +57,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -3416,8 +3417,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return scheduledExecutor;
     }
 
-    OrderedExecutor getExecutor() {
-        return executor;
+    ExecutorService getExecutor() {
+        return executor.chooseThread(getName());
     }
 
     private ManagedLedgerInfo getManagedLedgerInfo() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3416,11 +3416,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return ledgers;
     }
 
-    ScheduledExecutorService getScheduledExecutor() {
+    ScheduledExecutorService getPinnedScheduledExecutor() {
         return pinnedScheduledExecutor;
     }
 
-    Executor getExecutor() {
+    Executor getPinnedExecutor() {
         return pinnedExecutor;
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -154,7 +154,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         }
         checkArgument(ledger.getId() == lh.getId(), "ledgerId %s doesn't match with acked ledgerId %s", ledger.getId(),
                 lh.getId());
-        
+
         if (!checkAndCompleteOp(ctx)) {
             // means callback might have been completed by different thread (timeout task thread).. so do nothing
             return;
@@ -170,7 +170,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
             handleAddFailure(lh);
         } else {
             // Trigger addComplete callback in a thread hashed on the managed ledger name
-            ml.getExecutor().executeOrdered(ml.getName(), this);
+            ml.getExecutor().execute(this);
         }
     }
 
@@ -248,7 +248,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
     /**
      * Checks if add-operation is completed
-     * 
+     *
      * @return true if task is not already completed else returns false.
      */
     private boolean checkAndCompleteOp(Object ctx) {
@@ -269,7 +269,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
     /**
      * It handles add failure on the given ledger. it can be triggered when add-entry fails or times out.
-     * 
+     *
      * @param ledger
      */
     void handleAddFailure(final LedgerHandle ledger) {
@@ -278,7 +278,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         // be marked as failed.
         ml.mbean.recordAddEntryError();
 
-        ml.getExecutor().executeOrdered(ml.getName(), SafeRun.safeRun(() -> {
+        ml.getExecutor().execute(SafeRun.safeRun(() -> {
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock
             // from a BK callback.
             ml.ledgerClosed(ledger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -170,7 +170,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
             handleAddFailure(lh);
         } else {
             // Trigger addComplete callback in a thread hashed on the managed ledger name
-            ml.getExecutor().execute(this);
+            ml.getPinnedExecutor().execute(this);
         }
     }
 
@@ -278,7 +278,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         // be marked as failed.
         ml.mbean.recordAddEntryError();
 
-        ml.getExecutor().execute(SafeRun.safeRun(() -> {
+        ml.getPinnedExecutor().execute(SafeRun.safeRun(() -> {
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock
             // from a BK callback.
             ml.ledgerClosed(ledger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -93,7 +93,7 @@ class OpReadEntry implements ReadEntriesCallback {
 
         if (!entries.isEmpty()) {
             // There were already some entries that were read before, we can return them
-            cursor.ledger.getExecutor().execute(safeRun(() -> {
+            cursor.ledger.getPinnedExecutor().execute(safeRun(() -> {
                 callback.readEntriesComplete(entries, ctx);
                 recycle();
             }));
@@ -142,7 +142,7 @@ class OpReadEntry implements ReadEntriesCallback {
             }
 
             // Schedule next read
-            cursor.ledger.getExecutor().execute(safeRun(() -> {
+            cursor.ledger.getPinnedExecutor().execute(safeRun(() -> {
                 readPosition = cursor.ledger.startReadOperationOnLedger(nextReadPosition, OpReadEntry.this);
                 cursor.ledger.asyncReadEntries(OpReadEntry.this);
             }));
@@ -152,7 +152,7 @@ class OpReadEntry implements ReadEntriesCallback {
                 cursor.readOperationCompleted();
 
             } finally {
-                cursor.ledger.getExecutor().execute(safeRun(() -> {
+                cursor.ledger.getPinnedExecutor().execute(safeRun(() -> {
                     callback.readEntriesComplete(entries, ctx);
                     recycle();
                 }));

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -141,7 +141,7 @@ class OpReadEntry implements ReadEntriesCallback {
                 cursor.ledger.startReadOperationOnLedger(nextReadPosition, OpReadEntry.this);
             }
 
-            // Schedule next read in a different thread
+            // Schedule next read
             cursor.ledger.getExecutor().execute(safeRun(() -> {
                 readPosition = cursor.ledger.startReadOperationOnLedger(nextReadPosition, OpReadEntry.this);
                 cursor.ledger.asyncReadEntries(OpReadEntry.this);
@@ -152,7 +152,7 @@ class OpReadEntry implements ReadEntriesCallback {
                 cursor.readOperationCompleted();
 
             } finally {
-                cursor.ledger.getExecutor().executeOrdered(cursor.ledger.getName(), safeRun(() -> {
+                cursor.ledger.getExecutor().execute(safeRun(() -> {
                     callback.readEntriesComplete(entries, ctx);
                     recycle();
                 }));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -54,13 +54,13 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         OrderedScheduler executor = OrderedScheduler.newSchedulerBuilder().numThreads(1).build();
 
         ml1 = mock(ManagedLedgerImpl.class);
-        when(ml1.getScheduledExecutor()).thenReturn(executor);
+        when(ml1.getPinnedScheduledExecutor()).thenReturn(executor);
         when(ml1.getName()).thenReturn("cache1");
         when(ml1.getMBean()).thenReturn(new ManagedLedgerMBeanImpl(ml1));
-        when(ml1.getExecutor()).thenReturn(super.executor);
+        when(ml1.getPinnedExecutor()).thenReturn(super.executor);
 
         ml2 = mock(ManagedLedgerImpl.class);
-        when(ml2.getScheduledExecutor()).thenReturn(executor);
+        when(ml2.getPinnedScheduledExecutor()).thenReturn(executor);
         when(ml2.getName()).thenReturn("cache2");
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.assertEquals;
 
 import io.netty.buffer.Unpooled;
 
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +44,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class EntryCacheTest extends MockedBookKeeperTestCase {
@@ -56,7 +54,7 @@ public class EntryCacheTest extends MockedBookKeeperTestCase {
     protected void setUpTestCase() throws Exception {
         ml = mock(ManagedLedgerImpl.class);
         when(ml.getName()).thenReturn("name");
-        when(ml.getExecutor()).thenReturn(executor);
+        when(ml.getPinnedExecutor()).thenReturn(executor);
         when(ml.getMBean()).thenReturn(new ManagedLedgerMBeanImpl(ml));
     }
 


### PR DESCRIPTION
### Motivation

OpReadEntry is not multi-thread safe. OpReadEntry.entries is an ArrayList without any synchronization. 
However it is accessed from multiple threads. 

Here's an example of such code:

OpReadEntry.entries mutated:
https://github.com/apache/pulsar/blob/5ad405988fabb4b28dbdbd5aa5c9a10802f39af1/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L81

Mutation triggered from multiple threads:
https://github.com/apache/pulsar/blob/5ad405988fabb4b28dbdbd5aa5c9a10802f39af1/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L137-L148

The operations seem to happen sequentially when OpReadEntry.entries is mutated or accessed, but this is not enough for ensuring thread safety in Java.

The goal of this change is to improve Managed Ledger operations by running operations in the pinned executor thread where the thread is picked by the hash of the managed ledger name. This is how most of the code is already written, but there are some exceptions in the current code. **The goal of this PR change is to ensure that the pinned executor is used in all cases where work is scheduled to run using the ledger's executor.**

### Modifications

- Don't expose OrderedExecutor from ManagedLedgerImpl.getExecutor
  - instead, return executor that is pinned to a single thread with `.chooseThread(getName())`
     - most usages of ManagedLedgerImpl.getExecutor were already calling `.chooseThread(ml.getName())`, however
    some locations were omitting it. It's better to always pin the ManagedLedgerImpl.getExecutor
    to a single thread.

- Don't expose OrderedScheduler from ManagedLedgerImpl.getScheduledExecutor
 - instead return scheduled executor service that is pinned to a single thread with `.chooseThread(getName())`.
 
- Pin executor and scheduled executor usage inside ManagedLedgerImpl class

- this improves thread safety of Managed Ledger code base since more operations will happen in a single thread
  - some classes such as OpReadEntry are not multi-thread safe. OpReadEntry.entries is a ArrayList without any synchronization.

### Known gaps

- ManagedLedgerImpl uses two separate executors: the scheduled executor and a "normal" executor. This leads to multi-thread access. It would be better to combine the execution of both scheduled and "normal" execution to a single thread in some upcoming PRs.