### PR TITLE
Fix sink byte buffer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -37,6 +37,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,19 +75,20 @@ import org.apache.pulsar.common.io.SinkConfig;
 import org.apache.pulsar.common.io.SourceConfig;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.PublisherStats;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.functions.LocalRunner;
+import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactory;
 import org.apache.pulsar.functions.runtime.thread.ThreadRuntimeFactoryConfig;
 import org.apache.pulsar.functions.utils.FunctionCommon;
+import org.apache.pulsar.io.core.Sink;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -851,7 +853,7 @@ public class PulsarFunctionLocalRunTest {
         runWithNarClassLoader(() -> testPulsarSourceLocalRun(null, 2));
     }
 
-    private void testPulsarSinkLocalRun(String jarFilePathUrl, int parallelism) throws Exception {
+    private void testPulsarSinkLocalRun(String jarFilePathUrl, int parallelism, String className) throws Exception {
         final String namespacePortion = "io";
         final String replNamespace = tenant + "/" + namespacePortion;
         final String sourceTopic = "persistent://" + replNamespace + "/input";
@@ -869,7 +871,9 @@ public class PulsarFunctionLocalRunTest {
         SinkConfig sinkConfig = createSinkConfig(tenant, namespacePortion, sinkName, sourceTopic, subscriptionName);
 
         sinkConfig.setInputSpecs(Collections.singletonMap(sourceTopic, ConsumerConfig.builder().receiverQueueSize(1000).build()));
-        if (jarFilePathUrl == null || !jarFilePathUrl.endsWith(".nar")) {
+        if (className != null) {
+            sinkConfig.setClassName(className);
+        } else if (jarFilePathUrl == null || !jarFilePathUrl.endsWith(".nar")) {
             sinkConfig.setClassName("org.apache.pulsar.io.datagenerator.DataGeneratorPrintSink");
         }
 
@@ -935,6 +939,15 @@ public class PulsarFunctionLocalRunTest {
                 if (m != null) {
                     metricsMap.put(m.tags.get("instance_id"), m);
                 }
+            } else if (line.startsWith("pulsar_sink_sink_exceptions_total")) {
+                log.info("line: {}", line);
+                Map<String, PulsarFunctionTestUtils.Metric> metrics = PulsarFunctionTestUtils.parseMetrics(line);
+                assertFalse(metrics.isEmpty());
+                PulsarFunctionTestUtils.Metric m = metrics.get("pulsar_sink_sink_exceptions_total");
+                if (m == null) {
+                    m = metrics.get("pulsar_sink_sink_exceptions_total_1min");
+                }
+                assertEquals(m.value, 0);
             }
         });
         Assert.assertEquals(metricsMap.size(), parallelism);
@@ -972,7 +985,11 @@ public class PulsarFunctionLocalRunTest {
     }
 
     private void testPulsarSinkLocalRun(String jarFilePathUrl) throws Exception {
-        testPulsarSourceLocalRun(jarFilePathUrl, 1);
+        testPulsarSinkLocalRun(jarFilePathUrl, 1);
+    }
+
+    private void testPulsarSinkLocalRun(String jarFilePathUrl, int parallelism) throws Exception {
+        testPulsarSinkLocalRun(jarFilePathUrl, parallelism, null);
     }
 
     @Test(timeOut = 20000, groups = "builtin")
@@ -999,6 +1016,31 @@ public class PulsarFunctionLocalRunTest {
     @Test(timeOut = 40000)
     public void testPulsarSinkStatsMultipleInstances() throws Throwable {
         runWithNarClassLoader(() -> testPulsarSinkLocalRun(null, 2));
+    }
+
+    public static class StatsNullSink implements Sink<ByteBuffer> {
+        volatile long bytesTotal = 0;
+
+        @Override
+        public void open(Map map, final SinkContext sinkContext) throws Exception {
+
+        }
+
+        @Override
+        public void write(Record<ByteBuffer> record) throws Exception {
+            bytesTotal += record.getValue().capacity();
+            record.ack();
+        }
+
+        @Override
+        public void close() throws Exception {
+
+        }
+    }
+
+    @Test
+    public void test() throws Throwable{
+        runWithNarClassLoader(() -> testPulsarSinkLocalRun(null, 1, StatsNullSink.class.getName()));
     }
 
     private void runWithNarClassLoader(Assert.ThrowingRunnable throwingRunnable) throws Throwable {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -45,6 +45,7 @@ public class ConsumerConfig {
     private Map<String, String> consumerProperties = new HashMap<>();
     private Integer receiverQueueSize;
     private CryptoConfig cryptoConfig;
+    private boolean poolMessages;
 
     public ConsumerConfig(String schemaType) {
         this.schemaType = schemaType;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -145,7 +145,11 @@ public class TopicSchema {
     private static <T> Schema<T> newSchemaInstance(Class<T> clazz, SchemaType type, ConsumerConfig conf) {
         switch (type) {
         case NONE:
-            return (Schema<T>) Schema.BYTES;
+            if (ByteBuffer.class.isAssignableFrom(clazz)) {
+                return (Schema<T>) Schema.BYTEBUFFER;
+            } else {
+                return (Schema<T>) Schema.BYTES;
+            }
 
         case AUTO_CONSUME:
         case AUTO:


### PR DESCRIPTION
### Motivation

If a Pulsar Function/Source/Sink is of type ByteBuffer, an cast exception will occur:

```
6:44:00.226 INFO  [external-repl-prop/io/PulsarSink-test-0] o.a.p.f.i.JavaInstanceRunnable@357 - Encountered exception in sink write: 
java.lang.ClassCastException: class [B cannot be cast to class java.nio.ByteBuffer ([B and java.nio.ByteBuffer are in module java.base of loader 'bootstrap')
	at org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest$StatsNullSink.write(PulsarFunctionLocalRunTest.java:1027) ~[test-classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:355) [classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:338) [classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:283) [classes/:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

The is because if the function is of type ByteBuffer, the schema to used in the consumer is BYTES, which is not correct

### Modifications
Use the correct ByteBuffer schema when the type of the function/source/sink is ByteBuffer

### Verifying this change

Added a test

### Documentation

No changes necessary
 
#### For committer

For this PR, do we need to update docs?

No
