### PR TITLE
[PIP-82] [pulsar-broker] Use the qualified NS-name in RG-register/unr…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
+import lombok.val;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCount;
@@ -34,7 +35,9 @@ import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupMonitor
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupRefTypes;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,31 +236,70 @@ public class ResourceGroupService {
      * Registers a namespace as a user of a resource group.
      *
      * @param resourceGroupName
-     * @param namespaceName
+     * @param fqNamespaceName (i.e., in "tenant/Namespace" format)
      * @throws if the RG does not exist, or if the NS already references the RG.
      */
-    public void registerNameSpace(String resourceGroupName, String namespaceName) throws PulsarAdminException {
+    public void registerNameSpace(String resourceGroupName, String fqNamespaceName) throws PulsarAdminException {
+        // Check that it is a fully qualified NS (i.e., expect a '/' in it).
+        try {
+            val checkFqName = NamespaceName.get(fqNamespaceName);
+        } catch (RuntimeException rte) {
+            String errMesg = "Unexpected format found in fully-qualified namespace " + fqNamespaceName;
+            throw new PulsarAdminException(errMesg);
+        }
+
         ResourceGroup rg = checkResourceGroupExists(resourceGroupName);
 
         // Check that the NS-name doesn't already have a RG association.
         // [If it does, that should be unregistered before putting a different association.]
-        ResourceGroup oldRG = this.namespaceToRGsMap.get(namespaceName);
+        ResourceGroup oldRG = this.namespaceToRGsMap.get(fqNamespaceName);
         if (oldRG != null) {
-            String errMesg = "Namespace " + namespaceName + " already references a resource group: " + oldRG.getID();
+            String errMesg = "Namespace " + fqNamespaceName + " already references a resource group: " + oldRG.getID();
             throw new PulsarAdminException(errMesg);
         }
 
-        ResourceGroupOpStatus status = rg.registerUsage(namespaceName, ResourceGroupRefTypes.Namespaces, true,
+        ResourceGroupOpStatus status = rg.registerUsage(fqNamespaceName, ResourceGroupRefTypes.Namespaces, true,
                                                         this.resourceUsageTransportManagerMgr);
         if (status == ResourceGroupOpStatus.Exists) {
             String errMesg = String.format("Namespace {} already references the target resource group {}",
-                    namespaceName, resourceGroupName);
+                    fqNamespaceName, resourceGroupName);
             throw new PulsarAdminException(errMesg);
         }
 
         // Associate this NS-name with the RG.
-        this.namespaceToRGsMap.put(namespaceName, rg);
+        this.namespaceToRGsMap.put(fqNamespaceName, rg);
         rgNamespaceRegisters.labels(resourceGroupName).inc();
+    }
+
+    /**
+     * UnRegisters a namespace from a resource group.
+     *
+     * @param resourceGroupName
+     * @param fqNamespaceName i.e., in "tenant/Namespace" format)
+     * @throws if the RG does not exist, or if the NS does not references the RG yet.
+     */
+    public void unRegisterNameSpace(String resourceGroupName, String fqNamespaceName) throws PulsarAdminException {
+        // Check that it is a fully qualified NS (i.e., expect a '/' in it).
+        try {
+            val checkFqName = NamespaceName.get(fqNamespaceName);
+        } catch (RuntimeException rte) {
+            String errMesg = "Unexpected format found in fully-qualified namespace " + fqNamespaceName;
+            throw new PulsarAdminException(errMesg);
+        }
+
+        ResourceGroup rg = checkResourceGroupExists(resourceGroupName);
+
+        ResourceGroupOpStatus status = rg.registerUsage(fqNamespaceName, ResourceGroupRefTypes.Namespaces, false,
+                                                        this.resourceUsageTransportManagerMgr);
+        if (status == ResourceGroupOpStatus.DoesNotExist) {
+            String errMesg = String.format("Namespace {} does not yet reference resource group {}",
+                    fqNamespaceName, resourceGroupName);
+            throw new PulsarAdminException(errMesg);
+        }
+
+        // Dissociate this NS-name from the RG.
+        this.namespaceToRGsMap.remove(fqNamespaceName, rg);
+        rgNamespaceUnRegisters.labels(resourceGroupName).inc();
     }
 
     /**
@@ -268,29 +310,6 @@ public class ResourceGroupService {
      */
     public ResourceGroup getNamespaceResourceGroup(String namespaceName) {
         return this.namespaceToRGsMap.get(namespaceName);
-    }
-
-    /**
-     * UnRegisters a namespace from a resource group.
-     *
-     * @param resourceGroupName
-     * @param namespaceName
-     * @throws if the RG does not exist, or if the NS does not references the RG yet.
-     */
-    public void unRegisterNameSpace(String resourceGroupName, String namespaceName) throws PulsarAdminException {
-        ResourceGroup rg = checkResourceGroupExists(resourceGroupName);
-
-        ResourceGroupOpStatus status = rg.registerUsage(namespaceName, ResourceGroupRefTypes.Namespaces, false,
-                                                        this.resourceUsageTransportManagerMgr);
-        if (status == ResourceGroupOpStatus.DoesNotExist) {
-            String errMesg = String.format("Namespace {} does not yet reference resource group {}",
-                namespaceName, resourceGroupName);
-            throw new PulsarAdminException(errMesg);
-        }
-
-        // Dissociate this NS-name from the RG.
-        this.namespaceToRGsMap.remove(namespaceName, rg);
-        rgNamespaceUnRegisters.labels(resourceGroupName).inc();
     }
 
     /**
@@ -312,10 +331,11 @@ public class ResourceGroupService {
      * @param incStats
      * @returns true if the stats were updated; false if nothing was updated.
      */
-    public boolean incrementUsage(String tenantName, String nsName,
+    protected boolean incrementUsage(String tenantName, String nsName,
                                   ResourceGroupMonitoringClass monClass,
                                   BytesAndMessagesCount incStats) throws PulsarAdminException {
-        final ResourceGroup nsRG = this.namespaceToRGsMap.get(nsName);
+        final String tenantAndNsString = tenantName + "/" + nsName;
+        final ResourceGroup nsRG = this.namespaceToRGsMap.get(tenantAndNsString);
         final ResourceGroup tenantRG = this.tenantToRGsMap.get(tenantName);
         if (tenantRG == null && nsRG == null) {
             return false;
@@ -514,13 +534,18 @@ public class ResourceGroupService {
         Map<String, TopicStatsImpl> topicStatsMap = bs.getTopicStats();
 
         for (Map.Entry<String, TopicStatsImpl> entry : topicStatsMap.entrySet()) {
-            String topicName = entry.getKey();
-            TopicStatsImpl topicStats = entry.getValue();
-            TopicName topic = TopicName.get(topicName);
-            String tenantString = topic.getTenant();
-            String nsString = topic.getNamespacePortion();
+            final String topicName = entry.getKey();
+            final TopicStats topicStats = entry.getValue();
+            final TopicName topic = TopicName.get(topicName);
+            final String tenantString = topic.getTenant();
+            final String nsString = topic.getNamespacePortion();
+            final String fqNamespace = topic.getNamespace();
 
-            if (!this.tenantToRGsMap.containsKey(tenantString) && !this.namespaceToRGsMap.containsKey(nsString)) {
+            // Can't use containsKey here, as that checks for exact equality
+            // (we need a check for string-comparison).
+            val tenantRG = this.tenantToRGsMap.get(tenantString);
+            val namespaceRG = this.namespaceToRGsMap.get(fqNamespace);
+            if (tenantRG == null && namespaceRG == null) {
                 // This topic's NS/tenant are not registered to any RG.
                 continue;
             }
@@ -683,10 +708,10 @@ public class ResourceGroupService {
     // Given a RG-name, get the resource-group
     private ConcurrentHashMap<String, ResourceGroup> resourceGroupsMap = new ConcurrentHashMap<>();
 
-    // Given a tenant-name, get its associated resource-group
+    // Given a tenant-name, record its associated resource-group
     private ConcurrentHashMap<String, ResourceGroup> tenantToRGsMap = new ConcurrentHashMap<>();
 
-    // Given a NS-name, get its associated resource-group
+    // Given a qualified NS-name (i.e., in "tenant/namespace" format), record its associated resource-group
     private ConcurrentHashMap<String, ResourceGroup> namespaceToRGsMap = new ConcurrentHashMap<>();
 
     // Maps to maintain the usage per topic, in produce/consume directions.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.resourcegroup;
 
 import static java.lang.Float.max;
 import static java.lang.Math.abs;
+import lombok.val;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,7 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
         if (confUsage < 0) {
             // This can happen if the RG is not configured with this particular limit (message or byte count) yet.
             // It is safe to return a high value (so we don't limit) for the quota.
-            log.debug("Configured usage (%d) is not set; returning a high calculated quota", confUsage);
+            log.debug("Configured usage {} is not set; returning a high calculated quota", confUsage);
             return Long.MAX_VALUE;
         }
 
@@ -48,6 +49,13 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
                     myUsage, totalUsage);
             log.error(errMesg);
             throw new PulsarAdminException(errMesg);
+        }
+
+        if (myUsage > totalUsage) {
+            String errMesg = String.format("Local usage (%d) is greater than total usage (%d)",
+                    myUsage, totalUsage);
+            // Log as a warning [in case this can happen transiently (?)].
+            log.warn(errMesg);
         }
 
         // How much unused capacity is left over?
@@ -60,7 +68,11 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
         float myUsageFraction = (float) myUsage / totalUsage;
         float calculatedQuota = max(myUsage + residual * myUsageFraction, 0);
 
-        return (long) calculatedQuota;
+        val longCalculatedQuota = (long) calculatedQuota;
+        log.info("computeLocalQuota: myUsage={}, totalUsage={}, myFraction={}; newQuota returned={} [long: {}]",
+                myUsage, totalUsage, myUsageFraction, calculatedQuota, longCalculatedQuota);
+
+        return longCalculatedQuota;
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMesgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMesgsTest.java
@@ -358,9 +358,10 @@ public class RGUsageMTAggrWaitForAllMesgsTest extends ProducerConsumerBase {
 
     private void registerTenantsAndNamespaces(String[] topicStrings) throws Exception {
         for (String topicStr : topicStrings) {
-            TopicName topic = TopicName.get(topicStr);
-            String tenantRG = TopicToTenantRGName(topic);
-            String namespaceRG = TopicToNamespaceRGName(topic);
+            final TopicName topic = TopicName.get(topicStr);
+            final String tenantRG = TopicToTenantRGName(topic);
+            final String namespaceRG = TopicToNamespaceRGName(topic);
+            final String tenantAndNamespace = topic.getNamespace();
 
             // The tenant name and namespace name parts of the topic are the same as their corresponding RG-names.
             // Hence, the arguments to register look a little odd.
@@ -369,7 +370,7 @@ public class RGUsageMTAggrWaitForAllMesgsTest extends ProducerConsumerBase {
                 registeredTenants.add(tenantRG);
             }
             if (!registeredNamespaces.contains(namespaceRG)) {
-                this.rgservice.registerNameSpace(namespaceRG, namespaceRG);
+                this.rgservice.registerNameSpace(namespaceRG, tenantAndNamespace);
                 registeredNamespaces.add(namespaceRG);
             }
         }
@@ -377,9 +378,10 @@ public class RGUsageMTAggrWaitForAllMesgsTest extends ProducerConsumerBase {
 
     private void unRegisterTenantsAndNamespaces(String[] topicStrings) throws Exception {
         for (String topicStr : topicStrings) {
-            TopicName topic = TopicName.get(topicStr);
-            String tenantRG = TopicToTenantRGName(topic);
-            String namespaceRG = TopicToNamespaceRGName(topic);
+            final TopicName topic = TopicName.get(topicStr);
+            final String tenantRG = TopicToTenantRGName(topic);
+            final String namespaceRG = TopicToNamespaceRGName(topic);
+            final String tenantAndNamespace = topic.getNamespace();;
 
             // The tenant name and namespace name parts of the topic are the same as their corresponding RG-names.
             // Hence, the arguments to unRegister look a little odd.
@@ -388,7 +390,7 @@ public class RGUsageMTAggrWaitForAllMesgsTest extends ProducerConsumerBase {
                 registeredTenants.remove(tenantRG);
             }
             if (registeredNamespaces.contains(namespaceRG)) {
-                this.rgservice.unRegisterNameSpace(namespaceRG, namespaceRG);
+                this.rgservice.unRegisterNameSpace(namespaceRG, tenantAndNamespace);
                 registeredNamespaces.remove(namespaceRG);
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
@@ -113,7 +113,8 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
         final String tenantName = "SomeTenant";
         final String namespaceName = "SomeNameSpace";
         rgs.registerTenant(rgName, tenantName);
-        rgs.registerNameSpace(rgName, namespaceName);
+        final String tenantAndNamespaceName = tenantName + "/" + namespaceName;
+        rgs.registerNameSpace(rgName, tenantAndNamespaceName);
         mSecsStart = System.currentTimeMillis();
         for (int ix = 0; ix < numPerfTestIterations; ix++) {
             for (int monClassIdx = 0; monClassIdx < ResourceGroupMonitoringClass.values().length; monClassIdx++) {
@@ -126,7 +127,7 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
         log.info("{} iterations of incrementUsage on RGS in {} msecs ({} usecs for each)",
                 numPerfTestIterations, diffMsecs, (1000 * (float) diffMsecs)/numPerfTestIterations);
         rgs.unRegisterTenant(rgName, tenantName);
-        rgs.unRegisterNameSpace(rgName, namespaceName);
+        rgs.unRegisterNameSpace(rgName, tenantAndNamespaceName);
 
         // The overhead of a RG lookup
         ResourceGroup retRG;
@@ -194,7 +195,10 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
         final String tenantName = topic.getTenant();
         final String namespaceName = topic.getNamespacePortion();
         rgs.registerTenant(rgName, tenantName);
-        rgs.registerNameSpace(rgName, namespaceName);
+        // Registering with the (non-qualified) namespace should throw.
+        Assert.assertThrows(PulsarAdminException.class, () -> rgs.registerNameSpace(rgName, namespaceName));
+        final String tenantAndNamespace = tenantName + "/" + namespaceName;
+        rgs.registerNameSpace(rgName, tenantAndNamespace);
 
         // Delete of our valid config should throw until we unref correspondingly.
         Assert.assertThrows(PulsarAdminException.class, () -> rgs.resourceGroupDelete(rgName));
@@ -229,7 +233,9 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
         }
 
         rgs.unRegisterTenant(rgName, tenantName);
-        rgs.unRegisterNameSpace(rgName, namespaceName);
+        // Unregistering with the (non-qualified) namespace should throw.
+        Assert.assertThrows(PulsarAdminException.class, () -> rgs.unRegisterNameSpace(rgName, namespaceName));
+        rgs.unRegisterNameSpace(rgName, tenantAndNamespace);
 
         BytesAndMessagesCount publishQuota = rgs.getPublishRateLimiters(rgName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -128,7 +128,7 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
 
         final TopicName myTopic = TopicName.get(topicString);
         final String tenantString = myTopic.getTenant();
-        final String nsString = myTopic.getNamespacePortion();
+        final String nsString = myTopic.getNamespace();
         rgs.registerTenant(rgName, tenantString);
         rgs.registerNameSpace(rgName, nsString);
 


### PR DESCRIPTION
…egisters

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
To avoid aliasing, use the fully-qualified namespace name in register/unregister of namespaces to RGs.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as *(please describe tests)*.
    mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceGroupServiceTest -pl pulsar-broker
    mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.ResourceGroupUsageAggregationTest -pl pulsar-broker
    mvn test -Dtest=org.apache.pulsar.broker.resourcegroup.RGUsageMTAggrWaitForAllMesgsTest  -pl pulsar-broker


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

#### For contributor

For this PR, do we need to update docs?
No

This is an internal change in how resource-groups work.
  
#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

