### PR TITLE
[Offload] Add offload performance metrics for tiered storage.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -214,6 +214,13 @@ public interface LedgerOffloader {
     OffloadPoliciesImpl getOffloadPolicies();
 
     /**
+     * Get offload stats.
+     *
+     * @return the ledger offloader MBean
+     */
+    LedgerOffloaderMXBean getStats();
+
+    /**
      * Close the resources if necessary
      */
     void close();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderMXBean.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderMXBean.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.common.annotation.InterfaceAudience;
+import org.apache.bookkeeper.common.annotation.InterfaceStability;
+import org.apache.bookkeeper.mledger.util.StatsBuckets;
+import org.apache.pulsar.common.stats.Rate;
+
+
+/**
+ * Management Bean for a {@link LedgerOffloader}.
+ */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Stable
+public interface LedgerOffloaderMXBean {
+
+    /**
+     * The ledger offloader name.
+     *
+     * @return ledger offloader name.
+     */
+    String getDriverName();
+
+
+    /**
+     * Refresh offloader stats.
+     *
+     */
+    void refreshStats(long period, TimeUnit unit);
+
+
+
+    /**
+     * Record the offload total time.
+     *
+     * @return offload time per topic.
+     */
+    Map<String, Rate> getOffloadTimes();
+
+    /**
+     * Record the offload error count.
+     *
+     * @return offload errors per topic.
+     */
+    Map<String, Rate> getOffloadErrors();
+
+    /**
+     * Record the offload rate to storage.
+     *
+     * @return offload rate per topic.
+     */
+    Map<String, Rate> getOffloadRates();
+
+
+    /**
+     * Record the read ledger latency.
+     *
+     * @return read ledger latency per topic.
+     */
+    Map<String, StatsBuckets> getReadLedgerLatencyBuckets();
+
+    /**
+     * Record the write latency to tiered storage.
+     *
+     * @return write to storage latency per topic.
+     */
+    Map<String, StatsBuckets> getWriteToStorageLatencyBuckets();
+
+    /**
+     * Record the write to storage error count.
+     *
+     * @return write to storage errors per topic.
+     */
+    Map<String, Rate> getWriteToStorageErrors();
+
+    /**
+     * Record read offload index latency.
+     *
+     * @return read offload index latency per topic.
+     */
+    Map<String, StatsBuckets> getReadOffloadIndexLatencyBuckets();
+
+    /**
+     * Record read offload data latency.
+     *
+     * @return read offload data latency per topic.
+     */
+    Map<String, StatsBuckets> getReadOffloadDataLatencyBuckets();
+
+    /**
+     * Record read offload method rate.
+     *
+     * @return read offload data rate.
+     */
+    Map<String, Rate> getReadOffloadRates();
+
+    /**
+     * Record read offload error count.
+     *
+     * @return read offload data errors.
+     */
+    Map<String, Rate> getReadOffloadErrors();
+
+    /**
+     * Record streaming read offload method rate.
+     *
+     * @return streaming write to storage rate per topic.
+     */
+    Map<String, Rate> getStreamingWriteToStorageRates();
+
+    /**
+     * Record streaming read offload error count.
+     *
+     * @return streaming write to storage errors per topic.
+     */
+    Map<String, Rate> getStreamingWriteToStorageErrors();
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderMXBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderMXBeanImpl.java
@@ -1,0 +1,305 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
+import org.apache.bookkeeper.mledger.util.StatsBuckets;
+import org.apache.pulsar.common.stats.Rate;
+
+public class LedgerOffloaderMXBeanImpl implements LedgerOffloaderMXBean {
+
+    public static final long[] READ_ENTRY_LATENCY_BUCKETS_USEC = {500, 1_000, 5_000, 10_000, 20_000, 50_000, 100_000,
+            200_000, 1000_000};
+
+    private static final long OUT_DATED_CLEAN_PERIOD_MILLISECOND = 10 * 60 * 1000;
+
+    private final String driverName;
+
+    private Map<String, Long> topicAccessTime;
+
+    // offloadTimeMap record the time cost by one round offload
+    private final ConcurrentHashMap<String, Rate> offloadTimeMap = new ConcurrentHashMap<>();
+    // offloadErrorMap record error ocurred
+    private final ConcurrentHashMap<String, Rate> offloadErrorMap = new ConcurrentHashMap<>();
+    // offloadRateMap record the offload rate
+    private final ConcurrentHashMap<String, Rate> offloadRateMap = new ConcurrentHashMap<>();
+
+
+    // readLedgerLatencyBucketsMap record the time cost by ledger read
+    private final ConcurrentHashMap<String, StatsBuckets> readLedgerLatencyBucketsMap = new ConcurrentHashMap<>();
+    // writeToStorageLatencyBucketsMap record the time cost by write to storage
+    private final ConcurrentHashMap<String, StatsBuckets> writeToStorageLatencyBucketsMap = new ConcurrentHashMap<>();
+    // writeToStorageErrorMap record the error occurred in write storage
+    private final ConcurrentHashMap<String, Rate> writeToStorageErrorMap = new ConcurrentHashMap<>();
+
+
+    // streamingWriteToStorageRateMap and streamingWriteToStorageErrorMap is for streamingOffload
+    private final ConcurrentHashMap<String, Rate> streamingWriteToStorageRateMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Rate> streamingWriteToStorageErrorMap = new ConcurrentHashMap<>();
+
+    // readOffloadIndexLatencyBucketsMap and readOffloadDataLatencyBucketsMap are latency metrics about index and data
+    // readOffloadDataRateMap and readOffloadErrorMap is for reading offloaded data
+    private final ConcurrentHashMap<String, StatsBuckets> readOffloadIndexLatencyBucketsMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, StatsBuckets> readOffloadDataLatencyBucketsMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Rate> readOffloadDataRateMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Rate> readOffloadErrorMap = new ConcurrentHashMap<>();
+
+    public LedgerOffloaderMXBeanImpl(String driverName) {
+        this.driverName = driverName;
+        topicAccessTime = new ConcurrentHashMap<>();
+    }
+
+    private void accessTopic(String topicName) {
+        topicAccessTime.compute(topicName, (k, v) -> new Long(System.currentTimeMillis()));
+    }
+
+    private void removeOutdatedTopicMetricsIfNeeded() {
+        Iterator<Map.Entry<String, Long>> it = topicAccessTime.entrySet().iterator();
+        while (it.hasNext()) {
+            Long lastAccess = it.next().getValue();
+            if (System.currentTimeMillis() > lastAccess + OUT_DATED_CLEAN_PERIOD_MILLISECOND) {
+                removeTopicIfExist(it.next().getKey());
+                it.remove();
+            }
+        }
+    }
+
+    public void refreshStats(long period, TimeUnit unit) {
+        double seconds = unit.toMillis(period) / 1000.0;
+        if (seconds <= 0.0) {
+            // skip refreshing stats
+            return;
+        }
+        offloadTimeMap.values().forEach(rate->rate.calculateRate(seconds));
+        offloadErrorMap.values().forEach(rate->rate.calculateRate(seconds));
+        offloadRateMap.values().forEach(rate-> rate.calculateRate(seconds));
+        readLedgerLatencyBucketsMap.values().forEach(stat-> stat.refresh());
+        writeToStorageLatencyBucketsMap.values().forEach(stat -> stat.refresh());
+        writeToStorageErrorMap.values().forEach(rate->rate.calculateRate(seconds));
+        streamingWriteToStorageRateMap.values().forEach(rate -> rate.calculateRate(seconds));
+        streamingWriteToStorageErrorMap.values().forEach(rate->rate.calculateRate(seconds));
+        readOffloadDataRateMap.values().forEach(rate->rate.calculateRate(seconds));
+        readOffloadErrorMap.values().forEach(rate->rate.calculateRate(seconds));
+        readOffloadIndexLatencyBucketsMap.values().forEach(stat->stat.refresh());
+        readOffloadDataLatencyBucketsMap.values().forEach(stat->stat.refresh());
+
+        removeOutdatedTopicMetricsIfNeeded();
+    }
+
+    @Override
+    public String getDriverName() {
+        return this.driverName;
+    }
+
+    @Override
+    public Map<String, Rate> getOffloadTimes() {
+        return offloadTimeMap;
+    }
+
+    @Override
+    public Map<String, Rate> getOffloadErrors() {
+        return offloadErrorMap;
+    }
+
+    @Override
+    public Map<String, Rate> getOffloadRates() {
+        return offloadRateMap;
+    }
+
+    @Override
+    public Map<String, StatsBuckets> getReadLedgerLatencyBuckets() {
+        return readLedgerLatencyBucketsMap;
+    }
+
+    @Override
+    public Map<String, StatsBuckets> getWriteToStorageLatencyBuckets() {
+        return writeToStorageLatencyBucketsMap;
+    }
+
+    @Override
+    public Map<String, Rate> getWriteToStorageErrors() {
+        return writeToStorageErrorMap;
+    }
+
+    @Override
+    public Map<String, Rate> getStreamingWriteToStorageRates() {
+        return streamingWriteToStorageRateMap;
+    }
+
+    @Override
+    public Map<String, Rate> getStreamingWriteToStorageErrors() {
+        return streamingWriteToStorageErrorMap;
+    }
+
+    public void removeTopicIfExist(String topicName) {
+        offloadTimeMap.remove(topicName);
+        offloadErrorMap.remove(topicName);
+        offloadRateMap.remove(topicName);
+        readLedgerLatencyBucketsMap.remove(topicName);
+        writeToStorageLatencyBucketsMap.remove(topicName);
+        writeToStorageErrorMap.remove(topicName);
+        streamingWriteToStorageRateMap.remove(topicName);
+        streamingWriteToStorageErrorMap.remove(topicName);
+        readOffloadDataRateMap.remove(topicName);
+        readOffloadErrorMap.remove(topicName);
+        readOffloadIndexLatencyBucketsMap.remove(topicName);
+        readOffloadDataLatencyBucketsMap.remove(topicName);
+    }
+
+
+    @Override
+    public Map<String, StatsBuckets> getReadOffloadIndexLatencyBuckets() {
+        return readOffloadIndexLatencyBucketsMap;
+    }
+
+    @Override
+    public Map<String, StatsBuckets> getReadOffloadDataLatencyBuckets() {
+        return readOffloadDataLatencyBucketsMap;
+    }
+
+    @Override
+    public Map<String, Rate> getReadOffloadRates() {
+        return readOffloadDataRateMap;
+    }
+
+    @Override
+    public Map<String, Rate> getReadOffloadErrors() {
+        return readOffloadErrorMap;
+    }
+
+
+    public void recordOffloadTime(String topicName, long time, TimeUnit unit) {
+        if (topicName == null) {
+            return;
+        }
+        Rate adder = offloadTimeMap.computeIfAbsent(topicName, k -> new Rate());
+        adder.recordEvent(unit.toMillis(time));
+        accessTopic(topicName);
+    }
+
+    public void recordOffloadError(String topicName) {
+        if (topicName == null) {
+            return;
+        }
+        Rate adder = offloadErrorMap.computeIfAbsent(topicName, k -> new Rate());
+        adder.recordEvent(1);
+        accessTopic(topicName);
+    }
+
+    public void recordOffloadRate(String topicName, int size) {
+        if (topicName == null) {
+            return;
+        }
+        Rate rate = offloadRateMap.computeIfAbsent(topicName, k -> new Rate());
+        rate.recordEvent(size);
+        accessTopic(topicName);
+    }
+
+    public void recordReadLedgerLatency(String topicName, long latency, TimeUnit unit) {
+        if (topicName == null) {
+            return;
+        }
+        StatsBuckets statsBuckets = readLedgerLatencyBucketsMap.computeIfAbsent(topicName,
+                k -> new StatsBuckets(READ_ENTRY_LATENCY_BUCKETS_USEC));
+        statsBuckets.addValue(unit.toMicros(latency));
+        accessTopic(topicName);
+    }
+
+    public void recordWriteToStorageLatency(String topicName, long latency, TimeUnit unit) {
+        if (topicName == null) {
+            return;
+        }
+        StatsBuckets statsBuckets = writeToStorageLatencyBucketsMap.computeIfAbsent(topicName,
+                k -> new StatsBuckets(READ_ENTRY_LATENCY_BUCKETS_USEC));
+        statsBuckets.addValue(unit.toMicros(latency));
+        accessTopic(topicName);
+    }
+
+    public void recordWriteToStorageError(String topicName) {
+        if (topicName == null) {
+            return;
+        }
+        Rate adder = writeToStorageErrorMap.computeIfAbsent(topicName, k -> new Rate());
+        adder.recordEvent(1);
+        accessTopic(topicName);
+    }
+
+    public void recordStreamingWriteToStorageRate(String topicName, int size) {
+        if (topicName == null) {
+            return;
+        }
+        Rate rate = streamingWriteToStorageRateMap.computeIfAbsent(topicName, k -> new Rate());
+        rate.recordEvent(size);
+        accessTopic(topicName);
+    }
+
+    public void recordStreamingWriteToStorageError(String topicName) {
+        if (topicName == null) {
+            return;
+        }
+        Rate adder = streamingWriteToStorageErrorMap.computeIfAbsent(topicName, k -> new Rate());
+        adder.recordEvent(1);
+        accessTopic(topicName);
+    }
+
+
+    public void recordReadOffloadError(String topicName) {
+        if (topicName == null) {
+            return;
+        }
+        Rate adder = readOffloadErrorMap.computeIfAbsent(topicName, k -> new Rate());
+        adder.recordEvent(1);
+        accessTopic(topicName);
+    }
+
+    public void recordReadOffloadRate(String topicName, int size) {
+        if (topicName == null) {
+            return;
+        }
+        Rate rate = readOffloadDataRateMap.computeIfAbsent(topicName, k -> new Rate());
+        rate.recordEvent(size);
+        accessTopic(topicName);
+    }
+
+    public void recordReadOffloadIndexLatency(String topicName, long latency, TimeUnit unit) {
+        if (topicName == null) {
+            return;
+        }
+        StatsBuckets statsBuckets = readOffloadIndexLatencyBucketsMap.computeIfAbsent(topicName,
+                k -> new StatsBuckets(READ_ENTRY_LATENCY_BUCKETS_USEC));
+        statsBuckets.addValue(unit.toMicros(latency));
+        accessTopic(topicName);
+    }
+
+    public void recordReadOffloadDataLatency(String topicName, long latency, TimeUnit unit) {
+        if (topicName == null) {
+            return;
+        }
+        StatsBuckets statsBuckets = readOffloadDataLatencyBucketsMap.computeIfAbsent(topicName,
+                k -> new StatsBuckets(READ_ENTRY_LATENCY_BUCKETS_USEC));
+        statsBuckets.addValue(unit.toMicros(latency));
+        accessTopic(topicName);
+    }
+
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -26,8 +26,10 @@ import com.google.common.collect.Maps;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,6 +52,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -74,6 +77,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -240,14 +244,24 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         long period = now - lastStatTimestamp;
 
         mbean.refreshStats(period, TimeUnit.NANOSECONDS);
+        Set<LedgerOffloader> offloaders = new HashSet<>();
         ledgers.values().forEach(mlfuture -> {
             if (mlfuture.isDone() && !mlfuture.isCompletedExceptionally()) {
                 ManagedLedgerImpl ml = mlfuture.getNow(null);
                 if (ml != null) {
                     ml.mbean.refreshStats(period, TimeUnit.NANOSECONDS);
+
+                    // do metrics refresh for each offloader
+                    LedgerOffloader offloader = ml.getConfig().getLedgerOffloader();
+                    if (offloader != null && offloader != NullLedgerOffloader.INSTANCE && !offloaders.contains(offloader)) {
+                        offloaders.add(offloader);
+                        offloader.getStats().refreshStats(period, TimeUnit.NANOSECONDS);
+                    }
                 }
             }
         });
+
+        offloaders.clear();
 
         lastStatTimestamp = now;
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 
 /**
@@ -65,6 +66,11 @@ public class NullLedgerOffloader implements LedgerOffloader {
     @Override
     public OffloadPoliciesImpl getOffloadPolicies() {
         return null;
+    }
+
+    @Override
+    public LedgerOffloaderMXBean getStats() {
+        return new LedgerOffloaderMXBeanImpl("NullLedgerOffloader");
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
@@ -84,6 +85,11 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
                 OffloadPoliciesImpl.DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES,
                 OffloadPoliciesImpl.DEFAULT_OFFLOAD_DELETION_LAG_IN_MILLIS,
                 OffloadPoliciesImpl.DEFAULT_OFFLOADED_READ_PRIORITY);
+
+        @Override
+        public LedgerOffloaderMXBean getStats() {
+            return null;
+        }
 
         @Override
         public String getOffloadDriverName() {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
@@ -52,6 +52,7 @@ import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
@@ -248,6 +249,11 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         @Override
         public OffloadPoliciesImpl getOffloadPolicies() {
             return offloadPolicies;
+        }
+
+        @Override
+        public LedgerOffloaderMXBean getStats() {
+            return null;
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -40,6 +40,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -1046,6 +1047,11 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         @Override
         public OffloadPoliciesImpl getOffloadPolicies() {
             return offloadPolicies;
+        }
+
+        @Override
+        public LedgerOffloaderMXBean getStats() {
+            return null;
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
@@ -140,7 +140,6 @@ public class LedgerOffloaderMetrics extends AbstractMetrics {
                         statsBuckets.getBuckets(),
                         statsPeriodSeconds);
             }
-
             populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_readOffloadError",
                     (double) mbean.getReadOffloadErrors().getOrDefault(managedLedgerName, new Rate()).getCount());
             populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_readOffloadRate",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
@@ -152,12 +152,13 @@ public class LedgerOffloaderMetrics extends AbstractMetrics {
                     (double) mbean.getStreamingWriteToStorageErrors().
                             getOrDefault(managedLedgerName, new Rate()).getCount());
         } catch (Exception e) {
-            log.error("aggregate ledger offload metrics for topic: {} managedLedgerName {} failed ", topicName, managedLedgerName, e);
+            log.error("aggregate ledger offload metrics for topic: {} managedLedgerName {} failed ",
+                    topicName, managedLedgerName, e);
         } finally {
             return tempAggregatedMetricsMap;
         }
     }
-    
+
     /**
      * Aggregation by topic.
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.metrics;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
+import org.apache.bookkeeper.mledger.util.StatsBuckets;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.stats.Rate;
+
+@Slf4j
+public class LedgerOffloaderMetrics extends AbstractMetrics {
+    private final List<Metrics> metricsCollection;
+    private Map<String, Double> tempAggregatedMetricsMap;
+    private boolean isTopicLevel;
+    private String topicName;
+    private String nameSpace;
+    private int statsPeriodSeconds;
+
+    protected static final double[] WRITE_TO_STORAGE_BUCKETS_MS =
+            new double[LedgerOffloaderMXBeanImpl.READ_ENTRY_LATENCY_BUCKETS_USEC.length];
+
+    static {
+        for (int i = 0; i < LedgerOffloaderMXBeanImpl.READ_ENTRY_LATENCY_BUCKETS_USEC.length; i++) {
+            WRITE_TO_STORAGE_BUCKETS_MS[i] = LedgerOffloaderMXBeanImpl.READ_ENTRY_LATENCY_BUCKETS_USEC[i] / 1000.0;
+        }
+    }
+
+    private static final Buckets WRITE_TO_STORAGE_BUCKETS =
+            new Buckets("brk_ledgeroffloader_writeToStorageBuckets", WRITE_TO_STORAGE_BUCKETS_MS);
+
+    private static final Buckets READ_LEDGER_LATENCY_BUCKETS =
+            new Buckets("brk_ledgeroffloader_readLedgerLatencyBuckets", WRITE_TO_STORAGE_BUCKETS_MS);
+
+    private static final Buckets READ_OFFLOAD_INDEX_LATENCY_BUCKETS =
+            new Buckets("brk_readOffload_indexLatencyBuckets", WRITE_TO_STORAGE_BUCKETS_MS);
+
+    private static final Buckets READ_OFFLOAD_DATA_LATENCY_BUCKETS =
+            new Buckets("brk_readOffload_dataLatencyBuckets", WRITE_TO_STORAGE_BUCKETS_MS);
+
+    public LedgerOffloaderMetrics(PulsarService pulsar, boolean isTopicLevel, String nameSpace, String topicName) {
+        super(pulsar);
+        this.metricsCollection = Lists.newArrayList();
+        this.isTopicLevel = isTopicLevel;
+        this.nameSpace = nameSpace;
+        this.topicName = topicName;
+        this.tempAggregatedMetricsMap = Maps.newHashMap();
+        statsPeriodSeconds = ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+                .getConfig().getStatsPeriodSeconds();
+    }
+
+    @Override
+    public synchronized List<Metrics> generate() {
+            if (isTopicLevel) {
+                return aggregateInTopicLevel();
+            } else {
+                return aggregateByNameSpace();
+            }
+    }
+
+
+    private Map<String, Double> aggregate(Map<String, Double> tempAggregatedMetricsMap, String topicName) {
+        try {
+            Optional<Topic> existedTopic = pulsar.getBrokerService().getTopicIfExists(topicName).get();
+            if (!existedTopic.isPresent()) {
+                return tempAggregatedMetricsMap;
+            }
+            Topic topic = existedTopic.get();
+            if (!(topic instanceof PersistentTopic)) {
+                return tempAggregatedMetricsMap;
+            }
+
+            LedgerOffloader ledgerOffloader =
+                    ((PersistentTopic) topic).getManagedLedger().getConfig().getLedgerOffloader();
+            LedgerOffloaderMXBean mbean = ledgerOffloader.getStats();
+            if (ledgerOffloader == NullLedgerOffloader.INSTANCE || mbean == null) {
+                return tempAggregatedMetricsMap;
+            }
+
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_offloadError",
+                    (double) mbean.getOffloadErrors().getOrDefault(topicName, new Rate()).getCount());
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_offloadTime",
+                    mbean.getOffloadTimes().getOrDefault(topicName, new Rate()).getAverageValue());
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_writeRate",
+                    mbean.getOffloadRates().getOrDefault(topicName, new Rate()).getValueRate());
+
+
+            StatsBuckets statsBuckets = mbean.getReadLedgerLatencyBuckets().get(topicName);
+            if (statsBuckets != null) {
+                READ_LEDGER_LATENCY_BUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        statsBuckets.getBuckets(),
+                        statsPeriodSeconds);
+            }
+
+            statsBuckets = mbean.getWriteToStorageLatencyBuckets().get(topicName);
+            if (statsBuckets != null) {
+                WRITE_TO_STORAGE_BUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        statsBuckets.getBuckets(),
+                        statsPeriodSeconds);
+            }
+
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_writeError",
+                    (double) mbean.getWriteToStorageErrors().getOrDefault(topicName, new Rate()).getCount());
+
+            statsBuckets = mbean.getReadOffloadIndexLatencyBuckets().get(topicName);
+            if (statsBuckets != null) {
+                READ_OFFLOAD_INDEX_LATENCY_BUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        statsBuckets.getBuckets(),
+                        statsPeriodSeconds);
+            }
+
+            statsBuckets = mbean.getReadOffloadDataLatencyBuckets().get(topicName);
+            if (statsBuckets != null) {
+                READ_OFFLOAD_DATA_LATENCY_BUCKETS.populateBucketEntries(tempAggregatedMetricsMap,
+                        statsBuckets.getBuckets(),
+                        statsPeriodSeconds);
+            }
+
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_readOffloadError",
+                    (double) mbean.getReadOffloadErrors().getOrDefault(topicName, new Rate()).getCount());
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_readOffloadRate",
+                    mbean.getReadOffloadRates().getOrDefault(topicName, new Rate()).getValueRate());
+
+
+            // streaming offload
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_streamingWriteRate",
+                    mbean.getStreamingWriteToStorageRates().getOrDefault(topicName, new Rate()).getValueRate());
+            populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ledgeroffloader_streamingWriteError",
+                    (double) mbean.getStreamingWriteToStorageErrors().
+                            getOrDefault(topicName, new Rate()).getCount());
+        } catch (Exception e) {
+            log.error("aggregate ledger offload metrics for topic: " + topicName + " failed, ", e);
+        } finally {
+            return tempAggregatedMetricsMap;
+        }
+    }
+
+
+    /**
+     * Aggregation by topic.
+     *
+     * @return List<Metrics>
+     */
+    private List<Metrics> aggregateInTopicLevel() {
+        metricsCollection.clear();
+        tempAggregatedMetricsMap.clear();
+
+        Map<String, String> dimensionMap = Maps.newHashMap();
+        dimensionMap.put("namespace", TopicName.get(topicName).getNamespace());
+        dimensionMap.put("topic", topicName);
+
+        Metrics metrics = createMetrics(dimensionMap);
+
+        aggregate(tempAggregatedMetricsMap, topicName);
+
+        for (Entry<String, Double> ma : tempAggregatedMetricsMap.entrySet()) {
+            metrics.put(ma.getKey(), ma.getValue());
+        }
+
+        metricsCollection.add(metrics);
+
+        return metricsCollection;
+    }
+
+    /**
+     * Aggregation by namespace.
+     *
+     * @return List<Metrics>
+     */
+    private List<Metrics> aggregateByNameSpace() {
+        metricsCollection.clear();
+        tempAggregatedMetricsMap.clear();
+
+        Map<String, String> dimensionMap = Maps.newHashMap();
+        dimensionMap.put("namespace", nameSpace);
+
+        Metrics metrics = createMetrics(dimensionMap);
+
+        pulsar.getBrokerService().getMultiLayerTopicMap().get(nameSpace).forEach((bundle, topicsMap) -> {
+            topicsMap.forEach((topicName, topic) -> {
+                aggregate(tempAggregatedMetricsMap, topicName);
+            });
+        });
+
+        for (Entry<String, Double> ma : tempAggregatedMetricsMap.entrySet()) {
+            metrics.put(ma.getKey(), ma.getValue());
+        }
+        metricsCollection.add(metrics);
+
+        return metricsCollection;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/LedgerOffloaderMetrics.java
@@ -88,7 +88,6 @@ public class LedgerOffloaderMetrics extends AbstractMetrics {
             }
     }
 
-
     private Map<String, Double> aggregate(Map<String, Double> tempAggregatedMetricsMap, String topicName) {
         String managedLedgerName = "";
         try {
@@ -203,7 +202,6 @@ public class LedgerOffloaderMetrics extends AbstractMetrics {
             metrics.put(ma.getKey(), ma.getValue());
         }
         metricsCollection.add(metrics);
-
         return metricsCollection;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -154,9 +154,6 @@ public class PrometheusMetricsGenerator {
                                 List<Metrics> metrics =
                                         new LedgerOffloaderMetrics(pulsar, true, namespace, topicName).generate();
                                 metricList.addAll(metrics);
-                                log.info("topic:" + topic
-                                        + " generate ledger offloader topic level metrics succeed, size:"
-                                        + metrics.size());
                             } catch (Exception ex) {
                                 log.error("generate ledger offloader topic level metrics error", ex);
                             }
@@ -254,9 +251,9 @@ public class PrometheusMetricsGenerator {
                         continue;
                     }
                     stream.write(", ").write(metric.getKey()).write("=\"").write(metric.getValue()).write('"');
-                    if (value != null && !value.isEmpty()) {
-                        stream.write(", ").write("quantile=\"").write(value).write('"');
-                    }
+                }
+                if (value != null && !value.isEmpty()) {
+                    stream.write(", ").write("quantile=\"").write(value).write('"');
                 }
                 stream.write("} ").write(String.valueOf(entry.getValue()))
                         .write(' ').write(System.currentTimeMillis()).write("\n");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -58,6 +58,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -1314,6 +1315,11 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         @Override
         public OffloadPoliciesImpl getOffloadPolicies() {
             return offloadPolicies;
+        }
+
+        @Override
+        public LedgerOffloaderMXBean getStats() {
+            return null;
         }
 
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -1,0 +1,253 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import com.google.common.collect.Multimap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
+import org.apache.pulsar.common.util.SimpleTextOutputStream;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+
+
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+
+    public String convertByteBufToString(ByteBuf buf) {
+        String str;
+        if(buf.hasArray()) {
+            str = new String(buf.array(), buf.arrayOffset() + buf.readerIndex(), buf.readableBytes());
+        } else {
+            byte[] bytes = new byte[buf.readableBytes()];
+            buf.getBytes(buf.readerIndex(), bytes);
+            str = new String(bytes, 0, buf.readableBytes());
+        }
+        return str;
+    }
+
+    @Test(timeOut = 3000)
+    public void testTopicLevelMetrics() throws Exception {
+        String ns1 = "prop/ns-abc1";
+        admin.namespaces().createNamespace(ns1);
+
+        ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
+        SimpleTextOutputStream stream = new SimpleTextOutputStream(buf);
+
+        String []topics = new String[3];
+
+        LedgerOffloaderMXBeanImpl mbean = new LedgerOffloaderMXBeanImpl("test");
+        LedgerOffloader offloader = Mockito.mock(LedgerOffloader.class);
+        Topic topic = Mockito.mock(PersistentTopic.class);
+        CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
+        Optional<Topic> topicOptional = Optional.of(topic);
+        topicFuture.complete(topicOptional);
+        BrokerService brokerService = spy(pulsar.getBrokerService());
+        doReturn(brokerService).when(pulsar).getBrokerService();
+
+
+        for (int i = 0; i < 3; i++) {
+            String topicName = "persistent://prop/ns-abc1/testMetrics" + UUID.randomUUID();
+            topics[i] = topicName;
+            admin.topics().createNonPartitionedTopic(topicName);
+
+            doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
+            Assert.assertTrue(topic instanceof PersistentTopic);
+
+            ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
+            doReturn(ledgerM).when(((PersistentTopic) topic)).getManagedLedger();
+            ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
+            doReturn(config).when(ledgerM).getConfig();
+            doReturn(offloader).when(config).getLedgerOffloader();
+
+            Mockito.when(offloader.getStats()).thenReturn(mbean);
+
+            mbean.recordOffloadError(topicName);
+            mbean.recordOffloadError(topicName);
+            mbean.recordOffloadRate(topicName, 100);
+            mbean.recordOffloadTime(topicName, 10000000000L, TimeUnit.NANOSECONDS);
+            mbean.recordReadLedgerLatency(topicName, 1000, TimeUnit.NANOSECONDS);
+            mbean.recordReadOffloadError(topicName);
+            mbean.recordReadOffloadError(topicName);
+            mbean.recordReadOffloadIndexLatency(topicName, 1000000L, TimeUnit.NANOSECONDS);
+            mbean.recordReadOffloadRate(topicName, 100000);
+            mbean.recordStreamingWriteToStorageError(topicName);
+            mbean.recordStreamingWriteToStorageError(topicName);
+            mbean.recordStreamingWriteToStorageRate(topicName, 1000001);
+            mbean.recordWriteToStorageError(topicName);
+            mbean.recordWriteToStorageError(topicName);
+            mbean.recordWriteToStorageLatency(topicName, 20000, TimeUnit.NANOSECONDS);
+        }
+        mbean.refreshStats(1, TimeUnit.SECONDS);
+
+        Method parseMetricMethod = PrometheusMetricsGenerator.class.
+                getDeclaredMethod("generateLedgerOffloaderMetrics",
+                        PulsarService.class, SimpleTextOutputStream.class,
+                        boolean.class);
+        parseMetricMethod.setAccessible(true);
+        parseMetricMethod.invoke(null, pulsar, stream, true);
+
+
+        String metricsStr = convertByteBufToString(buf);
+//        System.out.println(metricsStr);
+        Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
+        String []metricName = new String[]{"pulsar_ledgeroffloader_writeError",
+                "pulsar_ledgeroffloader_offloadError", "pulsar_ledgeroffloader_readOffloadError",
+                "pulsar_ledgeroffloader_streamingWriteError"};
+        for (int s = 0; s < metricName.length; s++) {
+            Collection<PrometheusMetricsTest.Metric> metric = metrics.get(metricName[s]);
+            for (int i = 0; i < 3; i++) {
+                String namespace = ns1;
+                String topicName = topics[i];
+                LongAdder findNum = new LongAdder();
+                metric.forEach(item -> {
+                    if (namespace.equals(item.tags.get("namespace")) && topicName.equals(item.tags.get("topic"))) {
+                        Assert.assertTrue(item.value == 2);
+                        findNum.increment();
+                    }
+                });
+                Assert.assertTrue(findNum.intValue() == 1);
+            }
+        }
+    }
+
+    @Test(timeOut = 3000)
+    public void testNamespaceLevelMetrics() throws Exception {
+        String ns1 = "prop/ns-abc1";
+        String ns2 = "prop/ns-abc2";
+
+        ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
+        SimpleTextOutputStream stream = new SimpleTextOutputStream(buf);
+
+        String []topics = new String[6];
+
+        LedgerOffloaderMXBeanImpl mbean = new LedgerOffloaderMXBeanImpl("test");
+        LedgerOffloader offloader = Mockito.mock(LedgerOffloader.class);
+        Topic topic = Mockito.mock(PersistentTopic.class);
+        CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
+        Optional<Topic> topicOptional = Optional.of(topic);
+        topicFuture.complete(topicOptional);
+        BrokerService brokerService = spy(pulsar.getBrokerService());
+        doReturn(brokerService).when(pulsar).getBrokerService();
+
+        for (int s = 0; s < 2; s++) {
+            String nameSpace = ns1;
+            if (s == 1) {
+                nameSpace = ns2;
+            }
+            admin.namespaces().createNamespace(nameSpace);
+            String baseTopic1 = "persistent://" + nameSpace + "/testMetrics";
+            for (int i = 0; i < 6; i++) {
+                String topicName = baseTopic1 + UUID.randomUUID();
+                topics[i] = topicName;
+                admin.topics().createNonPartitionedTopic(topicName);
+                doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
+                Assert.assertTrue(topic instanceof PersistentTopic);
+
+
+                ManagedLedger ledgerM = Mockito.mock(ManagedLedger.class);
+                doReturn(ledgerM).when(((PersistentTopic) topic)).getManagedLedger();
+                ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
+                doReturn(config).when(ledgerM).getConfig();
+                doReturn(offloader).when(config).getLedgerOffloader();
+
+                Mockito.when(offloader.getStats()).thenReturn(mbean);
+
+                mbean.recordOffloadError(topicName);
+                mbean.recordOffloadRate(topicName, 100);
+                mbean.recordOffloadTime(topicName, 10000000000L, TimeUnit.NANOSECONDS);
+                mbean.recordReadLedgerLatency(topicName, 1000, TimeUnit.NANOSECONDS);
+                mbean.recordReadOffloadError(topicName);
+                mbean.recordReadOffloadIndexLatency(topicName, 1000000L, TimeUnit.NANOSECONDS);
+                mbean.recordReadOffloadRate(topicName, 100000);
+                mbean.recordStreamingWriteToStorageError(topicName);
+                mbean.recordStreamingWriteToStorageRate(topicName, 1000001);
+                mbean.recordWriteToStorageError(topicName);
+                mbean.recordWriteToStorageLatency(topicName, 20000, TimeUnit.NANOSECONDS);
+            }
+        }
+
+        mbean.refreshStats(1, TimeUnit.SECONDS);
+
+        Method parseMetricMethod = PrometheusMetricsGenerator.class.
+                getDeclaredMethod("generateLedgerOffloaderMetrics",
+                        PulsarService.class, SimpleTextOutputStream.class,
+                        boolean.class);
+        parseMetricMethod.setAccessible(true);
+        parseMetricMethod.invoke(null, pulsar, stream, false);
+
+
+        String metricsStr = convertByteBufToString(buf);
+        System.out.println(convertByteBufToString(buf));
+        Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
+        String []metricName = new String[]{"pulsar_ledgeroffloader_writeError",
+                "pulsar_ledgeroffloader_offloadError", "pulsar_ledgeroffloader_readOffloadError",
+                "pulsar_ledgeroffloader_streamingWriteError"};
+        for (int s = 0; s < metricName.length; s++) {
+            Collection<PrometheusMetricsTest.Metric> metric = metrics.get(metricName[s]);
+            for (int i = 0; i < 2; i++) {
+                String namespace = i == 1 ? ns2 : ns1;
+                LongAdder findNum = new LongAdder();
+                metric.forEach(item -> {
+                    if (namespace.equals(item.tags.get("namespace"))) {
+                        Assert.assertTrue(item.value == 6);
+                        findNum.increment();
+                    }
+                });
+                Assert.assertTrue(findNum.intValue() == 1);
+            }
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -110,6 +110,8 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
             ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
             doReturn(config).when(ledgerM).getConfig();
             doReturn(offloader).when(config).getLedgerOffloader();
+            doReturn(topicName).when(ledgerM).getName();
+
 
             Mockito.when(offloader.getStats()).thenReturn(mbean);
 
@@ -193,6 +195,7 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
                 topics[i] = topicName;
                 admin.topics().createNonPartitionedTopic(topicName);
                 doReturn(topicFuture).when(brokerService).getTopicIfExists(topicName);
+
                 Assert.assertTrue(topic instanceof PersistentTopic);
 
 
@@ -201,6 +204,7 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
                 ManagedLedgerConfig config = Mockito.mock(ManagedLedgerConfig.class);
                 doReturn(config).when(ledgerM).getConfig();
                 doReturn(offloader).when(config).getLedgerOffloader();
+                doReturn(topicName).when(ledgerM).getName();
 
                 Mockito.when(offloader.getStats()).thenReturn(mbean);
 

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
@@ -28,7 +28,7 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
-
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapFile;
@@ -36,11 +36,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.bookkeeper.mledger.offload.OffloadUtils.parseLedgerMetadata;
 
@@ -50,16 +52,25 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
     private final MapFile.Reader reader;
     private final long ledgerId;
     private final LedgerMetadata ledgerMetadata;
+    private final LedgerOffloaderMXBeanImpl mbean;
+    private final String managedLedgerName;
 
-    private FileStoreBackedReadHandleImpl(ExecutorService executor, MapFile.Reader reader, long ledgerId) throws IOException {
+    private FileStoreBackedReadHandleImpl(ExecutorService executor, MapFile.Reader reader, long ledgerId,
+                                          LedgerOffloaderMXBeanImpl mbean,
+                                          String managedLedgerName) throws IOException {
         this.ledgerId = ledgerId;
         this.executor = executor;
         this.reader = reader;
+        this.mbean = mbean;
+        this.managedLedgerName = managedLedgerName;
         LongWritable key = new LongWritable();
         BytesWritable value = new BytesWritable();
         try {
             key.set(FileSystemManagedLedgerOffloader.METADATA_KEY_INDEX);
+            long startReadIndexTime = System.nanoTime();
             reader.get(key, value);
+            mbean.recordReadOffloadIndexLatency(managedLedgerName,
+                    System.nanoTime() - startReadIndexTime, TimeUnit.NANOSECONDS);
             this.ledgerMetadata = parseLedgerMetadata(ledgerId, value.copyBytes());
         } catch (IOException e) {
             log.error("Fail to read LedgerMetadata for ledgerId {}",
@@ -76,7 +87,6 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
     @Override
     public LedgerMetadata getLedgerMetadata() {
         return ledgerMetadata;
-
     }
 
     @Override
@@ -106,7 +116,7 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                 return;
             }
             long entriesToRead = (lastEntry - firstEntry) + 1;
-            List<LedgerEntry> entries = new ArrayList<LedgerEntry>();
+            List<LedgerEntry> entries = new ArrayList<>();
             long nextExpectedId = firstEntry;
             LongWritable key = new LongWritable();
             BytesWritable value = new BytesWritable();
@@ -114,7 +124,10 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                 key.set(nextExpectedId - 1);
                 reader.seek(key);
                 while (entriesToRead > 0) {
+                    long startReadTime = System.nanoTime();
                     reader.next(key, value);
+                    mbean.recordReadOffloadDataLatency(managedLedgerName,
+                            System.nanoTime() - startReadTime, TimeUnit.NANOSECONDS);
                     int length = value.getLength();
                     long entryId = key.get();
                     if (entryId == nextExpectedId) {
@@ -123,14 +136,16 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                         buf.writeBytes(value.copyBytes());
                         entriesToRead--;
                         nextExpectedId++;
+                        mbean.recordReadOffloadRate(managedLedgerName, length);
                     } else if (entryId > lastEntry) {
                         log.info("Expected to read {}, but read {}, which is greater than last entry {}",
                                 nextExpectedId, entryId, lastEntry);
                         throw new BKException.BKUnexpectedConditionException();
                     }
-            }
+                }
                 promise.complete(LedgerEntriesImpl.create(entries));
             } catch (Throwable t) {
+                mbean.recordReadOffloadError(managedLedgerName);
                 promise.completeExceptionally(t);
                 entries.forEach(LedgerEntry::close);
             }
@@ -177,7 +192,8 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
         return promise;
     }
 
-    public static ReadHandle open(ScheduledExecutorService executor, MapFile.Reader reader, long ledgerId) throws IOException {
-            return new FileStoreBackedReadHandleImpl(executor, reader, ledgerId);
+    public static ReadHandle open(ScheduledExecutorService executor, MapFile.Reader reader, long ledgerId,
+                                  LedgerOffloaderMXBeanImpl mbean, String managedLedgerName) throws IOException {
+        return new FileStoreBackedReadHandleImpl(executor, reader, ledgerId, mbean, managedLedgerName);
     }
 }

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -21,11 +21,14 @@ package org.apache.bookkeeper.mledger.offload.filesystem.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.netty.util.Recycler;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.LedgerOffloaderMXBean;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
 import org.apache.bookkeeper.mledger.offload.filesystem.FileSystemLedgerOffloaderFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -46,6 +49,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.bookkeeper.mledger.offload.OffloadUtils.buildLedgerMetadataFormat;
@@ -65,6 +69,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     private static final long ENTRIES_PER_READ = 100;
     private OrderedScheduler assignmentScheduler;
     private OffloadPoliciesImpl offloadPolicies;
+    private LedgerOffloaderMXBeanImpl mbean;
 
     public static boolean driverSupported(String driver) {
         return DRIVER_NAMES.equals(driver);
@@ -107,6 +112,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(conf.getManagedLedgerOffloadMaxThreads())
                 .name("offload-assignment").build();
+        this.mbean = new LedgerOffloaderMXBeanImpl(driverName);
     }
 
     @VisibleForTesting
@@ -124,6 +130,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
                 .numThreads(conf.getManagedLedgerOffloadMaxThreads())
                 .name("offload-assignment").build();
+        this.mbean = new LedgerOffloaderMXBeanImpl(driverName);
     }
 
     @Override
@@ -140,7 +147,9 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     @Override
     public CompletableFuture<Void> offload(ReadHandle readHandle, UUID uuid, Map<String, String> extraMetadata) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
-        scheduler.chooseThread(readHandle.getId()).submit(new LedgerReader(readHandle, uuid, extraMetadata, promise, storageBasePath, configuration, assignmentScheduler, offloadPolicies.getManagedLedgerOffloadPrefetchRounds()));
+        scheduler.chooseThread(readHandle.getId()).submit(new LedgerReader(readHandle, uuid, extraMetadata, promise,
+                storageBasePath, configuration, assignmentScheduler,
+                offloadPolicies.getManagedLedgerOffloadPrefetchRounds(), mbean));
         return promise;
     }
 
@@ -155,9 +164,12 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         volatile Exception fileSystemWriteException = null;
         private OrderedScheduler assignmentScheduler;
         private int managedLedgerOffloadPrefetchRounds = 1;
+        private LedgerOffloaderMXBeanImpl mbean;
+        private long start;
 
         private LedgerReader(ReadHandle readHandle, UUID uuid, Map<String, String> extraMetadata, CompletableFuture<Void> promise,
-                             String storageBasePath, Configuration configuration, OrderedScheduler assignmentScheduler, int managedLedgerOffloadPrefetchRounds) {
+                             String storageBasePath, Configuration configuration, OrderedScheduler assignmentScheduler,
+                             int managedLedgerOffloadPrefetchRounds, LedgerOffloaderMXBeanImpl mbean) {
             this.readHandle = readHandle;
             this.uuid = uuid;
             this.extraMetadata = extraMetadata;
@@ -166,6 +178,8 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
             this.configuration = configuration;
             this.assignmentScheduler = assignmentScheduler;
             this.managedLedgerOffloadPrefetchRounds = managedLedgerOffloadPrefetchRounds;
+            this.mbean = mbean;
+            this.start = System.nanoTime();
         }
 
         @Override
@@ -198,7 +212,10 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                 do {
                     long end = Math.min(needToOffloadFirstEntryNumber + ENTRIES_PER_READ - 1, readHandle.getLastAddConfirmed());
                     log.debug("read ledger entries. start: {}, end: {}", needToOffloadFirstEntryNumber, end);
+                    long startReadTime = System.nanoTime();
                     LedgerEntries ledgerEntriesOnce = readHandle.readAsync(needToOffloadFirstEntryNumber, end).get();
+                    mbean.recordReadLedgerLatency(extraMetadata.get(MANAGED_LEDGER_NAME),
+                            System.nanoTime() - startReadTime, TimeUnit.NANOSECONDS);
                     semaphore.acquire();
                     countDownLatch = new CountDownLatch(1);
                     assignmentScheduler.chooseThread(ledgerId).submit(FileSystemWriter.create(ledgerEntriesOnce, dataWriter, semaphore,
@@ -210,6 +227,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                     throw fileSystemWriteException;
                 }
                 IOUtils.closeStream(dataWriter);
+                mbean.recordOffloadTime(extraMetadata.get(MANAGED_LEDGER_NAME), (System.nanoTime() - start), TimeUnit.NANOSECONDS);
                 promise.complete(null);
             } catch (Exception e) {
                 log.error("Exception when get CompletableFuture<LedgerEntries> : ManagerLedgerName: {}, " +
@@ -217,6 +235,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
+                mbean.recordOffloadError(extraMetadata.get(MANAGED_LEDGER_NAME));
                 promise.completeExceptionally(e);
             }
         }
@@ -258,8 +277,9 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         }
 
 
-        public static FileSystemWriter create(LedgerEntries ledgerEntriesOnce, MapFile.Writer dataWriter, Semaphore semaphore,
-                                              CountDownLatch countDownLatch, AtomicLong haveOffloadEntryNumber, LedgerReader ledgerReader) {
+        public static FileSystemWriter create(LedgerEntries ledgerEntriesOnce, MapFile.Writer dataWriter,
+                                              Semaphore semaphore, CountDownLatch countDownLatch,
+                                              AtomicLong haveOffloadEntryNumber, LedgerReader ledgerReader) {
             FileSystemWriter writer = RECYCLER.get();
             writer.ledgerReader = ledgerReader;
             writer.dataWriter = dataWriter;
@@ -272,7 +292,9 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
 
         @Override
         public void run() {
+            String managedLedgerName = ledgerReader.extraMetadata.get(MANAGED_LEDGER_NAME);
             if (ledgerReader.fileSystemWriteException == null) {
+                long start = System.nanoTime();
                 Iterator<LedgerEntry> iterator = ledgerEntriesOnce.iterator();
                 while (iterator.hasNext()) {
                     LedgerEntry entry = iterator.next();
@@ -283,10 +305,14 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
                         dataWriter.append(key, value);
                     } catch (IOException e) {
                         ledgerReader.fileSystemWriteException = e;
+                        ledgerReader.mbean.recordWriteToStorageError(managedLedgerName);
                         break;
                     }
                     haveOffloadEntryNumber.incrementAndGet();
+                    ledgerReader.mbean.recordOffloadRate(managedLedgerName, entry.getEntryBytes().length);
                 }
+                long writeEntryTimeInNs = System.nanoTime() - start;
+                ledgerReader.mbean.recordWriteToStorageLatency(managedLedgerName, writeEntryTimeInNs, TimeUnit.NANOSECONDS);
             }
             countDownLatch.countDown();
             ledgerEntriesOnce.close();
@@ -297,7 +323,6 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
 
     @Override
     public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid, Map<String, String> offloadDriverMetadata) {
-
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
         String storagePath = getStoragePath(storageBasePath, offloadDriverMetadata.get(MANAGED_LEDGER_NAME));
         String dataFilePath = getDataFilePath(storagePath, ledgerId, uuid);
@@ -305,7 +330,8 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
             try {
                 MapFile.Reader reader = new MapFile.Reader(new Path(dataFilePath),
                         configuration);
-                promise.complete(FileStoreBackedReadHandleImpl.open(scheduler.chooseThread(ledgerId), reader, ledgerId));
+                promise.complete(FileStoreBackedReadHandleImpl.open(scheduler.chooseThread(ledgerId), reader, ledgerId,
+                        mbean, offloadDriverMetadata.get(MANAGED_LEDGER_NAME)));
             } catch (Throwable t) {
                 log.error("Failed to open FileStoreBackedReadHandleImpl: ManagerLedgerName: {}, " +
                         "LegerId: {}, UUID: {}", offloadDriverMetadata.get(MANAGED_LEDGER_NAME), ledgerId, uuid, t);
@@ -341,6 +367,11 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     @Override
     public OffloadPoliciesImpl getOffloadPolicies() {
         return offloadPolicies;
+    }
+
+    @Override
+    public LedgerOffloaderMXBean getStats() {
+        return mbean;
     }
 
     @Override

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
@@ -27,6 +27,7 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
 import org.apache.bookkeeper.mledger.offload.filesystem.FileStoreTestBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -38,6 +39,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -76,6 +78,7 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
                 .withPassword("foobar".getBytes()).withDigestType(DigestType.CRC32).execute().get();
     }
 
+
     @Test
     public void testOffloadAndRead() throws Exception {
         LedgerOffloader offloader = fileSystemManagedLedgerOffloader;
@@ -109,6 +112,35 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
             assertEquals(toWriteEntry.getLength(), toTestEntry.getLength());
             assertEquals(toWriteEntry.getEntryBuffer(), toTestEntry.getEntryBuffer());
         }
+    }
+
+    @Test
+    public void testOffloadAndReadMetrics() throws Exception {
+        LedgerOffloader offloader = fileSystemManagedLedgerOffloader;
+        UUID uuid = UUID.randomUUID();
+        offloader.offload(toWrite, uuid, map).get();
+
+        LedgerOffloaderMXBeanImpl mbean = (LedgerOffloaderMXBeanImpl)offloader.getStats();
+        mbean.refreshStats(5, TimeUnit.SECONDS);
+        assertTrue(mbean.getOffloadErrors().get(topic) == null);
+        assertTrue(mbean.getOffloadTimes().get(topic).getAverageValue() > 0);
+        assertTrue(mbean.getOffloadRates().get(topic).getRate() > 0 );
+        assertTrue(mbean.getReadLedgerLatencyBuckets().get(topic).getCount() > 0);
+        assertTrue(mbean.getWriteToStorageErrors().get(topic) == null);
+        assertTrue(mbean.getWriteToStorageLatencyBuckets().get(topic).getCount() > 0);
+
+
+        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, map).get();
+        LedgerEntries toTestEntries = toTest.read(0, numberOfEntries - 1);
+        Iterator<LedgerEntry> toTestIter = toTestEntries.iterator();
+        while(toTestIter.hasNext()) {
+            LedgerEntry toTestEntry = toTestIter.next();
+        }
+        mbean.refreshStats(5, TimeUnit.SECONDS);
+        assertTrue(mbean.getReadOffloadErrors().get(topic) == null);
+        assertTrue(mbean.getReadOffloadRates().get(topic).getCount() > 0);
+        assertTrue(mbean.getReadOffloadDataLatencyBuckets().get(topic).getCount() > 0);
+        assertTrue(mbean.getReadOffloadIndexLatencyBuckets().get(topic).getCount() > 0);
     }
 
     @Test

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -21,6 +21,8 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
 import org.apache.bookkeeper.mledger.offload.jcloud.BackedInputStream;
 import org.apache.bookkeeper.mledger.offload.jcloud.impl.DataBlockUtils.VersionCheck;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -40,6 +42,8 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
     private final ByteBuf buffer;
     private final long objectLen;
     private final int bufferSize;
+    private LedgerOffloaderMXBeanImpl mbean;
+    private String managedLedgerName;
 
     private long cursor;
     private long bufferOffsetStart;
@@ -59,6 +63,15 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
         this.bufferOffsetStart = this.bufferOffsetEnd = -1;
     }
 
+    public BlobStoreBackedInputStreamImpl(BlobStore blobStore, String bucket, String key,
+                                          VersionCheck versionCheck,
+                                          long objectLen, int bufferSize,
+                                          LedgerOffloaderMXBeanImpl mbean, String managedLedgerName) {
+        this(blobStore, bucket, key, versionCheck, objectLen, bufferSize);
+        this.mbean = mbean;
+        this.managedLedgerName = managedLedgerName;
+    }
+
     /**
      * Refill the buffered input if it is empty.
      * @return true if there are bytes to read, false otherwise
@@ -73,7 +86,12 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
                                      objectLen - 1);
 
             try {
+                long startReadTime = System.nanoTime();
                 Blob blob = blobStore.getBlob(bucket, key, new GetOptions().range(startRange, endRange));
+                if (mbean != null) {
+                    mbean.recordReadOffloadDataLatency(managedLedgerName,
+                            System.nanoTime() - startReadTime, TimeUnit.NANOSECONDS);
+                }
                 versionCheck.check(key, blob);
 
                 try (InputStream stream = blob.getPayload().openStream()) {

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlockAwareSegmentInputStreamImpl.java
@@ -27,9 +27,11 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.mledger.impl.LedgerOffloaderMXBeanImpl;
 import org.apache.bookkeeper.mledger.offload.jcloud.BlockAwareSegmentInputStream;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.slf4j.Logger;
@@ -65,6 +67,8 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
     static final int ENTRY_HEADER_SIZE = 4 /* entry size */ + 8 /* entry id */;
     // Keep a list of all entries ByteBuf, each ByteBuf contains 2 buf: entry header and entry content.
     private List<ByteBuf> entriesByteBuf = null;
+    private LedgerOffloaderMXBeanImpl mbean = null;
+    private String ledgerNameForMetrics = null;
 
     public BlockAwareSegmentInputStreamImpl(ReadHandle ledger, long startEntryId, int blockSize) {
         this.ledger = ledger;
@@ -74,6 +78,12 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
         this.blockEntryCount = 0;
         this.dataBlockFullOffset = blockSize;
         this.entriesByteBuf = Lists.newLinkedList();
+    }
+
+    public BlockAwareSegmentInputStreamImpl(ReadHandle ledger, long startEntryId, int blockSize, LedgerOffloaderMXBeanImpl mbean, String ledgerName) {
+        this(ledger, startEntryId, blockSize);
+        this.mbean = mbean;
+        this.ledgerNameForMetrics = ledgerName;
     }
 
     // read ledger entries.
@@ -113,9 +123,15 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
 
     private List<ByteBuf> readNextEntriesFromLedger(long start, long maxNumberEntries) throws IOException {
         long end = Math.min(start + maxNumberEntries - 1, ledger.getLastAddConfirmed());
+        long startTime = System.nanoTime();
         try (LedgerEntries ledgerEntriesOnce = ledger.readAsync(start, end).get()) {
-            log.debug("read ledger entries. start: {}, end: {}", start, end);
-
+            if(log.isDebugEnabled()) {
+                log.debug("read ledger entries. start: {}, end: {} cost {}", start, end,
+                        TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - startTime));
+            }
+            if (mbean != null && ledgerNameForMetrics != null) {
+                mbean.recordReadLedgerLatency(ledgerNameForMetrics, System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            }
             List<ByteBuf> entries = Lists.newLinkedList();
 
             Iterator<LedgerEntry> iterator = ledgerEntriesOnce.iterator();

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfiguration.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/provider/TieredStorageConfiguration.java
@@ -71,6 +71,7 @@ public class TieredStorageConfiguration {
     public static final long DEFAULT_MIN_SEGMENT_TIME_IN_SECOND = 0;
     public static final String MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES = "maxOffloadSegmentSizeInBytes";
     public static final long DEFAULT_MAX_SEGMENT_SIZE_IN_BYTES = 1024 * 1024 * 1024;
+    public static final long DEFAULT_REFRESH_STATS_INTERVAL = 60L;
 
     protected static final int MB = 1024 * 1024;
 


### PR DESCRIPTION

### Motivation
Currently, there is no offload metrics for tiered storage, so it is very hard for us to debug the performance issues. For example , we can not find why offload is slow or why read offload is slow.  For above reasons.  we need to add some  offload metrics for monitoring.  

### Modifications
Add metrics during offload procedure and read offload data procedure. Including offloadTime, offloadError, offloadRate, readLedgerLatency, writeStoreLatency, writeStoreError, readOffloadIndexLatency, readOffloadDataLatency, readOffloadRate, readOffloadError. 

### Documentation

need  documentation.    
