### PR TITLE
[Tests] Fix cpp build not failing when tests fail

### DIFF
--- a/pulsar-client-cpp/docker-tests.sh
+++ b/pulsar-client-cpp/docker-tests.sh
@@ -65,7 +65,7 @@ DISABLE_COLOR_OUTPUT=""
 if [ "$GTEST_COLOR" = "no" ]; then
   DISABLE_COLOR_OUTPUT="| cat"
 fi
-$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && ./run-unit-tests.sh ${tests} $DISABLE_COLOR_OUTPUT"
+$DOCKER_CMD bash -c "set -o pipefail; cd /pulsar/pulsar-client-cpp && ./run-unit-tests.sh ${tests} $DISABLE_COLOR_OUTPUT"
 RES=$?
 if [ $RES -ne 0 ]; then
   (


### PR DESCRIPTION
### Motivation

- fixes issue that cpp build doesn't fail when tests fail
- merge after #11557

### Additional context

- https://github.com/apache/pulsar/pull/11557#issuecomment-893422981
- https://github.com/apache/pulsar/pull/10309/files#r683626563

### Modifications 

- `set -o pipefail;` is required when using `| cat`