### PR TITLE
[docs] Format and examples to specify a tenant/namespace for a topic.

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -107,7 +107,7 @@ Here is an example:
 
 ```JavaScript
 const producer = await client.createProducer({
-  topic: 'my-topic',
+  topic: 'my-topic', // or 'my-tenant/my-namespace/my-topic' to specify topic's property and namespace 
 });
 
 await producer.send({
@@ -137,7 +137,7 @@ Pulsar Node.js producers have the following methods available:
 
 | Parameter | Description | Default |
 | :-------- | :---------- | :------ |
-| `topic` | The Pulsar [topic](reference-terminology.md#topic) to which the producer publishes messages. | |
+| `topic` | The Pulsar [topic](reference-terminology.md#topic) to which the producer publishes messages. Format: `<topic-name>` or `<property(tenant)>/<namespace>/<topic-name>`. E.g.: `sample/ns1/my-topic` | |
 | `producerName` | A name for the producer. If you do not explicitly assign a name, Pulsar automatically generates a globally unique name.  If you choose to explicitly assign a name, it needs to be unique across *all* Pulsar clusters, otherwise the creation operation throws an error. | |
 | `sendTimeoutMs` | When publishing a message to a topic, the producer waits for an acknowledgment from the responsible Pulsar [broker](reference-terminology.md#broker). If a message is not acknowledged within the threshold set by this parameter, an error is thrown. If you set `sendTimeoutMs` to -1, the timeout is set to infinity (and thus removed). Removing the send timeout is recommended when using Pulsar's [message de-duplication](cookbooks-deduplication.md) feature. | 30000 |
 | `initialSequenceId` | The initial sequence ID of the message. When producer send message, add sequence ID to message. The ID is increased each time to send. | |


### PR DESCRIPTION
Added topic's name format and examples to specify a tenant and namespace of the topic. 
Previously not a single mention of "namespaces" and how to specify one.

### Motivation & context
Make docs easier.
I'm learning Apache Pulsar and had a confusion by the fact word "namespace" not mentioned even once in the nodejs part of the documentation. So it was impossible to know how to specify a namespace and/or tenant during topic manipulation (subscribing or connecting with a producer). 

### Modifications
To address this problem, I added the topic name format (based on Pulsar console output) and examples to the documentation.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API: (**no**)
  - The schema: (**no**)
  - The default values of configurations: (**no**)
  - The wire protocol: (**no**)
  - The rest endpoints: (**no**)
  - The admin cli options: (**no**)
  - Anything that affects deployment: (**no**)

### Documentation

This is modification to the documentation itself (and only).
