### PR TITLE
[Doc] Fix Pulsar c++ client windows build docs

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -253,7 +253,7 @@ ${PULSAR_PATH}/pulsar-client-cpp/vcpkg_installed
 
 ##### Examples will be placed in
 ```
-${PULSAR_PATH}/pulsar-client-cpp/build/examples
+${PULSAR_PATH}/pulsar-client-cpp/build/examples/Release
 ```
 
 ## Tests

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -235,6 +235,26 @@ ${PULSAR_PATH}/pulsar-client-cpp/cmake -DPROTOC_PATH=C:/protobuf/bin/protoc -DCM
 #This will generate pulsar-cpp.sln. Open this in Visual Studio and build the desired configurations.
 ```
 
+#### Checks
+
+##### Client library will be placed in
+```
+${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.lib
+${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
+```
+
+#### Examples
+
+##### Add windows environment paths
+```
+${PULSAR_PAHT}/pulsar-client-cpp/build/lib/Release
+${PULSAR_PATH}/pulsar-client-cpp/vcpkg_installed
+```
+
+##### Examples will be placed in
+```
+${PULSAR_PATH}/pulsar-client-cpp/build/examples
+```
 
 ## Tests
 ```shell

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -247,7 +247,7 @@ ${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
 
 ##### Add windows environment paths
 ```
-${PULSAR_PAHT}/pulsar-client-cpp/build/lib/Release
+${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release
 ${PULSAR_PATH}/pulsar-client-cpp/vcpkg_installed
 ```
 

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -237,7 +237,7 @@ ${PULSAR_PATH}/pulsar-client-cpp/cmake -DPROTOC_PATH=C:/protobuf/bin/protoc -DCM
 
 #### Checks
 
-##### Client library will be placed in
+##### Client libraries are available in the following places.
 ```
 ${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.lib
 ${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
@@ -245,13 +245,13 @@ ${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
 
 #### Examples
 
-##### Add windows environment paths
+##### Add windows environment paths.
 ```
 ${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release
 ${PULSAR_PATH}/pulsar-client-cpp/vcpkg_installed
 ```
 
-##### Examples will be placed in
+##### Examples are available in.
 ```
 ${PULSAR_PATH}/pulsar-client-cpp/build/examples/Release
 ```

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -261,8 +261,8 @@ cmake --build ./build --config Release
 4. Client library will be placed in.
 
 ```
-${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.lib
-${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
+${PULSAR_HOME}/pulsar-client-cpp/build/lib/Release/pulsar.lib
+${PULSAR_HOME}/pulsar-client-cpp/build/lib/Release/pulsar.dll
 ```
 
 ## Connection URLs

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -251,14 +251,14 @@ cd ${PULSAR_HOME}/pulsar-client-cpp
 vcpkg install --feature-flags=manifests --triplet x64-windows
 ```
 
-3. Build c++ libraries.
+3. Build C++ libraries.
 
 ```shell
 cmake -B ./build -A x64 -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF -DVCPKG_TRIPLET=x64-windows -DCMAKE_BUILD_TYPE=Release -S .
 cmake --build ./build --config Release
 ```
 
-4. Client library will be placed in.
+4. Client libraries are available in the following places.
 
 ```
 ${PULSAR_HOME}/pulsar-client-cpp/build/lib/Release/pulsar.lib

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -254,13 +254,7 @@ vcpkg install --feature-flags=manifests --triplet x64-windows
 3. Build c++ libraries.
 
 ```shell
-cmake \
- -B ./build \
- -A x64 \
- -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
- -DVCPKG_TRIPLET=x64-windows \
- -DCMAKE_BUILD_TYPE=Release \
- -S .
+cmake -B ./build -A x64 -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF -DVCPKG_TRIPLET=x64-windows -DCMAKE_BUILD_TYPE=Release -S .
 cmake --build ./build --config Release
 ```
 

--- a/site2/docs/client-libraries-cpp.md
+++ b/site2/docs/client-libraries-cpp.md
@@ -234,6 +234,43 @@ Pulsar releases are available in the [Homebrew](https://brew.sh/) core repositor
 brew install libpulsar
 ```
 
+## Windows (64-bit)
+
+### Compilation
+
+1. Clone the Pulsar repository.
+
+```shell
+$ git clone https://github.com/apache/pulsar
+```
+
+2. Install all necessary dependencies.
+
+```shell
+cd ${PULSAR_HOME}/pulsar-client-cpp
+vcpkg install --feature-flags=manifests --triplet x64-windows
+```
+
+3. Build c++ libraries.
+
+```shell
+cmake \
+ -B ./build \
+ -A x64 \
+ -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_TESTS=OFF \
+ -DVCPKG_TRIPLET=x64-windows \
+ -DCMAKE_BUILD_TYPE=Release \
+ -S .
+cmake --build ./build --config Release
+```
+
+4. Client library will be placed in.
+
+```
+${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.lib
+${PULSAR_PATH}/pulsar-client-cpp/build/lib/Release/pulsar.dll
+```
+
 ## Connection URLs
 
 To connect Pulsar using client libraries, you need to specify a Pulsar protocol URL.


### PR DESCRIPTION
### Motivation

Currently, docs that the Pulsar c++ client windows building-related docs are not complete.

### Modifications

Add Pulsar c++ client windows building steps in Apache Pulsar website.
Add Pulsar c++ client windows building result check section.