### PR TITLE
[Function worker] Load ServiceConfiguration from file, not from Worke…

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -22,6 +22,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.util.CmdGenerateDocs;
 
 /**
@@ -65,13 +67,17 @@ public class FunctionWorkerStarter {
         }
 
         WorkerConfig workerConfig;
+        ServiceConfiguration serviceConfiguration;
         if (isBlank(workerArguments.configFile)) {
             workerConfig = new WorkerConfig();
+            serviceConfiguration = new ServiceConfiguration();
         } else {
             workerConfig = WorkerConfig.load(workerArguments.configFile);
+            serviceConfiguration = PulsarConfigurationLoader.create(workerArguments.configFile, ServiceConfiguration.class);
+            serviceConfiguration.setClusterName(workerConfig.getPulsarFunctionsCluster());
         }
 
-        final Worker worker = new Worker(workerConfig);
+        final Worker worker = new Worker(workerConfig, serviceConfiguration);
         try {
             worker.start();
         } catch (Throwable th) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.functions.worker;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -56,7 +57,7 @@ public class Worker {
     private final ErrorNotifier errorNotifier;
 
     public Worker(WorkerConfig workerConfig, ServiceConfiguration serviceConfiguration) {
-        if (!serviceConfiguration.getClusterName().equals(workerConfig.getPulsarFunctionsCluster())) {
+        if (!Objects.equals(serviceConfiguration.getClusterName(), workerConfig.getPulsarFunctionsCluster())) {
             throw new IllegalArgumentException(String.format("ServiceConfiguration clusterName [%s] does not match "
                     + "WorkerConfig pulsarFunctionsCluster [%s]",
                     serviceConfiguration.getClusterName(),
@@ -100,7 +101,7 @@ public class Worker {
             this.configurationCacheService = new ConfigurationMetadataCacheService(this.pulsarResources,
                     this.workerConfig.getPulsarFunctionsCluster());
             return new AuthorizationService(this.serviceConfiguration, this.configurationCacheService);
-            }
+        }
         return null;
     }
 
@@ -122,7 +123,7 @@ public class Worker {
                 this.server.stop();
             }
             workerService.stop();
-        } catch(Exception e) {
+        } catch (Exception e) {
             log.warn("Failed to gracefully stop worker service ", e);
         }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
@@ -1,0 +1,29 @@
+package org.apache.pulsar.functions.worker;
+
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class WorkerTest {
+
+    @Test
+    public void testWorkerFailsForMismatchedClusterNames() {
+        WorkerConfig workerConfig = new WorkerConfig();
+        workerConfig.setPulsarFunctionsCluster("pulsar");
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setClusterName("cluster");
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Worker(workerConfig, serviceConfiguration));
+    }
+
+    @Test
+    public void testWorkerClassInitializesWithValidClusterName() {
+        WorkerConfig workerConfig = new WorkerConfig();
+        workerConfig.setPulsarFunctionsCluster("pulsar");
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setClusterName("pulsar");
+        // Test only verifies that initialization does not throw an exception
+        // Note that calling the start() method would fail because the configuration is incomplete
+        new Worker(workerConfig, serviceConfiguration);
+    }
+
+}

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.functions.worker;
 
 import org.apache.pulsar.broker.ServiceConfiguration;


### PR DESCRIPTION
…rConfig

### Motivation

Currently, it is not possible to pass custom configuration to a function worker for use in an Authentication or Authorization plugin. In order to support plugins created by end users, we need to make sure that configurations passed in at function worker initialization are passed through to the `ServiceConfiguration`. This PR seeks to make it possible to pass in those arbitrary configurations.

### Modifications

Update the `FunctionWorkerStarter` class to generate the `ServiceConfiguration` by reading it in from a file instead of building the class by converting the `WorkerConfig` to the `ServiceConfiguration`.

### Alternative Solution

We could also change how we generate the `WorkerConfig`. It is currently created by reading the config file into the class using an ObjectMapper. This does not really follow the general paradigm that Pulsar uses to generate config classes (at least the paradigm that I've noticed) where we use the `PulsarConfigurationLoader` class to load a config from a file. However, I am not sure that we want to remove the `WorkerConfig.load` method, given that it appears well tested.

I'm open to this solution as well. Please let me know what you think.

### Verifying this change

There are not currently tests validating this configuration logic. I'm happy to add a test, but I'm not sure where to add it. Please let me know how to proceed here.

Note that the only change in behavior here is that the `ServiceConfiguration` class will now have fields that were not present in the `WorkerConfig`. Previously, these fields would have been dropped when we created the `WorkerConfig`. As such, while this change will technically introduce changes to the configuration in the `ServiceConfiguration` class, it is only changing configuration for fields not present in the `WorkerConfig`.

Additionally, one potential difference could also come from differences in default values between the `WorkerConfig` and the `ServiceConfiguration`. There could be conflicts now, or in the future, that could make it confusing to figure out which configuration is _actually_ applied. This might be worth adding test coverage.

Note, also, that the `ServiceConfigruation` added in this PR is only used to configure the `AuthenticationService` and the `AuthorizationService`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: **possibly**
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: **yes (custom configuration)**

### Documentation

#### For contributor

For this PR, do we need to update docs?

I don't think additional documentation is needed because I think this change will make pulsar's configuration work as expected.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

