### PR TITLE
Use sendRequestWithId to add timeout to hasMessageAvailable

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1582,7 +1582,7 @@ Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consume
 
     pendingGetLastMessageIdRequests_.insert(std::make_pair(requestId, promise));
     lock.unlock();
-    sendCommand(Commands::newGetLastMessageId(consumerId, requestId));
+    sendRequestWithId(Commands::newGetLastMessageId(consumerId, requestId), requestId);
     return promise.getFuture();
 }
 


### PR DESCRIPTION
### Motivation

Add timeout for the reader.hasMessageAvailable(hasMsg).

### Modifications

Use `sendRequestWithId` instead if `sendCommand`, and former will get `OperationTimeout`.