### PR TITLE
[ManagedLedger] Compress managed ledger info

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -75,4 +75,9 @@ public class ManagedLedgerFactoryConfig {
      * cluster name for prometheus stats
      */
     private String clusterName;
+
+    /**
+     * ManagedLedgerInfo compression type. If the compression type is null or invalid, don't compress data.
+     */
+    private String managedLedgerInfoCompressionType = null;
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger;
 import lombok.Data;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
+import org.apache.pulsar.common.api.proto.CompressionType;
 
 /**
  * Configuration for a {@link ManagedLedgerFactory}.
@@ -79,5 +80,5 @@ public class ManagedLedgerFactoryConfig {
     /**
      * ManagedLedgerInfo compression type. If the compression type is null or invalid, don't compress data.
      */
-    private String managedLedgerInfoCompressionType = null;
+    private String managedLedgerInfoCompressionType = CompressionType.NONE.name();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -172,7 +172,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         this.bookkeeperFactory = bookKeeperGroupFactory;
         this.isBookkeeperManaged = isBookkeeperManaged;
         this.metadataStore = metadataStore;
-        this.store = new MetaStoreImpl(metadataStore, scheduledExecutor);
+        this.store = new MetaStoreImpl(metadataStore, scheduledExecutor, config.getManagedLedgerInfoCompressionType());
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
         this.entryCacheManager = new EntryCacheManager(this);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -351,7 +351,8 @@ public class MetaStoreImpl implements MetaStore {
                 decodeByteBuf = CompressionCodecProvider.getCompressionCodec(
                         CompressionType.valueOf(metadata.getCompressionType())).decode(byteBuf, (int) unpressedSize);
                 byte[] decodeBytes;
-                if (decodeByteBuf.hasArray() && !metadata.getCompressionType().equals(CompressionType.ZLIB.name())) {
+                // couldn't decode data by ZLIB compression byteBuf array() directly
+                if (decodeByteBuf.hasArray() && !CompressionType.ZLIB.name().equals(metadata.getCompressionType())) {
                     decodeBytes = decodeByteBuf.array();
                 } else {
                     decodeBytes = new byte[decodeByteBuf.readableBytes() - decodeByteBuf.readerIndex()];

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -55,24 +55,30 @@ public class MetaStoreImpl implements MetaStore {
     private final OrderedExecutor executor;
 
     public static final short MAGIC_MANAGED_LEDGER_INFO_METADATA = 0x0b9c;
-    private CompressionType compressionType = CompressionType.NONE;
+    private final CompressionType compressionType;
 
     public MetaStoreImpl(MetadataStore store, OrderedExecutor executor) {
         this.store = store;
         this.executor = executor;
+        this.compressionType = CompressionType.NONE;
     }
 
     public MetaStoreImpl(MetadataStore store, OrderedExecutor executor, String compressionType) {
         this.store = store;
         this.executor = executor;
+        CompressionType finalCompressionType;
         if (compressionType != null) {
             try {
-                this.compressionType = CompressionType.valueOf(compressionType);
+                finalCompressionType = CompressionType.valueOf(compressionType);
             } catch (Exception e) {
                 log.warn("Failed to get compression type {}, disable managedLedgerInfo compression, error msg: {}.",
                         compressionType, e.getMessage());
+                finalCompressionType = CompressionType.NONE;
             }
+        } else {
+            finalCompressionType = CompressionType.NONE;
         }
+        this.compressionType = finalCompressionType;
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -55,7 +55,7 @@ public class MetaStoreImpl implements MetaStore {
     private final MetadataStore store;
     private final OrderedExecutor executor;
 
-    private static final short MAGIC_MANAGED_LEDGER_INFO_METADATA = 0x878; // 1000 0111 1000
+    private static final int MAGIC_MANAGED_LEDGER_INFO_METADATA = 0x4778; // 0100 0111 0111 1000
     private final CompressionType compressionType;
 
     public MetaStoreImpl(MetadataStore store, OrderedExecutor executor) {

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -124,3 +124,8 @@ message ManagedCursorInfo {
     // Store which index in the batch message has been deleted
     repeated BatchedEntryDeletionIndexInfo batchedEntryDeletionIndexInfo = 7;
 }
+
+message ManagedLedgerInfoMetadata {
+    required string compressionType = 1;
+    required int32 unpressedSize = 2;
+}

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -125,7 +125,15 @@ message ManagedCursorInfo {
     repeated BatchedEntryDeletionIndexInfo batchedEntryDeletionIndexInfo = 7;
 }
 
+enum CompressionType {
+    NONE   = 0;
+    LZ4    = 1;
+    ZLIB   = 2;
+    ZSTD   = 3;
+    SNAPPY   = 4;
+}
+
 message ManagedLedgerInfoMetadata {
-    required string compressionType = 1;
-    required int32 unpressedSize = 2;
+    required CompressionType compressionType = 1;
+    required int32 uncompressedSize = 2;
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.offload.OffloadUtils;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.pulsar.common.api.proto.CompressionType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * ManagedLedgerInfo metadata test.
+ */
+@Slf4j
+public class ManagedLedgerInfoMetadataTest {
+
+    @Test
+    public void testEncodeAndDecode() throws IOException {
+        long ledgerId = 10000;
+        List<MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgerInfoList = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder builder = MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder();
+            builder.setLedgerId(ledgerId);
+            builder.setEntries(RandomUtils.nextInt());
+            builder.setSize(RandomUtils.nextLong());
+            builder.setTimestamp(System.currentTimeMillis());
+
+            UUID uuid = UUID.randomUUID();
+            builder.getOffloadContextBuilder()
+                    .setUidMsb(uuid.getMostSignificantBits())
+                    .setUidLsb(uuid.getLeastSignificantBits());
+            Map<String, String> offloadDriverMetadata = new HashMap<>();
+            offloadDriverMetadata.put("bucket", "test-bucket");
+            offloadDriverMetadata.put("managedLedgerOffloadDriver", "pulsar-offload-dev");
+            offloadDriverMetadata.put("serviceEndpoint", "https://s3.eu-west-1.amazonaws.com");
+            offloadDriverMetadata.put("region", "eu-west-1");
+            OffloadUtils.setOffloadDriverMetadata(
+                    builder,
+                    "aws-s3",
+                    offloadDriverMetadata
+            );
+
+            MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo = builder.build();
+            ledgerInfoList.add(ledgerInfo);
+            ledgerId ++;
+        }
+
+        MLDataFormats.ManagedLedgerInfo managedLedgerInfo = MLDataFormats.ManagedLedgerInfo.newBuilder()
+                .addAllLedgerInfo(ledgerInfoList)
+                .build();
+        MetaStoreImpl metaStore = new MetaStoreImpl(null, null);
+        byte[] compressionBytes = metaStore.compressLedgerInfo(managedLedgerInfo, CompressionType.ZSTD);
+        log.info("Uncompressed data size: {}, compressed data size: {}",
+                managedLedgerInfo.getSerializedSize(), compressionBytes.length);
+
+        MLDataFormats.ManagedLedgerInfo info1 = metaStore.parseManagedLedgerInfo(compressionBytes);
+        MLDataFormats.ManagedLedgerInfo info2 = metaStore.parseManagedLedgerInfo(managedLedgerInfo.toByteArray());
+        Assert.assertEquals(info1, info2);
+    }
+
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1602,9 +1602,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
             .getValue();
 
     @FieldContext(category = CATEGORY_STORAGE_ML,
-            doc = "ManagedLedgerInfo compression type, option values (LZ4, ZLIB, ZSTD, SNAPPY). \n"
-                    + "If not set value or value is invalid, then save the ManagedLedgerInfo bytes data directly.")
-    private String managedLedgerInfoCompressionType = null;
+            doc = "ManagedLedgerInfo compression type, option values (NONE, LZ4, ZLIB, ZSTD, SNAPPY). \n"
+                    + "If value is invalid or NONE, then save the ManagedLedgerInfo bytes data directly.")
+    private String managedLedgerInfoCompressionType = "NONE";
 
     /*** --- Load balancer --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1601,6 +1601,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String managedLedgerDataReadPriority = OffloadedReadPriority.TIERED_STORAGE_FIRST
             .getValue();
 
+    @FieldContext(category = CATEGORY_STORAGE_ML,
+            doc = "ManagedLedgerInfo compression type, option values (LZ4, ZLIB, ZSTD, SNAPPY). \n"
+                    + "If not set value or value is invalid, then save the ManagedLedgerInfo bytes data directly.")
+    private String managedLedgerInfoCompressionType = null;
+
     /*** --- Load balancer --- ****/
     @FieldContext(
             category = CATEGORY_LOAD_BALANCER,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -69,6 +69,7 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
                 conf.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());
         managedLedgerFactoryConfig.setTraceTaskExecution(conf.isManagedLedgerTraceTaskExecution());
         managedLedgerFactoryConfig.setCursorPositionFlushSeconds(conf.getManagedLedgerCursorPositionFlushSeconds());
+        managedLedgerFactoryConfig.setManagedLedgerInfoCompressionType(conf.getManagedLedgerInfoCompressionType());
 
         Configuration configuration = new ClientConfiguration();
         if (conf.isBookkeeperClientExposeStatsToPrometheus()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * ManagedLedgerInfo compression configuration test.
+ */
+public class ManagedLedgerCompressionTest extends BrokerTestBase {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setManagedLedgerInfoCompressionType(CompressionType.NONE.name());
+        super.baseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 1000 * 10)
+    public void testRestartBrokerEnableManagedLedgerInfoCompression() throws Exception {
+        String topic = newTopicName();
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .create();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("test")
+                .subscribe();
+
+        int messageCnt = 100;
+        for (int i = 0; i < messageCnt; i++) {
+            producer.newMessage().value("test".getBytes()).send();
+        }
+        for (int i = 0; i < messageCnt; i++) {
+            Message<byte[]> message = consumer.receive(1000, TimeUnit.SECONDS);
+            consumer.acknowledge(message);
+            Assert.assertNotNull(message);
+        }
+
+        stopBroker();
+        conf.setManagedLedgerInfoCompressionType(CompressionType.ZSTD.name());
+        startBroker();
+
+        for (int i = 0; i < messageCnt; i++) {
+            producer.newMessage().value("test".getBytes()).send();
+        }
+        for (int i = 0; i < messageCnt; i++) {
+            Message<byte[]> message = consumer.receive(1000, TimeUnit.SECONDS);
+            Assert.assertNotNull(message);
+            consumer.acknowledge(message);
+        }
+    }
+
+    @Test(timeOut = 1000 * 5)
+    public void testInvalidManagedLedgerInfoCompression() throws Exception {
+        stopBroker();
+        conf.setManagedLedgerInfoCompressionType("INVALID");
+        try {
+            startBroker();
+            Assert.fail("The managedLedgerInfo compression type is invalid, should fail.");
+        } catch (Exception e) {
+            Assert.assertEquals(e.getCause().getClass(), IllegalArgumentException.class);
+            Assert.assertEquals(
+                    "No enum constant org.apache.bookkeeper.mledger.proto.MLDataFormats.CompressionType.INVALID",
+                    e.getCause().getMessage());
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
@@ -82,10 +82,7 @@ public class ManagedLedgerCompressionTest extends BrokerTestBase {
             Assert.assertNotNull(message);
             consumer.acknowledge(message);
         }
-    }
 
-    @Test(timeOut = 1000 * 5)
-    public void testInvalidManagedLedgerInfoCompression() throws Exception {
         stopBroker();
         conf.setManagedLedgerInfoCompressionType("INVALID");
         try {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -186,11 +186,6 @@ message BrokerEntryMetadata {
     optional uint64 index = 2;
 }
 
-message ManagedLedgerInfoMetadata {
-    required CompressionType compressionType = 1;
-    required int32 unpressedSize = 2;
-}
-
 enum ServerError {
     UnknownError        = 0;
     MetadataError       = 1; // Error with ZK/metadata

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -186,6 +186,11 @@ message BrokerEntryMetadata {
     optional uint64 index = 2;
 }
 
+message ManagedLedgerInfoMetadata {
+    required CompressionType compressionType = 1;
+    required int32 unpressedSize = 2;
+}
+
 enum ServerError {
     UnknownError        = 0;
     MetadataError       = 1; // Error with ZK/metadata


### PR DESCRIPTION
### Motivation

Currently, the `ManagedLedgerInfo` contains offload context info, if there are too many ledgers in one ManagedLedger, a Zookeeper ZNode data will increase, it's hard for Zookeeper to manage these data. We could compress the `ManagedLedgerInfo` data, this will decrease the data size.

For example, if one `ManagedLedgerInfo` contains 30000 ledgers and each `LedgerInfo` contains offload context, the uncompressed data size is about 6MB, after compress with ZSTD, the compression data size could be decreased to about 1.3MB.

### Modifications

Add a `ManagedLedgerInfoMetadata` before `ManagedLedgerInfo`, the data structure as below.

```
[MAGIC_NUMBER] (2) + [METADATA_SIZE] (4) + [METADATA_PAYLOAD] + [MANAGED_LEDGER_INFO_PAYLOAD]
```

Add a new configuration `managedLedgerInfoCompressionType` to control ManagedLedgerInfo compression type, if not set this configuration, then don't compress ManagedLedgerInfo data.

### Migration

When reading data from the Zookeeper, check the magic number of the data, if the head data match the magic number then try to parse metadata and uncompress data, if encounter errors or not match fall back to parse `ManagedLedgerInfo` directly.

### Verifying this change

Verify compress and uncompress `ManagedLedgerInfo` data.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

