### PR TITLE
[Branch-2.8] fix com.squareup.okhttp-okhttp-2.7.4.jar unaccounted for in LICENSE bug

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -448,6 +448,7 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrifth - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3
+     - com.squareup.okhttp-okhttp-2.7.4.jar
      - com.squareup.okhttp3-logging-interceptor-3.14.9.jar
      - com.squareup.okhttp3-okhttp-3.14.9.jar
  * Okio - com.squareup.okio-okio-1.13.0.jar


### PR DESCRIPTION
### Motivation
branch 2.8 run license check failed.
```
com.squareup.okhttp-okhttp-2.7.4.jar unaccounted for in LICENSE

It looks like there are issues with the LICENSE/NOTICE.
```

### Modification
add `com.squareup.okhttp-okhttp-2.7.4.jar` into LICENSE.bin.txt