### PR TITLE
[websocket] Remove System.out.println from ConsumerHandler

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -283,7 +283,6 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     private void handleNack(ConsumerCommand command) throws IOException {
         MessageId msgId = MessageId.fromByteArrayWithTopic(Base64.getDecoder().decode(command.messageId),
             topic.toString());
-        System.out.println(msgId);
         consumer.negativeAcknowledge(msgId);
         checkResumeReceive();
     }


### PR DESCRIPTION
`System.out.println` is called in the code of WebSocket proxy. This seems to be for debugging and I think it should be removed.