### PR TITLE
fix java_test_functions build failed

### DIFF
--- a/tests/docker-images/java-test-functions/pom.xml
+++ b/tests/docker-images/java-test-functions/pom.xml
@@ -39,6 +39,17 @@
             <artifactId>pulsar-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
     </dependencies>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
### Motivation
When build java-test-functions, it throw the following exception
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project java-test-functions: Compilation failure: Compilation failure:
[ERROR] /Users/hangc/Workspace/release/pulsar-2.8.1/v2/pulsar/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java:[21,38] package com.fasterxml.jackson.databind does not exist
[ERROR] /Users/hangc/Workspace/release/pulsar-2.8.1/v2/pulsar/tests/docker-images/java-test-functions/src/main/java/org/apache/pulsar/tests/integration/io/TestGenericObjectSink.java:[23,31] package org.apache.avro.generic does not exist
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

### Modification
1. add maven dependency for `java-test-functions` module