### PR TITLE
[doc] add create functions with package URL related docs

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -199,16 +199,16 @@ public class CmdFunctions extends CmdBase {
         protected String DEPRECATED_className;
         @Parameter(names = "--classname", description = "The class name of a Pulsar Function")
         protected String className;
-        @Parameter(names = "--jar", description = "Path to the JAR file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
+        @Parameter(names = "--jar", description = "Path to the JAR file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.", listConverter = StringConverter.class)
         protected String jarFile;
         @Parameter(
                 names = "--py",
-                description = "Path to the main Python file/Python Wheel file for the function (if the function is written in Python)",
+                description = "Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.",
                 listConverter = StringConverter.class)
         protected String pyFile;
         @Parameter(
                 names = "--go",
-                description = "Path to the main Go executable binary for the function (if the function is written in Go)")
+                description = "Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.")
         protected String goFile;
         @Parameter(names = {"-i",
                 "--inputs"}, description = "The input topic or topics (multiple topics can be specified as a comma-separated list) of a Pulsar Function")

--- a/site2/docs/functions-cli.md
+++ b/site2/docs/functions-cli.md
@@ -24,10 +24,10 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 hostname-verification-enabled | Enable hostname verification. | false
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 instance-id-offset | Start the instanceIds from this offset. | 0
 log-topic | The topic to which the logs  a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
@@ -37,7 +37,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of  a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. | |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
@@ -71,9 +71,9 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 log-topic | The topic to which the logs of a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
 name | The name of a Pulsar Function. |  |
@@ -82,7 +82,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
@@ -123,9 +123,9 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 log-topic | The topic to which the logs of a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
 name | The name of a Pulsar Function. |  |
@@ -134,7 +134,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>

--- a/site2/docs/functions-deploy.md
+++ b/site2/docs/functions-deploy.md
@@ -154,11 +154,11 @@ $ bin/pulsar-admin functions create \
 > #### Resources are *per instance*
 > The resources that you apply to a given Pulsar Function are applied to each instance of the function. For example, if you apply 8 GB of RAM to a function with a parallelism of 5, you are applying 40 GB of RAM for the function in total. Make sure that you take the parallelism (the number of instances) factor into your resource calculations.
 
-### Use [Package management service](admin-api-packages.md)
+### Use Package management service
 
 Package management enables version management and simplifies the upgrade and rollback processes for Functions, Sinks, and Sources. When you use the same function, sink and source in different namespaces, you can upload them to a common package management system.
 
-To use Package management service, please ensure that the package management service has been enabled in your cluster by setting following properties in `broker.conf`.
+To use [Package management service](admin-api-packages.md), ensure that the package management service has been enabled in your cluster by setting the following properties in `broker.conf`.
 
 > Note: Package management service is not enabled by default.
 

--- a/site2/docs/functions-deploy.md
+++ b/site2/docs/functions-deploy.md
@@ -154,6 +154,25 @@ $ bin/pulsar-admin functions create \
 > #### Resources are *per instance*
 > The resources that you apply to a given Pulsar Function are applied to each instance of the function. For example, if you apply 8 GB of RAM to a function with a parallelism of 5, you are applying 40 GB of RAM for the function in total. Make sure that you take the parallelism (the number of instances) factor into your resource calculations.
 
+### Use [Package management service](admin-api-packages.md)
+
+Package management enables version management and simplifies the upgrade and rollback processes for Functions, Sinks, and Sources. When you use the same function, sink and source in different namespaces, you can upload them to a common package management system.
+
+To use Package management service, please ensure that the package management service has been enabled in your cluster by setting following properties in `broker.conf`.
+
+> Note: Package management service is not enabled by default.
+
+```yaml
+enablePackagesManagement=true
+packagesManagementStorageProvider=org.apache.pulsar.packages.management.storage.bookkeeper.BookKeeperPackagesStorageProvider
+packagesReplicas=1
+packagesManagementLedgerRootPath=/ledgers
+```
+
+With Package management service enabled, you can upload your function packages by [upload a package](admin-api-packages.md#upload-a-package) to the service and get the [package URL](admin-api-packages.md#package-url).
+
+When you have a ready to use package URL, you can create the function with package URL by setting `--jar`, `--py`, or `--go` to the package URL with `pulsar-admin functions create`. 
+
 ## Trigger Pulsar Functions
 
 If a Pulsar Function is running in [cluster mode](#cluster-mode), you can **trigger** it at any time using the command line. Triggering a function means that you send a message with a specific value to the function and get the function output (if any) via the command line.

--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -451,14 +451,15 @@ Options
 |`--instance-id-offset`|Start the instanceIds from this offset|0|
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function's namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
@@ -502,14 +503,15 @@ Options
 |`--function-config-file`|The path to a YAML config file specifying the function's configuration||
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function’s namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
@@ -567,14 +569,15 @@ Options
 |`--function-config-file`|The path to a YAML config file specifying the function's configuration||
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function’s namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||

--- a/site2/website/versioned_docs/version-2.8.1/functions-cli.md
+++ b/site2/website/versioned_docs/version-2.8.1/functions-cli.md
@@ -25,10 +25,10 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 hostname-verification-enabled | Enable hostname verification. | false
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 instance-id-offset | Start the instanceIds from this offset. | 0
 log-topic | The topic to which the logs  a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
@@ -38,7 +38,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of  a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. | |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
@@ -72,9 +72,9 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 log-topic | The topic to which the logs of a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
 name | The name of a Pulsar Function. |  |
@@ -83,7 +83,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>
@@ -124,9 +124,9 @@ dead-letter-topic | The topic where all messages that were not processed success
 disk | The disk in bytes that need to be allocated per function instance (applicable only to docker runtime). | |
 fqfn | The Fully Qualified Function Name (FQFN) for the function. |  |
 function-config-file | The path to a YAML config file specifying the configuration of a Pulsar Function. |  |
-go | Path to the main Go executable binary for the function (if the function is written in Go). |  |
+go | Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 inputs | The input topic or topics of a Pulsar Function (multiple topics can be specified as a comma-separated list). | |
-jar | Path to the jar file for the function (if the function is written in Java). It also supports URL-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package. |  |
+jar | Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 log-topic | The topic to which the logs of a Pulsar Function are produced. |  |
 max-message-retries | How many times should we try to process a message before giving up. |  |
 name | The name of a Pulsar Function. |  |
@@ -135,7 +135,7 @@ output | The output topic of a Pulsar Function (If none is specified, no output 
 output-serde-classname | The SerDe class to be used for messages output by the function. |  |
 parallelism | The parallelism factor of a Pulsar Function (i.e. the number of function instances to run). |  |
 processing-guarantees | The processing guarantees (delivery semantics) applied to the function. Available values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]. | ATLEAST_ONCE
-py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). |  |
+py | Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package. |  |
 ram | The ram in bytes that need to be allocated per function instance (applicable only to process/docker runtime). |  |
 retain-ordering | Function consumes and processes messages in order. |  |
 schema-type | The builtin schema type or custom schema class name to be used for messages output by the function. | <empty string>

--- a/site2/website/versioned_docs/version-2.8.1/functions-deploy.md
+++ b/site2/website/versioned_docs/version-2.8.1/functions-deploy.md
@@ -155,6 +155,25 @@ $ bin/pulsar-admin functions create \
 > #### Resources are *per instance*
 > The resources that you apply to a given Pulsar Function are applied to each instance of the function. For example, if you apply 8 GB of RAM to a function with a parallelism of 5, you are applying 40 GB of RAM for the function in total. Make sure that you take the parallelism (the number of instances) factor into your resource calculations.
 
+### Use Package management service
+
+Package management enables version management and simplifies the upgrade and rollback processes for Functions, Sinks, and Sources. When you use the same function, sink and source in different namespaces, you can upload them to a common package management system.
+
+To use [Package management service](admin-api-packages.md), ensure that the package management service has been enabled in your cluster by setting the following properties in `broker.conf`.
+
+> Note: Package management service is not enabled by default.
+
+```yaml
+enablePackagesManagement=true
+packagesManagementStorageProvider=org.apache.pulsar.packages.management.storage.bookkeeper.BookKeeperPackagesStorageProvider
+packagesReplicas=1
+packagesManagementLedgerRootPath=/ledgers
+```
+
+With Package management service enabled, you can upload your function packages by [upload a package](admin-api-packages.md#upload-a-package) to the service and get the [package URL](admin-api-packages.md#package-url).
+
+When you have a ready to use package URL, you can create the function with package URL by setting `--jar`, `--py`, or `--go` to the package URL with `pulsar-admin functions create`.
+
 ## Trigger Pulsar Functions
 
 If a Pulsar Function is running in [cluster mode](#cluster-mode), you can **trigger** it at any time using the command line. Triggering a function means that you send a message with a specific value to the function and get the function output (if any) via the command line.

--- a/site2/website/versioned_docs/version-2.8.1/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.8.1/reference-pulsar-admin.md
@@ -452,14 +452,15 @@ Options
 |`--instance-id-offset`|Start the instanceIds from this offset|0|
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function's namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
@@ -503,14 +504,15 @@ Options
 |`--function-config-file`|The path to a YAML config file specifying the function's configuration||
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function’s namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||
@@ -568,14 +570,15 @@ Options
 |`--function-config-file`|The path to a YAML config file specifying the function's configuration||
 |`--inputs`|The function's input topic or topics (multiple topics can be specified as a comma-separated list)||
 |`--log-topic`|The topic to which the function's logs are produced||
-|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.||
+|`--jar`|Path to the jar file for the function (if the function is written in Java). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--name`|The function's name||
 |`--namespace`|The function’s namespace||
 |`--output`|The function's output topic (If none is specified, no output is written)||
 |`--output-serde-classname`|The SerDe class to be used for messages output by the function||
 |`--parallelism`|The function’s parallelism factor, i.e. the number of instances of the function to run|1|
 |`--processing-guarantees`|The processing guarantees (aka delivery semantics) applied to the function. Possible Values: [ATLEAST_ONCE, ATMOST_ONCE, EFFECTIVELY_ONCE]|ATLEAST_ONCE|
-|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python)||
+|`--py`|Path to the main Python file/Python Wheel file for the function (if the function is written in Python). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
+|`--go`|Path to the main Go executable binary for the function (if the function is written in Go). It also supports URL path [http/https/file (file protocol assumes that file already exists on worker host)/function (package URL from packages management service)] from which worker can download the package.||
 |`--schema-type`|The builtin schema type or custom schema class name to be used for messages output by the function||
 |`--sliding-interval-count`|The number of messages after which the window slides||
 |`--sliding-interval-duration-ms`|The time duration after which the window slides||


### PR DESCRIPTION
Fixes #11665

### Motivation

#11666 add the implementation of package URL support, this PR works on the docs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

#### For contributor

For this PR, do we need to update docs?

- If yes, please update docs or create a follow-up issue if you need help.
  
- If no, please explain why.

#### For committer

For this PR, do we need to update docs?

- If yes,
  
  - if you update docs in this PR, label this PR with the `doc` label.
  
  - if you plan to update docs later, label this PR with the `doc-required` label.

  - if you need help on updating docs, create a follow-up issue with the `doc-required` label.
  
- If no, label this PR with the `no-need-doc` label and explain why.

