### PR TITLE
Added MetadataStore deleteRecursive operation

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -113,6 +113,15 @@ public interface MetadataStore extends AutoCloseable {
     CompletableFuture<Void> delete(String path, Optional<Long> expectedVersion);
 
     /**
+     * Delete a key-value pair and all the children nodes
+     *
+     * @param path
+     *            the path of the key to delete from the store
+     * @return a future to track the async request
+     */
+    CompletableFuture<Void> deleteRecursive(String path);
+
+    /**
      * Register a listener that will be called on changes in the underlying store.
      *
      * @param listener

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -113,7 +113,10 @@ public interface MetadataStore extends AutoCloseable {
     CompletableFuture<Void> delete(String path, Optional<Long> expectedVersion);
 
     /**
-     * Delete a key-value pair and all the children nodes
+     * Delete a key-value pair and all the children nodes.
+     *
+     * Note: the operation might not be carried in an atomic fashion. If the operation fails, the deletion of the
+     *       tree might be only partial.
      *
      * @param path
      *            the path of the key to delete from the store

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -116,6 +116,16 @@ public class FaultInjectionMetadataStore implements MetadataStore {
     }
 
     @Override
+    public CompletableFuture<Void> deleteRecursive(String path) {
+        Optional<MetadataStoreException> ex = programmedFailure(OperationType.DELETE, path);
+        if (ex.isPresent()) {
+            return FutureUtil.failedFuture(ex.get());
+        }
+
+        return store.deleteRecursive(path);
+    }
+
+    @Override
     public void registerListener(Consumer<Notification> listener) {
         store.registerListener(listener);
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -300,4 +300,30 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         assertEquals(n.getType(), NotificationType.ChildrenChanged);
         assertEquals(n.getPath(), key1);
     }
+
+    @Test(dataProvider = "impl")
+    public void testDeleteRecursive(String provider, String url) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        String prefix = newKey();
+
+        String key1 = newKey();
+        store.put(prefix + key1, "value-1".getBytes(), Optional.of(-1L)).join();
+
+        store.put(prefix + key1 + "/c1", "value".getBytes(), Optional.of(-1L)).join();
+        store.put(prefix + key1 + "/c2", "value".getBytes(), Optional.of(-1L)).join();
+        store.put(prefix + key1 + "/c1/x1", "value".getBytes(), Optional.of(-1L)).join();
+        store.put(prefix + key1 + "/c1/x2", "value".getBytes(), Optional.of(-1L)).join();
+        store.put(prefix + key1 + "/c2/y2", "value".getBytes(), Optional.of(-1L)).join();
+        store.put(prefix + key1 + "/c3", "value".getBytes(), Optional.of(-1L)).join();
+
+        String key2 = newKey();
+        store.put(prefix + key2, "value-2".getBytes(), Optional.of(-1L)).join();
+
+        store.deleteRecursive(prefix + key1).join();
+
+        assertEquals(store.getChildren(prefix).join(), Collections.singletonList(key2.substring(1)));
+    }
+
 }


### PR DESCRIPTION
### Motivation

There are several cases in which the recursive deletion of metadata is done in the code base. Instead we should just have a single implementation, directly in the MetadataStore API.