### PR TITLE
Fix the schema deletion when delete topic with delete schema

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -861,9 +861,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("truncate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).truncate("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -d"));
-        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", false);
-        verify(mockSchemas).deleteSchema("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("delete persistent://myprop/clust/ns1/ds1 -f -d"));
+        verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1", true, true);
 
         cmdTopics.run(split("unload persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
@@ -972,9 +971,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -d"));
-        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", false);
-        verify(mockSchemas, times(2)).deleteSchema("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("delete-partitioned-topic persistent://myprop/clust/ns1/ds1 -d -f"));
+        verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true, true);
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
         verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -461,10 +461,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            getTopics().deletePartitionedTopic(topic, force);
-            if (deleteSchema) {
-                getAdmin().schemas().deleteSchema(topic);
-            }
+            getTopics().deletePartitionedTopic(topic, force, deleteSchema);
         }
     }
 
@@ -485,10 +482,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
-            getTopics().delete(topic, force);
-            if (deleteSchema) {
-                getAdmin().schemas().deleteSchema(topic);
-            }
+            getTopics().delete(topic, force, deleteSchema);
         }
     }
 


### PR DESCRIPTION
The delete topic REST API already provided delete schema option,
but the delete topic command does not apply this option,
instead call the delete schema independently.

And the delete schema REST API has a different behavior with the delete topic
REST API with deleteSchema=true. When delete a topic with delete schema option,
the schema ledgers and schema indexes will be deleted, but delete schema independently
only write a delete marker to the schema storage.

We may need to improve the delete schema API, but the improvement does not in this PR.
This PR just correct the delete topic with delete schema behavior.

