### PR TITLE
[C++] Fix wrong Base64 paddings

### DIFF
--- a/pulsar-client-cpp/lib/ProtobufNativeSchema.cc
+++ b/pulsar-client-cpp/lib/ProtobufNativeSchema.cc
@@ -54,14 +54,19 @@ SchemaInfo createProtobufNativeSchema(const google::protobuf::Descriptor* descri
     std::string base64String{base64(bytes.data()), base64(bytes.data() + bytes.size())};
     // Pulsar broker only supports decoding Base64 with padding so we need to add padding '=' here
     const size_t numPadding = 4 - base64String.size() % 4;
-    for (size_t i = 0; i < numPadding; i++) {
-        base64String.push_back('=');
-    }
+    if (numPadding <= 2) {
+        for (size_t i = 0; i < numPadding; i++) {
+            base64String.push_back('=');
+        }
+    } else if (numPadding == 3) {
+        // The length of encoded Base64 string (without padding) should not be 4N+1
+        throw std::runtime_error("Unexpected padding number (3), the encoded Base64 string is:\n" +
+                                 base64String);
+    }  // else numPadding == 4, which means no padding characters need to be added
 
-    const std::string schemaJson =
-        R"({"fileDescriptorSet":")" + base64String +
-        R"(","rootMessageTypeName":")" + rootMessageTypeName +
-        R"(","rootFileDescriptorName":")" + rootFileDescriptorName + R"("})";
+    const std::string schemaJson = R"({"fileDescriptorSet":")" + base64String +
+                                   R"(","rootMessageTypeName":")" + rootMessageTypeName +
+                                   R"(","rootFileDescriptorName":")" + rootFileDescriptorName + R"("})";
 
     return SchemaInfo(SchemaType::PROTOBUF_NATIVE, "", schemaJson);
 }


### PR DESCRIPTION
### Motivation

This bug was introduced from #11492, which adds padding characters but it will still add 4 `=`s even if the length can be divided by 4. Following tests are broken currently:
- ProtobufNativeSchemaTest.testAutoCreateSchema
- ProtobufNativeSchemaTest.testEndToEnd
- ProtobufNativeSchemaTest.testSchemaJson
- ProtobufNativeSchemaTest.testSchemaIncompatibility

### Modifications

Only add at most 2 padding characters in Base64 encoding. If the Base64 encoded string's length is 4N+1, there must be something wrong with the encoding, so throw an exception in this case.

### Verifying this change

Currently CI of C++ client is broken, we only need to confirm with the workflow output to ensure this fix works.