### PR TITLE
[Broker] Call .release() when discarding entry to prevent direct memory leak

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -175,7 +175,9 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 Entry entry = iterator.next();
                 byte[] key = peekStickyKey(entry.getDataBuffer());
                 Consumer consumer = stickyKeyConsumerSelector.select(key);
+                // Skip the entry if it's not for current active consumer.
                 if (consumer == null || currentConsumer != consumer) {
+                    entry.release();
                     iterator.remove();
                 }
             }


### PR DESCRIPTION
### Motivation

I was reading the source code of org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer class and spotted a missing `org.apache.bookkeeper.mledger.Entry.release()` call. 

### Modifications

call the `.release()` method the same way as it's implemented in https://github.com/apache/pulsar/blob/feb4ff19e097a9d8f13b093e8fb25dc12c31227b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStreamingDispatcherSingleActiveConsumer.java#L142