### PR TITLE
[Python Client] Fix handle complex schema

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -57,14 +57,15 @@ class RecordMeta(type):
 
 class Record(with_metaclass(RecordMeta, object)):
 
-    def __init__(self, default=None, required_default=False, required=False, decode=False, *args, **kwargs):
+    def __init__(self, default=None, required_default=False, required=False, *args, **kwargs):
         self._required_default = required_default
         self._default = default
         self._required = required
 
         for k, value in self._fields.items():
             if k in kwargs:
-                if decode and isinstance(value, Record) and isinstance(kwargs[k], dict):
+                if isinstance(value, Record) and isinstance(kwargs[k], dict):
+                    # Use dict init Record object
                     copied = copy.copy(value)
                     copied.__init__(decode=True, **kwargs[k])
                     self.__setattr__(k, copied)

--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -92,4 +92,4 @@ class JsonSchema(Schema):
         return json.dumps(obj.__dict__, default=self._get_serialized_value, indent=True).encode('utf-8')
 
     def decode(self, data):
-        return self._record_cls(**json.loads(data))
+        return self._record_cls(decode=True, **json.loads(data))

--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -92,4 +92,4 @@ class JsonSchema(Schema):
         return json.dumps(obj.__dict__, default=self._get_serialized_value, indent=True).encode('utf-8')
 
     def decode(self, data):
-        return self._record_cls(decode=True, **json.loads(data))
+        return self._record_cls(**json.loads(data))

--- a/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
@@ -40,6 +40,8 @@ if HAS_AVRO:
         def _get_serialized_value(self, x):
             if isinstance(x, enum.Enum):
                 return x.name
+            elif isinstance(x, Record):
+                return self.encode_dict(x.__dict__)
             else:
                 return x
 
@@ -53,16 +55,13 @@ if HAS_AVRO:
         def encode_dict(self, d: dict):
             obj = {}
             for k, v in d.items():
-                if isinstance(v, Record):
-                    obj[k] = self.encode_dict(v.__dict__)
-                else:
-                    obj[k] = self._get_serialized_value(v)
+                obj[k] = self._get_serialized_value(v)
             return obj
 
         def decode(self, data):
             buffer = io.BytesIO(data)
             d = fastavro.schemaless_reader(buffer, self._schema)
-            return self._record_cls(decode=True, **d)
+            return self._record_cls(**d)
 
 else:
     class AvroSchema(Schema):


### PR DESCRIPTION
Fixes #7785, #11221

### Motivation

Currently, the Pulsar python client couldn't handle complex schema, users using complex schema will encounter errors.

### Modifications

Fix AvroSchema encodes and decodes complex schema.
Fix JsonSchema decodes complex schema.

### Verifying this change

This change added tests and can be verified as follows:

  - *Encode and decode complex schema data*
  - *Produce and consume complex schema data*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (yes)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
