### PR TITLE
[Functions] ConcurrentHashMap should be used for caching producers

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -167,7 +167,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         if (useThreadLocalProducers) {
             tlPublishProducers = new ThreadLocal<>();
         } else {
-            publishProducers = new HashMap<>();
+            publishProducers = new ConcurrentHashMap<>();
         }
 
         if (config.getFunctionDetails().getUserConfig().isEmpty()) {


### PR DESCRIPTION
### Motivation

- since `java.util.HashMap` is used, there is a potential issue that the datastructure gets corrupted.
There is existing code that gives the impression that the producer cache is used by multiple threads. 
For example:
https://github.com/apache/pulsar/blob/4046a6f9b73d635773c8696a8b9f28be1ce226cc/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java#L551-L559

### Modifications

use ConcurrentHashMap instead of HashMap for caching producers in ContextImpl class.
