### PR TITLE
[C++] Fix testConnectTimeout test by shutting down clients

### DIFF
--- a/pulsar-client-cpp/tests/ClientTest.cc
+++ b/pulsar-client-cpp/tests/ClientTest.cc
@@ -114,7 +114,9 @@ TEST(ClientTest, testConnectTimeout) {
     ASSERT_EQ(futureDefault.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
 
     clientLow.close();
+    clientLow.shutdown();
     clientDefault.close();
+    clientDefault.shutdown();
 }
 
 TEST(ClientTest, testGetNumberOfReferences) {


### PR DESCRIPTION
### Motivation

This test does not call shutdown() on the clients which causes a connect timer to not be cancelled and a mutex operation is performed by the timer after the mutex has already been destructed on the test completing. Only occurs when running many tests at a time.

### Modifications

Call shutdown on both clients in the test.

### Verifying this change

Run the existing tests and see no error. When it happens, the test passes but 10 seconds later (that is the connect timeout set in the test), the process terminates with the error "mutex lock failed: Invalid argument". This is caused by the compare_exchange_strong in PeriodicTask, after the underlying mutex has been destructed.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?

No. This is a minor fix to a test.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

