### PR TITLE
Fix null MessageId may be passed to its compareTo() method

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -115,10 +115,11 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
      */
     @Override
     public boolean isDuplicate(@NonNull MessageId messageId) {
-        if (lastCumulativeAck.messageId == null) {
+        final MessageId messageIdOfLastAck = lastCumulativeAck.messageId;
+        if (messageIdOfLastAck == null) {
             return false;
         }
-        if (messageId.compareTo(lastCumulativeAck.messageId) <= 0) {
+        if (messageId.compareTo(messageIdOfLastAck) <= 0) {
             // Already included in a cumulative ack
             return true;
         } else {


### PR DESCRIPTION
Fixes #11604 

### Motivation

There's a chance that null `MessageId` might be passed to its `compareTo()` method. Even if #10586 added the null check, it's still not thread safe because `lastCumulativeAck` might be modified after the null check between line 118 and line 121 in following code snippet:

https://github.com/apache/pulsar/blob/1e9f0cde6b473f786273bd4ce0df8b43622a61ed/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L118-L121

### Modifications

Add a local variable `messageIdOfLastAck` to cache `messageId` field of `lastCumulative` so that the `MessageId` won't change during the null check and `compareTo()` method.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.