### PR TITLE
Fix flaky-test testBlockByPublishRateLimiting

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -142,12 +142,14 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
 
         flushFuture.join();
 
-        assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(pulsar.getBrokerService().getPausedConnections(), 0));
 
         // Resume message publish.
         ((AbstractTopic)topicRef).producers.get("producer-name").getCnx().enableCnxAutoRead();
 
         flushFuture.get();
-        assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(pulsar.getBrokerService().getPausedConnections(), 0));
     }
 }


### PR DESCRIPTION
Fixes #10787

### Motivation
New code was added to this unit test, causing new problems.
The reason:
+1 and -1 of the counter will have thread switching. 
When the CPU is busy, we cannot guarantee that the thread will be scheduled after 1 second


