### PR TITLE
failed update partition of topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3642,13 +3642,13 @@ public class PersistentTopicsBase extends AdminResource {
                         String managedLedgerPath = ZkAdminPaths.managedLedgerPath(topicName.getPartition(i));
                         namespaceResources().getPartitionedTopicResources()
                                 .deleteAsync(managedLedgerPath).exceptionally(ex1 -> {
-                            log.error("[{}] Failed to delete managedLedger znode {}", clientAppId(),
+                            log.warn("[{}] Failed to clean up managedLedger znode {}", clientAppId(),
                                     managedLedgerPath, ex1.getCause());
                             return null;
                         });
                     }
                 }).exceptionally(ex -> {
-                    updatePartition.completeExceptionally(e);
+                    log.warn("[{}] Failed to clean up managedLedger znode", clientAppId(), ex.getCause());
                     return null;
                 });
                 updatePartition.completeExceptionally(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3640,11 +3640,10 @@ public class PersistentTopicsBase extends AdminResource {
                     int oldPartition = metadata.partitions;
                     for (int i = oldPartition; i < numPartitions; i++) {
                         String managedLedgerPath = ZkAdminPaths.managedLedgerPath(topicName.getPartition(i));
-                        try {
-                            namespaceResources().getPartitionedTopicResources().deleteAsync(managedLedgerPath);
-                        } catch (Exception cleanZnodeException) {
-                            log.error("Failed to clean managedLedger znode {}", managedLedgerPath, cleanZnodeException);
-                        }
+                        namespaceResources().getPartitionedTopicResources().deleteAsync(managedLedgerPath).exceptionally(ex1 -> {
+                            log.error("[{}] Failed to delete managedLedger znode {}", clientAppId(), managedLedgerPath, ex1.getCause());
+                            return null;
+                        });
                     }
                 }).exceptionally(ex -> {
                     updatePartition.completeExceptionally(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3640,8 +3640,10 @@ public class PersistentTopicsBase extends AdminResource {
                     int oldPartition = metadata.partitions;
                     for (int i = oldPartition; i < numPartitions; i++) {
                         String managedLedgerPath = ZkAdminPaths.managedLedgerPath(topicName.getPartition(i));
-                        namespaceResources().getPartitionedTopicResources().deleteAsync(managedLedgerPath).exceptionally(ex1 -> {
-                            log.error("[{}] Failed to delete managedLedger znode {}", clientAppId(), managedLedgerPath, ex1.getCause());
+                        namespaceResources().getPartitionedTopicResources()
+                                .deleteAsync(managedLedgerPath).exceptionally(ex1 -> {
+                            log.error("[{}] Failed to delete managedLedger znode {}", clientAppId(),
+                                    managedLedgerPath, ex1.getCause());
                             return null;
                         });
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3638,8 +3638,13 @@ public class PersistentTopicsBase extends AdminResource {
             } catch (Exception e) {
                 getPartitionedTopicMetadataAsync(topicName, false, false).thenAccept(metadata -> {
                     int oldPartition = metadata.partitions;
-                    for(int i = oldPartition; i < numPartitions; i++){
-                        namespaceResources().getPartitionedTopicResources().deleteAsync(ZkAdminPaths.managedLedgerPath(topicName.getPartition(i)));
+                    for (int i = oldPartition; i < numPartitions; i++) {
+                        String managedLedgerPath = ZkAdminPaths.managedLedgerPath(topicName.getPartition(i));
+                        try {
+                            namespaceResources().getPartitionedTopicResources().deleteAsync(managedLedgerPath);
+                        } catch (Exception cleanZnodeException) {
+                            log.error("Failed to clean managedLedger znode {}", managedLedgerPath, cleanZnodeException);
+                        }
                     }
                 }).exceptionally(ex -> {
                     updatePartition.completeExceptionally(e);


### PR DESCRIPTION
Fixes #11682 
### Motivation
1、`tryCreatePartitionsAsync` would create  znode under  `managed-ledgers/public/default/persistent/` after success invoke

2、there are chance, `updatePartitionedTopic` would failed, and managed-ledgers znode would  stay unclean. If We tried update partition once again , We would fail, because of managed-ledgers znode exists
https://github.com/apache/pulsar/blob/80171a733ab4799f912a8935f03c19554b9ca3b1/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java#L473-L485

### Modifications 
 clean up managed-ledger znode after we failed update partition.