### PR TITLE
[Tests] Fix BaseMetadataStoreTest retries

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -18,37 +18,39 @@
  */
 package org.apache.pulsar.metadata;
 
+import static org.testng.Assert.assertEquals;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-
-import static org.testng.Assert.assertEquals;
-
 public class BacklogQuotaCompatibilityTest {
 
     @Test
     public void testBackwardCompatibility() throws IOException {
-        String oldPolicyStr = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{}," +
-                "\"subscription_auth_roles\":{}},\"replication_clusters\":[],\"backlog_quota_map\":" +
-                "{\"destination_storage\":{\"limit\":1001,\"policy\":\"consumer_backlog_eviction\"}}," +
-                "\"clusterDispatchRate\":{},\"topicDispatchRate\":{},\"subscriptionDispatchRate\":{}," +
-                "\"replicatorDispatchRate\":{},\"clusterSubscribeRate\":{},\"publishMaxMessageRate\":{}," +
-                "\"latency_stats_sample_rate\":{},\"subscription_expiration_time_minutes\":0,\"deleted\":false," +
-                "\"encryption_required\":false,\"subscription_auth_mode\":\"None\"," +
-                "\"max_consumers_per_subscription\":0,\"offload_threshold\":-1," +
-                "\"schema_auto_update_compatibility_strategy\":\"Full\",\"schema_compatibility_strategy\":" +
-                "\"UNDEFINED\",\"is_allow_auto_update_schema\":true,\"schema_validation_enforced\":false," +
-                "\"subscription_types_enabled\":[]}\n";
+        String oldPolicyStr = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{},"
+                + "\"subscription_auth_roles\":{}},\"replication_clusters\":[],\"backlog_quota_map\":"
+                + "{\"destination_storage\":{\"limit\":1001,\"policy\":\"consumer_backlog_eviction\"}},"
+                + "\"clusterDispatchRate\":{},\"topicDispatchRate\":{},\"subscriptionDispatchRate\":{},"
+                + "\"replicatorDispatchRate\":{},\"clusterSubscribeRate\":{},\"publishMaxMessageRate\":{},"
+                + "\"latency_stats_sample_rate\":{},\"subscription_expiration_time_minutes\":0,\"deleted\":false,"
+                + "\"encryption_required\":false,\"subscription_auth_mode\":\"None\","
+                + "\"max_consumers_per_subscription\":0,\"offload_threshold\":-1,"
+                + "\"schema_auto_update_compatibility_strategy\":\"Full\",\"schema_compatibility_strategy\":"
+                + "\"UNDEFINED\",\"is_allow_auto_update_schema\":true,\"schema_validation_enforced\":false,"
+                + "\"subscription_types_enabled\":[]}\n";
 
-        JSONMetadataSerdeSimpleType jsonMetadataSerdeSimpleType = new JSONMetadataSerdeSimpleType(TypeFactory.defaultInstance().constructSimpleType(Policies.class, null));
+        JSONMetadataSerdeSimpleType jsonMetadataSerdeSimpleType = new JSONMetadataSerdeSimpleType(
+                TypeFactory.defaultInstance().constructSimpleType(Policies.class, null));
         Policies policies = (Policies) jsonMetadataSerdeSimpleType.deserialize(oldPolicyStr.getBytes());
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(), 1001);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(), 0);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getPolicy(), BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
+                1001);
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
+                0);
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getPolicy(),
+                BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
     }
 
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -31,14 +31,14 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     @BeforeClass(alwaysRun = true)
     @Override
-    protected void setup() throws Exception {
+    public final void setup() throws Exception {
         incrementSetupNumber();
         zks = new TestZKServer();
     }
 
     @AfterClass(alwaysRun = true)
     @Override
-    protected void cleanup() throws Exception {
+    public final void cleanup() throws Exception {
         markCurrentSetupNumberCleaned();
         zks.close();
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertTrue;
 import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -44,10 +45,19 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     @DataProvider(name = "impl")
     public Object[][] implementations() {
+        // A Supplier<String> must be used for the Zookeeper connection string parameter. The retried test run will
+        // use the same arguments as the failed attempt.
+        // The Zookeeper test server gets restarted by TestRetrySupport before the retry.
+        // The new connection string won't be available to the test method unless a
+        // Supplier<String> lambda is used for providing the value.
         return new Object[][] {
-                { "ZooKeeper", zks.getConnectionString() },
-                { "Memory", "memory://local" },
+                { "ZooKeeper", stringSupplier(() -> zks.getConnectionString()) },
+                { "Memory", stringSupplier(() -> "memory://local") },
         };
+    }
+
+    public static Supplier<String> stringSupplier(Supplier<String> supplier) {
+        return supplier;
     }
 
     protected String newKey() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -19,9 +19,8 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertNotEquals;
-
+import java.util.function.Supplier;
 import lombok.Cleanup;
-
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -31,9 +30,10 @@ import org.testng.annotations.Test;
 public class CounterTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
-    public void basicTest(String provider, String url) throws Exception {
+    public void basicTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService cs1 = new CoordinationServiceImpl(store);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
@@ -19,15 +19,13 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
-
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
+import java.util.function.Supplier;
 import lombok.Cleanup;
-
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -42,9 +40,10 @@ import org.testng.annotations.Test;
 public class LeaderElectionTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
-    public void basicTest(String provider, String url) throws Exception {
+    public void basicTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService coordinationService = new CoordinationServiceImpl(store);
@@ -74,16 +73,18 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void multipleMembers(String provider, String url) throws Exception {
+    public void multipleMembers(String provider, Supplier<String> urlSupplier) throws Exception {
         if (provider.equals("Memory")) {
             // There are no multiple session in local mem provider
             return;
         }
 
         @Cleanup
-        MetadataStoreExtended store1 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store1 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
         @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
 
         @Cleanup
@@ -129,9 +130,10 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void leaderNodeIsDeletedExternally(String provider, String url) throws Exception {
+    public void leaderNodeIsDeletedExternally(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService coordinationService = new CoordinationServiceImpl(store);
@@ -156,9 +158,10 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void closeAll(String provider, String url) throws Exception {
+    public void closeAll(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
         MetadataCache<String> cache = store.getMetadataCache(String.class);
 
         CoordinationService cs = new CoordinationServiceImpl(store);
@@ -185,9 +188,10 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
 
 
     @Test(dataProvider = "impl")
-    public void revalidateLeaderWithinSameSession(String provider, String url) throws Exception {
+    public void revalidateLeaderWithinSameSession(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         String path = newKey();
 
@@ -209,12 +213,15 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void revalidateLeaderWithDifferentSessionsSameValue(String provider, String url) throws Exception {
+    public void revalidateLeaderWithDifferentSessionsSameValue(String provider, Supplier<String> urlSupplier)
+            throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         String path = newKey();
 
@@ -237,17 +244,20 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
 
 
     @Test(dataProvider = "impl")
-    public void revalidateLeaderWithDifferentSessionsDifferentValue(String provider, String url) throws Exception {
+    public void revalidateLeaderWithDifferentSessionsDifferentValue(String provider, Supplier<String> urlSupplier)
+            throws Exception {
         if (provider.equals("Memory")) {
             // There are no multiple sessions for the local memory provider
             return;
         }
 
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         String path = newKey();
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -20,8 +20,6 @@ package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.fail;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,13 +29,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
+import java.util.function.Supplier;
 import lombok.Cleanup;
-
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
@@ -50,9 +45,10 @@ import org.testng.annotations.Test;
 public class LockManagerTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
-    public void acquireLocks(String provider, String url) throws Exception {
+    public void acquireLocks(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService coordinationService = new CoordinationServiceImpl(store);
@@ -98,9 +94,10 @@ public class LockManagerTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void cleanupOnClose(String provider, String url) throws Exception {
+    public void cleanupOnClose(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService coordinationService = new CoordinationServiceImpl(store);
@@ -127,9 +124,10 @@ public class LockManagerTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void updateValue(String provider, String url) throws Exception {
+    public void updateValue(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         MetadataCache<String> cache = store.getMetadataCache(String.class);
 
@@ -149,9 +147,10 @@ public class LockManagerTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void revalidateLockWithinSameSession(String provider, String url) throws Exception {
+    public void revalidateLockWithinSameSession(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService cs2 = new CoordinationServiceImpl(store);
@@ -180,16 +179,18 @@ public class LockManagerTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void revalidateLockOnDifferentSession(String provider, String url) throws Exception {
+    public void revalidateLockOnDifferentSession(String provider, Supplier<String> urlSupplier) throws Exception {
         if (provider.equals("Memory")) {
             // Local memory provider doesn't really have the concept of multiple sessions
             return;
         }
 
         @Cleanup
-        MetadataStoreExtended store1 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store1 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
         @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         @Cleanup
         CoordinationService cs1 = new CoordinationServiceImpl(store1);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
@@ -21,12 +21,10 @@ package org.apache.pulsar.metadata;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
-
 import java.util.EnumSet;
 import java.util.Optional;
-
+import java.util.function.Supplier;
 import lombok.Cleanup;
-
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
@@ -36,11 +34,12 @@ import org.testng.annotations.Test;
 public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
-    public void sequentialKeys(String provider, String url) throws Exception {
+    public void sequentialKeys(String provider, Supplier<String> urlSupplier) throws Exception {
         final String basePath = "/my/path";
 
         @Cleanup
-        MetadataStoreExtended store = MetadataStoreExtended.create(url, MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
+                MetadataStoreConfig.builder().build());
 
         Stat stat1 = store.put(basePath, "value-1".getBytes(), Optional.of(-1L), EnumSet.of(CreateOption.Sequential))
                 .join();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,9 +31,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
+import java.util.function.Supplier;
 import lombok.Cleanup;
-
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -50,9 +48,9 @@ import org.testng.annotations.Test;
 public class MetadataStoreTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
-    public void emptyStoreTest(String provider, String url) throws Exception {
+    public void emptyStoreTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         assertFalse(store.exists("/non-existing-key").join());
         assertFalse(store.exists("/non-existing-key/child").join());
@@ -78,9 +76,9 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void insertionTestWithExpectedVersion(String provider, String url) throws Exception {
+    public void insertionTestWithExpectedVersion(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         String key1 = newKey();
 
@@ -136,15 +134,15 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void getChildrenTest(String provider, String url) throws Exception {
+    public void getChildrenTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         String key = newKey();
-        int N = 10;
+        int n = 10;
         List<String> expectedChildren = new ArrayList<>();
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             store.put(key + "/c-" + i, new byte[0], Optional.empty()).join();
 
             expectedChildren.add("c-" + i);
@@ -153,7 +151,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         assertEquals(store.getChildren(key).join(), expectedChildren);
 
         // Nested children
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             store.put(key + "/c-0/cc-" + i, new byte[0], Optional.empty()).join();
         }
 
@@ -161,15 +159,15 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void deletionTest(String provider, String url) throws Exception {
+    public void deletionTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         String key = newKey();
-        int N = 10;
+        int n = 10;
         List<String> expectedChildren = new ArrayList<>();
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             store.put(key + "/c-" + i, new byte[0], Optional.empty()).join();
 
             expectedChildren.add("c-" + i);
@@ -182,7 +180,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
             assertException(e, MetadataStoreException.class);
         }
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             try {
                 store.delete(key + "/c-" + i, Optional.of(1L)).join();
                 fail("The key has children");
@@ -195,9 +193,9 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void emptyKeyTest(String provider, String url) throws Exception {
+    public void emptyKeyTest(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         try {
             store.delete("", Optional.empty()).join();
@@ -236,9 +234,9 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void notificationListeners(String provider, String url) throws Exception {
+    public void notificationListeners(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         BlockingQueue<Notification> notifications = new LinkedBlockingDeque<>();
         store.registerListener(n -> {


### PR DESCRIPTION
### Motivation

- A `Supplier<String>` must be used for the Zookeeper connection string parameters passed in a TestNG `DataProvider`.

- The retried test run will use the same arguments as the failed attempt.  The Zookeeper test server gets restarted by TestRetrySupport before a retry. The new connection string won't be available to the test method unless a `Supplier<String>` lambda is used for providing the value.

### Modifications

- Change String -> Supplier<String> for the `zks.getConnectionString()` argument (becomes `() -> zks.getConnectionString()`)