### PR TITLE
[Authorization] AuthorizationService should use provider's canLookupAsync method

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -194,10 +194,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             }
             canConsumeAsync(topicName, role, authenticationData, null).whenComplete((consumeAuthorized, e) -> {
                 if (e == null) {
-                    if (consumeAuthorized) {
-                        finalResult.complete(consumeAuthorized);
-                        return;
-                    }
+                    finalResult.complete(consumeAuthorized);
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug(
@@ -206,9 +203,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
 
                     }
                     finalResult.completeExceptionally(e);
-                    return;
                 }
-                finalResult.complete(false);
             });
         });
         return finalResult;


### PR DESCRIPTION
### Motivation

The AuthenticationService essentially implements the `canLookupAsync` method instead of relying on the provider's `canLookupAsync` method.

Before this change, the `AuthenticationService` was essentially calling `provider.canConsume` and `provider.canProduce` in order to determine if the role had sufficient permission to `lookup`. While the logic should be sufficient, it wasn't the correct implementation because the `provider` has a `canLookup` method that ought to be used.

### Modifications

* Modified `AuthenticationService` method `canLookupAsync` to first check if the role is a super user and then call the configured provider's `canLookupAsync` method. Note that this implementation follows the same paradigm as `canProduceAsync` and `canConsumeAsync` in the `AuthenticationService`.
* Clean up the `PulsarAuthorizationProvider` implementation of `canLookupAsync` to improve readability.

### Verifying this change

This change is already covered by existing tests, such as the `AuthorizationTest`. 

### Does this pull request potentially affect one of the following parts:

This test could result in a change of behavior for users that have implemented their own `AuthorizationProvider`. The `PulsarAuthorizationProvider` is not affected because its logic was equivalent before and after this change. 

### Documentation

#### For contributor

For this PR, do we need to update docs?

It's possible we'll want to update docs or to include a note about this fix for users who are upgrading. The main change in behavior is for users with a custom `AuthorizationProvider`.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

