### PR TITLE
Cleanup znode data when namespace deleted

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 public class LocalZooKeeperCacheService {
     private static final Logger LOG = LoggerFactory.getLogger(LocalZooKeeperCacheService.class);
 
-    private static final String MANAGED_LEDGER_ROOT = "/managed-ledgers";
+    public static final String MANAGED_LEDGER_ROOT = "/managed-ledgers";
     public static final String OWNER_INFO_ROOT = "/namespace";
     public static final String LOCAL_POLICIES_ROOT = "/admin/local-policies";
     public static final String AVAILABLE_BOOKIES_ROOT = "/ledgers/available";


### PR DESCRIPTION

Fixes #11734 


### Motivation

Now, forcely delete namespace  would  delete `/managed-ledger/tenant/namespace` `/admin/partitioned-topic/tenant/namespace`  znode, but  `/namespace/tenant/namespace` still is uncleaned

For non-force delete, these all znode would not be cleaned, I think we should also clean up these znode.

### Modifications

delete these znode  after namespace delete 


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API: (yes / no) no
  - The schema: (yes / no / don't know) no 
  - The default values of configurations: (yes / no)no
  - The wire protocol: (yes / no)no
  - The rest endpoints: (yes / no) no
  - The admin cli options: (yes / no) no 
  - Anything that affects deployment: (yes / no / don't know)no

### Documentation

#### For contributor

For this PR, we need not to update docs, because it's not related to codes expose to users.



