### PR TITLE
[Functions]Support protobuf schema for pulsar function

### DIFF
--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -79,6 +79,23 @@
       <version>${jackson.databind.version}</version>
     </dependency>
 
+    <!--In order to support protobuf schema, this dependency needs to be added-->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+
     <!-- logging -->
 
     <dependency>

--- a/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
+++ b/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
@@ -72,8 +72,9 @@ public class JavaInstanceDepsTest {
                         && !name.startsWith("org/apache/avro")
                         && !name.startsWith("com/fasterxml/jackson")
                         && !name.startsWith("org/apache/commons/compress")
-                        && !name.startsWith("com/google/protobuf")
-                        && !name.startsWith("com/google/gson")
+                        && !name.startsWith("com/google")
+                        && !name.startsWith("org/checkerframework")
+                        && !name.startsWith("javax/annotation")
                         && !name.startsWith("org/apache/logging/slf4j")
                         && !name.startsWith("org/apache/logging/log4j")) {
                     notAllowedClasses.add(name);

--- a/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
+++ b/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
@@ -72,6 +72,8 @@ public class JavaInstanceDepsTest {
                         && !name.startsWith("org/apache/avro")
                         && !name.startsWith("com/fasterxml/jackson")
                         && !name.startsWith("org/apache/commons/compress")
+                        && !name.startsWith("com/google/protobuf")
+                        && !name.startsWith("com/google/gson")
                         && !name.startsWith("org/apache/logging/slf4j")
                         && !name.startsWith("org/apache/logging/log4j")) {
                     notAllowedClasses.add(name);


### PR DESCRIPTION


Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Some users have encountered the following exception when using the protobuf schema, so add the relevant dependencies to the instance:

```
ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - Sink open produced uncaught exception:
java.lang.IllegalArgumentException: com.google.protobuf.GeneratedMessageV3 is not assignable from bold.proto.PersonOuterClass$Person
	at org.apache.pulsar.client.impl.schema.ProtobufSchema.of(ProtobufSchema.java:110) ~
```

### Modifications

* Add the relevant dependencies to the instance

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

#### For contributor

For this PR, do we need to update docs?

- If yes, please update docs or create a follow-up issue if you need help.
  
- If no, please explain why.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

