### PR TITLE
If a topic has compaction policies configured, we must ensure the subscription is always pre-created

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1233,15 +1233,13 @@ public class BrokerService implements Closeable {
                                         ? new SystemTopic(topic, ledger, BrokerService.this)
                                         : new PersistentTopic(topic, ledger, BrokerService.this);
                                 CompletableFuture<Void> preCreateSubForCompaction =
-                                        CompletableFuture.completedFuture(null);
-                                if (persistentTopic instanceof SystemTopic) {
-                                    preCreateSubForCompaction = ((SystemTopic) persistentTopic)
-                                            .preCreateSubForCompactionIfNeeded();
-                                }
+                                        persistentTopic.preCreateSubscriptionForCompactionIfNeeded();
                                 CompletableFuture<Void> replicationFuture = persistentTopic
                                         .initialize()
                                         .thenCompose(__ -> persistentTopic.checkReplication());
-                                FutureUtil.waitForAll(Lists.newArrayList(preCreateSubForCompaction, replicationFuture))
+
+
+                                CompletableFuture.allOf(preCreateSubForCompaction, replicationFuture)
                                 .thenCompose(v -> {
                                     // Also check dedup status
                                     return persistentTopic.checkDeduplicationStatus();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -19,13 +19,11 @@
 
 package org.apache.pulsar.broker.service.persistent;
 
-import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
-import org.apache.pulsar.common.api.proto.CommandSubscribe;
 
 public class SystemTopic extends PersistentTopic {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -64,18 +64,8 @@ public class SystemTopic extends PersistentTopic {
         return CompletableFuture.completedFuture(null);
     }
 
-    public CompletableFuture<Void> preCreateSubForCompactionIfNeeded() {
-        if (!super.hasCompactionTriggered()) {
-            // To pre-create the subscription for the compactor to avoid lost any data since we are using reader
-            // for reading data from the __change_events topic, if no durable subscription on the topic,
-            // the data might be lost. Since we are using the topic compaction on the __change_events topic
-            // to reduce the topic policy cache recovery time,
-            // so we can leverage the topic compaction cursor for retaining the data.
-            return super.createSubscription(COMPACTION_SUBSCRIPTION,
-                    CommandSubscribe.InitialPosition.Earliest, false)
-                    .thenCompose(__ -> CompletableFuture.completedFuture(null));
-        } else {
-            return CompletableFuture.completedFuture(null);
-        }
+    public CompletableFuture<Boolean> isCompactionEnabled() {
+        // All system topics are using compaction, even though is not explicitly set in the policies.
+        return CompletableFuture.completedFuture(true);
     }
 }


### PR DESCRIPTION
### Motivation

When using a compacted topic, the compaction cursor ensure that everything that is published after the last compaction run is retained in the topic. The problem is that the cursor is only created when the compaction runs for the first time. 

If a topic as a threshold-based compaction schedule, this might get triggered for the first time well after the retention time of the data, causing data loss at the beginning of the topic. Instead, we should ensure that when the topic is created the subscription is created as well, before the topic can accept publishes.

Similarly, if the policy is added later on, we should start retain data from that moment.

