### PR TITLE
Remove duplicate check for replicationClusterSet

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -760,15 +760,6 @@ public abstract class NamespacesBase extends AdminResource {
                 throw new RestException(Status.FORBIDDEN, "Invalid cluster id: " + clusterId);
             }
             validatePeerClusterConflict(clusterId, replicationClusterSet);
-        }
-        for (String clusterId : replicationClusterSet) {
-            if (!clusters.contains(clusterId)) {
-                throw new RestException(Status.FORBIDDEN, "Invalid cluster id: " + clusterId);
-            }
-            validatePeerClusterConflict(clusterId, replicationClusterSet);
-        }
-
-        for (String clusterId : replicationClusterSet) {
             validateClusterForTenant(namespaceName.getTenant(), clusterId);
         }
         updatePolicies(path(POLICIES, namespaceName.toString()), policies ->{


### PR DESCRIPTION
### Motivation
NamespacesBase#internalSetNamespaceReplicationClusters has duplicate codes:
https://github.com/apache/pulsar/blob/a6e1a3290d9eb42f4d03438c3ce9ced506ee8445/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L757-L773

### Modifications
Remove the duplicate codes.

#### For contributor

Small code adjustment, no need to update doc.

