### PR TITLE
Replace orElse with orElseGet to avoid calling too many times.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -417,7 +417,7 @@ public class PersistentTopics extends PersistentTopicsBase {
         preValidation(authoritative)
             .thenCompose(__ -> getTopicPoliciesAsyncWithRetry(topicName))
             .thenAccept(op -> {
-                TopicPolicies topicPolicies = op.orElse(new TopicPolicies());
+                TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 asyncResponse.resume(topicPolicies.getDeduplicationSnapshotIntervalSeconds());
             })
             .exceptionally(ex -> {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaHash.java
@@ -46,7 +46,7 @@ public class SchemaHash {
 
     public static SchemaHash of(Schema schema) {
         Optional<SchemaInfo> schemaInfo = Optional.ofNullable(schema).map(Schema::getSchemaInfo);
-        return of(schemaInfo.map(SchemaInfo::getSchema).orElse(new byte[0]),
+        return of(schemaInfo.map(SchemaInfo::getSchema).orElseGet(() -> new byte[0]),
                 schemaInfo.map(SchemaInfo::getType).orElse(null));
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -74,7 +74,7 @@ public class TopicSchema {
     public Schema<?> getSchema(String topic, Class<?> clazz, Optional<SchemaType> schemaType) {
         return cachedSchemas.computeIfAbsent(topic, key -> {
             // If schema type was not provided, try to get it from schema registry, or fallback to default types
-            SchemaType type = schemaType.orElse(getSchemaTypeOrDefault(topic, clazz));
+            SchemaType type = schemaType.orElseGet(() -> getSchemaTypeOrDefault(topic, clazz));
             return newSchemaInstance(clazz, type);
         });
     }

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
@@ -77,7 +77,7 @@ public class ZkBookieRackAffinityMapping extends AbstractDNSToSwitchMapping
         }
 
         try {
-            BookiesRackConfiguration racks = bookieMappingCache.get(BOOKIE_INFO_ROOT_PATH).orElse(new BookiesRackConfiguration());
+            BookiesRackConfiguration racks = bookieMappingCache.get(BOOKIE_INFO_ROOT_PATH).orElseGet(BookiesRackConfiguration::new);
             updateRacksWithHost(racks);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -185,7 +185,7 @@ public class ZkBookieRackAffinityMapping extends AbstractDNSToSwitchMapping
         try {
             // Trigger load of z-node in case it didn't exist
             Optional<BookiesRackConfiguration> racks = bookieMappingCache.get(BOOKIE_INFO_ROOT_PATH);
-            updateRacksWithHost(racks.orElse(new BookiesRackConfiguration()));
+            updateRacksWithHost(racks.orElseGet(BookiesRackConfiguration::new));
             if (!racks.isPresent()) {
                 // since different placement policy will have different default rack,
                 // don't be smart here and just return null


### PR DESCRIPTION
### Motivation
Use orElseGet when `orElse(xxx)` is not a raw value, otherwise it will calling the value every time.

### Documentation
This is an enhancement, no need to update doc.
