### PR TITLE
fix flaky test testReacquireLocksAfterSessionLost

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -127,7 +127,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
 
-        Awaitility.await().untilAsserted(() -> {
+        Awaitility.waitAtMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
             assertFalse(lock.getLockExpiredFuture().isDone());
         });
 


### PR DESCRIPTION
### Motivation
Then run ZKSessionTest#testReacquireLocksAfterSessionLost, it will fail occasionally.
```
Error:  testReacquireLocksAfterSessionLost(org.apache.pulsar.metadata.ZKSessionTest)  Time elapsed: 12.974 s  <<< FAILURE!
org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a lambda expression in org.apache.pulsar.metadata.ZKSessionTest that uses org.apache.pulsar.metadata.api.coordination.ResourceLock expected [false] but found [true] within 10 seconds.
  at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:165)
  at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
  at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
  at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:895)
  at org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:679)
  at org.apache.pulsar.metadata.ZKSessionTest.testReacquireLocksAfterSessionLost(ZKSessionTest.java:130)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:566)
  at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
  at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
  at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
  at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.AssertionError: expected [false] but found [true]
  at org.testng.Assert.fail(Assert.java:99)
  at org.testng.Assert.failNotEquals(Assert.java:1037)
  at org.testng.Assert.assertFalse(Assert.java:67)
  at org.testng.Assert.assertFalse(Assert.java:77)
  at org.apache.pulsar.metadata.ZKSessionTest.lambda$testReacquireLocksAfterSessionLost$0(ZKSessionTest.java:131)
  at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
  at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:222)
  at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:209)
  ... 4 more
```

### Modification
1. Change the waiting time from default 10s to 30s.