### PR TITLE
added an option to configure messageRouterClassName for MessageRoutingMode.CustomPartition

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -254,6 +254,19 @@ public interface ProducerBuilder<T> extends Cloneable {
     ProducerBuilder<T> messageRoutingMode(MessageRoutingMode messageRoutingMode);
 
     /**
+     * Set the messageRouterClassName for a partitioned producer when {@link MessageRoutingMode}
+     * is {@link MessageRoutingMode#CustomPartition}
+     *
+     * <p>This config gets precedence over {@link ProducerBuilder#messageRouter}.
+     *
+     * @param messageRouterClassName the message router class name whose instance should
+     *                               be created.
+     * @return the producer builder instance
+     * @see MessageRoutingMode
+     */
+    ProducerBuilder<T> messageRouterClassName(String messageRouterClassName);
+
+    /**
      * Change the {@link HashingScheme} used to chose the partition on where to publish a particular message.
      *
      * <p>Standard hashing functions available are:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -174,6 +174,12 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
+    public ProducerBuilder<T> messageRouterClassName(@NonNull String messageRouterClassName) {
+        conf.setMessageRouterClassName(messageRouterClassName);
+        return this;
+    }
+
+    @Override
     public ProducerBuilder<T> compressionType(@NonNull CompressionType compressionType) {
         conf.setCompressionType(compressionType);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -64,6 +64,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     private int maxPendingMessages = DEFAULT_MAX_PENDING_MESSAGES;
     private int maxPendingMessagesAcrossPartitions = DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
     private MessageRoutingMode messageRoutingMode = null;
+    private String messageRouterClassName = null;
     private HashingScheme hashingScheme = HashingScheme.JavaStringHash;
 
     private ProducerCryptoFailureAction cryptoFailureAction = ProducerCryptoFailureAction.FAIL;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -107,6 +107,16 @@ public class PartitionedProducerImplTest {
         assertTrue(messageRouter instanceof CustomMessageRouter);
     }
 
+    @Test
+    public void testInitializeCustomMessageRouterInstanceFromProperty() throws NoSuchFieldException, IllegalAccessException {
+        ProducerConfigurationData producerConfigurationData = new ProducerConfigurationData();
+        producerConfigurationData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
+        producerConfigurationData.setMessageRouterClassName("org.apache.pulsar.client.impl.TestMessageRouter");
+
+        MessageRouter messageRouter = getMessageRouter(producerConfigurationData);
+        assertTrue(messageRouter instanceof TestMessageRouter);
+    }
+
     private MessageRouter getMessageRouter(ProducerConfigurationData producerConfigurationData)
             throws NoSuchFieldException, IllegalAccessException {
         PartitionedProducerImpl impl = new PartitionedProducerImpl(
@@ -154,3 +164,5 @@ public class PartitionedProducerImplTest {
     }
 
 }
+
+class TestMessageRouter implements MessageRouter {}


### PR DESCRIPTION
Fixes: #11727

Introduced a new property to configure the class name of custom MessageRouter implementation.

If this enhancement looks good, it will need a doc change which I will make once the code part is approved.