### PR TITLE
[Client] Set key in message metadata for batch message built with KEY_BASED batch builder

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -224,6 +224,15 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         private void addMsg(MessageImpl<?> msg, SendCallback callback) {
             if (messages.size() == 0) {
                 sequenceId = Commands.initBatchMessageMetadata(messageMetadata, msg.getMessageBuilder());
+                if (msg.hasKey()) {
+                    messageMetadata.setPartitionKey(msg.getKey());
+                    if (msg.hasBase64EncodedKey()) {
+                        messageMetadata.setPartitionKeyB64Encoded(true);
+                    }
+                }
+                if (msg.hasOrderingKey()) {
+                    messageMetadata.setOrderingKey(Arrays.copyOf(msg.getOrderingKey(), msg.getOrderingKey().length));
+                }
                 batchedMessageMetadataAndPayload = PulsarByteBufAllocator.DEFAULT
                         .buffer(Math.min(maxBatchSize, ClientCnx.getMaxMessageSize()));
                 firstCallback = callback;


### PR DESCRIPTION
### Motivation

The `BatcherBuilder.KEY_BASED` doesn't seem to work with `KEY_SHARED` consumers.
When looking at the code, it can be seen that the message metadata for the batch message doesn't contain keying metadata that KEY_SHARED consumers use for selecting messages.

### Modifications

- revert changes made in #7416 which removed the necessary logic