### PR TITLE
[Broker] Fix replicated subscriptions direct memory leak

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -123,7 +123,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         }
 
         ByteBuf subscriptionUpdate = Markers.newReplicatedSubscriptionsUpdate(subscriptionName, clusterIds);
-        topic.publishMessage(subscriptionUpdate, this);
+        writeMarker(subscriptionUpdate);
     }
 
     private void receivedSnapshotRequest(ReplicatedSubscriptionsSnapshotRequest request) {
@@ -140,8 +140,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
                 request.getSourceCluster(),
                 localCluster,
                 lastMsgId.getLedgerId(), lastMsgId.getEntryId());
-
-        topic.publishMessage(marker, this);
+        writeMarker(marker);
     }
 
     private void receivedSnapshotResponse(Position position, ReplicatedSubscriptionsSnapshotResponse response) {
@@ -276,7 +275,11 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     }
 
     void writeMarker(ByteBuf marker) {
-        topic.publishMessage(marker, this);
+        try {
+            topic.publishMessage(marker, this);
+        } finally {
+            marker.release();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #11383

### Motivation

Using replicated subscriptions results in a direct memory leak. See #11383 for more details.

### Modifications

`.release()` wasn't called for marker messages sent by ReplicatedSubscriptionsController. Use `writeMarker` method to publish marker messages and call release in try-finally block.