### PR TITLE
[Tests] Fix flaky Presto tiered storage integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/presto/TestPulsarSQLBase.java
@@ -27,6 +27,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -175,7 +176,14 @@ public class TestPulsarSQLBase extends PulsarSQLTestSuite {
             queryAllDataSql = String.format("select * from pulsar.\"%s\".\"%s\";", namespace, topic);
         }
 
-        Awaitility.await().untilAsserted(
+        Awaitility.await()
+                // first poll immediately
+                .pollDelay(Duration.ofMillis(0))
+                // use relatively long poll interval so that polling doesn't consume too much resources
+                .pollInterval(Duration.ofSeconds(3))
+                // retry up to 15 seconds from first attempt
+                .atMost(Duration.ofSeconds(15))
+                .untilAsserted(
                 () -> {
                     ContainerExecResult containerExecResult = execQuery(queryAllDataSql);
                     assertThat(containerExecResult.getExitCode()).isEqualTo(0);


### PR DESCRIPTION
Fixes #11170

### Motivation

Presto tiered storage integration tests are flaky.

### Modifications

Modify the Awaitility configuration which checks the results.
- increase timeout
- set polling interval to 3 seconds