### PR TITLE
[Website] Update Github URL for Graduation

### DIFF
--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -95,7 +95,7 @@ const functionsApiUrl = url + "/functions-rest-api";
 const sourceApiUrl = url + "/source-rest-api";
 const sinkApiUrl = url + "/sink-rest-api";
 const packagesApiUrl = url + "/packages-rest-api";
-const githubUrl = 'https://github.com/apache/incubator-pulsar';
+const githubUrl = 'https://github.com/apache/pulsar';
 const baseUrl = '/';
 
 const siteVariables = {


### PR DESCRIPTION
### Motivation

While the link to the GitHub repos on the main website page does redirect it still shows as GitHub.com/apache/incubator-pulsar/

Changing this to the correct TLP link was a missed graduation step.

### Modifications

Removed "incubator-" from the GitHub link.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

This changes webpages.