### PR TITLE
[Issue 11558][Python] Check if the record is not None

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -149,6 +149,9 @@ class Record(with_metaclass(RecordMeta, object)):
         return self.__class__
 
     def validate_type(self, name, val):
+        if not val and not self._required:
+            return self.default()
+
         if not isinstance(val, self.__class__):
             raise TypeError("Invalid type '%s' for sub-record field '%s'. Expected: %s" % (
                 type(val), name, self.__class__))

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -305,7 +305,6 @@ class SchemaTest(TestCase):
         except TypeError:
             pass # Expected
 
-
     def test_serialize_json(self):
         class Example(Record):
             a = Integer()
@@ -428,7 +427,6 @@ class SchemaTest(TestCase):
                         'my-json-python-topic',
                         schema=JsonSchema(Example))
 
-
         # Validate that incompatible schema is rejected
         try:
             client.subscribe('my-json-python-topic', 'sub-1',
@@ -495,13 +493,11 @@ class SchemaTest(TestCase):
         self.assertEqual(b"Hello", msg.data())
         client.close()
 
-
     def test_bytes_schema(self):
         client = pulsar.Client(self.serviceUrl)
         producer = client.create_producer(
                         'my-bytes-python-topic',
                         schema=BytesSchema())
-
 
         # Validate that incompatible schema is rejected
         try:
@@ -829,7 +825,6 @@ class SchemaTest(TestCase):
 
         client.close()
 
-
     def test_default_value(self):
         class MyRecord(Record):
             A = Integer()
@@ -949,6 +944,28 @@ class SchemaTest(TestCase):
 
         encode_and_decode('avro')
         encode_and_decode('json')
+
+    def test_sub_record_set_to_none(self):
+        class NestedObj1(Record):
+            na1 = String()
+            nb1 = Double()
+
+        class NestedObj2(Record):
+            na2 = Integer()
+            nb2 = Boolean()
+            nc2 = NestedObj1()
+
+        data_schema = AvroSchema(NestedObj2)
+        r = NestedObj2(na2=1, nb2=True)
+
+        data_encode = data_schema.encode(r)
+        data_decode = data_schema.decode(data_encode)
+
+        self.assertEqual(data_decode.__class__.__name__, 'NestedObj2')
+        self.assertEqual(data_decode, r)
+        self.assertEqual(data_decode.na2, 1)
+        self.assertTrue(data_decode.nb2)
+
 
     def test_produce_and_consume_complex_schema_data(self):
         class NestedObj1(Record):


### PR DESCRIPTION

Fixes #11558

### Motivation

Not all sub-records are required in a schema. Taking this context into account, the code of the Record class ignored its own default values (`required=False` and `default=None`)


### Modifications

The modification is a continuation of the ones made in the PR https://github.com/apache/pulsar/pull/11508.
This time only the `Record` class has changed. The modification affects the validation. A check of the value and the `required` attribute is done before validating the data type.

So if the value is empty and the `required` is False, the default is returned instead of raising an exception.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:
  - *Added unit tests 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: yes
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

#### For contributor

No documentation update is required.
The definition of the `Record` class wasn't respected

#### For committer

For this PR, do we need to update docs?

No
