### PR TITLE
[pulsar-client] remove consumer reference from PulsarClient on subscription failure

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -868,6 +868,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             .exceptionally(e -> {
                 log.warn("Failed subscription for createPartitionedConsumer: {} {}, e:{}",
                     topicName, numPartitions,  e);
+                consumer.cleanupMultiConsumer();
                 subscribeFuture.completeExceptionally(
                     PulsarClientException.wrap(((Throwable) e).getCause(), String.format("Failed to subscribe %s with %d partitions", topicName, numPartitions)));
                 return null;


### PR DESCRIPTION
### Motivation

`MultiTopicsConsumerImpl` doesn't clean up reference from PulsarClient when it fails to subscribe which prevents GC to clean up consumer resources and it introduces memory leak. Below screen shot shows that pulsar-client doesn't remove failed `MultiTopicsConsumerImpl` and objects are keep growing.

![image](https://user-images.githubusercontent.com/2898254/130533664-3fbefe1d-eb01-4b7c-9afa-491d422e8fce.png)

### Modification
Clean up `MultiTopicsConsumerImpl` resources on failure.