### PR TITLE
Deep copy the tenants to avoid concurrent sort exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -76,8 +77,10 @@ public class TenantsBase extends PulsarWebResource {
                 asyncResponse.resume(new RestException(e));
                 return;
             }
-            tenants.sort(null);
-            asyncResponse.resume(tenants);
+            // deep copy the tenants to avoid concurrent sort exception
+            List<String> deepCopy = new ArrayList<>(tenants);
+            deepCopy.sort(null);
+            asyncResponse.resume(deepCopy);
         });
     }
 


### PR DESCRIPTION
### Motivation
Currently, the sort of tenants can be accessed from multi threads(pulsar-web jetty threads), which tenants are acquired from cache. So the concurrent sort of `tenants` could arise concurrent modification exception.

### Modifications

Before the tenants sort, deep copy the list to avoid concurrent access.

### Documentation

For this PR,  we don't need to update docs, because changes not visible from api.


