### PR TITLE
[Issue-11449] [docs] Updated Python installation steps for Mac

### DIFF
--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -23,7 +23,7 @@ $ pip install pulsar-client=={{pulsar:version_number}}
 ```
 
 ### Optional dependencies
-If you are installing the client libraries on Linux then in order to support aspects like pulsar functions or Avro serialization, additional optional components can be installed alongside the  `pulsar-client` library
+If you install the client libraries on Linux to support services like Pulsar functions or Avro serialization, you can install optional components alongside the  `pulsar-client` library.
 
 ```shell
 # avro serialization

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -23,8 +23,7 @@ $ pip install pulsar-client=={{pulsar:version_number}}
 ```
 
 ### Optional dependencies
-
-To support aspects like pulsar functions or Avro serialization, additional optional components can be installed alongside the  `pulsar-client` library
+If you are installing the client libraries on Linux then in order to support aspects like pulsar functions or Avro serialization, additional optional components can be installed alongside the  `pulsar-client` library
 
 ```shell
 # avro serialization


### PR DESCRIPTION


Fixes #11449 

### Motivation

The installation steps for the Python client library currently in the docs only work in Linux environments, and do not work with pip3 on a Mac

### Modifications

I have removed the "optional components" installation steps for Mac since they don't appear to be necessary based on my testing.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

No

### Documentation

#### For contributor

For this PR, do we need to update docs?

No, this is a documentation change



