### PR TITLE
[Python Schema] Fix python schema array map with record

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -67,8 +67,24 @@ class Record(with_metaclass(RecordMeta, object)):
                 if isinstance(value, Record) and isinstance(kwargs[k], dict):
                     # Use dict init Record object
                     copied = copy.copy(value)
-                    copied.__init__(decode=True, **kwargs[k])
+                    copied.__init__(**kwargs[k])
                     self.__setattr__(k, copied)
+                elif isinstance(value, Array) and isinstance(kwargs[k], list) and len(kwargs[k]) > 0 \
+                        and isinstance(value.array_type, Record) and isinstance(kwargs[k][0], dict):
+                    arr = []
+                    for item in kwargs[k]:
+                        copied = copy.copy(value.array_type)
+                        copied.__init__(**item)
+                        arr.append(copied)
+                    self.__setattr__(k, arr)
+                elif isinstance(value, Map) and isinstance(kwargs[k], dict) and len(kwargs[k]) > 0 \
+                    and isinstance(value.value_type, Record) and isinstance(list(kwargs[k].values())[0], dict):
+                    dic = {}
+                    for mapKey, mapValue in kwargs[k].items():
+                        copied = copy.copy(value.value_type)
+                        copied.__init__(**mapValue)
+                        dic[mapKey] = copied
+                    self.__setattr__(k, dic)
                 else:
                     # Value was overridden at constructor
                     self.__setattr__(k, kwargs[k])
@@ -128,6 +144,9 @@ class Record(with_metaclass(RecordMeta, object)):
 
     def type(self):
         return str(self.__class__.__name__)
+
+    def python_type(self):
+        return self.__class__
 
     def validate_type(self, name, val):
         if not isinstance(val, self.__class__):

--- a/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema_avro.py
@@ -42,6 +42,13 @@ if HAS_AVRO:
                 return x.name
             elif isinstance(x, Record):
                 return self.encode_dict(x.__dict__)
+            elif isinstance(x, list):
+                arr = []
+                for item in x:
+                    arr.append(self._get_serialized_value(item))
+                return arr
+            elif isinstance(x, dict):
+                return self.encode_dict(x)
             else:
                 return x
 

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -460,6 +460,9 @@ class SchemaTest(TestCase):
         msg = consumer.receive()
 
         self.assertEqual(r, msg.value())
+
+        producer.close()
+        consumer.close()
         client.close()
 
     def test_string_schema(self):
@@ -562,6 +565,9 @@ class SchemaTest(TestCase):
         msg = consumer.receive()
 
         self.assertEqual(r, msg.value())
+
+        producer.close()
+        consumer.close()
         client.close()
 
     def test_json_enum(self):
@@ -1013,8 +1019,6 @@ class SchemaTest(TestCase):
             self.assertEqual(value.arrayNested[1].na4, 'value na4 2')
             self.assertEqual(value.arrayNested[1].nb4, 200)
 
-            producer.close()
-            consumer.close()
             print('Produce and consume complex schema data finish. schema_type', schema_type)
 
         produce_consume_test('avro')


### PR DESCRIPTION
### Motivation

Currently, the schema type Array and Map couldn't work well with Record.

For example.

```
class NestedObj(Record):
    na2 = Integer()
    nb2 = Boolean()

class ComplexRecord(Record):
    a = Integer()
    b = Integer()
    arrayNested = Array(NestedObj())

nested_obj = NestedObj(na2=22, nb2=True)
r = ComplexRecord(a=1, b=2, arrayNested=[
    nested_obj, nested_obj, nested_obj
])
```

**error log**
```
  File "/Volumes/shit/Workspaces/GitHubFork/pulsar/pulsar-client-cpp/python/pulsar/schema/definition.py", line 74, in __init__
    self.__setattr__(k, kwargs[k])
  File "/Volumes/shit/Workspaces/GitHubFork/pulsar/pulsar-client-cpp/python/pulsar/schema/definition.py", line 117, in __setattr__
    value = field.validate_type(key, value)
  File "/Volumes/shit/Workspaces/GitHubFork/pulsar/pulsar-client-cpp/python/pulsar/schema/definition.py", line 369, in validate_type
    if type(x) != self.array_type.python_type():
AttributeError: 'NestedObj2' object has no attribute 'python_type'
```

### Modifications

Change the method `__init__()` of the `Record`, because decoding data will depend on this method, so we need to use `dict` data to initialize the `Record` object.

Add a new method `python_type()` for `Record`, the schema type `Array` and `Map` need to get `python_type` of the `Record`.

### Verifying this change

Add test to verify schema type Array and Map work with Record.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

