### PR TITLE
[Python Schema] Fix redefined `Record` or `Enum` in Python schema

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -97,15 +97,23 @@ class Record(with_metaclass(RecordMeta, object)):
 
     @classmethod
     def schema(cls):
+        return cls.schema_info(set())
+
+    @classmethod
+    def schema_info(cls, defined_names):
+        if cls.__name__ in defined_names:
+            return cls.__name__
+
+        defined_names.add(cls.__name__)
         schema = {
             'name': str(cls.__name__),
             'type': 'record',
             'fields': []
         }
-
         for name in sorted(cls._fields.keys()):
             field = cls._fields[name]
-            field_type = field.schema() if field._required else ['null', field.schema()]
+            field_type = field.schema_info(defined_names) \
+                if field._required else ['null', field.schema_info(defined_names)]
             schema['fields'].append({
                 'name': name,
                 'type': field_type,
@@ -196,6 +204,9 @@ class Field(object):
 
     def schema(self):
         # For primitive types, the schema would just be the type itself
+        return self.type()
+
+    def schema_info(self, defined_names):
         return self.type()
 
     def default(self):
@@ -347,6 +358,9 @@ class _Enum(Field):
         return self.enum_type
 
     def validate_type(self, name, val):
+        if val is None:
+            return None
+
         if type(val) is str:
             # The enum was passed as a string, we need to check it against the possible values
             if val in self.enum_type.__members__:
@@ -367,6 +381,12 @@ class _Enum(Field):
             return val
 
     def schema(self):
+        return self.schema_info(set())
+
+    def schema_info(self, defined_names):
+        if self.enum_type.__name__ in defined_names:
+            return self.enum_type.__name__
+        defined_names.add(self.enum_type.__name__)
         return {
             'type': self.type(),
             'name': self.enum_type.__name__,
@@ -393,6 +413,9 @@ class Array(Field):
         return list
 
     def validate_type(self, name, val):
+        if val is None:
+            return None
+
         super(Array, self).validate_type(name, val)
 
         for x in val:
@@ -402,9 +425,12 @@ class Array(Field):
         return val
 
     def schema(self):
+        return self.schema_info(set())
+
+    def schema_info(self, defined_names):
         return {
             'type': self.type(),
-            'items': self.array_type.schema() if isinstance(self.array_type, (Array, Map, Record))
+            'items': self.array_type.schema_info(defined_names) if isinstance(self.array_type, (Array, Map, Record))
                 else self.array_type.type()
         }
 
@@ -428,6 +454,9 @@ class Map(Field):
         return dict
 
     def validate_type(self, name, val):
+        if val is None:
+            return None
+
         super(Map, self).validate_type(name, val)
 
         for k, v in val.items():
@@ -440,9 +469,12 @@ class Map(Field):
         return val
 
     def schema(self):
+        return self.schema_info(set())
+
+    def schema_info(self, defined_names):
         return {
             'type': self.type(),
-            'values': self.value_type.schema() if isinstance(self.value_type, (Array, Map, Record))
+            'values': self.value_type.schema_info(defined_names) if isinstance(self.value_type, (Array, Map, Record))
                 else self.value_type.type()
         }
 


### PR DESCRIPTION
Fixes #11533

### Motivation

Refer to issue #11533 , currently, if users redefined the same `Record` or `Enum` in `Record`, the schema info isn't reused the defined name, this does not match the Avro schema info format.

### Modifications

Add a new method `schema_info(self, defined_names)` in `Record`, `Array`, `Map`, and `Enum`, all defined names will be added in the parameter `defined_names` when users use a defined `Record`, or `Enum`, the schema info will use the name of the defined `Record` or `Enum` as the type.

### Verifying this change

Add test to verify using same `Record` or `Enum` in a complex `Record`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

