### PR TITLE
[docs] Fix error in documentation for brokerClientAuthenticationParameters

### DIFF
--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -75,7 +75,7 @@ superUserRoles=admin
 # Authentication settings of the broker itself. Used when the broker connects to other brokers, either in same or other clusters
 brokerClientTlsEnabled=true
 brokerClientAuthenticationPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
-brokerClientAuthenticationParameters={"tlsCertFile":"/path/my-ca/admin.cert.pem,tlsKeyFile:/path/my-ca/admin.key-pk8.pem"}
+brokerClientAuthenticationParameters={"tlsCertFile":"/path/my-ca/broker.cert.pem,tlsKeyFile:/path/my-ca/broker.key-pk8.pem"}
 brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 


### PR DESCRIPTION

### Motivation
Fixing an error in the documentation; brokerClientAuthenticationParameters should hold the parameters for the broker not the client. Updated to reflect that.
