### PR TITLE
[ISSUE 11511] Fix brew error in site docs to compile C++ client.

### DIFF
--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -205,7 +205,7 @@ $ export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
 $ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
 # Protocol Buffers installation
-$ brew install protobuf boost boost-python log4cxx jsoncpp
+$ brew install protobuf boost boost-python log4cxx
 # If you are using python3, you need to install boost-python3 
 
 # Google Test installation

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -205,10 +205,8 @@ $ export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
 $ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
 # Protocol Buffers installation
-$ brew tap homebrew/versions
-$ brew install protobuf260
-$ brew install boost
-$ brew install log4cxx
+$ brew install protobuf boost boost-python log4cxx jsoncpp
+# If you are using python3, you need to install boost-python3 
 
 # Google Test installation
 $ git clone https://github.com/google/googletest.git


### PR DESCRIPTION
Fix [issue#11511](https://github.com/apache/pulsar/issues/11511).

This brew tap (Third-Party Repositories) had changed.
`brew tap homebrew/versions`