### PR TITLE
Handle receiveAsync() failures in MultiTopicsConsumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -269,6 +269,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 // recursion and stack overflow
                 internalPinnedExecutor.execute(() -> receiveMessageFromConsumer(consumer));
             }
+        }).exceptionally(ex -> {
+            log.error("Receive operation failed on consumer {} - Retrying later", consumer, ex);
+            internalPinnedExecutor.schedule(() -> receiveMessageFromConsumer(consumer), 10, TimeUnit.SECONDS);
+            return null;
         });
     }
 


### PR DESCRIPTION
### Motivation

In `MultiTopicsConsumer` we're doing a `receiveAsync()` operation to transfer messages from the individual consumers into the shared queue, but we're not handling the failure path of the returned `CompletableFuture`. 

This future should in theory never fail, but it fails if there is some bug in the code, as it was the case for #11824. 

The main issue is that since we're not handle the future failure path, the exception stack traces are completely hidden, making debugging such issues more complicated.

### Modification

 1. Print exception
 2. Retry later, to give it a chance to unblock itself