### PR TITLE
[WIP]Add metrics for compacted topic

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1012,6 +1012,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean enableNamespaceIsolationUpdateOnTime = false;
 
+    @FieldContext(minValue = 1,
+            category = CATEGORY_SERVER,
+            doc = "How frequently to refresh the compactor metrics. (seconds). Default is 60 seconds")
+    private int compactorMetricsRefreshIntervalSeconds = 60;
+
     /***** --- TLS --- ****/
     @FieldContext(
         category = CATEGORY_TLS,
@@ -1984,14 +1989,19 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean exposeManagedCursorMetricsInPrometheus = false;
     @FieldContext(
             category = CATEGORY_METRICS,
+            doc = "If true, export compacted topics metrics"
+    )
+    private boolean exposeCompactedTopicMetricsInPrometheus = false;
+    @FieldContext(
+            category = CATEGORY_METRICS,
             doc = "Classname of Pluggable JVM GC metrics logger that can log GC specific metrics")
     private String jvmGCMetricsLoggerClassName;
 
     @FieldContext(
-        category = CATEGORY_METRICS,
-        doc = "Enable expose the precise backlog stats.\n" +
-            " Set false to use published counter and consumed counter to calculate,\n" +
-            " this would be more efficient but may be inaccurate. Default is false."
+            category = CATEGORY_METRICS,
+            doc = "Enable expose the precise backlog stats.\n" +
+                    " Set false to use published counter and consumed counter to calculate,\n" +
+                    " this would be more efficient but may be inaccurate. Default is false."
     )
     private boolean exposePreciseBacklogInPrometheus = false;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/CompactorMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/CompactorMetrics.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.metrics;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.compaction.Compactor;
+import org.apache.pulsar.compaction.CompactorMXBean;
+
+@Slf4j
+public class CompactorMetrics extends AbstractMetrics {
+
+    private List<Metrics> metricsCollection;
+    private Map<String, Double> tempAggregatedMetricsMap;
+    private Map<Metrics, List<String>> topicsByDimensionMap;
+    private CompactorMXBean stats;
+
+    public CompactorMetrics(PulsarService pulsar) {
+        super(pulsar);
+        this.metricsCollection = Lists.newArrayList();
+        this.topicsByDimensionMap = Maps.newHashMap();
+        this.tempAggregatedMetricsMap = Maps.newHashMap();
+        this.stats = getCompactorMXBean();
+    }
+
+    @Override
+    public synchronized List<Metrics> generate() {
+        return aggregate(groupTopicsByDimension());
+    }
+
+
+    /**
+     * Aggregation by namespace, ledger, cursor.
+     *
+     * @return List<Metrics>
+     */
+    private List<Metrics> aggregate(Map<Metrics, List<String>> topicsByDimension) {
+        metricsCollection.clear();
+        if (stats != null) {
+            for (Map.Entry<Metrics, List<String>> e : topicsByDimension.entrySet()) {
+                Metrics metrics = e.getKey();
+                List<String> topics = e.getValue();
+                tempAggregatedMetricsMap.clear();
+                for (String topic : topics) {
+                    populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ct_CompactedSucceed",
+                            stats.getCompactTopicSucceed(topic));
+
+                    populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ct_CompactedError",
+                            stats.getCompactTopicError(topic));
+                }
+                for (Map.Entry<String, Double> ma : tempAggregatedMetricsMap.entrySet()) {
+                    metrics.put(ma.getKey(), ma.getValue());
+                }
+                metricsCollection.add(metrics);
+            }
+            Metrics metrics = createMetricsByDimension(pulsar.getConfiguration().getClusterName());
+            metrics.put("brk_ct_CompactedRate", stats.getCompactRate());
+            metrics.put("brk_ct_CompactedRate", stats.getCompactBytesRate());
+            metricsCollection.add(metrics);
+        }
+
+        return metricsCollection;
+    }
+
+    protected Metrics createMetricsByDimension(String cluster) {
+        Map<String, String> dimensionMap = Maps.newHashMap();
+        dimensionMap.put("cluster", cluster);
+        return createMetrics(dimensionMap);
+    }
+
+    private Map<Metrics, List<String>> groupTopicsByDimension() {
+        topicsByDimensionMap.clear();
+        if (stats != null) {
+            tempAggregatedMetricsMap.clear();
+            for (String topic : stats.getCompactedTopics()) {
+                String namespace = TopicName.get(topic).getNamespace();
+                Metrics metrics = super.createMetricsByDimension(namespace);
+                populateDimensionMap(topicsByDimensionMap, metrics, topic);
+            }
+        }
+        return topicsByDimensionMap;
+    }
+
+    private CompactorMXBean getCompactorMXBean() {
+        Compactor compactor = null;
+        try {
+            compactor = pulsar.getCompactor();
+        } catch (PulsarServerException e) {
+            log.error("get compactor error", e);
+        }
+        return Optional.ofNullable(compactor).map(c -> c.getStats()).orElse(null);
+    }
+
+    private void populateDimensionMap(Map<Metrics, List<String>> topicsByDimensionMap, Metrics metrics, String topic) {
+        if (!topicsByDimensionMap.containsKey(metrics)) {
+            topicsByDimensionMap.put(metrics, Lists.newArrayList(topic));
+        } else {
+            topicsByDimensionMap.get(metrics).add(topic);
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -43,6 +43,7 @@ import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.stats.metrics.CompactorMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedCursorMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerCacheMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
@@ -134,17 +135,24 @@ public class PrometheusMetricsGenerator {
         if (pulsar.getConfiguration().isExposeManagedLedgerMetricsInPrometheus()) {
             // generate managedLedger metrics
             parseMetricsToPrometheusMetrics(new ManagedLedgerMetrics(pulsar).generate(),
-                clusterName, Collector.Type.GAUGE, stream);
+                    clusterName, Collector.Type.GAUGE, stream);
         }
 
         if (pulsar.getConfiguration().isExposeManagedCursorMetricsInPrometheus()) {
             // generate managedCursor metrics
             parseMetricsToPrometheusMetrics(new ManagedCursorMetrics(pulsar).generate(),
-                clusterName, Collector.Type.GAUGE, stream);
+                    clusterName, Collector.Type.GAUGE, stream);
+        }
+
+        // TODO
+        if (pulsar.getConfiguration().isExposeCompactedTopicMetricsInPrometheus()) {
+            // generate compacted topic metrics
+            parseMetricsToPrometheusMetrics(new CompactorMetrics(pulsar).generate(),
+                    clusterName, Collector.Type.GAUGE, stream);
         }
 
         parseMetricsToPrometheusMetrics(Collections.singletonList(pulsar.getBrokerService()
-                .getPulsarStats().getBrokerOperabilityMetrics().generateConnectionMetrics()),
+                        .getPulsarStats().getBrokerOperabilityMetrics().generateConnectionMetrics()),
                 clusterName, Collector.Type.GAUGE, stream);
 
         // generate loadBalance metrics

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
@@ -42,6 +42,7 @@ public abstract class Compactor {
     protected final ScheduledExecutorService scheduler;
     private final PulsarClient pulsar;
     private final BookKeeper bk;
+    protected final CompactorMXBeanImpl mxBean;
 
     public Compactor(ServiceConfiguration conf,
                      PulsarClient pulsar,
@@ -51,6 +52,7 @@ public abstract class Compactor {
         this.scheduler = scheduler;
         this.pulsar = pulsar;
         this.bk = bk;
+        this.mxBean = new CompactorMXBeanImpl(conf.getCompactorMetricsRefreshIntervalSeconds());
     }
 
     public CompletableFuture<Long> compact(String topic) {
@@ -60,23 +62,30 @@ public abstract class Compactor {
 
     private CompletableFuture<Long> compactAndCloseReader(RawReader reader) {
         CompletableFuture<Long> promise = new CompletableFuture<>();
+        mxBean.addCompactStartOp(reader.getTopic());
         doCompaction(reader, bk).whenComplete(
                 (ledgerId, exception) -> {
                     reader.closeAsync().whenComplete((v, exception2) -> {
-                            if (exception2 != null) {
-                                log.warn("Error closing reader handle {}, ignoring", reader, exception2);
-                            }
-                            if (exception != null) {
-                                // complete with original exception
-                                promise.completeExceptionally(exception);
-                            } else {
-                                promise.complete(ledgerId);
-                            }
-                        });
+                        if (exception2 != null) {
+                            log.warn("Error closing reader handle {}, ignoring", reader, exception2);
+                        }
+                        if (exception != null) {
+                            // complete with original exception
+                            mxBean.addCompactEndOp(reader.getTopic(), false);
+                            promise.completeExceptionally(exception);
+                        } else {
+                            mxBean.addCompactEndOp(reader.getTopic(), true);
+                            promise.complete(ledgerId);
+                        }
+                    });
                 });
         return promise;
     }
 
     protected abstract CompletableFuture<Long> doCompaction(RawReader reader, BookKeeper bk);
+
+    public CompactorMXBean getStats() {
+        return this.mxBean;
+    }
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBean.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBean.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import java.util.Set;
+import org.apache.bookkeeper.common.annotation.InterfaceAudience;
+import org.apache.bookkeeper.common.annotation.InterfaceStability;
+
+/**
+ * JMX Bean interface for Compactor stats.
+ */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Stable
+public interface CompactorMXBean {
+
+    /**
+     * @return the count of compact succeeded
+     */
+    long getCompactTopicSucceed(String topic);
+
+    /**
+     * @return the count of compact error
+     */
+    long getCompactTopicError(String topic);
+
+    /**
+     * @return the compact rate
+     */
+    double getCompactRate();
+
+    /**
+     * @return the compact bytes rate
+     */
+    double getCompactBytesRate();
+
+    /**
+     * @return the message count of compacted topic
+     */
+    long getCompactedTopicMsgCount(String topic);
+
+    /**
+     * @return the size of compacted topic
+     */
+    double getCompactedTopicSize(String topic);
+
+    /**
+     * @return the removed event count of compacted topic
+     */
+    long getCompactedTopicRemovedEvents(String topic);
+
+    /**
+     * @return the collection of compacted topics
+     */
+    Set<String> getCompactedTopics();
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.pulsar.common.stats.Rate;
+import org.apache.pulsar.common.stats.Sum;
+
+public class CompactorMXBeanImpl implements CompactorMXBean {
+
+    private final Rate rateOp = new Rate();
+
+    private final ConcurrentMap<String, Sum> sumOps = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, Integer> actionOps = new ConcurrentHashMap();
+    private final ConcurrentHashMap<String, LongAdder> removedOps = new ConcurrentHashMap<>();
+
+    private final OrderedScheduler scheduledExecutor;
+    private long lastStatTimestamp = System.nanoTime();
+
+    public CompactorMXBeanImpl(int refreshInterval) {
+        this.scheduledExecutor = OrderedScheduler.newSchedulerBuilder()
+                .numThreads(1)
+                .name("compactor-scheduler")
+                .build();
+        this.scheduledExecutor.scheduleAtFixedRate(this::refreshStats,
+                refreshInterval, refreshInterval, TimeUnit.SECONDS);
+    }
+
+    private synchronized void refreshStats() {
+        long now = System.nanoTime();
+        long period = now - lastStatTimestamp;
+
+        refreshStats(period, TimeUnit.NANOSECONDS);
+
+        lastStatTimestamp = now;
+    }
+
+    public void refreshStats(long period, TimeUnit unit) {
+        double seconds = unit.toMillis(period) / 1000.0;
+        rateOp.calculateRate(seconds);
+    }
+
+    public void addCompactSample(String topic, int size) {
+        sumOps.compute(topic, (k, v) -> {
+            if (v == null) {
+                v = new Sum();
+            } else {
+                v.recordEvent(size);
+            }
+            return v;
+        });
+        rateOp.recordEvent(size);
+    }
+
+    public void addCompactRemoved(String topic) {
+        removedOps.compute(topic, (k, v) -> {
+            if (v == null) {
+                v = new LongAdder();
+            } else {
+                v.increment();
+            }
+            return v;
+        });
+    }
+
+    @Override
+    public long getCompactTopicSucceed(String topic) {
+        return actionOps.get(topic) != null && actionOps.get(topic) > 0 ? 1 : 0;
+    }
+
+    @Override
+    public long getCompactTopicError(String topic) {
+        return actionOps.get(topic) != null && actionOps.get(topic) < 0 ? 1 : 0;
+    }
+
+    @Override
+    public double getCompactRate() {
+        return rateOp.getRate();
+    }
+
+    @Override
+    public double getCompactBytesRate() {
+        return rateOp.getValueRate();
+    }
+
+    @Override
+    public long getCompactedTopicMsgCount(String topic) {
+        return sumOps.getOrDefault(topic, new Sum()).getCount();
+    }
+
+    @Override
+    public double getCompactedTopicSize(String topic) {
+        return sumOps.getOrDefault(topic, new Sum()).getValue();
+    }
+
+    @Override
+    public long getCompactedTopicRemovedEvents(String topic) {
+        return removedOps.getOrDefault(topic, new LongAdder()).longValue();
+    }
+
+    @Override
+    public Set<String> getCompactedTopics() {
+        return sumOps.keySet();
+    }
+
+    public void addCompactStartOp(String topic) {
+        actionOps.compute(topic, (k, v) -> 0);
+        sumOps.remove(topic);
+    }
+
+    public void addCompactEndOp(String topic, boolean succeed) {
+        actionOps.compute(topic, (k, v) -> succeed ? 1 : -1);
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -124,13 +124,15 @@ public class TwoPhaseCompactor extends Compactor {
             try {
                 MessageId id = m.getMessageId();
                 boolean deletedMessage = false;
+                boolean replaceMessage = false;
                 if (RawBatchConverter.isReadableBatch(m)) {
                     try {
                         for (ImmutableTriple<MessageId, String, Integer> e : RawBatchConverter
                                 .extractIdsAndKeysAndSize(m)) {
                             if (e != null) {
                                 if (e.getRight() > 0) {
-                                    latestForKey.put(e.getMiddle(), e.getLeft());
+                                    MessageId old = latestForKey.put(e.getMiddle(), e.getLeft());
+                                    replaceMessage = old != null;
                                 } else {
                                     deletedMessage = true;
                                     latestForKey.remove(e.getMiddle());
@@ -145,14 +147,17 @@ public class TwoPhaseCompactor extends Compactor {
                     Pair<String, Integer> keyAndSize = extractKeyAndSize(m);
                     if (keyAndSize != null) {
                         if (keyAndSize.getRight() > 0) {
-                            latestForKey.put(keyAndSize.getLeft(), id);
+                            MessageId old = latestForKey.put(keyAndSize.getLeft(), id);
+                            replaceMessage = old != null;
                         } else {
                             deletedMessage = true;
                             latestForKey.remove(keyAndSize.getLeft());
                         }
                     }
                 }
-
+                if (replaceMessage || deletedMessage) {
+                    mxBean.addCompactRemoved(reader.getTopic());
+                }
                 MessageId first = firstMessageId.orElse(deletedMessage ? null : id);
                 MessageId to = deletedMessage ? toMessageId.orElse(null) : id;
                 if (id.compareTo(lastMessageId) == 0) {
@@ -254,6 +259,7 @@ public class TwoPhaseCompactor extends Compactor {
                     RawMessage message = messageToAdd.get();
                     try {
                         outstanding.acquire();
+                        mxBean.addCompactSample(reader.getTopic(), message.getHeadersAndPayload().readableBytes());
                         CompletableFuture<Void> addFuture = addToCompactedLedger(lh, message)
                                 .whenComplete((res, exception2) -> {
                                     outstanding.release();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/Sum.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/Sum.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.stats;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ */
+public class Sum {
+
+    private final LongAdder countAdder = new LongAdder();
+    private final LongAdder valueAdder = new LongAdder();
+
+    public void recordEvent(long value) {
+        valueAdder.add(value);
+        countAdder.increment();
+    }
+
+    public void recordMultipleEvents(long events, long totalValue) {
+        valueAdder.add(totalValue);
+        countAdder.add(events);
+    }
+
+    public long getCount() {
+        return valueAdder.longValue();
+    }
+
+    public double getValue() {
+        return valueAdder.doubleValue();
+    }
+}


### PR DESCRIPTION
### Motivation
Currently, there are no relative metrics about compacted topic, which would be extremely useful while tracking potential flows or examining the overall condition of compacted topics .
So , I have added below metrics:
- compactRate : the broker compact rate. (broker level)
- compactBytesRate :  the broker compact bytes rate. （broker level)
- compactedError : the count of compacted occur error. (namespace level)
- compactedSucceed : the count of compacted succeed.(namespace level)
 - compactedTopicSize :  the size after compacted（topic level）
- compactedTopicMsgCount : the message count after compacted（topic level）
- compactedTopicRemovedEvents :  how many events had been removed after compacted (topic level).

Broker and namespace level metrics exposed to prometheus as well.
Topic level metrics are exposed by CLI.