### PR TITLE
[IO] Set the output message key when the source record has a key

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -49,13 +49,11 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.api.schema.GenericRecord;
-import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.functions.CryptoConfig;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.ProducerConfig;
-import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.functions.api.Record;
@@ -364,10 +362,7 @@ public class PulsarSink<T> implements Sink<T> {
         SinkRecord<T> sinkRecord = (SinkRecord<T>) record;
         TypedMessageBuilder<T> msg = pulsarSinkProcessor.newMessage(sinkRecord);
 
-        if (record.getKey().isPresent() && !(record.getSchema() instanceof KeyValueSchema &&
-                ((KeyValueSchema) record.getSchema()).getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED)) {
-            msg.key(record.getKey().get());
-        }
+        record.getKey().ifPresent(msg::key);
 
         msg.value(record.getValue());
 


### PR DESCRIPTION
### Motivation

I'm investigating an issue where setting batch-builder for a Debezium Postgres source doesn't seem to have an impact even after applying fixes made by #11706 for supporting `--batch-builder KEY_BASED` for sources.
When reading the code, I found a special condition for ignoring the source record key.
https://github.com/apache/pulsar/blob/3b651d910f39a29859434f0c5ba962c3ef8d2504/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java#L370-L373

### Modifications

Remove the extra condition. Always set the output message key when the source record has a key.