### PR TITLE
[pulsar-io] fix source stats exposing empty exceptions list

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
@@ -351,12 +351,12 @@ public class SourceStatsManager extends ComponentStatsManager {
 
     @Override
     public EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> getLatestSystemExceptions() {
-        return EMPTY_QUEUE;
+        return latestSystemExceptions;
     }
 
     @Override
     public EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> getLatestSourceExceptions() {
-        return EMPTY_QUEUE;
+        return latestSourceExceptions;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

`pulsar-admin sources status` always have empty list of `latestSystemExceptions` and `latestSourceExceptions`. With some code digging, it turns out that it always returns `EMPTY_QUEUE`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

#### For contributor

For this PR, do we need to update docs?

no, internal bug fix.


