### PR TITLE
Fix cannot import restlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2286,6 +2286,11 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>maven-restlet</id>
+      <name>Restlet repository</name>
+      <url>https://maven.restlet.talend.com</url>
+    </repository>
   </repositories>
 
 </project>


### PR DESCRIPTION

![Snipaste_2021-08-13_15-55-06](https://user-images.githubusercontent.com/38202348/129330530-6021e8c3-c7e2-4090-9bc7-9d7cf9204b00.jpg)

When I import pulsar in my idea, maven cannot resolve Restlet, and I find there is no Restlet in 'https://repo1.maven.org/maven2' or 'https://packages.confluent.io/maven/'

So I add repository 'https://maven.restlet.talend.com' to pom.xml and solve this problem.