### PR TITLE
[Python] Handle py::call_method error without mutating internal state

### DIFF
--- a/pulsar-client-cpp/python/custom_logger_test.py
+++ b/pulsar-client-cpp/python/custom_logger_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from unittest import TestCase, main
+import asyncio
+import logging
+from pulsar import Client
+
+class CustomLoggingTest(TestCase):
+
+    serviceUrl = 'pulsar://localhost:6650'
+
+    def test_async_func_with_custom_logger(self):
+        # boost::python::call may fail in C++ destructors, even worse, calls
+        # to PyErr_Print could corrupt the Python interpreter.
+        # See https://github.com/boostorg/python/issues/374 for details.
+        # This test is to verify these functions won't be called in C++ destructors
+        # so that Python's async function works well.
+        client = Client(
+            self.serviceUrl,
+            logger=logging.getLogger('custom-logger')
+        )
+
+        async def async_get(value):
+            consumer = client.subscribe('test_async_get', 'sub')
+            consumer.close()
+            return value
+
+        value = 'foo'
+        result = asyncio.run(async_get(value))
+        self.assertEqual(value, result)
+
+        client.close()
+
+if __name__ == '__main__':
+    main()

--- a/pulsar-client-cpp/python/custom_logger_test.py
+++ b/pulsar-client-cpp/python/custom_logger_test.py
@@ -50,4 +50,5 @@ class CustomLoggingTest(TestCase):
         client.close()
 
 if __name__ == '__main__':
+    logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
     main()

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -19,9 +19,7 @@
 #
 
 
-import logging
 from unittest import TestCase, main
-import asyncio
 import time
 import os
 import pulsar
@@ -104,10 +102,6 @@ class PulsarTest(TestCase):
         self.assertEqual(conf.replicate_subscription_state_enabled(), False)
         conf.replicate_subscription_state_enabled(True)
         self.assertEqual(conf.replicate_subscription_state_enabled(), True)
-
-    def test_client_logger(self):
-        logger = logging.getLogger("pulsar")
-        Client(self.serviceUrl, logger=logger)
 
     def test_connect_error(self):
         with self.assertRaises(pulsar.ConnectError):
@@ -1186,28 +1180,6 @@ class PulsarTest(TestCase):
         t2 = time.time()
         self.assertGreater(t2 - t1, 1.0)
         self.assertLess(t2 - t1, 1.5) # 1.5 seconds is long enough
-        client.close()
-
-    def test_async_func_with_custom_logger(self):
-        # boost::python::call may fail in C++ destructors, even worse, calls
-        # to PyErr_Print could corrupt the Python interpreter.
-        # See https://github.com/boostorg/python/issues/374 for details.
-        # This test is to verify these functions won't be called in C++ destructors
-        # so that Python's async function works well.
-        client = Client(
-            self.serviceUrl,
-            logger=logging.getLogger('custom-logger')
-        )
-
-        async def async_get(value):
-            consumer = client.subscribe('test_async_get', 'sub')
-            consumer.close()
-            return value
-
-        value = 'foo'
-        result = asyncio.run(async_get(value))
-        self.assertEqual(value, result)
-
         client.close()
 
     def _check_value_error(self, fun):

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -144,6 +144,10 @@ class LoggerWrapper: public Logger {
         Py_INCREF(_pyLogger);
     }
 
+    LoggerWrapper(LoggerWrapper&&) noexcept = delete;
+    LoggerWrapper& operator=(const LoggerWrapper&) = delete;
+    LoggerWrapper& operator=(LoggerWrapper&&) = delete;
+
     virtual ~LoggerWrapper() {
         Py_XDECREF(_pyLogger);
     }

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -154,7 +154,6 @@ class LoggerWrapper: public Logger {
 
             } catch (const py::error_already_set& e) {
                 _fallbackLogger->log(level, line, message);
-                PyErr_Print();
             }
 
             PyGILState_Release(state);
@@ -175,7 +174,7 @@ class LoggerWrapperFactory : public LoggerFactory {
             _pythonLogLevel = Optional<int>::of(level);
         } catch (const py::error_already_set& e) {
             // Failed to get log level from _pyLogger, set it to empty to fallback to _fallbackLogger
-            PyErr_Print();
+            _pythonLogLevel = Optional<int>::empty();
         }
 
         PyGILState_Release(state);

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -100,8 +100,8 @@ static ReaderConfiguration& ReaderConfiguration_setCryptoKeyReader(ReaderConfigu
 
 class LoggerWrapper: public Logger {
     PyObject* const _pyLogger;
-    int _pythonLogLevel;
-    std::unique_ptr<Logger> _fallbackLogger;
+    const int _pythonLogLevel;
+    const std::unique_ptr<Logger> _fallbackLogger;
 
     static constexpr int _getLogLevelValue(Level level) {
         return 10 + (level * 10);

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -73,12 +73,18 @@ if [ $RES -eq 0 ]; then
     cp *_test.py /tmp
     pushd /tmp
 
+    python python/custom_logger_test.py
+    RES=$?
+    echo "custom_logger_test.py: $RES"
+
     python pulsar_test.py
     RES=$?
+    echo "pulsar_test.py: $RES"
 
     echo "---- Running Python Function Instance unit tests"
     bash $ROOT_DIR/pulsar-functions/instance/src/scripts/run_python_instance_tests.sh
     RES=$?
+    echo "run_python_instance_tests.sh: $RES"
 
     popd
     popd

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -73,7 +73,7 @@ if [ $RES -eq 0 ]; then
     cp *_test.py /tmp
     pushd /tmp
 
-    python python/custom_logger_test.py
+    python custom_logger_test.py
     RES=$?
     echo "custom_logger_test.py: $RES"
 

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -73,9 +73,12 @@ if [ $RES -eq 0 ]; then
     cp *_test.py /tmp
     pushd /tmp
 
-    python custom_logger_test.py
-    RES=$?
-    echo "custom_logger_test.py: $RES"
+    # TODO: this test requires asyncio module that is supported by Python >= 3.3.
+    #  Hoeever, CI doesn't support Python3 yet, we should uncomment following
+    #  lines after Python3 CI script is added.
+    #python custom_logger_test.py
+    #RES=$?
+    #echo "custom_logger_test.py: $RES"
 
     python pulsar_test.py
     RES=$?


### PR DESCRIPTION
Fixes #11823

### Motivation

When the Python logger is customized with underlying `LoggerWrapper` objects, sometimes `async` Python functions may return an incorrect value like `None`. It's because there's a bug (or feature?) of Boost-python that `py::call_method` will fail in C++ object's destructor. See https://github.com/boostorg/python/issues/374 for details.

For the code example in #11823, it's because in `ConsumerImpl`'s destructor, the logger for `AckGroupingTrackerEnabled` will be created again because the logger is thread local and will be created in new threads. In this case, `py::call_method` in `LoggerWrapper#_updateCurrentPythonLogLevel` will fail, and `PyErr_Print` will be called and the error indicator will be cleared, which leads to the result that `async` functions' result became `None`.

### Modifications

- Reduce unnecessary `Logger.getEffectiveLevel` calls to get Python log level , just get the log level when the logger factory is initialized and pass the same level to all loggers.
- Remove the `PyErr_Print` calls in `LoggerWrapper` related code. In the cases when `py::call_method` failed, use the fallback logger to print logs.
- Add a dependent test for custom logger test because once the `LoggerFactory` was set all other tests would be affected.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added test `CustomLoggingTest`. Since `asyncio` module was introduced from Python 3.3 while CI is based on Python 2.7, this test cannot be tested by CI unless Python3 based CI was added.