### PR TITLE
Add getTxnID method in Transaction.java

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -62,14 +62,14 @@ public class TransactionTest extends TransactionTestBase {
     private static final String TENANT = "tnx";
     private static final String NAMESPACE1 = TENANT + "/ns1";
     private static final int NUM_BROKER = 1;
-    private static final int NUM_TC_PER_ = 1;
+    private static final int NUM_TC_PER = 1;
 
     @BeforeMethod
     protected void setup() throws Exception {
         this.setBrokerCount(NUM_BROKER);
         this.internalSetup();
 
-        String[] brokerServiceUrlArr = getPulsarServiceList().get(NUM_BROKER - 1).getBrokerServiceUrl().split(":");
+        String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length - 1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder()
                 .serviceUrl("http://localhost:" + webServicePort).build());
@@ -80,7 +80,7 @@ public class TransactionTest extends TransactionTestBase {
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
-        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), NUM_TC_PER_);
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), NUM_TC_PER);
         pulsarClient.close();
         pulsarClient = PulsarClient.builder()
                 .serviceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl())
@@ -154,7 +154,7 @@ public class TransactionTest extends TransactionTestBase {
     @Test
     public void testGetTxnID() throws Exception {
         // wait tc init success to ready state
-        Assert.assertTrue(waitForCoordinatorToBeAvailable(NUM_BROKER, NUM_TC_PER_));
+        Assert.assertTrue(waitForCoordinatorToBeAvailable(NUM_BROKER, NUM_TC_PER));
         Transaction transaction = pulsarClient.newTransaction()
                 .build().get();
         TxnID txnID = transaction.getTxnID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -61,12 +61,12 @@ public class TransactionTest extends TransactionTestBase {
 
     private static final String TENANT = "tnx";
     private static final String NAMESPACE1 = TENANT + "/ns1";
-    private static final int NUM_BROKER = 1;
-    private static final int NUM_TC_PER = 1;
+    private static final int NUM_BROKERS = 1;
+    private static final int NUM_PARTITIONS = 1;
 
     @BeforeMethod
     protected void setup() throws Exception {
-        this.setBrokerCount(NUM_BROKER);
+        this.setBrokerCount(NUM_BROKERS);
         this.internalSetup();
 
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
@@ -80,7 +80,7 @@ public class TransactionTest extends TransactionTestBase {
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
-        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), NUM_TC_PER);
+        admin.topics().createPartitionedTopic(TopicName.TRANSACTION_COORDINATOR_ASSIGN.toString(), NUM_PARTITIONS);
         pulsarClient.close();
         pulsarClient = PulsarClient.builder()
                 .serviceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl())
@@ -154,7 +154,7 @@ public class TransactionTest extends TransactionTestBase {
     @Test
     public void testGetTxnID() throws Exception {
         // wait tc init success to ready state
-        Assert.assertTrue(waitForCoordinatorToBeAvailable(NUM_BROKER, NUM_TC_PER));
+        Assert.assertTrue(waitForCoordinatorToBeAvailable(NUM_BROKERS, NUM_PARTITIONS));
         Transaction transaction = pulsarClient.newTransaction()
                 .build().get();
         TxnID txnID = transaction.getTxnID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -32,6 +32,8 @@ import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -138,5 +140,23 @@ public class TransactionTest extends TransactionTestBase {
                 .subscriptionType(SubscriptionType.Shared)
                 .enableBatchIndexAcknowledgment(true)
                 .subscribe();
+    }
+
+    @Test
+    public void testGetTxnID() throws Exception {
+        Awaitility.await().atMost(4, TimeUnit.SECONDS).until(()->{
+            try {
+                Transaction transaction = pulsarClient.newTransaction()
+                        .withTransactionTimeout(0, TimeUnit.SECONDS).build().get();
+            } catch (Exception e){
+                return false;
+            }
+            return true;
+        });
+        Transaction transaction = pulsarClient.newTransaction()
+                .withTransactionTimeout(0, TimeUnit.SECONDS).build().get();
+        TxnID txnID = transaction.getTxnID();
+        Assert.assertEquals(txnID.getLeastSigBits(), 1);
+        Assert.assertEquals(txnID.getMostSigBits(), 0);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -21,19 +21,17 @@ package org.apache.pulsar.broker.transaction;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.EventLoopGroup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import io.netty.channel.EventLoopGroup;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -49,17 +47,22 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
+import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
+import org.apache.pulsar.transaction.coordinator.TransactionMetadataStoreState;
+import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
-import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.ZooKeeper;
+import org.awaitility.Awaitility;
 
 @Slf4j
 public abstract class TransactionTestBase extends TestRetrySupport {
@@ -291,5 +294,16 @@ public abstract class TransactionTestBase extends TestRetrySupport {
             log.warn("Failed to clean up mocked pulsar service:", e);
         }
     }
-
+    public boolean waitForCoordinatorToBeAvailable(int numOfBroker, int numOfTCPerBroker){
+        // wait tc init success to ready state
+        Awaitility.await().untilAsserted(() -> {
+            TransactionMetadataStore transactionMetadataStore =
+                    getPulsarServiceList().get(numOfBroker - 1).getTransactionMetadataStoreService()
+                            .getStores().get(TransactionCoordinatorID.get(numOfTCPerBroker - 1));
+            assertNotNull(transactionMetadataStore);
+            assertEquals(((MLTransactionMetadataStore) transactionMetadataStore).getState(),
+                    TransactionMetadataStoreState.State.Ready);
+        });
+        return true;
+    }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/Transaction.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/Transaction.java
@@ -45,7 +45,7 @@ public interface Transaction {
 
     /**
      * Get TxnID of the transaction.
-     * @return TxnID
+     *  @return {@link TxnID} the txnID.
      */
     TxnID getTxnID();
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/Transaction.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/Transaction.java
@@ -43,4 +43,9 @@ public interface Transaction {
      */
     CompletableFuture<Void> abort();
 
+    /**
+     * Get TxnID of the transaction.
+     * @return TxnID
+     */
+    TxnID getTxnID();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -208,6 +208,11 @@ public class TransactionImpl implements Transaction {
         });
     }
 
+    @Override
+    public TxnID getTxnID() {
+        return new TxnID(txnIdMostBits, txnIdLeastBits);
+    }
+
     private CompletableFuture<Void> checkIfOpen() {
         if (state == State.OPEN) {
             return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
## Motivation
In order to facilitate the use of transaction, it is more convenient to obtain TxnId
## implement
Add getTxnID（） method in Transaction.java and implement in TransactionImp. 
## Test
Write a test in transactionTest  . 
  
