### PR TITLE
[Branch-2.8]fix testSetReplicatedSubscriptionStatus run failed

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-cpp-build-centos7.yaml
+++ b/.github/workflows/ci-cpp-build-centos7.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-jdk8.yaml
+++ b/.github/workflows/ci-unit-broker-jdk8.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -803,7 +803,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         // 3) Create the partitioned topic
         response = mock(AsyncResponse.class);
         ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
-        persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2, false);
+        persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2, true);
         verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
@@ -857,5 +857,4 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         verify(response, timeout(10000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
     }
-
 }


### PR DESCRIPTION
### Motivation
The test `testSetReplicatedSubscriptionStatus ` add by #10790, and the code `persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2, true);` `createLocalTopicOnly` set `true`. However, when the PR cherry-pick to branch-2.8, this commit `https://github.com/apache/pulsar/commit/0706bc01a428a9405c671a0f80fb54faccdd26e6`, which lead the test run failed.