### PR TITLE
[Java Client] Switch from pretty print to compact print for configs

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -111,7 +111,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     private void init(ConsumerConfigurationData<?> conf) {
         ObjectMapper m = new ObjectMapper();
         m.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        ObjectWriter w = m.writer();
 
         try {
             log.info("Starting Pulsar consumer status recorder with config: {}", w.writeValueAsString(conf));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -95,7 +95,7 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
     private void init(ProducerConfigurationData conf) {
         ObjectMapper m = new ObjectMapper();
         m.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+        ObjectWriter w = m.writer();
 
         try {
             log.info("Starting Pulsar producer perf with config: {}", w.writeValueAsString(conf));

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -396,8 +396,7 @@ public class PulsarWorkerService implements WorkerService {
         log.info("/** Starting worker id={} **/", workerConfig.getWorkerId());
 
         try {
-            log.info("Worker Configs: {}", new ObjectMapper().writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(workerConfig));
+            log.info("Worker Configs: {}", new ObjectMapper().writeValueAsString(workerConfig));
         } catch (JsonProcessingException e) {
             log.warn("Failed to print worker configs with error {}", e.getMessage(), e);
         }


### PR DESCRIPTION
### Motivation

When running the `ProducerStatsRecorderImpl` and `ConsumerStatsRecorderImpl`, there are several log lines that print configuration in pretty print formatting. This output can be easier to read, but it adds verbosity to logs, especially if there are many of these configs printing for many topics. Practically speaking, when tailing logs, these pretty printed configs take up much of one's screen and make it harder to see other logging events. Also, pretty printing can be problematic when using log aggregators that do not have good multi-line support, as the logs won't be grouped properly.

I propose switching to a compact output for these log lines to decrease the number of lines output and to make it easier for log aggregators to easily capture the whole log line.

Here is a sample of the current logging output:

```
20:36:18.628 [pulsar-io-4-2] INFO  org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - Starting Pulsar producer perf with config: {
  "topicName" : "persistent://public/default/example",
  "producerName" : null,
  "sendTimeoutMs" : 30000,
  "blockIfQueueFull" : false,
  "maxPendingMessages" : 1000,
  "maxPendingMessagesAcrossPartitions" : 50000,
  "messageRoutingMode" : "RoundRobinPartition",
  "hashingScheme" : "JavaStringHash",
  "cryptoFailureAction" : "FAIL",
  "batchingMaxPublishDelayMicros" : 1000,
  "batchingPartitionSwitchFrequencyByPublishDelay" : 10,
  "batchingMaxMessages" : 1000,
  "batchingMaxBytes" : 131072,
  "batchingEnabled" : true,
  "chunkingEnabled" : false,
  "compressionType" : "NONE",
  "initialSequenceId" : null,
  "autoUpdatePartitions" : true,
  "autoUpdatePartitionsIntervalSeconds" : 60,
  "multiSchema" : true,
  "accessMode" : "Shared",
  "properties" : { }
}
20:36:18.628 [pulsar-io-4-2] INFO  org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - Pulsar client config: {
  "serviceUrl" : "pulsar+ssl://172.17.0.11:6651",
  "authPluginClassName" : "org.apache.pulsar.client.impl.auth.AuthenticationToken",
  "authParams" : "*****",
  "authParamMap" : null,
  "operationTimeoutMs" : 30000,
  "statsIntervalSeconds" : 60,
  "numIoThreads" : 1,
  "numListenerThreads" : 1,
  "connectionsPerBroker" : 1,
  "useTcpNoDelay" : true,
  "useTls" : true,
  "tlsTrustCertsFilePath" : "/pulsar/certs/ca.crt",
  "tlsAllowInsecureConnection" : false,
  "tlsHostnameVerificationEnable" : false,
  "concurrentLookupRequest" : 5000,
  "maxLookupRequest" : 50000,
  "maxLookupRedirects" : 20,
  "maxNumberOfRejectedRequestPerConnection" : 50,
  "keepAliveIntervalSeconds" : 30,
  "connectionTimeoutMs" : 10000,
  "requestTimeoutMs" : 60000,
  "initialBackoffIntervalNanos" : 100000000,
  "maxBackoffIntervalNanos" : 60000000000,
  "enableBusyWait" : false,
  "listenerName" : null,
  "useKeyStoreTls" : false,
  "sslProvider" : null,
  "tlsTrustStoreType" : "JKS",
  "tlsTrustStorePath" : null,
  "tlsTrustStorePassword" : null,
  "tlsCiphers" : [ ],
  "tlsProtocols" : [ ],
  "memoryLimitBytes" : 0,
  "proxyServiceUrl" : null,
  "proxyProtocol" : null,
  "enableTransaction" : false
}
```

Further, I think this change is in line with other Pulsar logging. We already print out configuration in a compact format when starting a broker: https://github.com/apache/pulsar/blob/d57c1d29ffeee7a6f17a77e5d198892c6d1cdd27/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L790-L791


### Modifications

* Update 3 places where ObjectWriters are configured as pretty printers by removing the `writerWithDefaultPrettyPrinter` method call.

### Verifying this change

This is a trivial rework. The result of this update is that log lines will be compact json on a single line instead of pretty printed json on many lines.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

N/A