### PR TITLE
[Flaky test] Fix ManagedLedgerTest.testLedgerReachMaximumRolloverTime

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2986,8 +2986,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         // the ledger rollover scheduled time is between 1000 and 1050 ms,
         // wait 1100 ms, the ledger should be rolled over.
         Awaitility.await()
-                .atMost(1100, TimeUnit.MILLISECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
                 .until(() -> firstLedgerId != ml.addEntry("test".getBytes()).getLedgerId());
     }
 


### PR DESCRIPTION
Fixes #11669 

### Documentation

#### For contributor
This is a fix for flaky test, no need to update the doc.
