### PR TITLE
[pulsar-client-cpp] Expose getLastMessageId in the Reader API

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -29,6 +29,7 @@ class PulsarFriend;
 class ReaderImpl;
 
 typedef std::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
+typedef std::function<void(Result result, MessageId messageId)> GetLastMessageIdCallback;
 
 /**
  * A Reader can be used to scan through all the messages currently available in a topic.
@@ -136,6 +137,16 @@ class PULSAR_PUBLIC Reader {
      * @return Whether the reader is currently connected to the broker
      */
     bool isConnected() const;
+
+    /**
+     * Asynchronously get an id of the last available message or a message id with -1 as an entryId if the topic is empty.
+     */
+    void getLastMessageIdAsync(GetLastMessageIdCallback callback);
+
+    /**
+     * Get an id of the last available message or a message id with -1 as an entryId if the topic is empty.
+     */
+    Result getLastMessageId(MessageId& messageId);
 
    private:
     typedef std::shared_ptr<ReaderImpl> ReaderImplPtr;

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -139,7 +139,8 @@ class PULSAR_PUBLIC Reader {
     bool isConnected() const;
 
     /**
-     * Asynchronously get an ID of the last available message or a message ID with -1 as an entryId if the topic is empty.
+     * Asynchronously get an ID of the last available message or a message ID with -1 as an entryId if the
+     * topic is empty.
      */
     void getLastMessageIdAsync(GetLastMessageIdCallback callback);
 

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -139,12 +139,12 @@ class PULSAR_PUBLIC Reader {
     bool isConnected() const;
 
     /**
-     * Asynchronously get an id of the last available message or a message id with -1 as an entryId if the topic is empty.
+     * Asynchronously get an ID of the last available message or a message ID with -1 as an entryId if the topic is empty.
      */
     void getLastMessageIdAsync(GetLastMessageIdCallback callback);
 
     /**
-     * Get an id of the last available message or a message id with -1 as an entryId if the topic is empty.
+     * Get an ID of the last available message or a message ID with -1 as an entryId if the topic is empty.
      */
     Result getLastMessageId(MessageId& messageId);
 

--- a/pulsar-client-cpp/lib/Reader.cc
+++ b/pulsar-client-cpp/lib/Reader.cc
@@ -117,4 +117,19 @@ Result Reader::seek(uint64_t timestamp) {
 
 bool Reader::isConnected() const { return impl_ && impl_->isConnected(); }
 
+void Reader::getLastMessageIdAsync(GetLastMessageIdCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized, MessageId());
+        return;
+    }
+    impl_->getLastMessageIdAsync(callback);
+}
+
+Result Reader::getLastMessageId(MessageId& messageId) {
+    Promise<Result, MessageId> promise;
+
+    getLastMessageIdAsync(WaitForCallbackValue<MessageId>(promise));
+    return promise.getFuture().get(messageId);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -138,6 +138,10 @@ void ReaderImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
     consumer_->seekAsync(timestamp, callback);
 }
 
+void ReaderImpl::getLastMessageIdAsync(GetLastMessageIdCallback callback) {
+    consumer_->getLastMessageIdAsync(callback);
+}
+
 ReaderImplWeakPtr ReaderImpl::getReaderImplWeakPtr() { return readerImplWeakPtr_; }
 
 bool ReaderImpl::isConnected() const { return consumer_->isConnected(); }

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -60,6 +60,8 @@ class PULSAR_PUBLIC ReaderImpl : public std::enable_shared_from_this<ReaderImpl>
     void seekAsync(const MessageId& msgId, ResultCallback callback);
     void seekAsync(uint64_t timestamp, ResultCallback callback);
 
+    void getLastMessageIdAsync(GetLastMessageIdCallback callback);
+
     ReaderImplWeakPtr getReaderImplWeakPtr();
 
     bool isConnected() const;


### PR DESCRIPTION
### Motivation

The changes are trivial. getLastMessageIdAsync is already implemented in the ConsumerImpl class but it is only used internally for checking if there are any available messages in the topic. It is really helpful to have it exposed in the Reader API e.g., to be able to read all messages currently available in the topic. I.e., to get last message id and then to read all messages till this id. (hasMessageAvailable is not helpful because it potentially might always return 'false' if new messages are produced)

### Modifications

Trivial changes of ReaderImpl and Reader classes to expose getLastMessageId.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - The public API: yes

getLastMessageIdAsync and getLastMessageId methods were added to the C++ Reader API.

#### For contributor

For this PR, do we need to update docs?

No. Corresponding comments to the new methods in the Reader.h file were added.

