### PR TITLE
[docs] [ISSUE 11380] Update code example and description

### DIFF
--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -392,7 +392,7 @@ admin.namespaces().unloadNamespaceBundle(namespace, bundle)
 
 #### Split namespace bundles
 
-One namespace bundle can contain multiple topics but can be served by only one broker. If a single bundle is creating an excessive load on a broker, an admin can split the bundle using the command below, permitting one or more of the new bundles to be unloaded, thus spreading the load across the brokers.
+One namespace bundle can contain multiple topics but can be served by only one broker. If a single bundle is creating an excessive load on a broker, an admin can split the bundle using the command below, permitting one or more of the new bundles to be unloaded, thus balancing the load across the brokers.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->

--- a/site2/docs/admin-api-namespaces.md
+++ b/site2/docs/admin-api-namespaces.md
@@ -8,7 +8,7 @@ sidebar_label: Namespaces
 >
 > This page only shows **some frequently used operations**.
 >
-> - For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/)
+> - For the latest and complete information about `Pulsar admin`, including commands, flags, descriptions, and more, see [Pulsar admin doc](https://pulsar.apache.org/tools/pulsar-admin/).
 > 
 > - For the latest and complete information about `REST API`, including parameters, responses, samples, and more, see {@inject: rest:REST:/} API doc.
 > 
@@ -39,7 +39,9 @@ $ pulsar-admin namespaces create test-tenant/test-namespace
 
 <!--REST API-->
 
+```
 {@inject: endpoint|PUT|/admin/v2/namespaces/:tenant/:namespace|operation/createNamespace?version=[[pulsar:version_number]]}
+```
 
 <!--Java-->
 
@@ -84,7 +86,9 @@ $ pulsar-admin namespaces policies test-tenant/test-namespace
 
 <!--REST API-->
 
+```
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace|operation/getPolicies?version=[[pulsar:version_number]]}
+```
 
 <!--Java-->
 
@@ -110,7 +114,9 @@ test-tenant/ns2
 
 <!--REST API-->
 
+```
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant|operation/getTenantNamespaces?version=[[pulsar:version_number]]}
+```
 
 <!--Java-->
 
@@ -134,7 +140,9 @@ $ pulsar-admin namespaces delete test-tenant/ns1
 
 <!--REST API-->
 
+```
 {@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace|operation/deleteNamespace?version=[[pulsar:version_number]]}
+```
 
 <!--Java-->
 
@@ -147,7 +155,7 @@ admin.namespaces().deleteNamespace(namespace);
 
 #### Set replication cluster
 
-It sets replication clusters for a namespace, so Pulsar can internally replicate publish message from one colo to another colo.
+You can set replication clusters for a namespace to enable Pulsar to internally replicate the published messages from one colocation facility to another.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -172,7 +180,7 @@ admin.namespaces().setNamespaceReplicationClusters(namespace, clusters);
 
 #### Get replication cluster
 
-It gives a list of replication clusters for a given namespace.
+You can get the list of replication clusters for a given namespace.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -204,23 +212,19 @@ admin.namespaces().getNamespaceReplicationClusters(namespace)
 
 Backlog quota helps the broker to restrict bandwidth/storage of a namespace once it reaches a certain threshold limit. Admin can set the limit and take corresponding action after the limit is reached.
 
-  1.  producer_request_hold: broker will hold and not persist produce request payload
+  1.  producer_request_hold: broker holds but not persists produce request payload
 
-  2.  producer_exception: broker disconnects with the client by giving an exception.
+  2.  producer_exception: broker disconnects with the client by giving an exception
 
-  3.  consumer_backlog_eviction: broker will start discarding backlog messages
+  3.  consumer_backlog_eviction: broker starts discarding backlog messages
 
-  Backlog quota restriction can be taken care by defining restriction of backlog-quota-type: destination_storage
+Backlog quota restriction can be taken care by defining restriction of backlog-quota-type: destination_storage.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 
 ```
 $ pulsar-admin namespaces set-backlog-quota --limit 10G --limitTime 36000 --policy producer_request_hold test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -238,7 +242,7 @@ admin.namespaces().setBacklogQuota(namespace, new BacklogQuota(limit, limitTime,
 
 #### Get backlog quota policies
 
-It shows a configured backlog quota for a given namespace.
+You can get a configured backlog quota for a given namespace.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -271,17 +275,13 @@ admin.namespaces().getBacklogQuotaMap(namespace);
 
 #### Remove backlog quota policies
 
-It removes backlog quota policies for a given namespace
+You can remove backlog quota policies for a given namespace.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 
 ```
 $ pulsar-admin namespaces remove-backlog-quota test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -301,7 +301,7 @@ admin.namespaces().removeBacklogQuota(namespace, backlogQuotaType)
 
 #### Set persistence policies
 
-Persistence policies allow to configure persistency-level for all topic messages under a given namespace.
+Persistence policies allow users to configure persistency-level for all topic messages under a given namespace.
 
   -   Bookkeeper-ack-quorum: Number of acks (guaranteed copies) to wait for each entry, default: 0
 
@@ -316,10 +316,6 @@ Persistence policies allow to configure persistency-level for all topic messages
 
 ```
 $ pulsar-admin namespaces set-persistence --bookkeeper-ack-quorum 2 --bookkeeper-ensemble 3 --bookkeeper-write-quorum 2 --ml-mark-delete-max-rate 0 test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -337,7 +333,7 @@ admin.namespaces().setPersistence(namespace,new PersistencePolicies(bookkeeperEn
 
 #### Get persistence policies
 
-It shows the configured persistence policies of a given namespace.
+You can get the configured persistence policies of a given namespace.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -381,10 +377,6 @@ The namespace bundle is a virtual group of topics which belong to the same names
 $ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff test-tenant/ns1
 ```
 
-```
-N/A
-```
-
 <!--REST API-->
 
 ```
@@ -400,18 +392,13 @@ admin.namespaces().unloadNamespaceBundle(namespace, bundle)
 
 #### Split namespace bundles
 
-Each namespace bundle can contain multiple topics and each bundle can be served by only one broker. 
-If a single bundle is creating an excessive load on a broker, an admin splits the bundle using this command permitting one or more of the new bundles to be unloaded thus spreading the load across the brokers.
+One namespace bundle can contain multiple topics but can be served by only one broker. If a single bundle is creating an excessive load on a broker, an admin can split the bundle using the command below, permitting one or more of the new bundles to be unloaded, thus spreading the load across the brokers.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 
 ```
 $ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -431,17 +418,13 @@ admin.namespaces().splitNamespaceBundle(namespace, bundle)
 
 #### Set message-ttl
 
-It configures message’s time to live (in seconds) duration.
+You can configure the time to live (in seconds) duration for messages. In the example below, the message-ttl is set as 100s.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 
 ```
 $ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -459,7 +442,7 @@ admin.namespaces().setNamespaceMessageTTL(namespace, messageTTL)
 
 #### Get message-ttl
 
-It gives a message ttl of configured namespace.
+When the message-ttl for a namespace is set, you can use the command below to get the configured value. This example comtinues the example of the command `set message-ttl`, so the returned value is 100(s).
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
@@ -478,11 +461,20 @@ $ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 ```
 
+```
+100
+```
+
 <!--Java-->
 
 ```java
 admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
+
+```
+100
+```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 #### Remove message-ttl
@@ -494,10 +486,6 @@ Remove a message TTL of the configured namespace.
 
 ```
 $ pulsar-admin namespaces remove-message-ttl test-tenant/ns1
-```
-
-```
-100
 ```
 
 <!--REST API-->
@@ -527,10 +515,6 @@ It clears all message backlog for all the topics that belong to a specific names
 $ pulsar-admin namespaces clear-backlog --sub my-subscription test-tenant/ns1
 ```
 
-```
-N/A
-```
-
 <!--REST API-->
 
 ```
@@ -553,10 +537,6 @@ It clears all message backlog for all the topics that belong to a specific Names
 
 ```
 $ pulsar-admin namespaces clear-backlog  --bundle 0x00000000_0xffffffff  --sub my-subscription test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -583,10 +563,6 @@ Each namespace contains multiple topics and the retention size (storage size) of
 
 ```
 $ pulsar-admin namespaces set-retention --size 100 --time 10 test-tenant/ns1
-```
-
-```
-N/A
 ```
 
 <!--REST API-->
@@ -644,9 +620,9 @@ disables the throttling.
 
 > **Note**
 > - If neither `clusterDispatchRate` nor `topicDispatchRate` is configured, dispatch throttling is disabled.
-> >
+>
 > - If `topicDispatchRate` is not configured, `clusterDispatchRate` takes effect.
-> > 
+>
 > - If `topicDispatchRate` is configured, `topicDispatchRate` takes effect.
 
 <!--DOCUSAURUS_CODE_TABS-->

--- a/site2/docs/cookbooks-retention-expiry.md
+++ b/site2/docs/cookbooks-retention-expiry.md
@@ -123,7 +123,8 @@ admin.namespaces().setRetention(namespace, policies);
 
 You can fetch the retention policy for a namespace by specifying the namespace. The output will be a JSON object with two keys: `retentionTimeInMinutes` and `retentionSizeInMB`.
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`get-retention`](reference-pulsar-admin.md#namespaces) subcommand and specify the namespace.
 
@@ -137,15 +138,16 @@ $ pulsar-admin namespaces get-retention my-tenant/my-ns
 }
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/retention|operation/getRetention?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 admin.namespaces().getRetention(namespace);
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Backlog quotas
 
@@ -177,7 +179,8 @@ Backlog quotas are handled at the namespace level. They can be managed via:
 
 You can set a size and/or time threshold and backlog retention policy for all of the topics in a [namespace](reference-terminology.md#namespace) by specifying the namespace, a size limit and/or a time limit in second, and a policy by name.
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`set-backlog-quota`](reference-pulsar-admin.md#namespaces) subcommand and specify a namespace, a size limit using the `-l`/`--limit` , `-lt`/`--limitTime` flag to limit backlog, a retention policy using the `-p`/`--policy` flag and a policy type using `-t`/`--type` (default is destination_storage).
 
@@ -196,11 +199,11 @@ $ pulsar-admin namespaces set-backlog-quota my-tenant/my-ns/my-topic \
 --type message_age
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 long sizeLimit = 2147483648L;
@@ -208,12 +211,14 @@ BacklogQuota.RetentionPolicy policy = BacklogQuota.RetentionPolicy.producer_requ
 BacklogQuota quota = new BacklogQuota(sizeLimit, policy);
 admin.namespaces().setBacklogQuota(namespace, quota);
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Get backlog threshold and backlog retention policy
 
 You can see which size threshold and backlog retention policy has been applied to a namespace.
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`get-backlog-quotas`](reference-pulsar-admin.md#pulsar-admin-namespaces-get-backlog-quotas) subcommand and specify a namespace. Here's an example:
 
@@ -227,20 +232,22 @@ $ pulsar-admin namespaces get-backlog-quotas my-tenant/my-ns
 }
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/backlogQuotaMap|operation/getBacklogQuotaMap?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 Map<BacklogQuota.BacklogQuotaType,BacklogQuota> quotas =
   admin.namespaces().getBacklogQuotas(namespace);
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Remove backlog quotas
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`remove-backlog-quota`](reference-pulsar-admin.md#pulsar-admin-namespaces-remove-backlog-quota) subcommand and specify a namespace, use `t`/`--type` to specify backlog type to remove(default is destination_storage). Here's an example:
 
@@ -248,15 +255,16 @@ Use the [`remove-backlog-quota`](reference-pulsar-admin.md#pulsar-admin-namespac
 $ pulsar-admin namespaces remove-backlog-quota my-tenant/my-ns
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/backlogQuota|operation/removeBacklogQuota?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 admin.namespaces().removeBacklogQuota(namespace);
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Clear backlog
 
@@ -278,7 +286,8 @@ By default, Pulsar stores all unacknowledged messages forever. This can lead to 
 
 ### Set the TTL for a namespace
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`set-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces-set-message-ttl) subcommand and specify a namespace and a TTL (in seconds) using the `-ttl`/`--messageTTL` flag.
 
@@ -289,19 +298,21 @@ $ pulsar-admin namespaces set-message-ttl my-tenant/my-ns \
   --messageTTL 120 # TTL of 2 minutes
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|POST|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/setNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 admin.namespaces().setNamespaceMessageTTL(namespace, ttlInSeconds);
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Get the TTL configuration for a namespace
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`get-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces-get-message-ttl) subcommand and specify a namespace.
 
@@ -312,19 +323,21 @@ $ pulsar-admin namespaces get-message-ttl my-tenant/my-ns
 60
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|GET|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/getNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 admin.namespaces().getNamespaceMessageTTL(namespace)
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Remove the TTL configuration for a namespace
 
-#### pulsar-admin
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
 
 Use the [`remove-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces-remove-message-ttl) subcommand and specify a namespace.
 
@@ -334,15 +347,17 @@ Use the [`remove-message-ttl`](reference-pulsar-admin.md#pulsar-admin-namespaces
 $ pulsar-admin namespaces remove-message-ttl my-tenant/my-ns
 ```
 
-#### REST API
+<!--REST API-->
 
 {@inject: endpoint|DELETE|/admin/v2/namespaces/:tenant/:namespace/messageTTL|operation/removeNamespaceMessageTTL?version=[[pulsar:version_number]]}
 
-#### Java
+<!--Java-->
 
 ```java
 admin.namespaces().removeNamespaceMessageTTL(namespace)
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ## Delete messages from namespaces
 
 If you do not have any retention period and that you never have much of a backlog, the upper limit for retaining messages, which are acknowledged, equals to the Pulsar segment rollover period + entry log rollover period + (garbage collection interval * garbage collection ratios).


### PR DESCRIPTION
Fixes #11380 

It seems that the changed two file share common content on the usage of message retention policies. Do we need to keep the examples of the commands in both files?