### PR TITLE
Add compacted topic metrics for TopicStats in CLI

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1323,12 +1323,16 @@ public class PulsarService implements AutoCloseable {
     // only public so mockito can mock it
     public Compactor newCompactor() throws PulsarServerException {
         return new TwoPhaseCompactor(this.getConfiguration(),
-                                     getClient(), getBookKeeperClient(),
-                                     getCompactorExecutor());
+                getClient(), getBookKeeperClient(),
+                getCompactorExecutor());
     }
 
     public synchronized Compactor getCompactor() throws PulsarServerException {
-        if (this.compactor == null) {
+        return getCompactor(true);
+    }
+
+    public synchronized Compactor getCompactor(boolean shouldInitialize) throws PulsarServerException {
+        if (this.compactor == null && shouldInitialize) {
             this.compactor = newCompactor();
         }
         return this.compactor;
@@ -1337,8 +1341,8 @@ public class PulsarService implements AutoCloseable {
     protected synchronized OrderedScheduler getOffloaderScheduler(OffloadPoliciesImpl offloadPolicies) {
         if (this.offloaderScheduler == null) {
             this.offloaderScheduler = OrderedScheduler.newSchedulerBuilder()
-                .numThreads(offloadPolicies.getManagedLedgerOffloadMaxThreads())
-                .name("offloader").build();
+                    .numThreads(offloadPolicies.getManagedLedgerOffloadMaxThreads())
+                    .name("offloader").build();
         }
         return this.offloaderScheduler;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -159,6 +159,7 @@ import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
+import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -1728,8 +1729,15 @@ public class BrokerService implements Closeable {
                 }
             }
         }
-
         topics.remove(topic);
+
+        try {
+            Compactor compactor = pulsar.getCompactor(false);
+            if (compactor != null) {
+                compactor.getStats().removeTopic(topic);
+            }
+        } catch (PulsarServerException ignore) {
+        }
     }
 
     public int getNumberOfNamespaceBundles() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1906,13 +1906,13 @@ public class PersistentTopic extends AbstractTopic
         stats.lastOffloadSuccessTimeStamp = ledger.getLastOffloadedSuccessTimestamp();
         stats.lastOffloadFailureTimeStamp = ledger.getLastOffloadedFailureTimestamp();
         Optional<CompactorMXBean> mxBean = getCompactorMXBean();
-        stats.compact.lastCompactionRemovedEventCount = mxBean.map(stat ->
+        stats.compaction.lastCompactionRemovedEventCount = mxBean.map(stat ->
                 stat.getLastCompactionRemovedEventCount(topic)).orElse(0L);
-        stats.compact.lastCompactionSucceedTimestamp = mxBean.map(stat ->
+        stats.compaction.lastCompactionSucceedTimestamp = mxBean.map(stat ->
                 stat.getLastCompactionSucceedTimestamp(topic)).orElse(0L);
-        stats.compact.lastCompactionFailedTimestamp = mxBean.map(stat ->
+        stats.compaction.lastCompactionFailedTimestamp = mxBean.map(stat ->
                 stat.getLastCompactionFailedTimestamp(topic)).orElse(0L);
-        stats.compact.lastCompactionDurationTimeInMills = mxBean.map(stat ->
+        stats.compaction.lastCompactionDurationTimeInMills = mxBean.map(stat ->
                 stat.getLastCompactionDurationTimeInMills(topic)).orElse(0L);
 
         return stats;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
@@ -42,6 +42,7 @@ public abstract class Compactor {
     protected final ScheduledExecutorService scheduler;
     private final PulsarClient pulsar;
     private final BookKeeper bk;
+    protected final CompactorMXBeanImpl mxBean;
 
     public Compactor(ServiceConfiguration conf,
                      PulsarClient pulsar,
@@ -51,6 +52,7 @@ public abstract class Compactor {
         this.scheduler = scheduler;
         this.pulsar = pulsar;
         this.bk = bk;
+        this.mxBean = new CompactorMXBeanImpl();
     }
 
     public CompletableFuture<Long> compact(String topic) {
@@ -60,23 +62,30 @@ public abstract class Compactor {
 
     private CompletableFuture<Long> compactAndCloseReader(RawReader reader) {
         CompletableFuture<Long> promise = new CompletableFuture<>();
+        mxBean.addCompactionStartOp(reader.getTopic());
         doCompaction(reader, bk).whenComplete(
                 (ledgerId, exception) -> {
                     reader.closeAsync().whenComplete((v, exception2) -> {
-                            if (exception2 != null) {
-                                log.warn("Error closing reader handle {}, ignoring", reader, exception2);
-                            }
-                            if (exception != null) {
-                                // complete with original exception
-                                promise.completeExceptionally(exception);
-                            } else {
-                                promise.complete(ledgerId);
-                            }
-                        });
+                        if (exception2 != null) {
+                            log.warn("Error closing reader handle {}, ignoring", reader, exception2);
+                        }
+                        if (exception != null) {
+                            // complete with original exception
+                            mxBean.addCompactionEndOp(reader.getTopic(), false);
+                            promise.completeExceptionally(exception);
+                        } else {
+                            mxBean.addCompactionEndOp(reader.getTopic(), true);
+                            promise.complete(ledgerId);
+                        }
+                    });
                 });
         return promise;
     }
 
     protected abstract CompletableFuture<Long> doCompaction(RawReader reader, BookKeeper bk);
+
+    public CompactorMXBean getStats() {
+        return this.mxBean;
+    }
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBean.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBean.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import org.apache.bookkeeper.common.annotation.InterfaceAudience;
+import org.apache.bookkeeper.common.annotation.InterfaceStability;
+
+/**
+ * JMX Bean interface for Compactor stats.
+ */
+@InterfaceAudience.LimitedPrivate
+@InterfaceStability.Stable
+public interface CompactorMXBean {
+
+    /**
+     * @return the removed event count of last compaction
+     */
+    long getLastCompactionRemovedEventCount(String topic);
+
+    /**
+     * @return the timestamp of last succeed compaction
+     */
+    long getLastCompactionSucceedTimestamp(String topic);
+
+    /**
+     * @return the timestamp of last failed compaction
+     */
+    long getLastCompactionFailedTimestamp(String topic);
+
+    /**
+     * @return the duration time of last compaction
+     */
+    long getLastCompactionDurationTimeInMills(String topic);
+
+    /**
+     *  Remove metrics about this topic.
+     * @param topic
+     */
+    void removeTopic(String topic);
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+public class CompactorMXBeanImpl implements CompactorMXBean {
+
+    private final ConcurrentHashMap<String, CompactRecord> compactRecordOps = new ConcurrentHashMap<>();
+
+    public void addCompactionRemovedEvent(String topic) {
+        compactRecordOps.computeIfAbsent(topic, k -> new CompactRecord()).addCompactionRemovedEvent();
+    }
+
+    public void addCompactionStartOp(String topic) {
+        compactRecordOps.computeIfAbsent(topic, k -> new CompactRecord()).reset();
+    }
+
+    public void addCompactionEndOp(String topic, boolean succeed) {
+        CompactRecord compactRecord = compactRecordOps.computeIfAbsent(topic, k -> new CompactRecord());
+        compactRecord.lastCompactionDurationTimeInMills = System.currentTimeMillis()
+                - compactRecord.lastCompactionStartTimeOp;
+        compactRecord.lastCompactionRemovedEventCount = compactRecord.lastCompactionRemovedEventCountOp.longValue();
+        if (succeed) {
+            compactRecord.lastCompactionSucceedTimestamp = System.currentTimeMillis();
+        } else {
+            compactRecord.lastCompactionFailedTimestamp = System.currentTimeMillis();
+        }
+    }
+
+    @Override
+    public long getLastCompactionRemovedEventCount(String topic) {
+        return compactRecordOps.getOrDefault(topic, new CompactRecord()).lastCompactionRemovedEventCount;
+    }
+
+    @Override
+    public long getLastCompactionSucceedTimestamp(String topic) {
+        return compactRecordOps.getOrDefault(topic, new CompactRecord()).lastCompactionSucceedTimestamp;
+    }
+
+    @Override
+    public long getLastCompactionFailedTimestamp(String topic) {
+        return compactRecordOps.getOrDefault(topic, new CompactRecord()).lastCompactionFailedTimestamp;
+    }
+
+    @Override
+    public long getLastCompactionDurationTimeInMills(String topic) {
+        return compactRecordOps.getOrDefault(topic, new CompactRecord()).lastCompactionDurationTimeInMills;
+    }
+
+    @Override
+    public void removeTopic(String topic) {
+        compactRecordOps.remove(topic);
+    }
+
+    static class CompactRecord {
+
+        private long lastCompactionRemovedEventCount = 0L;
+        private long lastCompactionSucceedTimestamp = 0L;
+        private long lastCompactionFailedTimestamp = 0L;
+        private long lastCompactionDurationTimeInMills = 0L;
+
+        private LongAdder lastCompactionRemovedEventCountOp = new LongAdder();
+        private long lastCompactionStartTimeOp;
+
+        public void addCompactionRemovedEvent() {
+            lastCompactionRemovedEventCountOp.increment();
+        }
+
+        public void reset() {
+            lastCompactionRemovedEventCountOp.reset();
+            lastCompactionStartTimeOp = System.currentTimeMillis();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.compaction;
+
+import org.apache.pulsar.broker.service.BrokerService;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Test(groups = "broker-compaction")
+public class CompactorMXBeanImplTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        CompactorMXBeanImpl mxBean = new CompactorMXBeanImpl();
+        String topic = "topic1";
+        mxBean.addCompactionStartOp(topic);
+        assertEquals(mxBean.getLastCompactionRemovedEventCount(topic), 0, 0);
+        mxBean.addCompactionRemovedEvent(topic);
+        assertEquals(mxBean.getLastCompactionRemovedEventCount(topic), 0, 0);
+        mxBean.addCompactionEndOp(topic, true);
+        mxBean.addCompactionEndOp(topic, false);
+        assertEquals(mxBean.getLastCompactionRemovedEventCount(topic), 1, 0);
+        assertTrue(mxBean.getLastCompactionSucceedTimestamp(topic) > 0L);
+        assertTrue(mxBean.getLastCompactionFailedTimestamp(topic) > 0L);
+        assertTrue(mxBean.getLastCompactionDurationTimeInMills(topic) >= 0L);
+    }
+
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/CompactionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/CompactionStats.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+/**
+ * Statistics about compaction.
+ */
+public interface CompactionStats {
+
+    /** The removed event count of last compaction. */
+    long getLastCompactionRemovedEventCount();
+
+    /** The timestamp of last succeed compaction. */
+    long getLastCompactionSucceedTimestamp();
+
+    /** The timestamp of last failed compaction. */
+    long getLastCompactionFailedTimestamp();
+
+    /** The duration time of last compaction. */
+    long getLastCompactionDurationTimeInMills();
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
@@ -85,4 +85,7 @@ public interface TopicStats {
 
     /** The serialized size of non-contiguous deleted messages ranges. */
     int getNonContiguousDeletedMessagesRangesSerializedSize();
+
+    /** The compaction stats. */
+    CompactionStats getCompact();
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
@@ -87,5 +87,5 @@ public interface TopicStats {
     int getNonContiguousDeletedMessagesRangesSerializedSize();
 
     /** The compaction stats. */
-    CompactionStats getCompact();
+    CompactionStats getCompaction();
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/CompactionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/CompactionStatsImpl.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data.stats;
+
+import lombok.Data;
+import org.apache.pulsar.common.policies.data.CompactionStats;
+/**
+ * Statistics about compaction.
+ */
+@Data
+public class CompactionStatsImpl implements CompactionStats {
+
+    /** The removed event count of last compaction. */
+    public long lastCompactionRemovedEventCount;
+
+    /** The timestamp of last succeed compaction. */
+    public long lastCompactionSucceedTimestamp;
+
+    /** The timestamp of last failed compaction. */
+    public long lastCompactionFailedTimestamp;
+
+    /** The duration time of last compaction. */
+    public long lastCompactionDurationTimeInMills;
+
+    public void reset() {
+        this.lastCompactionRemovedEventCount = 0;
+        this.lastCompactionSucceedTimestamp = 0;
+        this.lastCompactionFailedTimestamp = 0;
+        this.lastCompactionDurationTimeInMills = 0;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -114,6 +113,9 @@ public class TopicStatsImpl implements TopicStats {
     /** The serialized size of non-contiguous deleted messages ranges. */
     public int nonContiguousDeletedMessagesRangesSerializedSize;
 
+    /** The compact stats */
+    public CompactionStatsImpl compact;
+
     public List<? extends PublisherStats> getPublishers() {
         return publishers;
     }
@@ -130,6 +132,7 @@ public class TopicStatsImpl implements TopicStats {
         this.publishers = new ArrayList<>();
         this.subscriptions = new HashMap<>();
         this.replication = new TreeMap<>();
+        this.compact = new CompactionStatsImpl();
     }
 
     public void reset() {
@@ -157,6 +160,7 @@ public class TopicStatsImpl implements TopicStats {
         this.lastOffloadLedgerId = 0;
         this.lastOffloadFailureTimeStamp = 0;
         this.lastOffloadSuccessTimeStamp = 0;
+        this.compact.reset();
     }
 
     // if the stats are added for the 1st time, we will need to make a copy of these stats and add it to the current

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
@@ -113,8 +113,8 @@ public class TopicStatsImpl implements TopicStats {
     /** The serialized size of non-contiguous deleted messages ranges. */
     public int nonContiguousDeletedMessagesRangesSerializedSize;
 
-    /** The compact stats */
-    public CompactionStatsImpl compact;
+    /** The compaction stats */
+    public CompactionStatsImpl compaction;
 
     public List<? extends PublisherStats> getPublishers() {
         return publishers;
@@ -132,7 +132,7 @@ public class TopicStatsImpl implements TopicStats {
         this.publishers = new ArrayList<>();
         this.subscriptions = new HashMap<>();
         this.replication = new TreeMap<>();
-        this.compact = new CompactionStatsImpl();
+        this.compaction = new CompactionStatsImpl();
     }
 
     public void reset() {
@@ -160,7 +160,7 @@ public class TopicStatsImpl implements TopicStats {
         this.lastOffloadLedgerId = 0;
         this.lastOffloadFailureTimeStamp = 0;
         this.lastOffloadSuccessTimeStamp = 0;
-        this.compact.reset();
+        this.compaction.reset();
     }
 
     // if the stats are added for the 1st time, we will need to make a copy of these stats and add it to the current

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
@@ -60,10 +60,10 @@ public class PersistentTopicStatsTest {
         assertEquals(topicStats.publishers.size(), 1);
         assertEquals(topicStats.subscriptions.size(), 1);
         assertEquals(topicStats.replication.size(), 1);
-        assertEquals(topicStats.compact.lastCompactionRemovedEventCount, 0);
-        assertEquals(topicStats.compact.lastCompactionSucceedTimestamp, 0);
-        assertEquals(topicStats.compact.lastCompactionFailedTimestamp, 0);
-        assertEquals(topicStats.compact.lastCompactionDurationTimeInMills, 0);
+        assertEquals(topicStats.compaction.lastCompactionRemovedEventCount, 0);
+        assertEquals(topicStats.compaction.lastCompactionSucceedTimestamp, 0);
+        assertEquals(topicStats.compaction.lastCompactionFailedTimestamp, 0);
+        assertEquals(topicStats.compaction.lastCompactionDurationTimeInMills, 0);
         topicStats.reset();
         assertEquals(topicStats.msgRateIn, 0.0);
         assertEquals(topicStats.msgThroughputIn, 0.0);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PersistentTopicStatsTest.java
@@ -60,6 +60,10 @@ public class PersistentTopicStatsTest {
         assertEquals(topicStats.publishers.size(), 1);
         assertEquals(topicStats.subscriptions.size(), 1);
         assertEquals(topicStats.replication.size(), 1);
+        assertEquals(topicStats.compact.lastCompactionRemovedEventCount, 0);
+        assertEquals(topicStats.compact.lastCompactionSucceedTimestamp, 0);
+        assertEquals(topicStats.compact.lastCompactionFailedTimestamp, 0);
+        assertEquals(topicStats.compact.lastCompactionDurationTimeInMills, 0);
         topicStats.reset();
         assertEquals(topicStats.msgRateIn, 0.0);
         assertEquals(topicStats.msgThroughputIn, 0.0);


### PR DESCRIPTION
### Motivation
Add below metrics to help track potential flows or examine the overall condition of compacted topics .
- lastCompactionRemovedEventCount : the removed event count of last compaction
- lastCompactionSucceedTimestamp : the timestamp of last succeed compaction
- lastCompactionFailedTimestamp : the timestamp of last failed compaction
- lastCompactionDurationTimeInMills: the duration time of last compaction

These 4 metrics will be displayed in topic stats CLI :
```
./pulsar-admin topics stats persistent://tenant/ns/topic
```

### Documentation
This patch will add metrics in CLI , which would generate doc automatically.

