### PR TITLE
fix generate javadoc for kafka-connect-adaptor failed

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -113,5 +113,11 @@
       <type>test-jar</type>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
Fix #11806 

### Modification
1. add `protobuf-java` dependency for `kafka-connect-adaptor`