### PR TITLE
Fix unnecessary user interactions when building pulsar-standalone image

### DIFF
--- a/docker/pulsar-standalone/Dockerfile
+++ b/docker/pulsar-standalone/Dockerfile
@@ -26,6 +26,8 @@ FROM apachepulsar/pulsar-dashboard:latest as dashboard
 # Restart from
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Note that the libpq-dev package is needed here in order to install
 # the required python psycopg2 package (for postgresql) later
 RUN apt-get update \


### PR DESCRIPTION
Avoiding user interaction with tzdata installation when building pulsar-standalone image (https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai)

Fix https://github.com/apache/pulsar/issues/11620
