### PR TITLE
Swap getTopicReference(topic) with serviceUnit.includes to reduce calling getTopicReference

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1678,7 +1678,7 @@ public class BrokerService implements Closeable {
     public void cleanUnloadedTopicFromCache(NamespaceBundle serviceUnit) {
         for (String topic : topics.keys()) {
             TopicName topicName = TopicName.get(topic);
-            if (getTopicReference(topic).isPresent() && serviceUnit.includes(topicName)) {
+            if (serviceUnit.includes(topicName) && getTopicReference(topic).isPresent()) {
                 log.info("[{}][{}] Clean unloaded topic from cache.", serviceUnit.toString(), topic);
                 pulsar.getBrokerService().removeTopicFromCache(topicName.toString(), serviceUnit);
             }


### PR DESCRIPTION
### Motivation

Swap getTopicReference(topic).isPresent() with serviceUnit.includes to avoid calling getTopicReference to many times.

#### For contributor

This is a small optimization and does not require documentation。

