### PR TITLE
add test for auto-created partitioned system topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.systopic;
+
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.common.events.EventsTopicNames;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class PartitionedSystemTopicTest extends BrokerTestBase {
+
+    static final int PARTITIONS = 5;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        resetConfig();
+        conf.setAllowAutoTopicCreation(false);
+        conf.setAllowAutoTopicCreationType("partitioned");
+        conf.setDefaultNumPartitions(PARTITIONS);
+
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testAutoCreatedPartitionedSystemTopic() throws Exception {
+        final String ns = "prop/ns-test";
+        admin.namespaces().createNamespace(ns, 2);
+        NamespaceEventsSystemTopicFactory systemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
+        TopicPoliciesSystemTopicClient systemTopicClientForNamespace = systemTopicFactory
+                .createTopicPoliciesSystemTopicClient(NamespaceName.get(ns));
+        SystemTopicClient.Reader reader = systemTopicClientForNamespace.newReader();
+
+        int partitions = admin.topics().getPartitionedTopicMetadata(
+                String.format("persistent://%s/%s", ns, EventsTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)).partitions;
+        Assert.assertEquals(admin.topics().getPartitionedTopicList(ns).size(), 1);
+        Assert.assertEquals(partitions, PARTITIONS);
+        Assert.assertEquals(admin.topics().getList(ns).size(), PARTITIONS);
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/events/EventsTopicNames.java
@@ -45,12 +45,6 @@ public class EventsTopicNames {
             Collections.unmodifiableSet(Sets.newHashSet(NAMESPACE_EVENTS_LOCAL_NAME, TRANSACTION_BUFFER_SNAPSHOT));
 
     public static boolean checkTopicIsEventsNames(TopicName topicName) {
-        String name;
-        if (topicName.isPartitioned()) {
-            name = TopicName.get(topicName.getPartitionedTopicName()).getLocalName();
-        } else {
-            name = topicName.getLocalName();
-        }
-        return EVENTS_TOPIC_NAMES.contains(name);
+        return EVENTS_TOPIC_NAMES.contains(TopicName.get(topicName.getPartitionedTopicName()).getLocalName());
     }
 }


### PR DESCRIPTION
### Motivations
When I tried to enable topic-level policy, I found that the tests for interacting with partitioned system topic (e.g. `__change_events`) was not very sufficient, so I added a test for using auto-created partitioned system topic.

### Modifications
- add a test for partitioned system topic
- make a small optimization in `EventsTopicNames#checkTopicIsEventsNames` to avoid unnecessary inspections (based on #10850 )