### PR TITLE
avoid non-durable subscription misuse an existed durable subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -900,6 +900,12 @@ public class PersistentTopic extends AbstractTopic
 
                 subscription = new PersistentSubscription(this, subscriptionName, cursor, false);
                 subscriptions.put(subscriptionName, subscription);
+            } else {
+                // if subscription exist, check if it's a durable subscription
+                if (subscription.getCursor() != null && subscription.getCursor().isDurable()) {
+                    return FutureUtil.failedFuture(
+                            new NotAllowedException("Durable subscribe with the same name already exist."));
+                }
             }
 
             if (startMessageRollbackDurationSec > 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -901,10 +901,10 @@ public class PersistentTopic extends AbstractTopic
                 subscription = new PersistentSubscription(this, subscriptionName, cursor, false);
                 subscriptions.put(subscriptionName, subscription);
             } else {
-                // if subscription exist, check if it's a durable subscription
+                // if subscription exists, check if it's a durable subscription
                 if (subscription.getCursor() != null && subscription.getCursor().isDurable()) {
                     return FutureUtil.failedFuture(
-                            new NotAllowedException("Durable subscribe with the same name already exist."));
+                            new NotAllowedException("Durable subscription with the same name already exists."));
                 }
             }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1561,69 +1561,50 @@ public class ServerCnxTest {
             }
         }).when(ledgerMock).asyncAddEntry(any(ByteBuf.class), any(AddEntryCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> true).when(cursorMock).isDurable();
+
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            Thread.sleep(300);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
+            return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(OpenCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[3]).openCursorComplete(cursorMock, null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            Thread.sleep(300);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[3]).openCursorComplete(cursorMock, null);
+            return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(Map.class),
                 any(OpenCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[2])
-                        .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            Thread.sleep(300);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[2])
+                    .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
+            return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(InitialPosition.class), any(OpenCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[3])
-                        .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            Thread.sleep(300);
+            ((OpenCursorCallback) invocationOnMock.getArguments()[3])
+                    .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
+            return null;
         }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(InitialPosition.class), any(Map.class),
                 any(OpenCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((DeleteCursorCallback) invocationOnMock.getArguments()[1]).deleteCursorComplete(null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            ((DeleteCursorCallback) invocationOnMock.getArguments()[1]).deleteCursorComplete(null);
+            return null;
         }).when(ledgerMock).asyncDeleteCursor(matches(".*success.*"), any(DeleteCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((DeleteCursorCallback) invocationOnMock.getArguments()[1])
-                        .deleteCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            ((DeleteCursorCallback) invocationOnMock.getArguments()[1])
+                    .deleteCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
+            return null;
         }).when(ledgerMock).asyncDeleteCursor(matches(".*fail.*"), any(DeleteCursorCallback.class), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((CloseCallback) invocationOnMock.getArguments()[0]).closeComplete(null);
-                return null;
-            }
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            ((CloseCallback) invocationOnMock.getArguments()[0]).closeComplete(null);
+            return null;
         }).when(cursorMock).asyncClose(any(CloseCallback.class), any());
 
         doReturn(successSubName).when(cursorMock).getName();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -94,6 +94,53 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
 
     }
 
+    @Test
+    public void testSameSubscriptionNameForDurableAndNonDurableSubscription() throws Exception {
+        String topicName = "persistent://my-property/my-ns/same-sub-name-topic";
+        // 1 setup producer and consumer
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName)
+                .create();
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .readCompacted(true)
+                .subscriptionMode(SubscriptionMode.Durable)
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscriptionName("mix-subscription")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+
+        // 2 send 10 messages
+        int messageNum = 10;
+        for (int i = 0; i < messageNum; i++) {
+            producer.send("message" + i);
+        }
+
+        // 3 receive the first 5 messages
+        for (int i = 0; i < 5; i++) {
+            Message<String> message = consumer.receive();
+            assertNotNull(message);
+            Assert.assertEquals(message.getValue(), "message" + i);
+            consumer.acknowledge(message);
+        }
+        consumer.close();
+
+        // 4 try to setup a reader with the same subscription name
+        try {
+            @Cleanup
+            Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName)
+                    .subscriptionName("mix-subscription")
+                    .startMessageId(MessageId.earliest)
+                    .create();
+            Assert.fail("should fail since partitioned topic was deleted");
+        } catch (PulsarClientException.NotAllowedException exception) {
+            //ignore
+        }
+    }
+
+
+
     @Test(timeOut = 10000)
     public void testDeleteInactiveNonPersistentSubscription() throws Exception {
         final String topic = "non-persistent://my-property/my-ns/topic-" + UUID.randomUUID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -97,11 +97,8 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
     @Test
     public void testSameSubscriptionNameForDurableAndNonDurableSubscription() throws Exception {
         String topicName = "persistent://my-property/my-ns/same-sub-name-topic";
-        // 1 setup producer and consumer
-        @Cleanup
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName)
-                .create();
 
+        // 1. create a subscription with SubscriptionMode.Durable
         @Cleanup
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
                 .readCompacted(true)
@@ -110,36 +107,24 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
                 .subscriptionName("mix-subscription")
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .subscribe();
-
-        // 2 send 10 messages
-        int messageNum = 10;
-        for (int i = 0; i < messageNum; i++) {
-            producer.send("message" + i);
-        }
-
-        // 3 receive the first 5 messages
-        for (int i = 0; i < 5; i++) {
-            Message<String> message = consumer.receive();
-            assertNotNull(message);
-            Assert.assertEquals(message.getValue(), "message" + i);
-            consumer.acknowledge(message);
-        }
         consumer.close();
 
-        // 4 try to setup a reader with the same subscription name
+        // 2. create a subscription with SubscriptionMode.NonDurable
         try {
             @Cleanup
-            Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName)
+            Consumer<String> consumerNoDurable =
+                    pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                    .readCompacted(true)
+                    .subscriptionMode(SubscriptionMode.NonDurable)
+                    .subscriptionType(SubscriptionType.Exclusive)
                     .subscriptionName("mix-subscription")
-                    .startMessageId(MessageId.earliest)
-                    .create();
-            Assert.fail("should fail since partitioned topic was deleted");
+                    .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                    .subscribe();
+            Assert.fail("should fail since durable subscription already exist.");
         } catch (PulsarClientException.NotAllowedException exception) {
             //ignore
         }
     }
-
-
 
     @Test(timeOut = 10000)
     public void testDeleteInactiveNonPersistentSubscription() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -97,7 +97,7 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
     @Test
     public void testSameSubscriptionNameForDurableAndNonDurableSubscription() throws Exception {
         String topicName = "persistent://my-property/my-ns/same-sub-name-topic";
-
+        // first test for create Durable subscription and then create NonDurable subscription
         // 1. create a subscription with SubscriptionMode.Durable
         @Cleanup
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
@@ -121,6 +121,36 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
                     .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                     .subscribe();
             Assert.fail("should fail since durable subscription already exist.");
+        } catch (PulsarClientException.NotAllowedException exception) {
+            //ignore
+        }
+
+        // second test for create NonDurable subscription and then create Durable subscription
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName)
+                .create();
+        // 1. create a subscription with SubscriptionMode.NonDurable
+        @Cleanup
+        Consumer<String> noDurableConsumer =
+                pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                        .subscriptionMode(SubscriptionMode.NonDurable)
+                        .subscriptionType(SubscriptionType.Shared)
+                        .subscriptionName("mix-subscription-01")
+                        .receiverQueueSize(1)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                        .subscribe();
+
+        // 2. create a subscription with SubscriptionMode.Durable
+        try {
+            @Cleanup
+            Consumer<String> durableConsumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                    .subscriptionMode(SubscriptionMode.Durable)
+                    .subscriptionType(SubscriptionType.Shared)
+                    .subscriptionName("mix-subscription-01")
+                    .receiverQueueSize(1)
+                    .startMessageIdInclusive()
+                    .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                    .subscribe();
         } catch (PulsarClientException.NotAllowedException exception) {
             //ignore
         }


### PR DESCRIPTION
Fixes #11612 

### Motivation

As described in #11612 , if a reader (or non durable subscription) use the same subscription name with an existed durable subscription, the reader will not behaves  as expected.

This pull request add an check for this situation to prevent non-durable subscription misuse an existed durable subscription

### Modifications

At the point of creating a  non-durable subscription , first check if the subscription existed and then check whether it's durable or not first.
And if there is a durable subscription already, return NotAllowedException.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

`NonDurableSubscriptionTest.testSameSubscriptionNameForDurableAndNonDurableSubscription`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
No doc need
