### PR TITLE
[Issue 11473] [Python] Fix fields that are ignoring the required key argument

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -162,6 +162,9 @@ class Field(object):
         pass
 
     def validate_type(self, name, val):
+        if not val and not self._required:
+            return self.default()
+
         if type(val) != self.python_type():
             raise TypeError("Invalid type '%s' for field '%s'. Expected: %s" % (type(val), name, self.python_type()))
         return val
@@ -286,6 +289,10 @@ class String(Field):
 
     def validate_type(self, name, val):
         t = type(val)
+
+        if not val and not self._required:
+            return self.default()
+
         if not (t is str or t.__name__ == 'unicode'):
             raise TypeError("Invalid type '%s' for field '%s'. Expected a string" % (t, name))
         return val
@@ -296,9 +303,7 @@ class String(Field):
         else:
             return None
 
-
 # Complex types
-
 
 class _Enum(Field):
     def __init__(self, enum_type):

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -305,7 +305,6 @@ class SchemaTest(TestCase):
         except TypeError:
             pass # Expected
 
-
     def test_serialize_json(self):
         class Example(Record):
             a = Integer()
@@ -410,6 +409,31 @@ class SchemaTest(TestCase):
         self.assertEqual(r.b, None)
         self.assertEqual(r.c, 'hello')
 
+    def test_none_value(self):
+        """
+        The objective of the test is to check that if no value is assigned to the attribute, the validation is returning
+        the expect default value as defined in the Field class
+        """
+        class Example(Record):
+            a = Null()
+            b = Boolean()
+            c = Integer()
+            d = Long()
+            e = Float()
+            f = Double()
+            g = Bytes()
+            h = String()
+
+        r = Example()
+
+        self.assertIsNone(r.a)
+        self.assertFalse(r.b)
+        self.assertIsNone(r.c)
+        self.assertIsNone(r.d)
+        self.assertIsNone(r.e)
+        self.assertIsNone(r.f)
+        self.assertIsNone(r.g)
+        self.assertIsNone(r.h)
     ####
 
     def test_json_schema(self):


### PR DESCRIPTION
Fixes #11473 


### Motivation

By default, classes that inherit from Fields have a `required` key argument which is False.

If an attribute is not declared with a value, an exception is raised.

```python
Invalid type '<class' NoneType '>' for field 'name'. Expected a string
```

### Modifications

The modifications made affect 2 classes: Field and String. In both cases, the `validate_type` method has been modified to take into account arguments inherited from the Field class, including` required` and `default`.

Validation looks to see if the field is required. If it is not required (`required=False`) and the value does not exist, the default value is returned.

This modification removes the error and allows to integrate the different types of fields based on the definition of the key arguments of the Field class

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

- *Added unit teststo validate that all types of fields are returning the expected default value and are not raising an error anymore*

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: yes
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

#### For commiter

No documentation update is required. 
The implementation of any fields is not include in the documentation.


