### PR TITLE
Fix graceful shutdown in docker-compose examples

### DIFF
--- a/docker-compose/kitchen-sink/docker-compose.yml
+++ b/docker-compose/kitchen-sink/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
-               bin/pulsar zookeeper"
+               exec bin/pulsar zookeeper"
     environment:
       ZOOKEEPER_SERVERS: zk1,zk2,zk3
     volumes:
@@ -49,7 +49,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
-               bin/pulsar zookeeper"
+               exec bin/pulsar zookeeper"
     environment:
       ZOOKEEPER_SERVERS: zk1,zk2,zk3
     volumes:
@@ -65,7 +65,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/zookeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/generate-zookeeper-config.sh conf/zookeeper.conf && \
-               bin/pulsar zookeeper"
+               exec bin/pulsar zookeeper"
     environment:
       ZOOKEEPER_SERVERS: zk1,zk2,zk3
     volumes:
@@ -102,7 +102,7 @@ services:
                bin/apply-config-from-env.py conf/bookkeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zkServers -p /initialized-$$clusterName -w && \
-               bin/pulsar bookie"
+               exec bin/pulsar bookie"
     environment:
       clusterName: test
       zkServers: zk1:2181,zk2:2181,zk3:2181
@@ -128,7 +128,7 @@ services:
                bin/apply-config-from-env.py conf/bookkeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zkServers -p /initialized-$$clusterName -w && \
-               bin/pulsar bookie"
+               exec bin/pulsar bookie"
     environment:
       clusterName: test
       zkServers: zk1:2181,zk2:2181,zk3:2181
@@ -155,7 +155,7 @@ services:
                bin/apply-config-from-env.py conf/bookkeeper.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zkServers -p /initialized-$$clusterName -w && \
-               bin/pulsar bookie"
+               exec bin/pulsar bookie"
     environment:
       clusterName: test
       zkServers: zk1:2181,zk2:2181,zk3:2181
@@ -182,7 +182,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/broker.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar broker"
+               exec bin/pulsar broker"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -211,7 +211,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/broker.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar broker"
+               exec bin/pulsar broker"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -241,7 +241,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/broker.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar broker"
+               exec bin/pulsar broker"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -272,7 +272,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/proxy.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar proxy"
+               exec bin/pulsar proxy"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -305,7 +305,7 @@ services:
       bash -c "bin/apply-config-from-env.py conf/websocket.conf && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar websocket"
+               exec bin/pulsar websocket"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -335,7 +335,7 @@ services:
                bin/gen-yml-from-env.py conf/functions_worker.yml && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar functions-worker"
+               exec bin/pulsar functions-worker"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181
@@ -371,7 +371,7 @@ services:
       bash -c "bin/apply-config-from-env-with-prefix.py SQL_PREFIX_ conf/presto/catalog/pulsar.properties && \
                bin/apply-config-from-env.py conf/pulsar_env.sh && \
                bin/watch-znode.py -z $$zookeeperServers -p /initialized-$$clusterName -w && \
-               bin/pulsar sql-worker run"
+               exec bin/pulsar sql-worker run"
     environment:
       clusterName: test
       zookeeperServers: zk1:2181,zk2:2181,zk3:2181

--- a/docker-compose/standalone-dashboard/docker-compose.yml
+++ b/docker-compose/standalone-dashboard/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: >
       /bin/bash -c
       "bin/apply-config-from-env.py conf/standalone.conf
-      && bin/pulsar standalone --advertised-address standalone"
+      && exec bin/pulsar standalone --advertised-address standalone"
 
   dashboard:
     image: apachepulsar/pulsar-dashboard


### PR DESCRIPTION
### Motivation

In the case #11768 , the docker-compose environment won't start after stopping it. Pulsar gets killed without a graceful shutdown. When investigating the reason, it was noticed that docker-compose examples are invalid. Instead of `bash -c "bin/pulsar standalone"`, the command should contain `exec`, for example `bash -c "exec bin/pulsar standalone"`.

- Get OS signals passed to container process by using shell built-in "exec"
- this is required so that the process running in the container is able to receive OS signals
  - explained in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
    and https://docs.docker.com/engine/reference/builder/#entrypoint
- receiving SIGTERM signal is required for graceful shutdown.

### Modifications

- replace `bin/pulsar` with `exec bin/pulsar` in docker-compose examples.

### Additional context

- a similar change has been made to Pulsar Helm charts in 8/2020: https://github.com/apache/pulsar-helm-chart/pull/59