### PR TITLE
Add Pulsar Summit Asia 2021 CFP Blog

### DIFF
--- a/site2/website/blog/2021-08-18-asia-cfp.md
+++ b/site2/website/blog/2021-08-18-asia-cfp.md
@@ -1,0 +1,47 @@
+---
+author: Dianjin
+title: Announcing Pulsar Summit Asia 2021: CFP Is Open!
+---
+We’re proud to announce the Pulsar Summit Asia 2021!
+
+2021 has been a remarkable year for the Apache Pulsar community. [Both the technology and community are growing rapidly this year](https://streamnative.io/en/blog/community/2021-06-14-pulsar-hits-its-400th-contributor-and-passes-kafka-in-monthly-active-contributors), and [Pulsar Virtual Summit North America 2021](https://www.na2021.pulsar-summit.org) was a big success with 33 break-out sessions and more than 550 registrations.
+
+Last year, [Pulsar Summit Asia](https://pulsar-summit.org/en/event/asia-2020) featured more than 40 interactive sessions by tech leads, open-source developers, software engineers, and software architects from Tencent Group, BIGO, Kingsoft Cloud, Splunk, Yahoo! JAPAN, Nutanix, Dada Group, TIBCO, Huawei Cloud, and more. The conference garnered nearly 1,000 attendees around the globe mostly from Asia, including attendees from top tech, fintech and media companies.
+
+Cumulatively, the Pulsar Summits drew more than 100 speakers, thousands of attendees, and hundreds of companies from diverse industries. It is a unique opportunity to network and learn about Pulsar project updates, ecosystem developments, best practices, and adoption stories.
+
+**This year, the Pulsar Summit Asia will be hosted on November 20-21, 2021 by StreamNative. You can join us offline in Beijing for one day of Pulsar Training and one day of keynotes and breakout sessions. All the talks will be streamed live online.**
+# CFP Details
+Join us and speak at the Pulsar Summit Asia 2021!
+We are looking for Pulsar stories that are innovative, informative, or thought-provoking. Here are some suggestions:
+- Your Pulsar use case / success story
+- A technical deep dive
+- Pulsar best practices
+- Pulsar ecosystem updates
+
+To speak at the summit, please [submit an abstract](https://sessionize.com/pulsar-summit-asia-2021/) about your presentation. Remember to keep your proposal short, relevant and engaging.
+# First-time Speakers Welcomed! 
+First time submitting? Don't feel intimidated. We strongly encourage first-time speakers to submit talks for the Pulsar Summit Asia 2021. If your submission is similar to a previous talk in the past Pulsar Summits, please include information on how this version will be different. We hope to see some exciting updates on the topic.
+
+We welcome submissions from around the globe. Our hybrid conference model has taken time differences into consideration. After your talk is accepted, we will schedule the sessions and send you the presentation options. 
+
+# Speaker Benefits
+As a speaker, you will receive: 
+- The chance to demonstrate your experience and deep knowledge in the rapidly growing event streaming space.
+- Your name, title, company, and bio will be featured on the Pulsar Summit Asia 2021 website.
+- Your session will be added to the Pulsar Summit YouTube Channel and promoted on Twitter,  LinkedIn and WeChat.
+- A professionally produced video of your presentation.
+Exclusive Pulsar swag only available to the speakers.
+
+# Important Dates
+- CFP opens: August 18th, 2021 
+- CFP closes: September 8th, 2021 
+- Speaker notifications: September 22th, 2021
+- Schedule announcement: October 13th, 2021 
+
+Submissions are open until September 8th. If you want some advice or feedback on your proposal, or have any questions about the summit, please do not hesitate to contact us at organizers@pulsar-summit.org. We are happy to help!
+
+# Sponsor Pulsar Summit Asia
+Pulsar Summit is a conference for the community and sponsorship is needed. Sponsoring this event provides a great opportunity for your organization to further engage with the Apache Pulsar community. Contact us at organizers@pulsar-summit.org to learn more.
+
+Help us make Pulsar Summit Asia 2021 a big success by spreading the word and submitting your proposal! Follow Pulsar Summit on [Twitter](https://twitter.com/PulsarSummit) to receive the latest updates of the conference.

--- a/site2/website/blog/2021-08-18-asia-cfp.md
+++ b/site2/website/blog/2021-08-18-asia-cfp.md
@@ -29,7 +29,7 @@ We welcome submissions from around the globe. Our hybrid conference model has ta
 As a speaker, you will receive: 
 - The chance to demonstrate your experience and deep knowledge in the rapidly growing event streaming space.
 - Your name, title, company, and bio will be featured on the Pulsar Summit Asia 2021 website.
-- Your session will be added to the Pulsar Summit YouTube Channel and promoted on Twitter,  LinkedIn and WeChat.
+- Your session will be added to the Pulsar Summit YouTube Channel and promoted on Twitter,  LinkedIn, and WeChat.
 - A professionally produced video of your presentation.
 Exclusive Pulsar swag only available to the speakers.
 


### PR DESCRIPTION
### Motivation
*Pulsar Summit Asia 2021 CFP is open*

### Modifications
Add Pulsar Summit Asia 2021 CFP Blog on Pulsar website to call for submissions.

### Documentation
For this PR, do we need to update docs?
No, it isn't related to technical updates.