### PR TITLE
avoid create new subscription name for reader if it's already configed

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -48,12 +48,14 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
 
     public MultiTopicsReaderImpl(PulsarClientImpl client, ReaderConfigurationData<T> readerConfiguration,
                                  ExecutorProvider executorProvider, CompletableFuture<Consumer<T>> consumerFuture, Schema<T> schema) {
-        String subscription = "multiTopicsReader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
-        if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
-            subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
-        }
+        String subscription;
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionName())) {
             subscription = readerConfiguration.getSubscriptionName();
+        } else {
+            subscription = "multiTopicsReader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+            if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
+                subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
+            }
         }
         ConsumerConfigurationData<T> consumerConfiguration = new ConsumerConfigurationData<>();
         consumerConfiguration.getTopicNames().addAll(readerConfiguration.getTopicNames());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -52,13 +52,14 @@ public class ReaderImpl<T> implements Reader<T> {
 
     public ReaderImpl(PulsarClientImpl client, ReaderConfigurationData<T> readerConfiguration,
                       ExecutorProvider executorProvider, CompletableFuture<Consumer<T>> consumerFuture, Schema<T> schema) {
-
-        String subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
-        if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
-            subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
-        }
+        String subscription;
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionName())) {
             subscription = readerConfiguration.getSubscriptionName();
+        } else {
+            subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+            if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
+                subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
+            }
         }
 
         ConsumerConfigurationData<T> consumerConfiguration = new ConsumerConfigurationData<>();


### PR DESCRIPTION
### Motivation
For a reader,  pulsar will  create a new subscription name first without checking whether it's existed or not.

```java
 String subscription = "multiTopicsReader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
        if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
            subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
        }
if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionName())) {
            subscription = readerConfiguration.getSubscriptionName();
        }
```

This pull request aims to avoid create a new subscription name for reader if it's already set before.


### Modifications

Check subscription from the `ReaderConfigurationData` first and if already exist, we do not need to create a subscription name.

### Verifying this change


This change is a trivial rework without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no)
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: ( no)
  - The admin cli options: ( no)
  - Anything that affects deployment: ( now)

### Documentation

 no document need  be added or updated since this change has nothing to do with API and configuration



