### PR TITLE
[broker] Improve error logs in BacklogQuotaManager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -191,13 +191,13 @@ public class BacklogQuotaManager {
                 }
                 // Skip messages on the slowest consumer
                 if (log.isDebugEnabled()) {
-                    log.debug("Skipping [{}] messages on slowest consumer [{}] having backlog entries : [{}]",
-                            messagesToSkip, slowestConsumer.getName(), entriesInBacklog);
+                    log.debug("[{}] Skipping [{}] messages on slowest consumer [{}] having backlog entries : [{}]",
+                            persistentTopic.getName(), messagesToSkip, slowestConsumer.getName(), entriesInBacklog);
                 }
                 slowestConsumer.skipEntries(messagesToSkip, IndividualDeletedEntries.Include);
             } catch (Exception e) {
-                log.error("Error skipping [{}] messages from slowest consumer : [{}]", messagesToSkip,
-                        slowestConsumer.getName());
+                log.error("[{}] Error skipping [{}] messages from slowest consumer [{}]", persistentTopic.getName(),
+                        messagesToSkip, slowestConsumer.getName(), e);
             }
 
             // Make sure that unconsumed size is updated every time when we skip the messages.
@@ -250,7 +250,7 @@ public class BacklogQuotaManager {
                     ledgerInfo = mLedger.getLedgerInfo(ledgerId).get();
                 }
             } catch (Exception e) {
-                log.error("Error resetting cursor for slowest consumer [{}]: {}",
+                log.error("[{}] Error resetting cursor for slowest consumer [{}]", persistentTopic.getName(),
                         mLedger.getSlowestConsumer().getName(), e);
             }
         }


### PR DESCRIPTION
### Motivation

The following error was detected on one of our brokers.
```
Error skipping [310] messages from slowest consumer : [shared5]
```
However, this message does not tell we which topic caused the problem. Also, the stack trace of the exception is not output. Therefore, it is difficult to investigate the cause.

### Modifications

Output the topic name and the stack trace of the exception along with the above error message.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.