### PR TITLE
[Issue 11485][C++] Connect timer cancellation does not call timeout callback

### DIFF
--- a/pulsar-client-cpp/lib/PeriodicTask.cc
+++ b/pulsar-client-cpp/lib/PeriodicTask.cc
@@ -43,7 +43,7 @@ void PeriodicTask::stop() {
 }
 
 void PeriodicTask::handleTimeout(const ErrorCode& ec) {
-    if (state_ != Ready) {
+    if (state_ != Ready || ec.value() == boost::system::errc::operation_canceled) {
         return;
     }
 


### PR DESCRIPTION
Fixes #11485

### Motivation

Multiple endpoints, for example "localhost", "127.0.0.1", may need to be iterated over before a connection succeeds. In each iteration the connectTimeoutTask (PeriodicTask) is stopped and started. Stopping it cancels the timer, which fires the handler (handleTimeout) which in turn calls the connect timeout callback which closes the socket. This causes the createProducerAsync to return ResultConnectError. This causes a large number of tests to fail.

### Modifications

This change checks the error_code in the PeriodicTask timer handler and returns if it is operation_cancelled, avoiding erroneously calling the callback.

### Verifying this change

All existing tests pass.

### Does this pull request potentially affect one of the following parts:

None

### Documentation

#### For contributor

For this PR, do we need to update docs?

- No, because this is a minor fix to an internal operation.
