### PR TITLE
Issue 11338: add documentation about the upgrade of Pulsar 2.8.0

### DIFF
--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -5,7 +5,7 @@
 
 ### Update notice
 
-Due to a breaking change in the Schema API, it may happen that some Pulsar Functions or Pulsar IO connectors fail to work, 
+Due to a [breaking change in the Schema API](https://github.com/apache/pulsar/pull/10878), it may happen that some Pulsar Functions or Pulsar IO connectors fail to work, 
 throwing an `IncompatibleClassChangeError`.
 
 In this case, you need to rebuild your Function using Apache Pulsar 2.8.0 as a dependency and redeploy it.

--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -5,12 +5,15 @@
 
 ### Update notice
 
-Due to a breaking change in the Schema API it may happen that some Pulsar Functions or Pulsar IO Connector fail to work, 
+Due to a breaking change in the Schema API, it may happen that some Pulsar Functions or Pulsar IO connectors fail to work, 
 throwing an `IncompatibleClassChangeError`.
-In this case you have to rebuild your Function using Apache Pulsar 2.8.0 as dependency and redeploy it.
-If you are running on Kubernetes you can temporarily let the Functions Worker pod run with a previous version of Pulsar
+
+In this case, you need to rebuild your Function using Apache Pulsar 2.8.0 as a dependency and redeploy it.
+
+If you are running on Kubernetes, you can temporarily let the Functions Worker pod run with a previous version of Pulsar
 in order to not cause downtime.
-More context in [this issue](https://github.com/apache/pulsar/issues/11338).
+
+For more context about this issue, see [[Pulsar Functions and IO] Cannot upgrade Function built for Pulsar 2.7 to Pulsar 2.8](https://github.com/apache/pulsar/issues/11338).
 
 #### PIPs
 - [PIP 45] Pluggable metadata interface [#9148](https://github.com/apache/pulsar/pull/9148) [#9221](https://github.com/apache/pulsar/pull/9221) [#9240](https://github.com/apache/pulsar/pull/9240) [#9273](https://github.com/apache/pulsar/pull/9273) [#9274](https://github.com/apache/pulsar/pull/9274) [#9338](https://github.com/apache/pulsar/pull/9338) [#9346](https://github.com/apache/pulsar/pull/9346) [#9351](https://github.com/apache/pulsar/pull/9351) [#9412](https://github.com/apache/pulsar/pull/9412) [#9485](https://github.com/apache/pulsar/pull/9485) [#9586](https://github.com/apache/pulsar/pull/9586) [#9967](https://github.com/apache/pulsar/pull/9967) [#9973](https://github.com/apache/pulsar/pull/9973) [#10391](https://github.com/apache/pulsar/pull/10391) [#10457](https://github.com/apache/pulsar/pull/10457) [#10532](https://github.com/apache/pulsar/pull/10532) [#10545](https://github.com/apache/pulsar/pull/10545) [#10647](https://github.com/apache/pulsar/pull/10647)

--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -3,6 +3,15 @@
 
 ### 2.8.0 &mdash; 2021-06-12 <a id=“2.8.0”></a>
 
+### Update notice
+
+Due to a breaking change in the Schema API it may happen that some Pulsar Functions or Pulsar IO Connector fail to work, 
+throwing an `IncompatibleClassChangeError`.
+In this case you have to rebuild your Function using Apache Pulsar 2.8.0 as dependency and redeploy it.
+If you are running on Kubernetes you can temporarily let the Functions Worker pod run with a previous version of Pulsar
+in order to not cause downtime.
+More context in [this issue](https://github.com/apache/pulsar/issues/11338).
+
 #### PIPs
 - [PIP 45] Pluggable metadata interface [#9148](https://github.com/apache/pulsar/pull/9148) [#9221](https://github.com/apache/pulsar/pull/9221) [#9240](https://github.com/apache/pulsar/pull/9240) [#9273](https://github.com/apache/pulsar/pull/9273) [#9274](https://github.com/apache/pulsar/pull/9274) [#9338](https://github.com/apache/pulsar/pull/9338) [#9346](https://github.com/apache/pulsar/pull/9346) [#9351](https://github.com/apache/pulsar/pull/9351) [#9412](https://github.com/apache/pulsar/pull/9412) [#9485](https://github.com/apache/pulsar/pull/9485) [#9586](https://github.com/apache/pulsar/pull/9586) [#9967](https://github.com/apache/pulsar/pull/9967) [#9973](https://github.com/apache/pulsar/pull/9973) [#10391](https://github.com/apache/pulsar/pull/10391) [#10457](https://github.com/apache/pulsar/pull/10457) [#10532](https://github.com/apache/pulsar/pull/10532) [#10545](https://github.com/apache/pulsar/pull/10545) [#10647](https://github.com/apache/pulsar/pull/10647)
 - [PIP 50] Package management service [#8637](https://github.com/apache/pulsar/pull/8637) [#8680](https://github.com/apache/pulsar/pull/8680) [#8744](https://github.com/apache/pulsar/pull/8744) [#8764](https://github.com/apache/pulsar/pull/8764) [#8816](https://github.com/apache/pulsar/pull/8816) [#8817](https://github.com/apache/pulsar/pull/8817) [#8858](https://github.com/apache/pulsar/pull/8858) [#8861](https://github.com/apache/pulsar/pull/8861) [#8893](https://github.com/apache/pulsar/pull/8893) [#8907](https://github.com/apache/pulsar/pull/8907)


### PR DESCRIPTION
Fixes #11338.
Add a note in the "Release notes" about how to fix the IncompatibleClassChange.