### PR TITLE
[Docs] Update Minikube link

### DIFF
--- a/site2/docs/getting-started-helm.md
+++ b/site2/docs/getting-started-helm.md
@@ -27,7 +27,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/deploy-kubernetes.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/deploy-kubernetes.md
@@ -92,7 +92,7 @@ Pulsar can be deployed on a custom, non-GKE Kubernetes cluster as well. You can 
 
 The easiest way to run a Kubernetes cluster is to do so locally. To install a mini local cluster for testing purposes, running in local VMs, you can either:
 
-1. Use [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) to run a single-node Kubernetes cluster
+1. Use [minikube](https://minikube.sigs.k8s.io/docs/start/) to run a single-node Kubernetes cluster
 1. Create a local cluster running on multiple VMs on the same machine
 
 ### Minikube

--- a/site2/website/versioned_docs/version-2.5.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.5.0/getting-started-helm.md
@@ -29,7 +29,7 @@ For deploying a Pulsar cluster for production usage, please read the documentati
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide.
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide.
 
 1. Create a kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.0/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.1/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.2/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.6.3/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.3/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.6.4/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.6.4/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.7.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.0/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.1/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.7.2/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.2/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.7.3/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.7.3/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.8.0/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.8.0/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 

--- a/site2/website/versioned_docs/version-2.8.1/getting-started-helm.md
+++ b/site2/website/versioned_docs/version-2.8.1/getting-started-helm.md
@@ -28,7 +28,7 @@ For deploying a Pulsar cluster for production usage, read the documentation on [
 
 Before installing a Pulsar Helm chart, you have to create a Kubernetes cluster. You can follow [the instructions](helm-prepare.md) to prepare a Kubernetes cluster.
 
-We use [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
+We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) in this quick start guide. To prepare a Kubernetes cluster, follow these steps:
 
 1. Create a Kubernetes cluster on Minikube.
 


### PR DESCRIPTION
### Motivation

The current minikube link is outdated, https://kubernetes.io/docs/getting-started-guides/minikube/ will be redirected to https://kubernetes.io/docs/setup/ that has no minikube related docs.

### Modifications

Update link of all documents under `site2/` directory from https://kubernetes.io/docs/getting-started-guides/minikube/ to https://minikube.sigs.k8s.io/docs/start/.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
