### PR TITLE
[Branch-2.8] Enable CI test on branch-2.8 for pull request

### DIFF
--- a/.github/workflows/ci-build-macos.yaml
+++ b/.github/workflows/ci-build-macos.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-cpp-build-centos7.yaml
+++ b/.github/workflows/ci-cpp-build-centos7.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'

--- a/.github/workflows/ci-cpp-build-windows.yaml
+++ b/.github/workflows/ci-cpp-build-windows.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-client-cpp/**'

--- a/.github/workflows/ci-cpp.yaml
+++ b/.github/workflows/ci-cpp.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-go-functions-style.yaml
+++ b/.github/workflows/ci-go-functions-style.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'

--- a/.github/workflows/ci-go-functions-test.yaml
+++ b/.github/workflows/ci-go-functions-test.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
     paths:
       - '.github/workflows/**'
       - 'pulsar-function-go/**'

--- a/.github/workflows/ci-integration-backwards-compatibility.yaml
+++ b/.github/workflows/ci-integration-backwards-compatibility.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-cli.yaml
+++ b/.github/workflows/ci-integration-cli.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-function.yaml
+++ b/.github/workflows/ci-integration-function.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-messaging.yaml
+++ b/.github/workflows/ci-integration-messaging.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-process.yaml
+++ b/.github/workflows/ci-integration-process.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-schema.yaml
+++ b/.github/workflows/ci-integration-schema.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-sql.yaml
+++ b/.github/workflows/ci-integration-sql.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-standalone.yaml
+++ b/.github/workflows/ci-integration-standalone.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-thread.yaml
+++ b/.github/workflows/ci-integration-thread.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-tiered-filesystem.yaml
+++ b/.github/workflows/ci-integration-tiered-filesystem.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-tiered-jcloud.yaml
+++ b/.github/workflows/ci-integration-tiered-jcloud.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-integration-transaction.yaml
+++ b/.github/workflows/ci-integration-transaction.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-license.yaml
+++ b/.github/workflows/ci-license.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-shade-test.yaml
+++ b/.github/workflows/ci-shade-test.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-broker-gp1.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp1.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-broker-gp2.yaml
+++ b/.github/workflows/ci-unit-broker-broker-gp2.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-client-api.yaml
+++ b/.github/workflows/ci-unit-broker-client-api.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-client-impl.yaml
+++ b/.github/workflows/ci-unit-broker-client-impl.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-jdk8.yaml
+++ b/.github/workflows/ci-unit-broker-jdk8.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-broker-other.yaml
+++ b/.github/workflows/ci-unit-broker-other.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit-proxy.yaml
+++ b/.github/workflows/ci-unit-proxy.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*

--- a/.github/workflows/ci-unit.yaml
+++ b/.github/workflows/ci-unit.yaml
@@ -22,6 +22,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - branch-*


### PR DESCRIPTION
### Motivation
When create pull request for branch-2.8, it won't trigger CI test, which is difficult to address bugs bring by this PR before merged. 

### Modification
1. Enable all CI test for pull request.