### PR TITLE
Revert PR 11594 to avoid copy data to direct buffer

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -317,7 +317,6 @@ public class MetaStoreImpl implements MetaStore {
             return managedLedgerInfo.toByteArray();
         }
         ByteBuf metadataByteBuf = null;
-        ByteBuf uncompressedByteBuf = null;
         ByteBuf encodeByteBuf = null;
         try {
             MLDataFormats.ManagedLedgerInfoMetadata mlInfoMetadata = MLDataFormats.ManagedLedgerInfoMetadata
@@ -330,13 +329,9 @@ public class MetaStoreImpl implements MetaStore {
             metadataByteBuf.writeShort(MAGIC_MANAGED_LEDGER_INFO_METADATA);
             metadataByteBuf.writeInt(mlInfoMetadata.getSerializedSize());
             metadataByteBuf.writeBytes(mlInfoMetadata.toByteArray());
-            byte[] byteArray = managedLedgerInfo.toByteArray();
-            // The reason for copy the data to a direct buffer here is to ensure the metadata compression feature can
-            // work on JDK1.8, for more details to see: https://github.com/apache/pulsar/issues/11593
-            uncompressedByteBuf = Unpooled.directBuffer(byteArray.length);
-            uncompressedByteBuf.writeBytes(byteArray);
+
             encodeByteBuf = getCompressionCodec(compressionType)
-                    .encode(uncompressedByteBuf);
+                    .encode(Unpooled.wrappedBuffer(managedLedgerInfo.toByteArray()));
             CompositeByteBuf compositeByteBuf = PulsarByteBufAllocator.DEFAULT.compositeBuffer();
             compositeByteBuf.addComponent(true, metadataByteBuf);
             compositeByteBuf.addComponent(true, encodeByteBuf);
@@ -346,9 +341,6 @@ public class MetaStoreImpl implements MetaStore {
         } finally {
             if (metadataByteBuf != null) {
                 metadataByteBuf.release();
-            }
-            if (uncompressedByteBuf != null) {
-                uncompressedByteBuf.release();
             }
             if (encodeByteBuf != null) {
                 encodeByteBuf.release();
@@ -360,7 +352,6 @@ public class MetaStoreImpl implements MetaStore {
         ByteBuf byteBuf = Unpooled.wrappedBuffer(data);
         if (byteBuf.readableBytes() > 0 && byteBuf.readShort() == MAGIC_MANAGED_LEDGER_INFO_METADATA) {
             ByteBuf decodeByteBuf = null;
-            ByteBuf compressedByteBuf = null;
             try {
                 int metadataSize = byteBuf.readInt();
                 byte[] metadataBytes = new byte[metadataSize];
@@ -369,12 +360,8 @@ public class MetaStoreImpl implements MetaStore {
                         MLDataFormats.ManagedLedgerInfoMetadata.parseFrom(metadataBytes);
 
                 long unpressedSize = metadata.getUncompressedSize();
-                // The reason for copy the data to a direct buffer here is to ensure the metadata compression feature
-                // can work on JDK1.8, for more details to see: https://github.com/apache/pulsar/issues/11593
-                compressedByteBuf = Unpooled.directBuffer(byteBuf.readableBytes());
-                compressedByteBuf.writeBytes(byteBuf);
                 decodeByteBuf = getCompressionCodec(metadata.getCompressionType())
-                        .decode(compressedByteBuf, (int) unpressedSize);
+                        .decode(byteBuf, (int) unpressedSize);
                 byte[] decodeBytes;
                 // couldn't decode data by ZLIB compression byteBuf array() directly
                 if (decodeByteBuf.hasArray() && !CompressionType.ZLIB.equals(metadata.getCompressionType())) {
@@ -391,9 +378,6 @@ public class MetaStoreImpl implements MetaStore {
             } finally {
                 if (decodeByteBuf != null) {
                     decodeByteBuf.release();
-                }
-                if (compressedByteBuf != null) {
-                    compressedByteBuf.release();
                 }
                 byteBuf.release();
             }


### PR DESCRIPTION
### Motivation
Due to aircompressor 0.19 can't work with heap buffer on JDK1.8, so #11594 use copy data to direct buffer to avoid `NoSuchMethodError` exception. Now aircompressor released 0.20 and #11790 has upgrade the aircompressor version to 0.20 to fix this issue, we can revert #11594 to avoid copy data to direct buffer to improve performance.

### Modification
1. revert #11594, but keep the tests.