### PR TITLE
[pulsar io] make KafkaSourceRecord ack() non-blocking to avoid deadlock

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -163,9 +163,15 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
             } else {
                 // there is no records any more, then waiting for the batch to complete writing
                 // to sink and the offsets are committed as well, then do next round read.
-                flushFuture.get();
-                flushFuture = null;
-                currentBatch = null;
+                try {
+                    flushFuture.get();
+                } catch (ExecutionException ex) {
+                    // log the error, continue execution
+                    log.error("execution exception while get flushFuture", ex);
+                } finally {
+                    flushFuture = null;
+                    currentBatch = null;
+                }
             }
         }
     }
@@ -181,7 +187,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
     private static Map<String, String> PROPERTIES = Collections.emptyMap();
     private static Optional<Long> RECORD_SEQUENCE = Optional.empty();
-    private static long FLUSH_TIMEOUT_MS = 2000;
+    private static long FLUSH_TIMEOUT_MS = 60000;
 
     public abstract class AbstractKafkaSourceRecord<T> implements Record {
         @Getter
@@ -234,9 +240,17 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
                 offsetWriter.cancelFlush();
                 flushFuture.completeExceptionally(new Exception("No Offsets Added Error"));
             } else {
-                log.trace("Finished flushing offsets to storage");
-                currentBatch = null;
-                flushFuture.complete(null);
+                try {
+                    sourceTask.commit();
+
+                    log.info("Finished flushing offsets to storage");
+                    currentBatch = null;
+                    flushFuture.complete(null);
+                } catch (InterruptedException exception) {
+                    log.warn("Flush of {} offsets interrupted, cancelling", this);
+                    offsetWriter.cancelFlush();
+                    flushFuture.completeExceptionally(new Exception("Failed to commit offsets"));
+                }
             }
         }
 
@@ -260,21 +274,6 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
                     log.error("No offsets to commit!");
                     flushFuture.completeExceptionally(new Exception("No Offsets Added Error"));
                     return;
-                }
-
-                // Wait until the offsets are flushed
-                try {
-                    doFlush.get(FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                    sourceTask.commit();
-                } catch (InterruptedException e) {
-                    log.warn("Flush of {} offsets interrupted, cancelling", this);
-                    offsetWriter.cancelFlush();
-                } catch (ExecutionException e) {
-                    log.error("Flush of {} offsets threw an unexpected exception: ", this, e);
-                    offsetWriter.cancelFlush();
-                } catch (TimeoutException e) {
-                    log.error("Timed out waiting to flush {} offsets to storage", this);
-                    offsetWriter.cancelFlush();
                 }
             }
         }

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -51,7 +51,6 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
 
     private Map<ByteBuffer, ByteBuffer> data;
     private PulsarClient client;
-    private String serviceUrl;
     private String topic;
     private Producer<byte[]> producer;
     private Reader<byte[]> reader;
@@ -68,8 +67,7 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
         checkArgument(!isBlank(topic), "Offset storage topic must be specified");
         this.data = new HashMap<>();
 
-        log.info("Configure offset backing store on pulsar topic {} at cluster {}",
-            topic, serviceUrl);
+        log.info("Configure offset backing store on pulsar topic {} at cluster {}", topic);
     }
 
     void readToEnd(CompletableFuture<Void> future) {
@@ -153,8 +151,8 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
             readToEnd(endFuture);
             endFuture.join();
         } catch (PulsarClientException e) {
-            log.error("Failed to setup pulsar producer/reader to cluster at {}", serviceUrl, e);
-            throw new RuntimeException("Failed to setup pulsar producer/reader to cluster at " + serviceUrl, e);
+            log.error("Failed to setup pulsar producer/reader to cluster", e);
+            throw new RuntimeException("Failed to setup pulsar producer/reader to cluster ",  e);
         }
     }
 


### PR DESCRIPTION
### Motivation
The `ack()` method of the `AbstractKafkaSourceRecord` should be non-blocking. Otherwise there'll be deadlock for pulsar-client-io thread and the main `public/default/debezium-mongodb-source-0` thread. And further blocks the whole debezium connector to work correctly.


### Modifications

1. remove the blocking `future.get()` call from `ack()`
2. move the commit logic into callbacks

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

#### For contributor

For this PR, do we need to update docs?

No. Internal bug fix.
