### PR TITLE
[Security] Upgrade Jetty to 9.4.43.v20210629

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -424,25 +424,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-http-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-io-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-security-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-server-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-util-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.42.v20210604.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.42.v20210604.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.42.v20210604.jar
+    - org.eclipse.jetty-jetty-client-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-http-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-io-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-security-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-server-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-util-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.43.v20210629.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.43.v20210629.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.43.v20210629.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.66.Final</netty.version>
     <netty-tc-native.version>2.0.40.Final</netty-tc-native.version>
-    <jetty.version>9.4.42.v20210604</jetty.version>
+    <jetty.version>9.4.43.v20210629</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.9</athenz.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -253,22 +253,22 @@ The Apache Software License, Version 2.0
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty
-    - http2-client-9.4.42.v20210604.jar
-    - http2-common-9.4.42.v20210604.jar
-    - http2-hpack-9.4.42.v20210604.jar
-    - http2-http-client-transport-9.4.42.v20210604.jar
-    - jetty-alpn-client-9.4.42.v20210604.jar
-    - http2-server-9.4.42.v20210604.jar
-    - jetty-alpn-java-client-9.4.42.v20210604.jar
-    - jetty-client-9.4.42.v20210604.jar
-    - jetty-http-9.4.42.v20210604.jar
-    - jetty-io-9.4.42.v20210604.jar
-    - jetty-jmx-9.4.42.v20210604.jar
-    - jetty-security-9.4.42.v20210604.jar
-    - jetty-server-9.4.42.v20210604.jar
-    - jetty-servlet-9.4.42.v20210604.jar
-    - jetty-util-9.4.42.v20210604.jar
-    - jetty-util-ajax-9.4.42.v20210604.jar
+    - http2-client-9.4.43.v20210629.jar
+    - http2-common-9.4.43.v20210629.jar
+    - http2-hpack-9.4.43.v20210629.jar
+    - http2-http-client-transport-9.4.43.v20210629.jar
+    - jetty-alpn-client-9.4.43.v20210629.jar
+    - http2-server-9.4.43.v20210629.jar
+    - jetty-alpn-java-client-9.4.43.v20210629.jar
+    - jetty-client-9.4.43.v20210629.jar
+    - jetty-http-9.4.43.v20210629.jar
+    - jetty-io-9.4.43.v20210629.jar
+    - jetty-jmx-9.4.43.v20210629.jar
+    - jetty-security-9.4.43.v20210629.jar
+    - jetty-server-9.4.43.v20210629.jar
+    - jetty-servlet-9.4.43.v20210629.jar
+    - jetty-util-9.4.43.v20210629.jar
+    - jetty-util-ajax-9.4.43.v20210629.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode


### PR DESCRIPTION
Fixes #11659

### Motivation

- resolves security vulnerability CVE-2021-34429

### Modifications

Upgrade Jetty to 9.4.43.v20210629