### PR TITLE
[website]Update website docker image version

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -27,7 +27,7 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pulsar-client-cpp
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
-BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-py2-website}"
+BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-16.04-pb3-website}"
 
 IMAGE="$BUILD_IMAGE_NAME:$BUILD_IMAGE_VERSION"
 


### PR DESCRIPTION



### Motivation

Fixed https://github.com/apache/pulsar/runs/3230519747?check_suite_focus=true 

```
/pulsar/pulsar-client-cpp/lib/ProtobufNativeSchema.cc: In function 'pulsar::SchemaInfo pulsar::createProtobufNativeSchema(const google::protobuf::Descriptor*)':
/pulsar/pulsar-client-cpp/lib/ProtobufNativeSchema.cc:51:47: error: 'class google::protobuf::FileDescriptorSet' has no member named 'ByteSizeLong'
     std::vector<char> bytes(fileDescriptorSet.ByteSizeLong());
                                               ^
lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/build.make:1797: recipe for target 'lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o' failed
make[3]: *** [lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/ProtobufNativeSchema.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/all] Error 2
CMakeFiles/Makefile2:151: recipe for target 'lib/CMakeFiles/PULSAR_OBJECT_LIB.dir/all' failed
make[1]: *** [python/CMakeFiles/_pulsar.dir/rule] Error 2
make: *** [_pulsar] Error 2
CMakeFiles/Makefile2:310: recipe for target 'python/CMakeFiles/_pulsar.dir/rule' failed
Makefile:227: recipe for target '_pulsar' failed
Error: Process completed with exit code 2.

```

### Modifications

* Update Docker image

### Verifying this change

Local test pass

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

#### For contributor

For this PR, do we need to update docs?

- If yes, please update docs or create a follow-up issue if you need help.
  
- If no, please explain why.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

