### PR TITLE
Remove unsupport command description in doc

### DIFF
--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -211,14 +211,8 @@ Once you add each server to the `zookeeper.conf` configuration and have the appr
 $ bin/pulsar-daemon start zookeeper
 ```
 
-> If you plan to deploy Zookeeper with the Bookie on the same node, you
-> need to start zookeeper by using different stats port.
-
-Start zookeeper with [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool like:
-
-```bash
-$ PULSAR_EXTRA_OPTS="-Dstats_server_port=8001" bin/pulsar-daemon start zookeeper
-```
+> If you plan to deploy Zookeeper with the Bookie on the same node, you need to start zookeeper by using different stats
+> port by configuring the `metricsProvider.httpPort` in zookeeper.conf.
 
 ## Initialize cluster metadata
 

--- a/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.0/deploy-bare-metal.md
@@ -212,14 +212,8 @@ Once you add each server to the `zookeeper.conf` configuration and have the appr
 $ bin/pulsar-daemon start zookeeper
 ```
 
-> If you plan to deploy Zookeeper with the Bookie on the same node, you
-> need to start zookeeper by using different stats port.
-
-Start zookeeper with [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool like:
-
-```bash
-$ PULSAR_EXTRA_OPTS="-Dstats_server_port=8001" bin/pulsar-daemon start zookeeper
-```
+> If you plan to deploy Zookeeper with the Bookie on the same node, you need to start zookeeper by using different stats
+> port by configuring the `metricsProvider.httpPort` in zookeeper.conf.
 
 ## Initialize cluster metadata
 

--- a/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.8.1/deploy-bare-metal.md
@@ -212,14 +212,8 @@ Once you add each server to the `zookeeper.conf` configuration and have the appr
 $ bin/pulsar-daemon start zookeeper
 ```
 
-> If you plan to deploy Zookeeper with the Bookie on the same node, you
-> need to start zookeeper by using different stats port.
-
-Start zookeeper with [`pulsar-daemon`](reference-cli-tools.md#pulsar-daemon) CLI tool like:
-
-```bash
-$ PULSAR_EXTRA_OPTS="-Dstats_server_port=8001" bin/pulsar-daemon start zookeeper
-```
+> If you plan to deploy Zookeeper with the Bookie on the same node, you need to start zookeeper by using different stats
+> port by configuring the `metricsProvider.httpPort` in zookeeper.conf.
 
 ## Initialize cluster metadata
 


### PR DESCRIPTION
### Motivation
We upgrade zookeeper from 3.5.7 to 3.6.x, and due to zookeeper 3.6.0+ has add internal prometheus metric provider, So we remove old prometheus metric provider in ZooKeeperStarter and ConfigurationStoreStarter. So `-Dstats_server_port` is not supported anymore.

Fix #11467.