### PR TITLE
[Issue 11521] [managed-ledger] Fix NPE in managed-ledger read callback.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -106,7 +106,6 @@ class OpReadEntry implements ReadEntriesCallback {
             if (nexReadPosition == null) {
                 callback.readEntriesFailed(exception, ctx);
                 cursor.ledger.mbean.recordReadEntriesError();
-                recycle();
                 return;
             }
             updateReadPosition(nexReadPosition);
@@ -124,7 +123,6 @@ class OpReadEntry implements ReadEntriesCallback {
 
             callback.readEntriesFailed(exception, ctx);
             cursor.ledger.mbean.recordReadEntriesError();
-            recycle();
         }
     }
 


### PR DESCRIPTION
Fixes #11521 

### Motivation

Under certain circumstances, NPE exception is seen in broker logs.

### Modifications

From code inspection, there appears to be a race condition between the execution of following line (which is executed asynchronously):

https://github.com/apache/pulsar/blob/3cd4f368abd93c229d69f77049edc95b5c1a3071/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L97

and the following line:

https://github.com/apache/pulsar/blob/3cd4f368abd93c229d69f77049edc95b5c1a3071/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L127

Fix is to remove the extraneous call to recycle().

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

This is a bug fix, there is no documentation impact.