### PR TITLE
[Issue 11493] Fix #11493. Simple implementation of getting number of references from C++ client

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -355,9 +355,19 @@ class PULSAR_PUBLIC Client {
      */
     void shutdown();
 
+    /**
+     * @brief Get the Number Of alive Producers on current client.
+     *
+     * @return The number of alive Producers on current client.
+     */
     uint64_t getNumberOfProducers();
+
+    /**
+     * @brief Get the Number Of alive Consumers on current client.
+     *
+     * @return The number of alive Consumers on current client.
+     */
     uint64_t getNumberOfConsumers();
-    uint64_t getNumberOfReaders();
 
    private:
     Client(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration,

--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -356,16 +356,16 @@ class PULSAR_PUBLIC Client {
     void shutdown();
 
     /**
-     * @brief Get the Number Of alive Producers on current client.
+     * @brief Get the number of alive producers on the current client.
      *
-     * @return The number of alive Producers on current client.
+     * @return The number of alive producers on the  current client.
      */
     uint64_t getNumberOfProducers();
 
     /**
-     * @brief Get the Number Of alive Consumers on current client.
+     * @brief Get the number of alive consumers on the current client.
      *
-     * @return The number of alive Consumers on current client.
+     * @return The number of alive consumers on the current client.
      */
     uint64_t getNumberOfConsumers();
 

--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -355,6 +355,10 @@ class PULSAR_PUBLIC Client {
      */
     void shutdown();
 
+    uint64_t getNumberOfProducers();
+    uint64_t getNumberOfConsumers();
+    uint64_t getNumberOfReaders();
+
    private:
     Client(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration,
            bool poolConnections);

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -175,4 +175,8 @@ Result Client::close() {
 void Client::closeAsync(CloseCallback callback) { impl_->closeAsync(callback); }
 
 void Client::shutdown() { impl_->shutdown(); }
+
+uint64_t Client::getNumberOfProducers() { return impl_->getNumberOfProducers(); }
+uint64_t Client::getNumberOfConsumers() { return impl_->getNumberOfConsumers(); }
+uint64_t Client::getNumberOfReaders() { return impl_->getNumberOfReaders(); }
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -178,5 +178,4 @@ void Client::shutdown() { impl_->shutdown(); }
 
 uint64_t Client::getNumberOfProducers() { return impl_->getNumberOfProducers(); }
 uint64_t Client::getNumberOfConsumers() { return impl_->getNumberOfConsumers(); }
-uint64_t Client::getNumberOfReaders() { return impl_->getNumberOfReaders(); }
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -593,7 +593,7 @@ uint64_t ClientImpl::getNumberOfProducers() {
     uint64_t numberOfAliveProducers = 0;
     for (const auto& producer : producers_) {
         if (producer.lock()->isConnected()) {
-           numberOfAliveProducers++;
+            numberOfAliveProducers++;
         }
     }
     return numberOfAliveProducers;
@@ -602,7 +602,7 @@ uint64_t ClientImpl::getNumberOfProducers() {
 uint64_t ClientImpl::getNumberOfConsumers() {
     Lock lock(mutex_);
     uint64_t numberOfAliveConsumers = 0;
-    for (const auto& consumer : consumers_){
+    for (const auto& consumer : consumers_) {
         if (consumer.lock()->isConnected()) {
             numberOfAliveConsumers++;
         }
@@ -610,12 +610,7 @@ uint64_t ClientImpl::getNumberOfConsumers() {
     return numberOfAliveConsumers;
 }
 
-uint64_t ClientImpl::getNumberOfReaders() {
-    
-    return 0;
-}
-
-
+uint64_t ClientImpl::getNumberOfReaders() { return 0; }
 
 const ClientConfiguration& ClientImpl::getClientConfig() const { return clientConfiguration_; }
 

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -588,6 +588,35 @@ uint64_t ClientImpl::newRequestId() {
     return requestIdGenerator_++;
 }
 
+uint64_t ClientImpl::getNumberOfProducers() {
+    Lock lock(mutex_);
+    uint64_t numberOfAliveProducers = 0;
+    for (const auto& producer : producers_) {
+        if (producer.lock()->isConnected()) {
+           numberOfAliveProducers++;
+        }
+    }
+    return numberOfAliveProducers;
+}
+
+uint64_t ClientImpl::getNumberOfConsumers() {
+    Lock lock(mutex_);
+    uint64_t numberOfAliveConsumers = 0;
+    for (const auto& consumer : consumers_){
+        if (consumer.lock()->isConnected()) {
+            numberOfAliveConsumers++;
+        }
+    }
+    return numberOfAliveConsumers;
+}
+
+uint64_t ClientImpl::getNumberOfReaders() {
+    
+    return 0;
+}
+
+
+
 const ClientConfiguration& ClientImpl::getClientConfig() const { return clientConfiguration_; }
 
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -593,8 +593,8 @@ uint64_t ClientImpl::getNumberOfProducers() {
     uint64_t numberOfAliveProducers = 0;
     for (const auto& producer : producers_) {
         const auto& producerImpl = producer.lock();
-        if (producerImpl && producerImpl->isConnected()) {
-            numberOfAliveProducers++;
+        if (producerImpl) {
+            numberOfAliveProducers += producerImpl->getNumberOfConnectedProducer();
         }
     }
     return numberOfAliveProducers;
@@ -605,8 +605,8 @@ uint64_t ClientImpl::getNumberOfConsumers() {
     uint64_t numberOfAliveConsumers = 0;
     for (const auto& consumer : consumers_) {
         const auto consumerImpl = consumer.lock();
-        if (consumerImpl && consumerImpl->isConnected()) {
-            numberOfAliveConsumers++;
+        if (consumerImpl) {
+            numberOfAliveConsumers += consumerImpl->getNumberOfConnectedConsumer();
         }
     }
     return numberOfAliveConsumers;

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -592,7 +592,8 @@ uint64_t ClientImpl::getNumberOfProducers() {
     Lock lock(mutex_);
     uint64_t numberOfAliveProducers = 0;
     for (const auto& producer : producers_) {
-        if (producer.lock()->isConnected()) {
+        const auto& producerImpl = producer.lock();
+        if (producerImpl && producerImpl->isConnected()) {
             numberOfAliveProducers++;
         }
     }
@@ -603,14 +604,13 @@ uint64_t ClientImpl::getNumberOfConsumers() {
     Lock lock(mutex_);
     uint64_t numberOfAliveConsumers = 0;
     for (const auto& consumer : consumers_) {
-        if (consumer.lock()->isConnected()) {
-            numberOfAliveConsumers++;
+        const auto consumerImpl = consumer.lock();
+        if (consumerImpl) {
+            if (consumerImpl->isConnected()) numberOfAliveConsumers++;
         }
     }
     return numberOfAliveConsumers;
 }
-
-uint64_t ClientImpl::getNumberOfReaders() { return 0; }
 
 const ClientConfiguration& ClientImpl::getClientConfig() const { return clientConfiguration_; }
 

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -605,8 +605,8 @@ uint64_t ClientImpl::getNumberOfConsumers() {
     uint64_t numberOfAliveConsumers = 0;
     for (const auto& consumer : consumers_) {
         const auto consumerImpl = consumer.lock();
-        if (consumerImpl) {
-            if (consumerImpl->isConnected()) numberOfAliveConsumers++;
+        if (consumerImpl && consumerImpl->isConnected()) {
+            numberOfAliveConsumers++;
         }
     }
     return numberOfAliveConsumers;

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -86,7 +86,7 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
     uint64_t getNumberOfProducers();
     uint64_t getNumberOfConsumers();
     uint64_t getNumberOfReaders();
-    
+
     const ClientConfiguration& getClientConfig() const;
 
     const ClientConfiguration& conf() const;

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -85,7 +85,6 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
 
     uint64_t getNumberOfProducers();
     uint64_t getNumberOfConsumers();
-    uint64_t getNumberOfReaders();
 
     const ClientConfiguration& getClientConfig() const;
 

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -83,6 +83,10 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
     uint64_t newConsumerId();
     uint64_t newRequestId();
 
+    uint64_t getNumberOfProducers();
+    uint64_t getNumberOfConsumers();
+    uint64_t getNumberOfReaders();
+    
     const ClientConfiguration& getClientConfig() const;
 
     const ClientConfiguration& conf() const;

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -1233,4 +1233,6 @@ bool ConsumerImpl::isConnected() const {
     return !getCnx().expired() && state_ == Ready;
 }
 
+uint64_t ConsumerImpl::getNumberOfConnectedConsumer() { return isConnected() ? 1 : 0; }
+
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -125,6 +125,7 @@ class ConsumerImpl : public ConsumerImplBase,
     void seekAsync(uint64_t timestamp, ResultCallback callback) override;
     void negativeAcknowledge(const MessageId& msgId) override;
     bool isConnected() const override;
+    uint64_t getNumberOfConnectedConsumer() override;
 
     virtual void disconnectConsumer();
     Result fetchSingleMessageFromBroker(Message& msg);

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -56,6 +56,7 @@ class ConsumerImplBase {
     virtual void seekAsync(uint64_t timestamp, ResultCallback callback) = 0;
     virtual void negativeAcknowledge(const MessageId& msgId) = 0;
     virtual bool isConnected() const = 0;
+    virtual uint64_t getNumberOfConnectedConsumer() = 0;
 
    private:
     virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled) = 0;

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -749,3 +749,15 @@ bool MultiTopicsConsumerImpl::isConnected() const {
     }
     return true;
 }
+
+uint64_t MultiTopicsConsumerImpl::getNumberOfConnectedConsumer() {
+    Lock lock(mutex_);
+    uint64_t numberOfConnectedConsumer = 0;
+    const auto consumers = consumers_;
+    for (const auto& topicAndConsumer : consumers) {
+        if (topicAndConsumer.second->isConnected()) {
+            numberOfConnectedConsumer++;
+        }
+    }
+    return numberOfConnectedConsumer;
+}

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.cc
@@ -754,6 +754,7 @@ uint64_t MultiTopicsConsumerImpl::getNumberOfConnectedConsumer() {
     Lock lock(mutex_);
     uint64_t numberOfConnectedConsumer = 0;
     const auto consumers = consumers_;
+    lock.unlock();
     for (const auto& topicAndConsumer : consumers) {
         if (topicAndConsumer.second->isConnected()) {
             numberOfConnectedConsumer++;

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -78,6 +78,8 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     void seekAsync(uint64_t timestamp, ResultCallback callback) override;
     void negativeAcknowledge(const MessageId& msgId) override;
     bool isConnected() const override;
+    uint64_t getNumberOfConnectedConsumer() override;
+
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, MultiTopicsBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     // return first topic name when all topics name valid, or return null pointer

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -635,4 +635,17 @@ bool PartitionedConsumerImpl::isConnected() const {
     return true;
 }
 
+uint64_t PartitionedConsumerImpl::getNumberOfConnectedConsumer() {
+    uint64_t numberOfConnectedConsumer = 0;
+    Lock consumersLock(consumersMutex_);
+    const auto consumers = consumers_;
+    consumersLock.unlock();
+    for (const auto& consumer : consumers) {
+        if (consumer->isConnected()) {
+            numberOfConnectedConsumer++;
+        }
+    }
+    return numberOfConnectedConsumer;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -74,6 +74,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     void seekAsync(uint64_t timestamp, ResultCallback callback) override;
     void negativeAcknowledge(const MessageId& msgId) override;
     bool isConnected() const override;
+    uint64_t getNumberOfConnectedConsumer() override;
 
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, PartitionedBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -387,4 +387,17 @@ bool PartitionedProducerImpl::isConnected() const {
     return true;
 }
 
+uint64_t PartitionedProducerImpl::getNumberOfConnectedProducer() {
+    uint64_t numberOfConnectedProducer = 0;
+    Lock producersLock(producersMutex_);
+    const auto producers = producers_;
+    producersLock.unlock();
+    for (const auto& producer : producers) {
+        if (producer->isConnected()) {
+            numberOfConnectedProducer++;
+        }
+    }
+    return numberOfConnectedProducer;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -64,7 +64,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     void triggerFlush() override;
     void flushAsync(FlushCallback callback) override;
     bool isConnected() const override;
-
+    uint64_t getNumberOfConnectedProducer() override;
     void handleSinglePartitionProducerCreated(Result result, ProducerImplBaseWeakPtr producerBaseWeakPtr,
                                               const unsigned int partitionIndex);
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -826,5 +826,7 @@ bool ProducerImpl::isConnected() const {
     return !getCnx().expired() && state_ == Ready;
 }
 
+uint64_t ProducerImpl::getNumberOfConnectedProducer() { return isConnected() ? 1 : 0; }
+
 }  // namespace pulsar
 /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -70,6 +70,7 @@ class ProducerImpl : public HandlerBase,
     void triggerFlush() override;
     void flushAsync(FlushCallback callback) override;
     bool isConnected() const override;
+    uint64_t getNumberOfConnectedProducer() override;
 
     bool removeCorruptMessage(uint64_t sequenceId);
 

--- a/pulsar-client-cpp/lib/ProducerImplBase.h
+++ b/pulsar-client-cpp/lib/ProducerImplBase.h
@@ -45,6 +45,7 @@ class ProducerImplBase {
     virtual void triggerFlush() = 0;
     virtual void flushAsync(FlushCallback callback) = 0;
     virtual bool isConnected() const = 0;
+    virtual uint64_t getNumberOfConnectedProducer() = 0;
 };
 }  // namespace pulsar
 #endif  // PULSAR_PRODUCER_IMPL_BASE_HEADER

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -122,8 +122,11 @@ TEST(ClientTest, testGetNumberOfReferences) {
 
     // Producer test
     uint64_t numberOfProducers = 0;
-    const std::string nonPartitionedTopic = "nonPartitionedTopic";
-    const std::string partitionedTopic = "partitionedTopic";
+    const std::string nonPartitionedTopic =
+        "testGetNumberOfReferencesNonPartitionedTopic" + std::to_string(time(nullptr));
+
+    const std::string partitionedTopic =
+        "testGetNumberOfReferencesPartitionedTopic" + std::to_string(time(nullptr));
     Producer producer;
     client.createProducer(nonPartitionedTopic, producer);
     numberOfProducers = 1;
@@ -141,24 +144,34 @@ TEST(ClientTest, testGetNumberOfReferences) {
     client.createProducer(partitionedTopic, producer);
     numberOfProducers = 2;
     ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+    producer.close();
+    numberOfProducers = 0;
+    ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+
 
     // Consumer test
     uint64_t numberOfConsumers = 0;
 
-    Consumer consumer;
-    client.subscribe(nonPartitionedTopic, "consumer-1", consumer);
+    Consumer consumer1;
+    client.subscribe(nonPartitionedTopic, "consumer-1", consumer1);
     numberOfConsumers = 1;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
-    consumer.close();
+    consumer1.close();
     numberOfConsumers = 0;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
-    client.subscribe(partitionedTopic, "consumer-2", consumer);
+    Consumer consumer2;
+    Consumer consumer3;
+    client.subscribe(partitionedTopic, "consumer-2", consumer2);
     numberOfConsumers = 2;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
-    client.subscribe(nonPartitionedTopic, "consumer-3", consumer);
+    client.subscribe(nonPartitionedTopic, "consumer-3", consumer3);
     numberOfConsumers = 3;
+    ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+    consumer2.close();
+    consumer3.close();
+    numberOfConsumers = 0;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
     client.close();

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -148,7 +148,6 @@ TEST(ClientTest, testGetNumberOfReferences) {
     numberOfProducers = 0;
     ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
 
-
     // Consumer test
     uint64_t numberOfConsumers = 0;
 

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -115,31 +115,31 @@ TEST(ClientTest, testConnectTimeout) {
     clientDefault.close();
 }
 
-TEST(ClientTest, testGetNumberOfReferences){
-   Client client("pulsar://localhost:6650");
-   uint64_t numberOfProducers = 0;
-   
-   Producer producer;
-   client.createProducer("persistent://public/default/testGetNumberOfReferences", producer);
-   numberOfProducers = 1;
-   ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+TEST(ClientTest, testGetNumberOfReferences) {
+    Client client("pulsar://localhost:6650");
+    uint64_t numberOfProducers = 0;
 
-   producer.close();
-   numberOfProducers = 0;
-   ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+    Producer producer;
+    client.createProducer("persistent://public/default/testGetNumberOfReferences", producer);
+    numberOfProducers = 1;
+    ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
 
-   uint64_t numberOfConsumers = 0;
+    producer.close();
+    numberOfProducers = 0;
+    ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
 
-   Consumer consumer;
-   client.subscribe("persistent://public/default/testGetNumberOfReferences", "consumer-1", consumer);
-   numberOfConsumers = 1;
-   ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+    uint64_t numberOfConsumers = 0;
 
-   consumer.close();
-   numberOfConsumers = 0;
-   ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+    Consumer consumer;
+    client.subscribe("persistent://public/default/testGetNumberOfReferences", "consumer-1", consumer);
+    numberOfConsumers = 1;
+    ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
-   uint64_t numberOfReaders = 0;
-   ASSERT_EQ(numberOfReaders, client.getNumberOfReaders());
-   client.close();
+    consumer.close();
+    numberOfConsumers = 0;
+    ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+
+    uint64_t numberOfReaders = 0;
+    ASSERT_EQ(numberOfReaders, client.getNumberOfReaders());
+    client.close();
 }

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -114,3 +114,32 @@ TEST(ClientTest, testConnectTimeout) {
     clientLow.close();
     clientDefault.close();
 }
+
+TEST(ClientTest, testGetNumberOfReferences){
+   Client client("pulsar://localhost:6650");
+   uint64_t numberOfProducers = 0;
+   
+   Producer producer;
+   client.createProducer("persistent://public/default/testGetNumberOfReferences", producer);
+   numberOfProducers = 1;
+   ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+
+   producer.close();
+   numberOfProducers = 0;
+   ASSERT_EQ(numberOfProducers, client.getNumberOfProducers());
+
+   uint64_t numberOfConsumers = 0;
+
+   Consumer consumer;
+   client.subscribe("persistent://public/default/testGetNumberOfReferences", "consumer-1", consumer);
+   numberOfConsumers = 1;
+   ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+
+   consumer.close();
+   numberOfConsumers = 0;
+   ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
+
+   uint64_t numberOfReaders = 0;
+   ASSERT_EQ(numberOfReaders, client.getNumberOfReaders());
+   client.close();
+}

--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -139,7 +139,5 @@ TEST(ClientTest, testGetNumberOfReferences) {
     numberOfConsumers = 0;
     ASSERT_EQ(numberOfConsumers, client.getNumberOfConsumers());
 
-    uint64_t numberOfReaders = 0;
-    ASSERT_EQ(numberOfReaders, client.getNumberOfReaders());
     client.close();
 }


### PR DESCRIPTION


Fixes #11493 

Master Issue: #11493 

### Motivation
In Pulsar, we use a single client to create multiple producers/consumers/readers. Is there any method/attribute that can give information on number of producers/readers/consumers connected to the given pulsar client instance at the given point of time?

Say there is a single pulsar client instance. Multiple consumers and readers are created from the given client instance. This client needs to be cleaned up when all the references are closed. In this case, it would be of help, to get information on the number of the consumers/readers/ getPartitionsForTopic calls are active on the given client. Ie, having the number of references for the given client can provide information on whether it is fine to clean up the client instance at the given point of time.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Add these method to `Client.h`, `Client.cc`, `ClientImpl.h`, `CliemtImpl.cc` :
```
uint64_t getNumberOfProducer()
uint64_t getNumberOfConsumer()
uint64_t getNumberOfReader() (May not be used)
```
To count alive producers, I get each producer by weak point and check if it is connected.

### Verifying this change

This change added tests and can be verified as follows:

Add unit test to check if these functions can return correct references number. Test file is `ClientTest.cc`. Test function is `TEST(ClientTest, testGetNumberOfReferences)`.

### Documentation


For this PR, do we need to update docs?

I will add doc to C++ client part in follow-up issue.
