### PR TITLE
Reduce the probability of cache inconsistencies

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
@@ -213,11 +213,6 @@ public class FunctionMetaDataManager implements AutoCloseable {
             throw new IllegalStateException("Not the leader");
         }
 
-        if (delete) {
-            needsScheduling = proccessDeregister(functionMetaData);
-        } else {
-            needsScheduling = processUpdate(functionMetaData);
-        }
         byte[] toWrite;
         if (workerConfig.getUseCompactedMetadataTopic()) {
             if (delete) {
@@ -243,6 +238,11 @@ public class FunctionMetaDataManager implements AutoCloseable {
                 builder = builder.key(FunctionCommon.getFullyQualifiedName(functionMetaData.getFunctionDetails()));
             }
             lastMessageSeen = builder.send();
+            if (delete) {
+                needsScheduling = proccessDeregister(functionMetaData);
+            } else {
+                needsScheduling = processUpdate(functionMetaData);
+            }
         } catch (Exception e) {
             log.error("Could not write into Function Metadata topic", e);
             throw new IllegalStateException("Internal Error updating function at the leader", e);


### PR DESCRIPTION
### Motivation
Now when updating the function metadata, the cache is updated first and then send message to the topic. 
There may be a situation where the local cache updated successfully but the message sending fails.

### Modifications
Send the message first, then update the local cache
