### PR TITLE
[stats] Add Key_Shared metadata to topic stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -143,7 +143,7 @@ public class NonPersistentSubscription implements Subscription {
                 break;
             case Key_Shared:
                 KeySharedMeta ksm = consumer.getKeySharedMeta();
-                KeySharedMode keySharedMode = ksm.getKeySharedMode();
+                keySharedMode = ksm.getKeySharedMode();
                 if (dispatcher == null || dispatcher.getType() != SubType.Key_Shared
                         || ((NonPersistentStickyKeyDispatcherMultipleConsumers) dispatcher).getKeySharedMode()
                         != keySharedMode) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -72,6 +72,8 @@ public class NonPersistentSubscription implements Subscription {
     // If isDurable is false(such as a Reader), remove subscription from topic when closing this subscription.
     private final boolean isDurable;
 
+    private KeySharedMode keySharedMode = null;
+
     public NonPersistentSubscription(NonPersistentTopic topic, String subscriptionName, boolean isDurable) {
         this.topic = topic;
         this.topicName = topic.getName();
@@ -460,6 +462,12 @@ public class NonPersistentSubscription implements Subscription {
 
         subStats.type = getTypeString();
         subStats.msgDropRate = dispatcher.getMessageDropRate().getValueRate();
+
+        KeySharedMode keySharedMode = this.keySharedMode;
+        if (getType() == SubType.Key_Shared && keySharedMode != null) {
+            subStats.keySharedMode = keySharedMode.toString();
+        }
+
         return subStats;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
 
 public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDispatcherMultipleConsumers {
 
-    private final KeySharedMode keySharedMode;
     private final boolean allowOutOfOrderDelivery;
     private final StickyKeyConsumerSelector selector;
 
@@ -75,7 +74,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm) {
         super(topic, cursor, subscription, ksm.isAllowOutOfOrderDelivery());
 
-        this.keySharedMode = ksm.getKeySharedMode();
         this.allowOutOfOrderDelivery = ksm.isAllowOutOfOrderDelivery();
         this.recentlyJoinedConsumers = allowOutOfOrderDelivery ? null : new LinkedHashMap<>();
         this.stuckConsumers = new HashSet<>();
@@ -426,10 +424,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     public boolean isAllowOutOfOrderDelivery() {
         return allowOutOfOrderDelivery;
-    }
-
-    public KeySharedMode getKeySharedMode() {
-        return keySharedMode;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDispatcherMultipleConsumers {
 
+    private final KeySharedMode keySharedMode;
     private final boolean allowOutOfOrderDelivery;
     private final StickyKeyConsumerSelector selector;
 
@@ -74,6 +75,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm) {
         super(topic, cursor, subscription, ksm.isAllowOutOfOrderDelivery());
 
+        this.keySharedMode = ksm.getKeySharedMode();
         this.allowOutOfOrderDelivery = ksm.isAllowOutOfOrderDelivery();
         this.recentlyJoinedConsumers = allowOutOfOrderDelivery ? null : new LinkedHashMap<>();
         this.stuckConsumers = new HashSet<>();
@@ -94,7 +96,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             break;
 
         default:
-            throw new IllegalArgumentException("Invalid key-shared mode: " + ksm.getKeySharedMode());
+            throw new IllegalArgumentException("Invalid key-shared mode: " + keySharedMode);
         }
     }
 
@@ -420,6 +422,14 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     public Map<String, List<String>> getConsumerKeyHashRanges() {
         return selector.getConsumerKeyHashRanges();
+    }
+
+    public boolean isAllowOutOfOrderDelivery() {
+        return allowOutOfOrderDelivery;
+    }
+
+    public KeySharedMode getKeySharedMode() {
+        return keySharedMode;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1067,8 +1067,14 @@ public class PersistentSubscription implements Subscription {
         subStats.isReplicated = isReplicated();
         subStats.isDurable = cursor.isDurable();
         if (getType() == SubType.Key_Shared && dispatcher instanceof PersistentStickyKeyDispatcherMultipleConsumers) {
-            LinkedHashMap<Consumer, PositionImpl> recentlyJoinedConsumers =
-                    ((PersistentStickyKeyDispatcherMultipleConsumers) dispatcher).getRecentlyJoinedConsumers();
+            PersistentStickyKeyDispatcherMultipleConsumers keySharedDispatcher =
+                    (PersistentStickyKeyDispatcherMultipleConsumers) dispatcher;
+
+            subStats.allowOutOfOrderDelivery = keySharedDispatcher.isAllowOutOfOrderDelivery();
+            subStats.keySharedMode = keySharedDispatcher.getKeySharedMode().toString();
+
+            LinkedHashMap<Consumer, PositionImpl> recentlyJoinedConsumers = keySharedDispatcher
+                    .getRecentlyJoinedConsumers();
             if (recentlyJoinedConsumers != null && recentlyJoinedConsumers.size() > 0) {
                 recentlyJoinedConsumers.forEach((k, v) -> {
                     subStats.consumersAfterMarkDeletePosition.put(k.consumerName(), v.toString());

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -97,6 +97,12 @@ public interface SubscriptionStats {
     /** Mark that the subscription state is kept in sync across different regions. */
     boolean isReplicated();
 
+    /** Whether out of order delivery is allowed on the Key_Shared subscription. */
+    boolean isAllowOutOfOrderDelivery();
+
+    /** Whether the Key_Shared subscription mode is AUTO_SPLIT or STICKY. */
+    String getKeySharedMode();
+
     /** This is for Key_Shared subscription to get the recentJoinedConsumers in the Key_Shared subscription. */
     Map<String, String> getConsumersAfterMarkDeletePosition();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -103,6 +103,12 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Mark that the subscription state is kept in sync across different regions. */
     public boolean isReplicated;
 
+    /** Whether out of order delivery is allowed on the Key_Shared subscription. */
+    public boolean allowOutOfOrderDelivery;
+
+    /** Whether the Key_Shared subscription mode is AUTO_SPLIT or STICKY. */
+    public String keySharedMode;
+
     /** This is for Key_Shared subscription to get the recentJoinedConsumers in the Key_Shared subscription. */
     public Map<String, String> consumersAfterMarkDeletePosition;
 
@@ -165,6 +171,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
                 this.consumers.get(i).add(stats.consumers.get(i));
             }
         }
+        this.allowOutOfOrderDelivery |= stats.allowOutOfOrderDelivery;
         this.consumersAfterMarkDeletePosition.putAll(stats.consumersAfterMarkDeletePosition);
         this.nonContiguousDeletedMessagesRanges += stats.nonContiguousDeletedMessagesRanges;
         this.nonContiguousDeletedMessagesRangesSerializedSize += stats.nonContiguousDeletedMessagesRangesSerializedSize;

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -295,6 +295,10 @@ You can check the following statistics of a given non-partitioned topic.
 
           -   **replicated**: Mark that the subscription state is kept in sync across different regions.
 
+          -   **allowOutOfOrderDelivery**: Whether out of order delivery is allowed on the Key_Shared subscription.
+
+          -   **keySharedMode**: Whether the Key_Shared subscription mode is AUTO_SPLIT or STICKY.
+
           -   **consumersAfterMarkDeletePosition**: This is for Key_Shared subscription to get the recentJoinedConsumers in the Key_Shared subscription.
 
           -   **nonContiguousDeletedMessagesRanges**: The number of non-contiguous deleted messages ranges.
@@ -440,6 +444,7 @@ The following is an example of a topic status.
         "connectedSince" : "2021-06-09T17:22:45.353+08:00",
         "clientVersion" : "2.9.0-SNAPSHOT"
       } ],
+      "allowOutOfOrderDelivery": false,
       "consumersAfterMarkDeletePosition" : { },
       "nonContiguousDeletedMessagesRanges" : 0,
       "nonContiguousDeletedMessagesRangesSerializedSize" : 0,

--- a/site2/docs/getting-started-docker.md
+++ b/site2/docs/getting-started-docker.md
@@ -178,6 +178,7 @@ The output is something like this:
             ],
             "isDurable": true,
             "isReplicated": false,
+            "allowOutOfOrderDelivery": false,
             "consumersAfterMarkDeletePosition": {},
             "nonContiguousDeletedMessagesRanges": 0,
             "nonContiguousDeletedMessagesRangesSerializedSize": 0,


### PR DESCRIPTION
### Motivation

Users can specify the Key_Shared subscription policy as follows:
```java
Consumer<byte[]> consumer = pulsarClient.newConsumer()
        .topic("persistent://public/default/t1")
        .subscriptionName("sub1")
        .subscriptionType(SubscriptionType.Key_Shared)
        .keySharedPolicy(KeySharedPolicy.autoSplitHashRange().setAllowOutOfOrderDelivery(true))
        .subscribe();
```

However, these metadata are not currently included in the topic stats.

### Modifications

Added the following two fields to the topic stats:
- allowOutOfOrderDelivery
- keySharedMode

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)