### PR TITLE
Fix data lost when using earliest position to subscribe to a topic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -899,7 +899,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         final ManagedCursorImpl cursor = new ManagedCursorImpl(bookKeeper, config, this, cursorName);
         CompletableFuture<ManagedCursor> cursorFuture = new CompletableFuture<>();
         uninitializedCursors.put(cursorName, cursorFuture);
-        cursor.initialize(getLastPosition(), properties, new VoidCallback() {
+        PositionImpl position = InitialPosition.Earliest == initialPosition ? getFirstPosition() : getLastPosition();
+        cursor.initialize(position, properties, new VoidCallback() {
             @Override
             public void operationComplete() {
                 log.info("[{}] Opened new cursor: {}", name, cursor);


### PR DESCRIPTION
When subscribing to a topic with earliest position, the ManagedLedger always using
the last position to init the cursor. If the no cursor update happens and the broker restarts
or topic been unloaded or the topic ownership changed, will lead to the data lost, the unacked messages
will not redeliver to the consumer again.

The root cause is if we are using the last position to init the cursor, the cursor will update the
mark delete position as the last position first to the Zookeeper, if the cursor can't a chance to
update the mark delete position again before been closed, when recoving the cursor again, will using
the mark delete posiion that stored in the Zookeeper, so the issue happens.

The fix is to add check for the initial position of the cursor, if we are using the Earliest as the initial position,
use the first position to init the cursor.

The new added test can cover the changes, and without this change, the test would failed.

