### PR TITLE
[python] Support CryptoKeyReader for Reader API in python clients

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -751,7 +751,8 @@ class Client:
                       receiver_queue_size=1000,
                       reader_name=None,
                       subscription_role_prefix=None,
-                      is_read_compacted=False
+                      is_read_compacted=False,
+                      crypto_key_reader=None
                       ):
         """
         Create a reader on a particular topic
@@ -801,6 +802,9 @@ class Client:
           Sets the subscription role prefix.
         * `is_read_compacted`:
           Selects whether to read the compacted version of the topic
+        * crypto_key_reader:
+           Symmetric encryption class implementation, configuring public key encryption messages for the producer
+           and private key decryption messages for the consumer
         """
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
@@ -809,6 +813,7 @@ class Client:
         _check_type_or_none(str, reader_name, 'reader_name')
         _check_type_or_none(str, subscription_role_prefix, 'subscription_role_prefix')
         _check_type(bool, is_read_compacted, 'is_read_compacted')
+        _check_type_or_none(CryptoKeyReader, crypto_key_reader, 'crypto_key_reader')
 
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:
@@ -820,6 +825,8 @@ class Client:
             conf.subscription_role_prefix(subscription_role_prefix)
         conf.schema(schema.schema_info())
         conf.read_compacted(is_read_compacted)
+        if crypto_key_reader:
+            conf.crypto_key_reader(crypto_key_reader.cryptoKeyReader)
 
         c = Reader()
         c._reader = self._client.create_reader(topic, start_message_id, conf)

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -378,7 +378,7 @@ class PulsarTest(TestCase):
                                           encryption_key="client-rsa.pem",
                                           crypto_key_reader=crypto_key_reader)
         reader = client.create_reader(topic=topic,
-                                      MessageId.earliest,
+                                      start_message_id=MessageId.earliest,
                                       crypto_key_reader=crypto_key_reader)
         producer.send('hello')
         msg = consumer.receive(TM)

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -377,11 +377,24 @@ class PulsarTest(TestCase):
         producer = client.create_producer(topic=topic,
                                           encryption_key="client-rsa.pem",
                                           crypto_key_reader=crypto_key_reader)
+        reader = client.create_reader(topic=topic,
+                                      MessageId.earliest,
+                                      crypto_key_reader=crypto_key_reader)
         producer.send('hello')
         msg = consumer.receive(TM)
         self.assertTrue(msg)
         self.assertEqual(msg.value(), 'hello')
         consumer.unsubscribe()
+
+        msg = reader.read_next(TM)
+        self.assertTrue(msg)
+        self.assertEqual(msg.data(), b'hello')
+
+        with self.assertRaises(pulsar.Timeout):
+            reader.read_next(100)
+
+        reader.close()
+
         client.close()
 
     def test_tls_auth3(self):

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -89,6 +89,13 @@ static ProducerConfiguration& ProducerConfiguration_setCryptoKeyReader(ProducerC
     return conf;
 }
 
+static ReaderConfiguration& ReaderConfiguration_setCryptoKeyReader(ReaderConfiguration& conf,
+                                                                        py::object cryptoKeyReader) {
+    CryptoKeyReaderWrapper cryptoKeyReaderWrapper = py::extract<CryptoKeyReaderWrapper>(cryptoKeyReader);
+    conf.setCryptoKeyReader(cryptoKeyReaderWrapper.cryptoKeyReader);
+    return conf;
+}
+
 class LoggerWrapper: public Logger {
     PyObject* _pyLogger;
     Logger* fallbackLogger;
@@ -290,5 +297,6 @@ void export_config() {
             .def("subscription_role_prefix", &ReaderConfiguration::setSubscriptionRolePrefix)
             .def("read_compacted", &ReaderConfiguration::isReadCompacted)
             .def("read_compacted", &ReaderConfiguration::setReadCompacted)
+            .def("crypto_key_reader", &ReaderConfiguration_setCryptoKeyReader, return_self<>())
             ;
 }


### PR DESCRIPTION
### Motivation

The Reader API in the python client does not support reading an encrypted message. 
This PR adds the same and leverages existing  C++ Reader API which supports the same.

### Modifications

* Updated `pulsar.Client.create_reader` to accept  `crypto_key_reader` argument
* Update existing unit test for Python encryption.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows: 

  - **Modified existing PulsarTest.test_encryption to also use a reader**

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: **Yes**
    - This is a backward compatible update to the signature of a [public method](https://pulsar.apache.org/api/python/2.8.0-SNAPSHOT/#pulsar.Client.create_reader) in Pulsar Python Client API
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

#### For contributor

For this PR, do we need to update docs?

**No. These updates will be picked up automatically by pdoc as described at https://pulsar.apache.org/docs/en/client-libraries-python/**  

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

