### PR TITLE
[testclient] Fix IndexOutOfBoundsException when --subscriptions size is less than --num-subscriptions in consumption

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -223,9 +223,7 @@ public class PerformanceConsumer {
             PerfClientUtils.exit(-1);
         }
 
-        if (arguments.subscriptionType != SubscriptionType.Exclusive &&
-                arguments.subscriptions != null &&
-                arguments.subscriptions.size() != arguments.numConsumers) {
+        if (arguments.subscriptions != null && arguments.subscriptions.size() != arguments.numSubscriptions) {
             // keep compatibility with the previous version
             if (arguments.subscriptions.size() == 1) {
                 List<String> defaultSubscriptions = Lists.newArrayList();
@@ -234,7 +232,7 @@ public class PerformanceConsumer {
                 }
                 arguments.subscriptions = defaultSubscriptions;
             } else {
-                System.out.println("The size of subscriptions list should be equal to --num-consumers when subscriptionType isn't Exclusive");
+                System.out.println("The size of subscriptions list should be equal to --num-subscriptions");
                 jc.usage();
                 PerfClientUtils.exit(-1);
             }


### PR DESCRIPTION
Fixes #11775 

### Motivation
Fix IndexOutOfBoundsException when --subscriptions size is less than --num-subscriptions in consumption

### Modifications
 judge whether `--subscriptions size` and `--num-subscriptions` are equal in exclusive or non-exclusive mode
