### PR TITLE
[server] Fixed Casting Error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -55,7 +55,7 @@ public class BacklogQuotaManager {
         this.isTopicLevelPoliciesEnable = pulsar.getConfiguration().isTopicLevelPoliciesEnabled();
         double backlogQuotaGB = pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB();
         this.defaultQuota = BacklogQuotaImpl.builder()
-                .limitSize(backlogQuotaGB > 0 ? (long) backlogQuotaGB * BacklogQuotaImpl.BYTES_IN_GIGABYTE
+                .limitSize(backlogQuotaGB > 0 ? (long) (backlogQuotaGB * BacklogQuotaImpl.BYTES_IN_GIGABYTE)
                         : pulsar.getConfiguration().getBacklogQuotaDefaultLimitBytes())
                 .limitTime(pulsar.getConfiguration().getBacklogQuotaDefaultLimitSecond())
                 .retentionPolicy(pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
@@ -39,7 +39,7 @@ public class ConfigHelper {
 
     public static BacklogQuota sizeBacklogQuota(ServiceConfiguration configuration) {
         long backlogQuotaBytes = configuration.getBacklogQuotaDefaultLimitGB() > 0
-                ? ((long) configuration.getBacklogQuotaDefaultLimitGB() * BacklogQuotaImpl.BYTES_IN_GIGABYTE)
+                ? ((long) (configuration.getBacklogQuotaDefaultLimitGB() * BacklogQuotaImpl.BYTES_IN_GIGABYTE))
                 : configuration.getBacklogQuotaDefaultLimitBytes();
         return BacklogQuota.builder()
                 .limitSize(backlogQuotaBytes)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -30,12 +31,20 @@ import static org.testng.Assert.assertEquals;
 @Test(groups = "broker")
 public class BacklogQuotaManagerConfigurationTest {
 
+    private ServiceConfiguration serviceConfiguration;
+    private PulsarService pulsarService;
+
+    @BeforeMethod
+    public void setup() {
+        serviceConfiguration = new ServiceConfiguration();
+        initializeServiceConfiguration();
+        pulsarService = getPulsarService();
+    }
+
     @Test
     public void testBacklogQuotaDefaultLimitGBConversion() {
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-        initializeServiceConfiguration(serviceConfiguration);
+        serviceConfiguration.setBacklogQuotaDefaultLimitGB(1.6);
 
-        PulsarService pulsarService = getPulsarService(serviceConfiguration);
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
         assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
@@ -43,11 +52,9 @@ public class BacklogQuotaManagerConfigurationTest {
 
     @Test
     public void testBacklogQuotaDefaultLimitPrecedence() {
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-        initializeServiceConfiguration(serviceConfiguration);
+        serviceConfiguration.setBacklogQuotaDefaultLimitGB(1.6);
         serviceConfiguration.setBacklogQuotaDefaultLimitBytes(123);
 
-        PulsarService pulsarService = getPulsarService(serviceConfiguration);
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
         assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
@@ -55,24 +62,20 @@ public class BacklogQuotaManagerConfigurationTest {
 
     @Test
     public void testBacklogQuotaDefaultLimitBytes() {
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-        initializeServiceConfiguration(serviceConfiguration);
         serviceConfiguration.setBacklogQuotaDefaultLimitGB(0);
         serviceConfiguration.setBacklogQuotaDefaultLimitBytes(123);
 
-        PulsarService pulsarService = getPulsarService(serviceConfiguration);
         BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
 
         assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 123);
     }
 
-    private void initializeServiceConfiguration(ServiceConfiguration serviceConfiguration) {
-        serviceConfiguration.setBacklogQuotaDefaultLimitGB(1.6);
+    private void initializeServiceConfiguration() {
         serviceConfiguration.setClusterName("test");
         serviceConfiguration.setZookeeperServers("http://localhost:2181");
     }
 
-    private PulsarService getPulsarService(ServiceConfiguration serviceConfiguration) {
+    private PulsarService getPulsarService() {
         PulsarService pulsarService = mock(PulsarService.class);
         ConfigurationCacheService configurationCacheService = mock(ConfigurationCacheService.class);
         when(pulsarService.getConfiguration()).thenReturn(serviceConfiguration);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.cache.ConfigurationCacheService;
+import org.apache.pulsar.common.policies.data.impl.BacklogQuotaImpl;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "broker")
+public class BacklogQuotaManagerConfigurationTest {
+
+    @Test
+    public void testBacklogQuotaConfiguration() {
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        double backlogQuotaDefaultLimitGB = 1.6;
+        initializeServiceConfiguration(serviceConfiguration, backlogQuotaDefaultLimitGB);
+        PulsarService pulsarService = getPulsarService(serviceConfiguration);
+
+        // Test correct conversion of double value
+        BacklogQuotaManager backlogQuotaManager = new BacklogQuotaManager(pulsarService);
+        assertEquals((long) (backlogQuotaDefaultLimitGB * BacklogQuotaImpl.BYTES_IN_GIGABYTE),
+                backlogQuotaManager.getDefaultQuota().getLimitSize());
+
+        int backlogQuotaDefaultLimitBytes = 123;
+
+        // Test precedence of backlogQuotaDefaultLimitGB over backlogQuotaDefaultLimitBytes
+        serviceConfiguration.setBacklogQuotaDefaultLimitBytes(backlogQuotaDefaultLimitBytes);
+        backlogQuotaManager = new BacklogQuotaManager(pulsarService);
+        assertEquals((long) (backlogQuotaDefaultLimitGB * BacklogQuotaImpl.BYTES_IN_GIGABYTE),
+                backlogQuotaManager.getDefaultQuota().getLimitSize());
+
+        // Test backlogQuotaDefaultLimitBytes is applied if backlogQuotaDefaultLimitGB <= 0
+        serviceConfiguration.setBacklogQuotaDefaultLimitGB(0);
+        serviceConfiguration.setBacklogQuotaDefaultLimitBytes(backlogQuotaDefaultLimitBytes);
+        backlogQuotaManager = new BacklogQuotaManager(pulsarService);
+        assertEquals(backlogQuotaDefaultLimitBytes, backlogQuotaManager.getDefaultQuota().getLimitSize());
+    }
+
+    private void initializeServiceConfiguration(ServiceConfiguration serviceConfiguration, double backlogQuotaDefaultLimitGB) {
+        serviceConfiguration.setBacklogQuotaDefaultLimitGB(backlogQuotaDefaultLimitGB);
+        serviceConfiguration.setClusterName("test");
+        serviceConfiguration.setZookeeperServers("http://localhost:2181");
+    }
+
+    private PulsarService getPulsarService(ServiceConfiguration serviceConfiguration) {
+        PulsarService pulsarService = mock(PulsarService.class);
+        ConfigurationCacheService configurationCacheService = mock(ConfigurationCacheService.class);
+        when(pulsarService.getConfiguration()).thenReturn(serviceConfiguration);
+        when(pulsarService.getConfigurationCache()).thenReturn(configurationCacheService);
+        return pulsarService;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
@@ -72,7 +72,7 @@ public class BacklogQuotaManagerConfigurationTest {
 
     private void initializeServiceConfiguration() {
         serviceConfiguration.setClusterName("test");
-        serviceConfiguration.setZookeeperServers("http://localhost:2181");
+        serviceConfiguration.setZookeeperServers("localhost:2181");
     }
 
     private PulsarService getPulsarService() {


### PR DESCRIPTION
Fixed a casting error introduced in #11671.
The double value of user-configured backlogQuota in GB is converted to long before converting to bytes.