### PR TITLE
Make getTopicPoliciesAsyncWithRetry as a default method

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -341,8 +341,14 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected CompletableFuture<Optional<TopicPolicies>> getTopicPoliciesAsyncWithRetry(TopicName topicName) {
-        return pulsar().getTopicPoliciesService()
-                .getTopicPoliciesAsyncWithRetry(topicName, null, pulsar().getExecutor());
+        try {
+            checkTopicLevelPolicyEnable();
+            return pulsar().getTopicPoliciesService()
+                    .getTopicPoliciesAsyncWithRetry(topicName, null, pulsar().getExecutor());
+        } catch (Exception e) {
+            log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);
+            return FutureUtil.failedFuture(e);
+        }
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -29,9 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.ws.rs.WebApplicationException;
@@ -41,13 +38,10 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.internal.TopicsImpl;
-import org.apache.pulsar.client.impl.Backoff;
-import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -79,7 +73,6 @@ public abstract class AdminResource extends PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
     public static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
     public static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
-    private static final long DEFAULT_GET_TOPIC_POLICY_TIMEOUT = 30_000;
 
     protected BookKeeper bookKeeper() {
         return pulsar().getBookKeeperClient();
@@ -348,46 +341,10 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected CompletableFuture<Optional<TopicPolicies>> getTopicPoliciesAsyncWithRetry(TopicName topicName) {
-        return internalGetTopicPoliciesAsyncWithRetry(topicName,
-                new AtomicLong(DEFAULT_GET_TOPIC_POLICY_TIMEOUT), null, null);
+        return pulsar().getTopicPoliciesService()
+                .getTopicPoliciesAsyncWithRetry(topicName, null, pulsar().getExecutor());
     }
 
-    protected CompletableFuture<Optional<TopicPolicies>> internalGetTopicPoliciesAsyncWithRetry(TopicName topicName,
-            final AtomicLong remainingTime, final Backoff backoff, CompletableFuture<Optional<TopicPolicies>> future) {
-        CompletableFuture<Optional<TopicPolicies>> response = future == null ? new CompletableFuture<>() : future;
-        try {
-            checkTopicLevelPolicyEnable();
-            response.complete(Optional.ofNullable(pulsar()
-                    .getTopicPoliciesService().getTopicPolicies(topicName)));
-        } catch (RestException re) {
-            response.completeExceptionally(re);
-        } catch (BrokerServiceException.TopicPoliciesCacheNotInitException e) {
-            Backoff usedBackoff = backoff == null ? new BackoffBuilder()
-                    .setInitialTime(500, TimeUnit.MILLISECONDS)
-                    .setMandatoryStop(DEFAULT_GET_TOPIC_POLICY_TIMEOUT, TimeUnit.MILLISECONDS)
-                    .setMax(DEFAULT_GET_TOPIC_POLICY_TIMEOUT, TimeUnit.MILLISECONDS)
-                    .create() : backoff;
-            long nextDelay = Math.min(usedBackoff.next(), remainingTime.get());
-            if (nextDelay <= 0) {
-                response.completeExceptionally(new TimeoutException(
-                        String.format("Failed to get topic policy withing configured timeout %s ms",
-                                DEFAULT_GET_TOPIC_POLICY_TIMEOUT)));
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.error("Topic {} policies have not been initialized yet, retry after {}ms",
-                            topicName, nextDelay);
-                }
-                pulsar().getExecutor().schedule(() -> {
-                    remainingTime.addAndGet(-nextDelay);
-                    internalGetTopicPoliciesAsyncWithRetry(topicName, remainingTime, usedBackoff, response);
-                }, nextDelay, TimeUnit.MILLISECONDS);
-            }
-        } catch (Exception e) {
-            log.error("[{}] Failed to get topic policies {}", clientAppId(), topicName, e);
-            response.completeExceptionally(e);
-        }
-        return response;
-    }
 
     protected boolean checkBacklogQuota(BacklogQuota quota, RetentionPolicies retention) {
         if (retention == null || retention.getRetentionSizeInMB() <= 0 || retention.getRetentionTimeInMinutes() <= 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -55,14 +55,15 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     private final PulsarService pulsarService;
     private volatile NamespaceEventsSystemTopicFactory namespaceEventsSystemTopicFactory;
 
-    private final Map<TopicName, TopicPolicies> policiesCache = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<TopicName, TopicPolicies> policiesCache = new ConcurrentHashMap<>();
 
     private final Map<NamespaceName, AtomicInteger> ownedBundlesCountPerNamespace = new ConcurrentHashMap<>();
 
     private final Map<NamespaceName, CompletableFuture<SystemTopicClient.Reader<PulsarEvent>>>
             readerCaches = new ConcurrentHashMap<>();
-
-    private final Map<NamespaceName, Boolean> policyCacheInitMap = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<NamespaceName, Boolean> policyCacheInitMap = new ConcurrentHashMap<>();
 
     private final Map<TopicName, List<TopicPolicyListener<TopicPolicies>>> listeners = new ConcurrentHashMap<>();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -69,8 +69,7 @@ public interface TopicPoliciesService {
      * @return CompletableFuture<Optional<TopicPolicies>>
      */
     default CompletableFuture<Optional<TopicPolicies>> getTopicPoliciesAsyncWithRetry(TopicName topicName,
-                                                                                      final Backoff backoff,
-                                                                                      ScheduledExecutorService scheduledExecutorService) {
+              final Backoff backoff, ScheduledExecutorService scheduledExecutorService) {
         CompletableFuture<Optional<TopicPolicies>> response = new CompletableFuture<>();
         Backoff usedBackoff = backoff == null ? new BackoffBuilder()
                 .setInitialTime(500, TimeUnit.MILLISECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -240,7 +240,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         try {
             service.getTopicPoliciesAsyncWithRetry(TOPIC1, backoff, pulsar.getExecutor()).get();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TopicPoliciesCacheNotInitException);
+            assertTrue(e.getCause().getCause() instanceof TopicPoliciesCacheNotInitException);
         }
         long cost = System.currentTimeMillis() - start;
         assertTrue("actual:" + cost, cost >= 5000 - 1000);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -18,15 +18,25 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicPoliciesCacheNotInitException;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.Backoff;
+import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.awaitility.Awaitility;
@@ -34,14 +44,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertNull;
 
 @Test(groups = "broker")
 public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServiceBaseTest {
@@ -222,5 +224,25 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         admin.lookups().lookupTopic(TOPIC6.toString());
         systemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
         systemTopicBasedTopicPoliciesService = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+    }
+
+    @Test
+    public void testGetPolicyTimeout() throws Exception {
+        SystemTopicBasedTopicPoliciesService service = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        Awaitility.await().untilAsserted(() -> assertTrue(service.policyCacheInitMap.get(TOPIC1.getNamespaceObject())));
+        service.policyCacheInitMap.put(TOPIC1.getNamespaceObject(), false);
+        long start = System.currentTimeMillis();
+        Backoff backoff = new BackoffBuilder()
+                .setInitialTime(500, TimeUnit.MILLISECONDS)
+                .setMandatoryStop(5000, TimeUnit.MILLISECONDS)
+                .setMax(1000, TimeUnit.MILLISECONDS)
+                .create();
+        try {
+            service.getTopicPoliciesAsyncWithRetry(TOPIC1, backoff, pulsar.getExecutor()).get();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof TopicPoliciesCacheNotInitException);
+        }
+        long cost = System.currentTimeMillis() - start;
+        assertTrue("actual:" + cost, cost >= 5000 - 1000);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -53,7 +53,7 @@ public class RetryUtil {
             long next = backoff.next();
             boolean isMandatoryStop = backoff.isMandatoryStopMade();
             if (isMandatoryStop) {
-                callback.completeExceptionally(e.getCause());
+                callback.completeExceptionally(e);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("execute with retry fail, will retry in {} ms", next, e);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -53,7 +53,7 @@ public class RetryUtil {
             long next = backoff.next();
             boolean isMandatoryStop = backoff.isMandatoryStopMade();
             if (isMandatoryStop) {
-                callback.completeExceptionally(e);
+                callback.completeExceptionally(e.getCause());
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("execute with retry fail, will retry in {} ms", next, e);


### PR DESCRIPTION
### Motivation
Admin API needs to use `getTopicPoliciesAsyncWithRetry`, it also needs to be used in BrokerService, so move it to TopicService

### Modifications

### Documentation
no need doc

