### PR TITLE
fix getPreviousPosition npe

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3218,8 +3218,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             }
         }
 
-        // in case there are only empty ledgers, we return a position in the first one
-        return PositionImpl.get(headMap.firstEntry().getKey(), -1);
+        Map.Entry<Long, LedgerInfo> firstLedgerEntry = headMap.firstEntry();
+        if(firstLedgerEntry != null) {
+            // in case there are only empty ledgers, we return a position in the first one
+            return PositionImpl.get(firstLedgerEntry.getKey(), -1);
+        } else {
+            return PositionImpl.get(position.getLedgerId(), -1);
+        }
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3203,11 +3203,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return PositionImpl.get(position.getLedgerId(), position.getEntryId() - 1);
         }
 
-        final NavigableMap<Long, LedgerInfo> ledgersCopied = new TreeMap<>(ledgers);
         // The previous position will be the last position of an earlier ledgers
-        NavigableMap<Long, LedgerInfo> headMap = ledgersCopied.headMap(position.getLedgerId(), false);
+        NavigableMap<Long, LedgerInfo> headMap = ledgers.headMap(position.getLedgerId(), false);
 
-        if (headMap.isEmpty()) {
+        final Map.Entry<Long, LedgerInfo> firstEntry = headMap.firstEntry();
+        if (firstEntry == null) {
             // There is no previous ledger, return an invalid position in the current ledger
             return PositionImpl.get(position.getLedgerId(), -1);
         }
@@ -3215,13 +3215,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         // We need to find the most recent non-empty ledger
         for (long ledgerId : headMap.descendingKeySet()) {
             LedgerInfo li = headMap.get(ledgerId);
-            if (li.getEntries() > 0) {
+            if (li != null && li.getEntries() > 0) {
                 return PositionImpl.get(li.getLedgerId(), li.getEntries() - 1);
             }
         }
 
         // in case there are only empty ledgers, we return a position in the first one
-        return PositionImpl.get(headMap.firstEntry().getKey(), -1);
+        return PositionImpl.get(firstEntry.getKey(), -1);
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -48,12 +48,12 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -3203,7 +3203,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return PositionImpl.get(position.getLedgerId(), position.getEntryId() - 1);
         }
 
-        final ConcurrentNavigableMap<Long, LedgerInfo> ledgersCopied = new ConcurrentSkipListMap<>(ledgers);
+        final NavigableMap<Long, LedgerInfo> ledgersCopied = new TreeMap<>(ledgers);
         // The previous position will be the last position of an earlier ledgers
         NavigableMap<Long, LedgerInfo> headMap = ledgersCopied.headMap(position.getLedgerId(), false);
 


### PR DESCRIPTION
Fixes  #11619


### Motivation 
There's a chance that headMap might be empty even if a empty check added. because remove would be executed in ledgers. after the empty check between line 3214 and line 3219 in following code snippet:

headMap is a view of ledgers

https://github.com/apache/pulsar/blob/31231d602b6d4e6f3c79712e097deb0605fdff24/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L3206-L3222



### Modifications 
Add a null checker of headMap.firstEntry

Verifying this change
 Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.