### PR TITLE
[Tests] Use TestRetrySupport for BaseMetadataStoreTests to cleanup state between retries

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/TestRetrySupport.java
@@ -33,6 +33,10 @@ import org.testng.annotations.BeforeMethod;
  * This is useful for making test retries to work on classes which use BeforeClass
  * and AfterClass methods to setup a test environment that is shared across all test methods in the test
  * class.
+ *
+ * The setup method implementation must call incrementSetupNumber method and the cleanup method must call
+ * markCurrentSetupNumberCleaned method. This is required by the state tracking logic.
+ *
  */
 public abstract class TestRetrySupport {
     private static final Logger LOG = LoggerFactory.getLogger(TestRetrySupport.class);
@@ -83,12 +87,25 @@ public abstract class TestRetrySupport {
         LOG.debug("currentSetupNumber={}", currentSetupNumber);
     }
 
+    /**
+     * This method should be called in the cleanup method of the concrete class.
+     */
     protected final void markCurrentSetupNumberCleaned() {
         cleanedUpSetupNumber = currentSetupNumber;
         LOG.debug("cleanedUpSetupNumber={}", cleanedUpSetupNumber);
     }
 
+    /**
+     * Initializes the test environment state.
+     *
+     * The implementation of this method must call incrementSetupNumber method.
+     */
     protected abstract void setup() throws Exception;
 
+    /**
+     * Cleans up the state of the environment.
+     *
+     * The implementation of this method must call the markCurrentSetupNumberCleaned method.
+     */
     protected abstract void cleanup() throws Exception;
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -19,23 +19,26 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertTrue;
-
 import java.util.concurrent.CompletionException;
-
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
-public abstract class BaseMetadataStoreTest {
+public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     protected TestZKServer zks;
 
     @BeforeClass(alwaysRun = true)
-    void setup() throws Exception {
+    @Override
+    protected void setup() throws Exception {
+        incrementSetupNumber();
         zks = new TestZKServer();
     }
 
     @AfterClass(alwaysRun = true)
-    void teardown() throws Exception {
+    @Override
+    protected void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         zks.close();
     }
 


### PR DESCRIPTION
### Motivation

Attempt to mitigate the flaky tests in LockManagerTest #11690 and ZkSessionTest #11032 which use the BaseMetadataStoreTests base class. Test retries didn't succeed since the state didn't get cleaned between tests.

The downside of better test retries is that it might suppress production issues in metadata store implementation. The flakiness might be a sign of a real problem.

### Modifications

- use the TestRetrySupport base class for BaseMetadataStoreTests to cleanup state between retries.
- also improve TestRetrySupport javadoc since it has special requirements for the implementation.
