### PR TITLE
Fix: Cast exception occurs if function/source/sink type is ByteBuffer

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -145,7 +145,11 @@ public class TopicSchema {
     private static <T> Schema<T> newSchemaInstance(Class<T> clazz, SchemaType type, ConsumerConfig conf) {
         switch (type) {
         case NONE:
-            return (Schema<T>) Schema.BYTES;
+            if (ByteBuffer.class.isAssignableFrom(clazz)) {
+                return (Schema<T>) Schema.BYTEBUFFER;
+            } else {
+                return (Schema<T>) Schema.BYTES;
+            }
 
         case AUTO_CONSUME:
         case AUTO:


### PR DESCRIPTION
### Motivation

If a Pulsar Function/Source/Sink is of type ByteBuffer, an cast exception will occur:

```
6:44:00.226 INFO  [external-repl-prop/io/PulsarSink-test-0] o.a.p.f.i.JavaInstanceRunnable@357 - Encountered exception in sink write: 
java.lang.ClassCastException: class [B cannot be cast to class java.nio.ByteBuffer ([B and java.nio.ByteBuffer are in module java.base of loader 'bootstrap')
	at org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest$StatsNullSink.write(PulsarFunctionLocalRunTest.java:1027) ~[test-classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:355) [classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:338) [classes/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:283) [classes/:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

The is because if the function is of type ByteBuffer, the schema to used in the consumer is BYTES, which is not correct

### Modifications
Use the correct ByteBuffer schema when the type of the function/source/sink is ByteBuffer

### Verifying this change

Added a test

### Documentation

No changes necessary
 
#### For committer

For this PR, do we need to update docs?

No
