### PR TITLE
[Branch-2.8]Fix jetty-alpn-java-client license

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -256,7 +256,7 @@ The Apache Software License, Version 2.0
     - http2-hpack-9.4.42.v20210604.jar
     - http2-http-client-transport-9.4.42.v20210604.jar
     - jetty-alpn-client-9.4.42.v20210604.jar
-    - jetty-alpn-java-client-9.4.42.v20210604.jar
+    - jetty-alpn-openjdk8-client-9.4.42.v20210604.jar
     - http2-server-9.4.42.v20210604.jar
     - jetty-client-9.4.42.v20210604.jar
     - jetty-http-9.4.42.v20210604.jar


### PR DESCRIPTION
### Motivation
When run license check, it throw the following exception.
```bash
~/dev/pulsar/src/check-binary-license apache-pulsar-2.8.1-bin.tar.gz
jetty-alpn-openjdk8-client-9.4.42.v20210604.jar unaccounted for in
lib/presto/LICENSE
jetty-alpn-java-client-9.4.42.v20210604.jar mentioned in
lib/presto/LICENSE, but not bundled
```

### Modification
1. update the license.