### PR TITLE
Source tarball: apply executable file permissions to shell scripts (fixes #10917) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1623,13 +1623,6 @@ flexible messaging model and an intuitive client API.</description>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly-plugin.version}</version>
           <inherited>false</inherited>
-          <dependencies>
-              <dependency>
-                  <groupId>org.apache.apache.resources</groupId>
-                  <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                  <version>1.0.6</version>
-              </dependency>
-          </dependencies>
           <executions>
               <execution>
                   <id>source-release-assembly-tar-gz</id>
@@ -1640,10 +1633,9 @@ flexible messaging model and an intuitive client API.</description>
                   <configuration>
                       <skipAssembly>${skipSourceReleaseAssembly}</skipAssembly>
                       <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
-                      <descriptorRefs>
-                          <!-- defined in Apache Parent Pom -->
-                          <descriptorRef>${sourceReleaseAssemblyDescriptor}</descriptorRef>
-                      </descriptorRefs>
+                      <descriptors>
+                        <descriptor>src/assembly-source-package.xml</descriptor>
+                      </descriptors>
                       <finalName>apache-pulsar-${project.version}-src</finalName>
                       <appendAssemblyId>false</appendAssemblyId>
                       <formats>

--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -36,8 +36,8 @@
       <excludes>
         <!-- need special permissions -->
         <exclude>src/*.sh</exclude>
-        <exclude>pulsar-client-cpp/docker/*</exclude>
-        <exclude>docker/pulsar/scripts/*</exclude>
+        <exclude>pulsar-client-cpp/docker/*.sh</exclude>
+        <exclude>docker/pulsar/scripts/*.sh</exclude>
 
         <!-- Pulsar standalone -->
         <exclude>data/**</exclude>

--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
 
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
 -->
 <!-- copied by https://github.com/apache/maven-resources/blob/trunk/apache-source-release-assembly-descriptor/src/main/resources/assemblies/source-shared.xml
      that was the original default configuration for ASF projects

--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!-- copied by https://github.com/apache/maven-resources/blob/trunk/apache-source-release-assembly-descriptor/src/main/resources/assemblies/source-shared.xml
+     that was the original default configuration for ASF projects
+     -->
+<assembly>
+  <id>source-release</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <!-- main project directory structure -->
+    <fileSet>
+      <directory>.</directory>
+      <outputDirectory></outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+      <excludes>
+        <!-- need special permissions -->
+        <exclude>src/*.sh</exclude>
+
+        <!-- Pulsar standalone -->
+        <exclude>data/**</exclude>
+        <exclude>logs/**</exclude>
+
+        <!-- build output -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/).*${project.build.directory}.*]</exclude>
+        
+        <!-- NOTE: Most of the following excludes should not be required 
+             if the standard release process is followed. This is because the 
+             release plugin checks out project sources into a location like
+             target/checkout, then runs the build from there. The result is
+             a source-release archive that comes from a pretty clean directory
+             structure.
+             
+             HOWEVER, if the release plugin is configured to run extra goals
+             or generate a project website, it's definitely possible that some
+             of these files will be present. So, it's safer to exclude them.
+        -->
+             
+        <!-- IDEs -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?maven-eclipse\.xml]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.project]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.classpath]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iws]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.idea(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?out(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.ipr]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iml]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.settings(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.externalToolBuilders(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.deployables(/.*)?]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.wtpmodules(/.*)?]</exclude>
+        
+        <!-- misc -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?cobertura\.ser]</exclude>
+        
+        <!-- release-plugin temp files -->
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.releaseBackup]</exclude>
+        <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]</exclude>
+      </excludes>
+    </fileSet>
+    <!-- license, readme, etc. calculated at build time -->
+    <fileSet>
+      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF</directory>
+      <outputDirectory></outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>src</directory>
+      <outputDirectory>/src</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -36,6 +36,8 @@
       <excludes>
         <!-- need special permissions -->
         <exclude>src/*.sh</exclude>
+        <exclude>pulsar-client-cpp/docker/*</exclude>
+        <exclude>docker/pulsar/scripts/*</exclude>
 
         <!-- Pulsar standalone -->
         <exclude>data/**</exclude>
@@ -86,6 +88,22 @@
     <fileSet>
       <directory>src</directory>
       <outputDirectory>/src</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>pulsar-client-cpp/docker</directory>
+      <outputDirectory>/pulsar-client-cpp/docker</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>docker/pulsar/scripts</directory>
+      <outputDirectory>/docker/pulsar/scripts</outputDirectory>
       <includes>
         <include>*.sh</include>
       </includes>


### PR DESCRIPTION
The source tarball cannot be built because some .sh files are missing executable file permissions, see #10917 

Modifications:
- copy the Source Assembly descriptor from the main Maven ASF repo to src
- add exclusions for "data" and "logs"
- set 755 permissions on every .sh file in "src"

Tests:
the build of the docker images and the C client uses the src tarball, so there is minimal test coverage.
Apart from this the only way to test this patch is to try to build Pulsar from the generated source tarball