### PR TITLE
[C++] Make some clean up methods thread safe

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -129,7 +129,7 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
     }
 }
 
-ClientImpl::~ClientImpl() {}
+ClientImpl::~ClientImpl() { shutdown(); }
 
 const ClientConfiguration& ClientImpl::conf() const { return clientConfiguration_; }
 
@@ -567,8 +567,14 @@ void ClientImpl::shutdown() {
         }
     }
 
-    LOG_DEBUG(producers.size() << " producers and " << consumers.size() << " consumers have been shutdown.");
-    pool_.close();
+    if (producers.size() + consumers.size() > 0) {
+        LOG_DEBUG(producers.size() << " producers and " << consumers.size()
+                                   << " consumers have been shutdown.");
+    }
+    if (!pool_.close()) {
+        // pool_ has already been closed. It means shutdown() has been called before.
+        return;
+    }
     LOG_DEBUG("ConnectionPool is closed");
     ioExecutorProvider_->close();
     LOG_DEBUG("ioExecutorProvider_ is closed");

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -129,7 +129,7 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
     }
 }
 
-ClientImpl::~ClientImpl() { shutdown(); }
+ClientImpl::~ClientImpl() {}
 
 const ClientConfiguration& ClientImpl::conf() const { return clientConfiguration_; }
 
@@ -567,10 +567,15 @@ void ClientImpl::shutdown() {
         }
     }
 
+    LOG_DEBUG(producers.size() << " producers and " << consumers.size() << " consumers have been shutdown.");
     pool_.close();
+    LOG_DEBUG("ConnectionPool is closed");
     ioExecutorProvider_->close();
+    LOG_DEBUG("ioExecutorProvider_ is closed");
     listenerExecutorProvider_->close();
+    LOG_DEBUG("listenerExecutorProvider_ is closed");
     partitionListenerExecutorProvider_->close();
+    LOG_DEBUG("partitionListenerExecutorProvider_ is closed");
 }
 
 uint64_t ClientImpl::newProducerId() {

--- a/pulsar-client-cpp/lib/ConnectionPool.cc
+++ b/pulsar-client-cpp/lib/ConnectionPool.cc
@@ -41,7 +41,12 @@ ConnectionPool::ConnectionPool(const ClientConfiguration& conf, ExecutorServiceP
       poolConnections_(poolConnections),
       mutex_() {}
 
-void ConnectionPool::close() {
+bool ConnectionPool::close() {
+    bool expectedState = false;
+    if (!closed_.compare_exchange_strong(expectedState, true)) {
+        return false;
+    }
+
     std::unique_lock<std::mutex> lock(mutex_);
     if (poolConnections_) {
         for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {
@@ -52,10 +57,17 @@ void ConnectionPool::close() {
         }
         pool_.clear();
     }
+    return true;
 }
 
 Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(
     const std::string& logicalAddress, const std::string& physicalAddress) {
+    if (closed_) {
+        Promise<Result, ClientConnectionWeakPtr> promise;
+        promise.setFailed(ResultAlreadyClosed);
+        return promise.getFuture();
+    }
+
     std::unique_lock<std::mutex> lock(mutex_);
 
     if (poolConnections_) {

--- a/pulsar-client-cpp/lib/ConnectionPool.h
+++ b/pulsar-client-cpp/lib/ConnectionPool.h
@@ -24,6 +24,7 @@
 
 #include "ClientConnection.h"
 
+#include <atomic>
 #include <string>
 #include <map>
 #include <mutex>
@@ -36,7 +37,12 @@ class PULSAR_PUBLIC ConnectionPool {
     ConnectionPool(const ClientConfiguration& conf, ExecutorServiceProviderPtr executorProvider,
                    const AuthenticationPtr& authentication, bool poolConnections = true);
 
-    void close();
+    /**
+     * Close the connection pool.
+     *
+     * @return false if it has already been closed.
+     */
+    bool close();
 
     /**
      * Get a connection from the pool.
@@ -65,6 +71,7 @@ class PULSAR_PUBLIC ConnectionPool {
     PoolMap pool_;
     bool poolConnections_;
     std::mutex mutex_;
+    std::atomic_bool closed_{false};
 
     friend class ConnectionPoolTest;
 };

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -19,6 +19,7 @@
 #ifndef _PULSAR_EXECUTOR_SERVICE_HEADER_
 #define _PULSAR_EXECUTOR_SERVICE_HEADER_
 
+#include <atomic>
 #include <memory>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
@@ -73,6 +74,8 @@ class PULSAR_PUBLIC ExecutorService : private boost::noncopyable {
      * io_service
      */
     std::thread worker_;
+
+    std::atomic_bool closed_{false};
 };
 
 typedef std::shared_ptr<ExecutorService> ExecutorServicePtr;

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -35,7 +35,7 @@ namespace pulsar {
 #endif
 
 #define DECLARE_LOG_OBJECT()                                                                     \
-    inline pulsar::Logger* logger() {                                                            \
+    static pulsar::Logger* logger() {                                                            \
         static thread_local std::unique_ptr<pulsar::Logger> threadSpecificLogPtr;                \
         pulsar::Logger* ptr = threadSpecificLogPtr.get();                                        \
         if (PULSAR_UNLIKELY(!ptr)) {                                                             \

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -24,7 +24,6 @@
 #include "ProducerImpl.h"
 
 namespace pulsar {
-DECLARE_LOG_OBJECT()
 
 static const std::string EMPTY_STRING;
 

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -38,7 +38,17 @@
 #include <boost/property_tree/ptree.hpp>
 namespace ptree = boost::property_tree;
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#endif
+
 #include <boost/xpressive/xpressive.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 

--- a/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
+++ b/pulsar-client-cpp/tests/BinaryLookupServiceTest.cc
@@ -27,8 +27,6 @@
 #include <pulsar/Authentication.h>
 #include <boost/exception/all.hpp>
 
-DECLARE_LOG_OBJECT()
-
 using namespace pulsar;
 
 TEST(BinaryLookupServiceTest, basicLookup) {

--- a/pulsar-client-cpp/tests/CustomLoggerTest.cc
+++ b/pulsar-client-cpp/tests/CustomLoggerTest.cc
@@ -56,7 +56,7 @@ TEST(CustomLoggerTest, testCustomLogger) {
         // reset to previous log factory
         Client client("pulsar://localhost:6650", clientConfig);
         client.close();
-        ASSERT_EQ(logLines.size(), 8);
+        ASSERT_EQ(logLines.size(), 7);
         LogUtils::resetLoggerFactory();
     });
     testThread.join();
@@ -65,7 +65,7 @@ TEST(CustomLoggerTest, testCustomLogger) {
     Client client("pulsar://localhost:6650", clientConfig);
     client.close();
     // custom logger didn't get any new lines
-    ASSERT_EQ(logLines.size(), 8);
+    ASSERT_EQ(logLines.size(), 7);
 }
 
 TEST(CustomLoggerTest, testConsoleLoggerFactory) {

--- a/pulsar-client-cpp/tests/CustomLoggerTest.cc
+++ b/pulsar-client-cpp/tests/CustomLoggerTest.cc
@@ -56,7 +56,7 @@ TEST(CustomLoggerTest, testCustomLogger) {
         // reset to previous log factory
         Client client("pulsar://localhost:6650", clientConfig);
         client.close();
-        ASSERT_EQ(logLines.size(), 3);
+        ASSERT_EQ(logLines.size(), 8);
         LogUtils::resetLoggerFactory();
     });
     testThread.join();
@@ -65,7 +65,7 @@ TEST(CustomLoggerTest, testCustomLogger) {
     Client client("pulsar://localhost:6650", clientConfig);
     client.close();
     // custom logger didn't get any new lines
-    ASSERT_EQ(logLines.size(), 3);
+    ASSERT_EQ(logLines.size(), 8);
 }
 
 TEST(CustomLoggerTest, testConsoleLoggerFactory) {

--- a/pulsar-client-cpp/tests/MessageTest.cc
+++ b/pulsar-client-cpp/tests/MessageTest.cc
@@ -22,8 +22,6 @@
 #include <string>
 #include <lib/LogUtils.h>
 
-DECLARE_LOG_OBJECT()
-
 using namespace pulsar;
 TEST(MessageTest, testMessageContents) {
     MessageBuilder msgBuilder1;

--- a/pulsar-client-cpp/tests/ReaderConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ReaderConfigurationTest.cc
@@ -22,11 +22,8 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
-#include <lib/LogUtils.h>
 #include <lib/ReaderImpl.h>
 #include "NoOpsCryptoKeyReader.h"
-
-DECLARE_LOG_OBJECT()
 
 using namespace pulsar;
 


### PR DESCRIPTION
Fixes #11760 

### Motivation

`BasicEndToEndTest.testLookupThrottling` is flaky, from the logs of #11760 we can see the test crashed in `ClientImpl::shutdown`. The `Connection closed` log shows that `ConnectionPool` has been closed, so the problem is related to the close of three `ExecutorServiceProvider`s of `ClientImpl`.

`ExecutorServiceProvider::close` is not thread safe because `ExecutorServiceProvider::get` might access the `executors_` field in different threads and `get` uses a lock to guarantee thread-safety while `close` doesn't. In addition, some clean up methods including `ClientImpl#shutdown` and `ExecutorService#close` might be called twice or more, which is not necessary and has potential bugs.

### Modifications

The main changes are:
- Add a lock to guarantee thread-safety of `ExecutorServiceProvider::close`.
- Use an atomic variable to make sure the logic in `ExecutorService#close` is called only once.
- Avoid `ConnectionPool#getConnectionAsync` being called after `close` method is closed. In this case, return a future that is completed with `ResultAlreadyClosed`.
- Add more debug logs.

In addition, this PR involves other changes. First, the master branch's source code cannot be compiled in my local env (macOS + Clang 12.0.0 + Boost 1.74), the error is:

```
/usr/local/include/boost/proto/expr.hpp:140:44: error: unknown warning group '-Wdeprecated-copy', ignored [-Werror,-Wunknown-warning-option]
            #pragma GCC diagnostic ignored "-Wdeprecated-copy"
```

I followed https://github.com/boostorg/proto/issues/30 to fix this compilation error.

Another change is to fix the logs format, we can see the filename is always the same from logs in #11760. The reason is #11668 has changed `logger()` method from `static` to `inline`. It will make all C++'s translation units share the same  and random chosen definition of `logger()`, but we need different definitions with different `__FILE__` in different translation units. So this PR modified `static` back to `inline` and fix related compilation errors.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.