### PR TITLE
[Issue 11496][C++] Allow partitioned producers to start lazily

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -263,6 +263,25 @@ class PULSAR_PUBLIC ProducerConfiguration {
     HashingScheme getHashingScheme() const;
 
     /**
+     * This config affects producers of partitioned topics only. It controls whether
+     * producers register and connect immediately to the owner broker of each partition
+     * or start lazily on demand. Lazy starts occur when a message needs to be routed
+     * to a partition that the producer has not yet registered and connected to.
+     * Using this mode can reduce the strain on brokers for topics with large numbers of
+     * partitions and when the SinglePartition routing policy is used without keyed messages.
+     * Because producer registration and connection is on demand, this can produce extra
+     * latency while the registration is being carried out.
+     * @param true/false as to whether to start partition producers lazily
+     * @return
+     */
+    ProducerConfiguration& setLazyStartPartitionedProducers(bool);
+
+    /**
+     * The getter associated with setLazyStartPartitionedProducers()
+     */
+    bool getLazyStartPartitionedProducers() const;
+
+    /**
      * The setter associated with getBlockIfQueueFull()
      */
     ProducerConfiguration& setBlockIfQueueFull(bool);

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -265,12 +265,14 @@ class PULSAR_PUBLIC ProducerConfiguration {
     /**
      * This config affects producers of partitioned topics only. It controls whether
      * producers register and connect immediately to the owner broker of each partition
-     * or start lazily on demand. Lazy starts occur when a message needs to be routed
-     * to a partition that the producer has not yet registered and connected to.
+     * or start lazily on demand. The internal producer of one partition is always
+     * started eagerly, chosen by the routing policy, but the internal producers of
+     * any additional partitions are started on demand, upon receiving their first
+     * message.
      * Using this mode can reduce the strain on brokers for topics with large numbers of
      * partitions and when the SinglePartition routing policy is used without keyed messages.
-     * Because producer registration and connection is on demand, this can produce extra
-     * latency while the registration is being carried out.
+     * Because producer connection can be on demand, this can produce extra send latency
+     * for the first messages of a given partition.
      * @param true/false as to whether to start partition producers lazily
      * @return
      */

--- a/pulsar-client-cpp/include/pulsar/c/producer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/producer_configuration.h
@@ -144,6 +144,12 @@ PULSAR_PUBLIC void pulsar_producer_configuration_set_hashing_scheme(pulsar_produ
 PULSAR_PUBLIC pulsar_hashing_scheme
 pulsar_producer_configuration_get_hashing_scheme(pulsar_producer_configuration_t *conf);
 
+PULSAR_PUBLIC void pulsar_producer_configuration_set_lazy_start_partitioned_producers(
+    pulsar_producer_configuration_t *conf, int useLazyStartPartitionedProducers);
+
+PULSAR_PUBLIC int pulsar_producer_configuration_get_lazy_start_partitioned_producers(
+    pulsar_producer_configuration_t *conf);
+
 PULSAR_PUBLIC void pulsar_producer_configuration_set_block_if_queue_full(
     pulsar_producer_configuration_t *conf, int blockIfQueueFull);
 

--- a/pulsar-client-cpp/lib/HandlerBase.h
+++ b/pulsar-client-cpp/lib/HandlerBase.h
@@ -97,6 +97,7 @@ class HandlerBase {
 
     enum State
     {
+        NotStarted,
         Pending,
         Ready,
         Closing,

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -67,7 +67,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     uint64_t getNumberOfConnectedProducer() override;
     void handleSinglePartitionProducerCreated(Result result, ProducerImplBaseWeakPtr producerBaseWeakPtr,
                                               const unsigned int partitionIndex);
-
+    void createLazyPartitionProducer(const unsigned int partitionIndex);
     void handleSinglePartitionProducerClose(Result result, const unsigned int partitionIndex,
                                             CloseCallback callback);
 
@@ -104,7 +104,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     unsigned int getNumPartitions() const;
     unsigned int getNumPartitionsWithLock() const;
 
-    ProducerImplPtr newInternalProducer(unsigned int partition) const;
+    ProducerImplPtr newInternalProducer(unsigned int partition);
 
     MessageRoutingPolicyPtr routerPolicy_;
 
@@ -129,6 +129,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     void runPartitionUpdateTask();
     void getPartitionMetadata();
     void handleGetPartitions(const Result result, const LookupDataResultPtr& partitionMetadata);
+    bool assertState(const PartitionedProducerState state);
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -104,7 +104,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
     unsigned int getNumPartitions() const;
     unsigned int getNumPartitionsWithLock() const;
 
-    ProducerImplPtr newInternalProducer(unsigned int partition);
+    ProducerImplPtr newInternalProducer(unsigned int partition, bool lazy);
 
     MessageRoutingPolicyPtr routerPolicy_;
 

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -114,7 +114,7 @@ void Producer::flushAsync(FlushCallback callback) {
 void Producer::producerFailMessages(Result result) {
     if (impl_) {
         ProducerImpl* producerImpl = static_cast<ProducerImpl*>(impl_.get());
-        producerImpl->failPendingMessages(result);
+        producerImpl->failPendingMessages(result, true);
     }
 }
 

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -204,6 +204,16 @@ ProducerConfiguration& ProducerConfiguration::addEncryptionKey(std::string key) 
     return *this;
 }
 
+ProducerConfiguration& ProducerConfiguration::setLazyStartPartitionedProducers(
+    bool useLazyStartPartitionedProducers) {
+    impl_->useLazyStartPartitionedProducers = useLazyStartPartitionedProducers;
+    return *this;
+}
+
+bool ProducerConfiguration::getLazyStartPartitionedProducers() const {
+    return impl_->useLazyStartPartitionedProducers;
+}
+
 ProducerConfiguration& ProducerConfiguration::setSchema(const SchemaInfo& schemaInfo) {
     impl_->schemaInfo = schemaInfo;
     return *this;

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -37,6 +37,7 @@ struct ProducerConfigurationImpl {
     ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::UseSinglePartition};
     MessageRoutingPolicyPtr messageRouter;
     ProducerConfiguration::HashingScheme hashingScheme{ProducerConfiguration::BoostHash};
+    bool useLazyStartPartitionedProducers{false};
     bool blockIfQueueFull{false};
     bool batchingEnabled{true};
     unsigned int batchingMaxMessages{1000};

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -246,6 +246,7 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
                 scheduleReconnection(shared_from_this());
             } else {
                 LOG_ERROR(getName() << "Failed to create producer: " << strResult(result));
+                failPendingMessages(result, true);
                 producerCreatedPromise_.setFailed(result);
                 Lock lock(mutex_);
                 state_ = Failed;

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -94,6 +94,8 @@ class ProducerImpl : public HandlerBase,
 
     void batchMessageTimeoutHandler(const boost::system::error_code& ec);
 
+    void startSendTimeoutTimer();
+
     friend class PulsarFriend;
 
     friend class Producer;

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -71,6 +71,7 @@ class ProducerImpl : public HandlerBase,
     void flushAsync(FlushCallback callback) override;
     bool isConnected() const override;
     uint64_t getNumberOfConnectedProducer() override;
+    bool isStarted() const;
 
     bool removeCorruptMessage(uint64_t sequenceId);
 

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -162,7 +162,7 @@ class ProducerImpl : public HandlerBase,
     std::shared_ptr<PendingCallbacks> getPendingCallbacksWhenFailed();
     std::shared_ptr<PendingCallbacks> getPendingCallbacksWhenFailedWithLock();
 
-    void failPendingMessages(Result result);
+    void failPendingMessages(Result result, bool withLock);
 
     MessageCryptoPtr msgCrypto_;
     DeadlineTimerPtr dataKeyGenTImer_;

--- a/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ProducerConfiguration.cc
@@ -135,6 +135,16 @@ void pulsar_producer_configuration_set_message_router(pulsar_producer_configurat
     conf->conf.setMessageRouter(std::make_shared<MessageRoutingPolicy>(router, ctx));
 }
 
+void pulsar_producer_configuration_set_lazy_start_partitioned_producers(
+    pulsar_producer_configuration_t *conf, int useLazyStartPartitionedProducers) {
+    conf->conf.setLazyStartPartitionedProducers(useLazyStartPartitionedProducers);
+}
+
+int pulsar_producer_configuration_get_lazy_start_partitioned_producers(
+    pulsar_producer_configuration_t *conf) {
+    return conf->conf.getLazyStartPartitionedProducers();
+}
+
 void pulsar_producer_configuration_set_block_if_queue_full(pulsar_producer_configuration_t *conf,
                                                            int blockIfQueueFull) {
     conf->conf.setBlockIfQueueFull(blockIfQueueFull);

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -464,6 +464,7 @@ class Client:
                         batching_max_allowed_size_in_bytes=128*1024,
                         batching_max_publish_delay_ms=10,
                         message_routing_mode=PartitionsRoutingMode.RoundRobinDistribution,
+                        lazy_start_partitioned_producers=False,
                         properties=None,
                         batching_type=BatchingType.Default,
                         encryption_key=None,
@@ -518,6 +519,15 @@ class Client:
         * `message_routing_mode`:
           Set the message routing mode for the partitioned producer. Default is `PartitionsRoutingMode.RoundRobinDistribution`,
           other option is `PartitionsRoutingMode.UseSinglePartition`
+        * `lazy_start_partitioned_producers`:
+          This config affects producers of partitioned topics only. It controls whether
+          producers register and connect immediately to the owner broker of each partition
+          or start lazily on demand. Lazy starts occur when a message needs to be routed
+          to a partition that the producer has not yet registered and connected to.
+          Using this mode can reduce the strain on brokers for topics with large numbers of
+          partitions and when the SinglePartition routing policy is used without keyed messages.
+          Because producer registration and connection is on demand, this can produce extra
+          latency while the registration is being carried out.
         * `properties`:
           Sets the properties for the producer. The properties associated with a producer
           can be used for identify a producer at broker side.
@@ -558,6 +568,7 @@ class Client:
         _check_type(BatchingType, batching_type, 'batching_type')
         _check_type_or_none(str, encryption_key, 'encryption_key')
         _check_type_or_none(CryptoKeyReader, crypto_key_reader, 'crypto_key_reader')
+        _check_type(bool, lazy_start_partitioned_producers, 'lazy_start_partitioned_producers')
 
         conf = _pulsar.ProducerConfiguration()
         conf.send_timeout_millis(send_timeout_millis)
@@ -571,6 +582,7 @@ class Client:
         conf.batching_max_publish_delay_ms(batching_max_publish_delay_ms)
         conf.partitions_routing_mode(message_routing_mode)
         conf.batching_type(batching_type)
+        conf.lazy_start_partitioned_producers(lazy_start_partitioned_producers)
         if producer_name:
             conf.producer_name(producer_name)
         if initial_sequence_id:

--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -522,12 +522,14 @@ class Client:
         * `lazy_start_partitioned_producers`:
           This config affects producers of partitioned topics only. It controls whether
           producers register and connect immediately to the owner broker of each partition
-          or start lazily on demand. Lazy starts occur when a message needs to be routed
-          to a partition that the producer has not yet registered and connected to.
+          or start lazily on demand. The internal producer of one partition is always
+          started eagerly, chosen by the routing policy, but the internal producers of
+          any additional partitions are started on demand, upon receiving their first
+          message.
           Using this mode can reduce the strain on brokers for topics with large numbers of
           partitions and when the SinglePartition routing policy is used without keyed messages.
-          Because producer registration and connection is on demand, this can produce extra
-          latency while the registration is being carried out.
+          Because producer connection can be on demand, this can produce extra send latency
+          for the first messages of a given partition.
         * `properties`:
           Sets the properties for the producer. The properties associated with a producer
           can be used for identify a producer at broker side.

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -233,6 +233,8 @@ void export_config() {
             .def("block_if_queue_full", &ProducerConfiguration::setBlockIfQueueFull, return_self<>())
             .def("partitions_routing_mode", &ProducerConfiguration::getPartitionsRoutingMode)
             .def("partitions_routing_mode", &ProducerConfiguration::setPartitionsRoutingMode, return_self<>())
+            .def("lazy_start_partitioned_producers", &ProducerConfiguration::getLazyStartPartitionedProducers)
+            .def("lazy_start_partitioned_producers", &ProducerConfiguration::setLazyStartPartitionedProducers, return_self<>())
             .def("batching_enabled", &ProducerConfiguration::getBatchingEnabled, return_value_policy<copy_const_reference>())
             .def("batching_enabled", &ProducerConfiguration::setBatchingEnabled, return_self<>())
             .def("batching_max_messages", &ProducerConfiguration::getBatchingMaxMessages, return_value_policy<copy_const_reference>())

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -521,20 +521,21 @@ TEST(BasicEndToEndTest, testInvalidUrlPassed) {
     ASSERT_EQ(ResultConnectError, result);
 }
 
-TEST(BasicEndToEndTest, testPartitionedProducerConsumer) {
+void testPartitionedProducerConsumer(bool lazyStartPartitionedProducers, std::string topicName) {
     Client client(lookupUrl);
-    std::string topicName = "testPartitionedProducerConsumer";
 
     // call admin api to make it partitioned
-    std::string url =
-        adminUrl + "admin/v2/persistent/public/default/testPartitionedProducerConsumer/partitions";
+    std::string url = adminUrl + "admin/v2/persistent/public/default/" + topicName + "/partitions";
+    makeDeleteRequest(url);
     int res = makePutRequest(url, "3");
 
     LOG_INFO("res = " << res);
     ASSERT_FALSE(res != 204 && res != 409);
 
+    ProducerConfiguration conf;
+    conf.setLazyStartPartitionedProducers(lazyStartPartitionedProducers);
     Producer producer;
-    Result result = client.createProducer(topicName, producer);
+    Result result = client.createProducer(topicName, conf, producer);
     ASSERT_EQ(ResultOk, result);
 
     Consumer consumer;
@@ -559,6 +560,14 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumer) {
         consumer.acknowledge(m);
     }
     client.shutdown();
+}
+
+TEST(BasicEndToEndTest, testPartitionedProducerConsumer) {
+    testPartitionedProducerConsumer(false, "testPartitionedProducerConsumer");
+}
+
+TEST(BasicEndToEndTest, testPartitionedLazyProducerConsumer) {
+    testPartitionedProducerConsumer(true, "testPartitionedProducerConsumerLazy");
 }
 
 TEST(BasicEndToEndTest, testPartitionedProducerConsumerSubscriptionName) {
@@ -1247,6 +1256,7 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
             oldConnections.push_back(clientConnectionPtr);
             clientConnectionPtr->close();
         }
+        LOG_INFO("checking message " << i);
         ASSERT_EQ(producer.send(msg), ResultOk);
     }
 
@@ -1278,6 +1288,61 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
         ASSERT_TRUE(receivedMsgContent.find("msg-" + std::to_string(i)) != receivedMsgContent.end());
         ASSERT_TRUE(receivedMsgIndex.find(std::to_string(i)) != receivedMsgIndex.end());
     }
+}
+
+void testHandlerReconnectionPartitionProducers(bool lazyStartPartitionedProducers, bool batchingEnabled) {
+    Client client(adminUrl);
+    std::string uniqueChunk = unique_str();
+    std::string topicName = "testHandlerReconnectionLogicLazyProducers" + uniqueChunk;
+
+    std::string url = adminUrl + "admin/v2/persistent/public/default/" + topicName + "/partitions";
+    int res = makePutRequest(url, "1");
+
+    ProducerConfiguration producerConf;
+    producerConf.setSendTimeout(10000);
+    producerConf.setLazyStartPartitionedProducers(lazyStartPartitionedProducers);
+    producerConf.setBatchingEnabled(batchingEnabled);
+    Producer producer;
+
+    ASSERT_EQ(client.createProducer(topicName, producerConf, producer), ResultOk);
+
+    std::vector<ClientConnectionPtr> oldConnections;
+
+    int numOfMessages = 10;
+    std::string propertyName = "msgIndex";
+    for (int i = 0; i < numOfMessages; i++) {
+        std::string messageContent = "msg-" + std::to_string(i);
+        Message msg =
+            MessageBuilder().setContent(messageContent).setProperty(propertyName, std::to_string(i)).build();
+        if (i % 3 == 1) {
+            ProducerImpl &pImpl = PulsarFriend::getInternalProducerImpl(producer, 0);
+            ClientConnectionPtr clientConnectionPtr;
+            do {
+                ClientConnectionWeakPtr clientConnectionWeakPtr = PulsarFriend::getClientConnection(pImpl);
+                clientConnectionPtr = clientConnectionWeakPtr.lock();
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            } while (!clientConnectionPtr);
+            oldConnections.push_back(clientConnectionPtr);
+            clientConnectionPtr->close();
+        }
+        ASSERT_EQ(producer.send(msg), ResultOk);
+    }
+}
+
+TEST(BasicEndToEndTest, testHandlerReconnectionPartitionedProducersWithoutBatching) {
+    testHandlerReconnectionPartitionProducers(false, false);
+}
+
+TEST(BasicEndToEndTest, testHandlerReconnectionPartitionedProducersWithBatching) {
+    testHandlerReconnectionPartitionProducers(false, true);
+}
+
+TEST(BasicEndToEndTest, testHandlerReconnectionLazyPartitionedProducersWithoutBatching) {
+    testHandlerReconnectionPartitionProducers(true, false);
+}
+
+TEST(BasicEndToEndTest, testHandlerReconnectionLazyPartitionedProducersWithBatching) {
+    testHandlerReconnectionPartitionProducers(true, true);
 }
 
 TEST(BasicEndToEndTest, testRSAEncryption) {
@@ -2027,12 +2092,16 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerPubSub) {
     std::string url4 =
         adminUrl + "admin/v2/persistent/public/default/patternMultiTopicsNotMatchPubSub4/partitions";
 
+    makeDeleteRequest(url1);
     int res = makePutRequest(url1, "2");
     ASSERT_FALSE(res != 204 && res != 409);
+    makeDeleteRequest(url2);
     res = makePutRequest(url2, "3");
     ASSERT_FALSE(res != 204 && res != 409);
+    makeDeleteRequest(url3);
     res = makePutRequest(url3, "4");
     ASSERT_FALSE(res != 204 && res != 409);
+    makeDeleteRequest(url4);
     res = makePutRequest(url4, "4");
     ASSERT_FALSE(res != 204 && res != 409);
 
@@ -2136,10 +2205,13 @@ TEST(BasicEndToEndTest, testpatternMultiTopicsHttpConsumerPubSub) {
     std::string url3 =
         adminUrl + "admin/v2/persistent/public/default/patternMultiTopicsHttpConsumerPubSub3/partitions";
 
+    makeDeleteRequest(url1);
     int res = makePutRequest(url1, "2");
     ASSERT_FALSE(res != 204 && res != 409);
+    makeDeleteRequest(url2);
     res = makePutRequest(url2, "3");
     ASSERT_FALSE(res != 204 && res != 409);
+    makeDeleteRequest(url3);
     res = makePutRequest(url3, "4");
     ASSERT_FALSE(res != 204 && res != 409);
 
@@ -2262,6 +2334,7 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerAutoDiscovery) {
     auto createProducer = [&client](Producer &producer, const std::string &topic, int numPartitions) {
         if (numPartitions > 0) {
             const std::string url = adminUrl + "admin/v2/persistent/public/default/" + topic + "/partitions";
+            makeDeleteRequest(url);
             int res = makePutRequest(url, std::to_string(numPartitions));
             ASSERT_TRUE(res == 204 || res == 409);
         }
@@ -2446,7 +2519,7 @@ static void simpleCallback(Result code, const MessageId &msgId) {
     LOG_INFO("Received code: " << code << " -- MsgID: " << msgId);
 }
 
-TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
+void testSyncFlushBatchMessagesPartitionedTopic(bool lazyStartPartitionedProducers) {
     Client client(lookupUrl);
     std::string uniqueChunk = unique_str();
     std::string topicName = "persistent://public/default/partition-testSyncFlushBatchMessages" + uniqueChunk;
@@ -2468,6 +2541,7 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
     // set batch message number numOfMessages, and max delay 60s
     producerConfiguration.setBatchingMaxMessages(numOfMessages / numberOfPartitions);
     producerConfiguration.setBatchingMaxPublishDelayMs(60000);
+    producerConfiguration.setLazyStartPartitionedProducers(lazyStartPartitionedProducers);
 
     Result result = client.createProducer(topicName, producerConfiguration, producer);
     ASSERT_EQ(ResultOk, result);
@@ -2541,6 +2615,14 @@ TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
 
     producer.close();
     client.shutdown();
+}
+
+TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopic) {
+    testSyncFlushBatchMessagesPartitionedTopic(false);
+}
+
+TEST(BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopicLazyProducers) {
+    testSyncFlushBatchMessagesPartitionedTopic(true);
 }
 
 TEST(BasicEndToEndTest, testGetTopicPartitions) {
@@ -2660,7 +2742,7 @@ TEST(BasicEndToEndTest, testFlushInProducer) {
     client.shutdown();
 }
 
-TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
+void testFlushInPartitionedProducer(bool lazyStartPartitionedProducers) {
     Client client(lookupUrl);
     std::string uniqueChunk = unique_str();
     std::string topicName =
@@ -2685,6 +2767,7 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     producerConfiguration.setBatchingMaxMessages(numOfMessages / numberOfPartitions);
     producerConfiguration.setBatchingMaxPublishDelayMs(60000);
     producerConfiguration.setMessageRouter(std::make_shared<SimpleRoundRobinRoutingPolicy>());
+    producerConfiguration.setLazyStartPartitionedProducers(lazyStartPartitionedProducers);
 
     Result result = client.createProducer(topicName, producerConfiguration, producer);
     ASSERT_EQ(ResultOk, result);
@@ -2762,6 +2845,10 @@ TEST(BasicEndToEndTest, testFlushInPartitionedProducer) {
     producer.close();
     client.shutdown();
 }
+
+TEST(BasicEndToEndTest, testFlushInPartitionedProducer) { testFlushInPartitionedProducer(false); }
+
+TEST(BasicEndToEndTest, testFlushInLazyPartitionedProducer) { testFlushInPartitionedProducer(true); }
 
 TEST(BasicEndToEndTest, testReceiveAsync) {
     ClientConfiguration config;

--- a/pulsar-client-cpp/tests/ProducerTest.cc
+++ b/pulsar-client-cpp/tests/ProducerTest.cc
@@ -163,6 +163,7 @@ TEST(ProducerTest, testSendAsyncCloseAsyncConcurrentlyWithLazyProducers) {
     // run sendAsync and closeAsync concurrently and verify that all sendAsync callbacks are called
     // and that messages sent after closeAsync is invoked receive ResultAlreadyClosed.
     for (int run = 0; run < 20; run++) {
+        LOG_INFO("Start of run " << run);
         Client client(serviceUrl);
         const std::string partitionedTopic =
             "testProducerIsConnectedPartitioned-" + std::to_string(time(nullptr));
@@ -237,5 +238,6 @@ TEST(ProducerTest, testSendAsyncCloseAsyncConcurrentlyWithLazyProducers) {
         }
 
         client.close();
+        LOG_INFO("End of run " << run);
     }
 }

--- a/pulsar-client-cpp/tests/ProducerTest.cc
+++ b/pulsar-client-cpp/tests/ProducerTest.cc
@@ -18,11 +18,13 @@
  */
 #include <pulsar/Client.h>
 #include <gtest/gtest.h>
+#include <thread>
 
 #include "HttpHelper.h"
 
 #include "lib/Future.h"
 #include "lib/Utils.h"
+#include "lib/Latch.h"
 #include "lib/LogUtils.h"
 DECLARE_LOG_OBJECT()
 
@@ -125,4 +127,115 @@ TEST(ProducerTest, testIsConnected) {
     ASSERT_FALSE(producer.isConnected());
 
     client.close();
+}
+
+TEST(ProducerTest, testSendAsyncAfterCloseAsyncWithLazyProducers) {
+    Client client(serviceUrl);
+    const std::string partitionedTopic =
+        "testProducerIsConnectedPartitioned-" + std::to_string(time(nullptr));
+
+    int res = makePutRequest(
+        adminUrl + "admin/v2/persistent/public/default/" + partitionedTopic + "/partitions", "10");
+    ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
+
+    ProducerConfiguration producerConfiguration;
+    producerConfiguration.setLazyStartPartitionedProducers(true);
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(partitionedTopic, producerConfiguration, producer));
+
+    Message msg = MessageBuilder().setContent("test").build();
+
+    Promise<bool, Result> promiseClose;
+    producer.closeAsync(WaitForCallback(promiseClose));
+
+    Promise<Result, MessageId> promise;
+    producer.sendAsync(msg, WaitForCallbackValue<MessageId>(promise));
+
+    MessageId mi;
+    ASSERT_EQ(ResultAlreadyClosed, promise.getFuture().get(mi));
+
+    Result result;
+    promiseClose.getFuture().get(result);
+    ASSERT_EQ(ResultOk, result);
+}
+
+TEST(ProducerTest, testSendAsyncCloseAsyncConcurrentlyWithLazyProducers) {
+    // run sendAsync and closeAsync concurrently and verify that all sendAsync callbacks are called
+    // and that messages sent after closeAsync is invoked receive ResultAlreadyClosed.
+    for (int run = 0; run < 20; run++) {
+        Client client(serviceUrl);
+        const std::string partitionedTopic =
+            "testProducerIsConnectedPartitioned-" + std::to_string(time(nullptr));
+
+        int res = makePutRequest(
+            adminUrl + "admin/v2/persistent/public/default/" + partitionedTopic + "/partitions", "10");
+        ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
+
+        ProducerConfiguration producerConfiguration;
+        producerConfiguration.setLazyStartPartitionedProducers(true);
+        producerConfiguration.setPartitionsRoutingMode(ProducerConfiguration::UseSinglePartition);
+        producerConfiguration.setBatchingEnabled(true);
+        Producer producer;
+        ASSERT_EQ(ResultOk, client.createProducer(partitionedTopic, producerConfiguration, producer));
+
+        int sendCount = 100;
+        std::vector<Promise<Result, MessageId>> promises(sendCount);
+        Promise<bool, Result> promiseClose;
+
+        // only call closeAsync once at least 10 messages have been sent
+        Latch sendStartLatch(10);
+        Latch closeLatch(1);
+        int closedAt = 0;
+
+        std::thread t1([&]() {
+            for (int i = 0; i < sendCount; i++) {
+                sendStartLatch.countdown();
+                Message msg = MessageBuilder().setContent("test").build();
+
+                if (closeLatch.getCount() == 0 && closedAt == 0) {
+                    closedAt = i;
+                    LOG_INFO("closedAt set to " << closedAt)
+                }
+
+                producer.sendAsync(msg, WaitForCallbackValue<MessageId>(promises[i]));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        });
+
+        std::thread t2([&]() {
+            sendStartLatch.wait(std::chrono::milliseconds(1000));
+            LOG_INFO("Closing");
+            producer.closeAsync(WaitForCallback(promiseClose));
+            LOG_INFO("Close called");
+            closeLatch.countdown();
+            Result result;
+            promiseClose.getFuture().get(result);
+            ASSERT_EQ(ResultOk, result);
+            LOG_INFO("Closed");
+        });
+
+        t1.join();
+        t2.join();
+
+        // make sure that all messages after the moment when closeAsync was invoked
+        // return AlreadyClosed
+        for (int i = 0; i < sendCount; i++) {
+            LOG_DEBUG("Checking " << i)
+
+            // whether a message was sent successfully or not, it's callback
+            // must have been invoked
+            ASSERT_EQ(true, promises[i].isComplete());
+            MessageId mi;
+            Result res = promises[i].getFuture().get(mi);
+            LOG_DEBUG("Result is " << res);
+
+            // for the messages sent after closeAsync was invoked, they
+            // should all return ResultAlreadyClosed
+            if (i >= closedAt) {
+                ASSERT_EQ(ResultAlreadyClosed, res);
+            }
+        }
+
+        client.close();
+    }
 }

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -61,6 +61,11 @@ class PulsarFriend {
         return *producerImpl;
     }
 
+    static ProducerImpl& getInternalProducerImpl(Producer producer, int index) {
+        PartitionedProducerImpl* producerImpl = static_cast<PartitionedProducerImpl*>(producer.impl_.get());
+        return *(producerImpl->producers_[index]);
+    }
+
     static void producerFailMessages(Producer producer, Result result) {
         producer.producerFailMessages(result);
     }

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -253,52 +253,227 @@ pulsar+ssl://pulsar.us-west.example.com:6651
 
 ## Create a consumer
 
-To use Pulsar as a consumer, you need to create a consumer on the C++ client. The following is an example. 
+To use Pulsar as a consumer, you need to create a consumer on the C++ client. There are two main ways of using the consumer:
+- Blocking style: synchronously calling `receive(msg)`.
+- Non-blocking (event based) style: using a message listener.
+
+### Blocking example
+
+The benefit of this approach is that it is the simplest code. Simply keeps calling `receive(msg)` which blocks until a message is received.
+
+This example starts a subscription at the earliest offset and consumes 100 messages.
 
 ```c++
-Client client("pulsar://localhost:6650");
+#include <pulsar/Client.h>
 
-Consumer consumer;
-Result result = client.subscribe("my-topic", "my-subscription-name", consumer);
-if (result != ResultOk) {
-    LOG_ERROR("Failed to subscribe: " << result);
-    return -1;
+using namespace pulsar;
+
+int main() {
+    Client client("pulsar://localhost:6650");
+
+    Consumer consumer;
+    ConsumerConfiguration config;
+    config.setSubscriptionInitialPosition(InitialPositionEarliest);
+    Result result = client.subscribe("persistent://public/default/my-topic", "consumer-1", config, consumer);
+    if (result != ResultOk) {
+        std::cout << "Failed to subscribe: " << result << std::endl;
+        return -1;
+    }
+
+    Message msg;
+    int ctr = 0;
+    // consume 100 messages
+    while (ctr < 100) {
+        consumer.receive(msg);
+        std::cout << "Received: " << msg
+            << "  with payload '" << msg.getDataAsString() << "'" << std::endl;
+
+        consumer.acknowledge(msg);
+        ctr++;
+    }
+
+    std::cout << "Finished consuming synchronously!" << std::endl;
+
+    client.close();
+    return 0;
+}
+```
+
+### Consumer with a message listener
+
+We can avoid the need to run a loop with blocking calls with an event based style by using a message listener which is invoked for each message that is received.
+
+This example starts a subscription at the earliest offset and consumes 100 messages.
+
+```c++
+#include <pulsar/Client.h>
+#include <atomic>
+#include <thread>
+
+using namespace pulsar;
+
+std::atomic<uint32_t> messagesReceived;
+
+void handleAckComplete(Result res) {
+    std::cout << "Ack res: " << res << std::endl;
 }
 
-Message msg;
-
-while (true) {
-    consumer.receive(msg);
-    LOG_INFO("Received: " << msg
-            << "  with payload '" << msg.getDataAsString() << "'");
-
-    consumer.acknowledge(msg);
+void listener(Consumer consumer, const Message& msg) {
+    std::cout << "Got message " << msg << " with content '" << msg.getDataAsString() << "'" << std::endl;
+    messagesReceived++;
+    consumer.acknowledgeAsync(msg.getMessageId(), handleAckComplete);
 }
 
-client.close();
+int main() {
+    Client client("pulsar://localhost:6650");
+
+    Consumer consumer;
+    ConsumerConfiguration config;
+    config.setMessageListener(listener);
+    config.setSubscriptionInitialPosition(InitialPositionEarliest);
+    Result result = client.subscribe("persistent://public/default/my-topic", "consumer-1", config, consumer);
+    if (result != ResultOk) {
+        std::cout << "Failed to subscribe: " << result << std::endl;
+        return -1;
+    }
+
+    // wait for 100 messages to be consumed
+    while (messagesReceived < 100) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    std::cout << "Finished consuming asynchronously!" << std::endl;
+
+    client.close();
+    return 0;
+}
 ```
 
 ## Create a producer
 
-To use Pulsar as a producer, you need to create a producer on the C++ client. The following is an example. 
+To use Pulsar as a producer, you need to create a producer on the C++ client. There are two main ways of using a producer:
+- Blocking style where each call to `send` waits for an ack from the broker.
+- Non-blocking asynchronous style where `sendAsync` is called instead of `send` and a callback is supplied for when the ack is received from the broker.
+
+### Simple blocking example
+
+This example sends 100 messages using the blocking style. While simple, it does not produce high throughput as it waits for each ack to come back before sending the next message.
 
 ```c++
-Client client("pulsar://localhost:6650");
+#include <pulsar/Client.h>
+#include <thread>
 
-Producer producer;
-Result result = client.createProducer("my-topic", producer);
-if (result != ResultOk) {
-    LOG_ERROR("Error creating producer: " << result);
-    return -1;
+using namespace pulsar;
+
+int main() {
+    Client client("pulsar://localhost:6650");
+
+    Result result = client.createProducer("persistent://public/default/my-topic", producer);
+    if (result != ResultOk) {
+        std::cout << "Error creating producer: " << result << std::endl;
+        return -1;
+    }
+
+    // Send 100 messages synchronously
+    int ctr = 0;
+    while (ctr < 100) {
+        std::string content = "msg" + std::to_string(ctr);
+        Message msg = MessageBuilder().setContent(content).setProperty("x", "1").build();
+        Result result = producer.send(msg);
+        if (result != ResultOk) {
+            std::cout << "The message " << content << " could not be sent, received code: " << result << std::endl;
+        } else {
+            std::cout << "The message " << content << " sent successfully" << std::endl;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ctr++;
+    }
+
+    std::cout << "Finished producing synchronously!" << std::endl;
+
+    client.close();
+    return 0;
+}
+```
+
+### Non-blocking example
+
+This example sends 100 messages using the non-blocking style calling `sendAsync` instead of `send`. This allows the producer to have multiple messages inflight at a time which increases throughput.
+
+The producer configuration `blockIfQueueFull` is useful here to avoid `ResultProducerQueueIsFull` errors when the internal queue for outgoing send requests becomes full. Once the internal queue is full, `sendAsync` becomes blocking which can make your code simpler.
+
+Without this configuration, the result code `ResultProducerQueueIsFull` is passed to the callback. You must decide how to deal with that (retry, discard etc).
+
+```c++
+#include <pulsar/Client.h>
+#include <thread>
+
+using namespace pulsar;
+
+std::atomic<uint32_t> acksReceived;
+
+void callback(Result code, const MessageId& msgId, std::string msgContent) {
+    // message processing logic here
+    std::cout << "Received ack for msg: " << msgContent << " with code: "
+        << code << " -- MsgID: " << msgId << std::endl;
+    acksReceived++;
 }
 
-// Publish 10 messages to the topic
-for (int i = 0; i < 10; i++){
-    Message msg = MessageBuilder().setContent("my-message").build();
-    Result res = producer.send(msg);
-    LOG_INFO("Message sent: " << res);
+int main() {
+    Client client("pulsar://localhost:6650");
+
+    ProducerConfiguration producerConf;
+    producerConf.setBlockIfQueueFull(true);
+    Producer producer;
+    Result result = client.createProducer("persistent://public/default/my-topic",
+                                          producerConf, producer);
+    if (result != ResultOk) {
+        std::cout << "Error creating producer: " << result << std::endl;
+        return -1;
+    }
+
+    // Send 100 messages asynchronously
+    int ctr = 0;
+    while (ctr < 100) {
+        std::string content = "msg" + std::to_string(ctr);
+        Message msg = MessageBuilder().setContent(content).setProperty("x", "1").build();
+        producer.sendAsync(msg, std::bind(callback,
+                                          std::placeholders::_1, std::placeholders::_2, content));
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ctr++;
+    }
+
+    // wait for 100 messages to be acked
+    while (acksReceived < 100) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    std::cout << "Finished producing asynchronously!" << std::endl;
+
+    client.close();
+    return 0;
 }
-client.close();
+```
+
+### Partitioned topics and lazy producers
+
+When scaling out a Pulsar topic, you may configure a topic to have hundreds of partitions. Likewise, you may have also scaled out your producers so there are hundreds or even thousands of producers. This can put some strain on the Pulsar brokers as when you create a producer on a partitioned topic, internally it creates one internal producer per partition which involves communications to the brokers for each one. So for a topic with 1000 partitions and 1000 producers, it ends up creating 1,000,000 internal producers across the producer applications, each of which has to communicate with a broker to find out which broker it should connect to and then perform the connection handshake.
+
+You can reduce the load caused by this combination of a large number of partitions and many producers by doing the following:
+- use SinglePartition partition routing mode (this ensures that all messages are only sent to a single, randomly selected partition)
+- use non-keyed messages (when messages are keyed, routing is based on the hash of the key and so messages will end up being sent to multiple partitions)
+- use lazy producers (this ensures that an internal producer is only created on demand when a message needs to be routed to a partition)
+
+With our example above, that reduces the number of internal producers spread out over the 1000 producer apps from 1,000,000 to just 1000.
+
+Note that there can be extra latency for the first message sent. If you set a low send timeout, this timeout could be reached if the initial connection handshake is slow to complete.
+
+```c++
+ProducerConfiguration producerConf;
+producerConf.setPartitionsRoutingMode(ProducerConfiguration::UseSinglePartition);
+producerConf.setLazyStartPartitionedProducers(true);
 ```
 
 ## Enable authentication in connection URLs


### PR DESCRIPTION
Fixes #11496 also matches part of PIP 79.

C++ implementation that closely matches the proposed Java client changes from reducing partitioned producer connections and lookups: PR 10279

### Motivation

Producers that send messages to partitioned topics start a producer per partition, even when using single partition routing. For topics that have the combination of a large number of producers and a large number of partitions, this can put strain on the brokers. With say 1000 partitions and single partition routing with non-keyed messages, 999 topic owner lookups and producer registrations are performed that could be avoided.

PIP 79 also describes this. I wrote this before realising that PIP 79 also covers this. This implementation can be reviewed and contrasted to the Java client implementation in https://github.com/apache/pulsar/pull/10279.

### Modifications

Allows partitioned producers to start producers for individual partitions lazily. Starting a producer involves a topic owner
lookup to find out which broker is the owner of the partition, then registering the producer for that partition with the owner
broker. For topics with many partitions and when using SinglePartition routing without keyed messages, all of these
lookups and producer registrations are a waste except for the single chosen partition.

This change allows the user to control whether a producer on a partitioned topic uses this lazy start or not, via a new config
in ProducerConfiguration. When ProducerConfiguration.setLazyStartPartitionedProducers(true) is set, the PartitionedProducerImpl.start() becomes a synchronous operation that only does housekeeping (no network operations).
The producer of any given partition is started (which includes a topic owner lookup and registration) upon sending the first message to that partition. While the producer starts, messages are buffered.

The sendTimeout timer is only activated once a producer has been fully started, which should give enough time for any buffered messages to be sent. For very short send timeouts, this setting could cause send timeouts during the start phase. The default of 30s should however not cause this issue.

### Verifying this change

This change added tests and can be verified as follows:
  - BasicEndToEndTest, testPartitionedProducerConsumer
  - BasicEndToEndTest, testSyncFlushBatchMessagesPartitionedTopicLazyProducers
  - BasicEndToEndTest, testFlushInLazyPartitionedProducer

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes) - client configuration
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?

Yes, the new client config would need documenting. Can contribute that if this PR is accepted.


#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

