### PR TITLE
[Broker] Update Authz Check Before Completing Topic Level Policy Operation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -282,7 +282,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.OFFLOAD, PolicyOperation.READ)
             .thenCompose(__ -> internalGetOffloadPolicies(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -304,7 +304,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Offload policies for the specified topic") OffloadPoliciesImpl offloadPolicies) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.OFFLOAD, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetOffloadPolicies(offloadPolicies))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -325,7 +325,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.OFFLOAD, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetOffloadPolicies(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -348,7 +348,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxUnackedMessagesOnConsumer(applied))
             .thenApply(asyncResponse::resume).exceptionally(ex -> {
                 handleTopicPolicyException("getMaxUnackedMessagesOnConsumer", ex, asyncResponse);
@@ -371,7 +371,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Max unacked messages on consumer policies for the specified topic")
                     Integer maxUnackedNum) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxUnackedMessagesOnConsumer(maxUnackedNum))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -392,7 +392,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxUnackedMessagesOnConsumer(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -414,7 +414,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION_SNAPSHOT, PolicyOperation.READ)
             .thenCompose(__ -> getTopicPoliciesAsyncWithRetry(topicName))
             .thenAccept(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
@@ -441,7 +441,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION_SNAPSHOT, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDeduplicationSnapshotInterval(interval))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -462,7 +462,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION_SNAPSHOT, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDeduplicationSnapshotInterval(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -485,7 +485,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.INACTIVE_TOPIC, PolicyOperation.READ)
             .thenCompose(__ -> internalGetInactiveTopicPolicies(applied))
             .thenApply(asyncResponse::resume).exceptionally(ex -> {
                 handleTopicPolicyException("getInactiveTopicPolicies", ex, asyncResponse);
@@ -507,7 +507,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "inactive topic policies for the specified topic")
             InactiveTopicPolicies inactiveTopicPolicies) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.INACTIVE_TOPIC, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetInactiveTopicPolicies(inactiveTopicPolicies))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -528,7 +528,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.INACTIVE_TOPIC, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetInactiveTopicPolicies(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -551,7 +551,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxUnackedMessagesOnSubscription(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -575,8 +575,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Max unacked messages on subscription policies for the specified topic")
                     Integer maxUnackedNum) {
         validateTopicName(tenant, namespace, encodedTopic);
-        validateTopicPolicyOperation(topicName, PolicyName.MAX_UNACKED, PolicyOperation.WRITE);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxUnackedMessagesOnSubscription(maxUnackedNum))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -599,8 +598,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        validateTopicPolicyOperation(topicName, PolicyName.MAX_UNACKED, PolicyOperation.WRITE);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_UNACKED, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxUnackedMessagesOnSubscription(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -623,7 +621,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DELAYED_DELIVERY, PolicyOperation.READ)
             .thenCompose(__ -> internalGetDelayedDeliveryPolicies(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -648,8 +646,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                     DelayedDeliveryPolicies deliveryPolicies) {
         validateTopicName(tenant, namespace, encodedTopic);
         validatePoliciesReadOnlyAccess();
-        validateTopicPolicyOperation(topicName, PolicyName.DELAYED_DELIVERY, PolicyOperation.WRITE);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DELAYED_DELIVERY, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDelayedDeliveryPolicies(deliveryPolicies))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -673,8 +670,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
         validatePoliciesReadOnlyAccess();
-        validateTopicPolicyOperation(topicName, PolicyName.DELAYED_DELIVERY, PolicyOperation.WRITE);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DELAYED_DELIVERY, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDelayedDeliveryPolicies(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1591,7 +1587,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.BACKLOG, PolicyOperation.READ)
             .thenCompose(__ -> internalGetBacklogQuota(applied))
             .thenAccept(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -1618,7 +1614,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("backlogQuotaType") BacklogQuotaType backlogQuotaType, BacklogQuotaImpl backlogQuota) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.BACKLOG, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetBacklogQuota(backlogQuotaType, backlogQuota))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1642,7 +1638,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.BACKLOG, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetBacklogQuota(backlogQuotaType, null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1666,7 +1662,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.TTL, PolicyOperation.READ)
             .thenCompose(__ -> getTopicPoliciesAsyncWithRetry(topicName))
             .thenAccept(op -> asyncResponse.resume(op
                 .map(TopicPolicies::getMessageTTLInSeconds)
@@ -1702,7 +1698,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.TTL, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMessageTTL(messageTTL))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1728,7 +1724,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.TTL, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMessageTTL(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1753,7 +1749,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION, PolicyOperation.READ)
             .thenCompose(__ -> internalGetDeduplication(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -1779,7 +1775,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "DeduplicationEnabled policies for the specified topic")
                     Boolean enabled) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDeduplication(enabled))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1803,7 +1799,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.DEDUPLICATION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDeduplication(null))
             .thenRun(() -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -1828,7 +1824,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RETENTION, PolicyOperation.READ)
             .thenCompose(__ -> internalGetRetention(applied))
             .thenAccept(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -1854,7 +1850,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Retention policies for the specified namespace") RetentionPolicies retention) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RETENTION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetRetention(retention))
             .thenRun(() -> {
                 try {
@@ -1889,7 +1885,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RETENTION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveRetention())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove retention: namespace={}, topic={}",
@@ -1920,7 +1916,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.PERSISTENCE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetPersistence(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -1947,7 +1943,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Bookkeeper persistence policies for specified topic")
             PersistencePolicies persistencePolicies) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.PERSISTENCE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetPersistence(persistencePolicies))
             .thenRun(() -> {
                 try {
@@ -1982,7 +1978,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.PERSISTENCE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemovePersistence())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove persistence policies: namespace={}, topic={}",
@@ -2012,7 +2008,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_SUBSCRIPTIONS, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxSubscriptionsPerTopic())
             .thenAccept(op -> asyncResponse.resume(op.isPresent() ? op.get()
                     : Response.noContent().build()))
@@ -2039,7 +2035,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "The max subscriptions of the topic") int maxSubscriptionsPerTopic) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_SUBSCRIPTIONS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxSubscriptionsPerTopic(maxSubscriptionsPerTopic))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated maxSubscriptionsPerTopic: namespace={}, topic={}"
@@ -2068,7 +2064,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_SUBSCRIPTIONS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxSubscriptionsPerTopic(null))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove maxSubscriptionsPerTopic: namespace={}, topic={}",
@@ -2097,7 +2093,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.REPLICATION_RATE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetReplicatorDispatchRate(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2123,7 +2119,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Replicator dispatch rate of the topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetReplicatorDispatchRate(dispatchRate))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated replicatorDispatchRate: namespace={}, topic={}"
@@ -2152,7 +2148,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetReplicatorDispatchRate(null))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove replicatorDispatchRate limit: namespace={}, topic={}",
@@ -2181,7 +2177,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_PRODUCERS, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxProducers(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2207,7 +2203,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "The max producers of the topic") int maxProducers) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_PRODUCERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxProducers(maxProducers))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated max producers: namespace={}, topic={}, maxProducers={}",
@@ -2238,7 +2234,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_PRODUCERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveMaxProducers())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove max producers: namespace={}, topic={}",
@@ -2269,7 +2265,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxConsumers(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2295,7 +2291,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "The max consumers of the topic") int maxConsumers) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxConsumers(maxConsumers))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated max consumers: namespace={}, topic={}, maxConsumers={}",
@@ -2326,7 +2322,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveMaxConsumers())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove max consumers: namespace={}, topic={}",
@@ -2356,7 +2352,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_MESSAGE_SIZE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxMessageSize())
             .thenAccept(policies -> {
                 asyncResponse.resume(policies.isPresent() ? policies.get() : Response.noContent().build());
@@ -2384,7 +2380,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "The max message size of the topic") int maxMessageSize) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_MESSAGE_SIZE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxMessageSize(maxMessageSize))
             .thenRun(() -> {
                 log.info("[{}] Successfully set max message size: namespace={}, topic={}, maxMessageSiz={}",
@@ -2415,7 +2411,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_MESSAGE_SIZE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxMessageSize(null))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove max message size: namespace={}, topic={}",
@@ -2649,7 +2645,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetDispatchRate(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2674,7 +2670,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Dispatch rate for the specified topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetDispatchRate(dispatchRate))
             .thenRun(() -> {
                 try {
@@ -2709,7 +2705,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveDispatchRate())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic dispatch rate: tenant={}, namespace={}, topic={}",
@@ -2741,7 +2737,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetSubscriptionDispatchRate(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2768,7 +2764,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Subscription message dispatch rate for the specified topic")
                     DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetSubscriptionDispatchRate(dispatchRate))
             .thenRun(() -> {
                 try {
@@ -2803,7 +2799,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveSubscriptionDispatchRate())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic subscription dispatch rate: tenant={}, namespace={}, topic={}",
@@ -2835,7 +2831,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.COMPACTION, PolicyOperation.READ)
             .thenCompose(__ -> internalGetCompactionThreshold(applied))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
@@ -2860,7 +2856,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Dispatch rate for the specified topic") long compactionThreshold) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.COMPACTION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetCompactionThreshold(compactionThreshold))
             .thenRun(() -> {
                 try {
@@ -2895,7 +2891,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.COMPACTION, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveCompactionThreshold())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic compaction threshold: tenant={}, namespace={}, topic={}",
@@ -2926,7 +2922,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.READ)
             .thenCompose(__ -> internalGetMaxConsumersPerSubscription())
             .thenAccept(op -> asyncResponse.resume(op.isPresent() ? op.get()
                     : Response.noContent().build()))
@@ -2953,7 +2949,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Dispatch rate for the specified topic") int maxConsumersPerSubscription) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetMaxConsumersPerSubscription(maxConsumersPerSubscription))
             .thenRun(() -> {
                 try {
@@ -2988,7 +2984,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.MAX_CONSUMERS, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveMaxConsumersPerSubscription())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic max consumers per subscription:"
@@ -3020,7 +3016,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetPublishRate())
             .thenAccept(op -> asyncResponse.resume(op.isPresent() ? op.get()
                     : Response.noContent().build()))
@@ -3046,7 +3042,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Dispatch rate for the specified topic") PublishRate publishRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetPublishRate(publishRate))
             .thenRun(() -> {
                 try {
@@ -3081,7 +3077,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemovePublishRate())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic publish rate: tenant={}, namespace={}, topic={}",
@@ -3112,7 +3108,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.SUBSCRIPTION_AUTH_MODE, PolicyOperation.READ)
             .thenCompose(__ -> internalGetSubscriptionTypesEnabled())
             .thenAccept(op -> {
                 asyncResponse.resume(op.isPresent() ? op.get()
@@ -3141,7 +3137,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Enable sub types for the specified topic")
             Set<SubscriptionType> subscriptionTypesEnabled) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.SUBSCRIPTION_AUTH_MODE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetSubscriptionTypesEnabled(subscriptionTypesEnabled))
             .thenRun(() -> {
                 try {
@@ -3177,7 +3173,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.READ)
                 .thenCompose(__ -> internalGetSubscribeRate(applied))
                 .thenApply(asyncResponse::resume).exceptionally(ex -> {
             handleTopicPolicyException("getSubscribeRate", ex, asyncResponse);
@@ -3202,7 +3198,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Subscribe rate for the specified topic") SubscribeRate subscribeRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalSetSubscribeRate(subscribeRate))
             .thenRun(() -> {
                 try {
@@ -3237,7 +3233,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Subscribe rate for the specified topic") SubscribeRate subscribeRate) {
         validateTopicName(tenant, namespace, encodedTopic);
-        preValidation(authoritative)
+        preValidation(authoritative, PolicyName.RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> internalRemoveSubscribeRate())
             .thenRun(() -> {
                 log.info("[{}] Successfully remove topic subscribe rate: tenant={}, namespace={}, topic={}",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthzTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthzTest.java
@@ -1,0 +1,428 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockAuthentication;
+import org.apache.pulsar.broker.auth.MockAuthenticationProvider;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Topic Policies are only meant to be modified by tenant admin roles. This
+ * test class verifies each tenant policy operation's authorization implementation
+ * by ensuring an authenticated user with tenant admin privileges can make these calls
+ * without exception and an authenticated user without tenant admin privileges fails
+ * to make these calls with a resulting 403 response code.
+ */
+@Slf4j
+@Test(groups = "broker")
+public class TopicPoliciesAuthzTest extends MockedPulsarServiceBaseTest {
+
+    private final String clusterName = "test";
+    private final String testTenant = "my-tenant";
+    private final String testNamespace = "my-namespace";
+    private final String myNamespace = testTenant + "/" + testNamespace;
+    private final String testTopic = "persistent://" + myNamespace + "/my-topic";
+    // Create the roles that will be used to verify the different levels of permission
+    private final String superuserRole = "pass.superuser";
+    private final String tenantAdminRole = "pass.tenantadmin";
+    private final String basicUserRole = "pass.basic";
+    private PulsarAdmin tenantAdmin = null;
+    private PulsarAdmin basicUser = null;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        conf.setSystemTopicEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationEnabled(true);
+        conf.setSuperUserRoles(ImmutableSet.of(superuserRole));
+        conf.setAuthenticationProviders(ImmutableSet.of(MockAuthenticationProvider.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(MockAuthentication.class.getName());
+        conf.setBrokerClientAuthenticationParameters("user:" + superuserRole);
+
+        // Now that the config is set, start the cluster
+        super.internalSetup();
+
+        admin.clusters().createCluster(clusterName,
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet(tenantAdminRole), Sets.newHashSet(clusterName));
+        admin.tenants().createTenant(this.testTenant, tenantInfo);
+        admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));
+        // User has all basic permissions for the namespace, but is lacking admin privileges for tenant
+        admin.namespaces().grantPermissionOnNamespace(myNamespace, basicUserRole,
+                Sets.newHashSet(AuthAction.values()));
+        admin.topics().createPartitionedTopic(testTopic, 2);
+        // Create the admin clients we'll test with
+        tenantAdmin = PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(new MockAuthentication(tenantAdminRole)).build();
+        basicUser = PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(new MockAuthentication(basicUserRole)).build();
+    }
+
+    @Override
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
+        pulsarAdminBuilder.authentication(new MockAuthentication(superuserRole));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    /**
+     * Runnables that, when run, should result in PulsarAdminExceptions that have 403 status codes.
+     * @param runnable - a runnable that is expected to throw an exception
+     */
+    private void assertFailsWith403(Assert.ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+            Assert.fail("Succeeded on call that was supposed to fail.");
+        } catch (PulsarAdminException e) {
+            Assert.assertEquals(e.getStatusCode(), HttpStatus.FORBIDDEN_403);
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Throwable e) {
+            Assert.fail("Received unexpected exception", e);
+        }
+    }
+
+    @Test
+    public void testOffloadPoliciesAuthz() throws Exception {
+        OffloadPolicies policies = OffloadPolicies.builder().build();
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setOffloadPolicies(testTopic, policies);
+        tenantAdmin.topics().getOffloadPolicies(testTopic);
+        tenantAdmin.topics().removeOffloadPolicies(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getOffloadPolicies(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setOffloadPolicies(testTopic, policies));
+        assertFailsWith403(() -> basicUser.topics().removeOffloadPolicies(testTopic));
+    }
+
+    @Test
+    public void testMaxUnackedMessagesOnConsumerAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxUnackedMessagesOnConsumer(testTopic, 1);
+        tenantAdmin.topics().getMaxUnackedMessagesOnConsumer(testTopic);
+        tenantAdmin.topics().removeMaxUnackedMessagesOnConsumer(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxUnackedMessagesOnConsumer(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxUnackedMessagesOnConsumer(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxUnackedMessagesOnConsumer(testTopic));
+    }
+
+    @Test
+    public void testDeduplicationSnapshotIntervalAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setDeduplicationSnapshotInterval(testTopic, 1);
+        tenantAdmin.topics().getDeduplicationSnapshotInterval(testTopic);
+        tenantAdmin.topics().removeDeduplicationSnapshotInterval(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getDeduplicationSnapshotInterval(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setDeduplicationSnapshotInterval(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeDeduplicationSnapshotInterval(testTopic));
+    }
+
+    @Test
+    public void testInactiveTopicPoliciesAuthz() throws Exception {
+        InactiveTopicPolicies policies = new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                60, true);
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setInactiveTopicPolicies(testTopic, policies);
+        tenantAdmin.topics().getInactiveTopicPolicies(testTopic);
+        tenantAdmin.topics().removeInactiveTopicPolicies(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getInactiveTopicPolicies(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setInactiveTopicPolicies(testTopic, policies));
+        assertFailsWith403(() -> basicUser.topics().removeInactiveTopicPolicies(testTopic));
+    }
+
+    @Test
+    public void testMaxUnackedMessagesOnSubscriptionAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxUnackedMessagesOnSubscription(testTopic, 1);
+        tenantAdmin.topics().getMaxUnackedMessagesOnSubscription(testTopic);
+        tenantAdmin.topics().removeMaxUnackedMessagesOnSubscription(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxUnackedMessagesOnSubscription(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxUnackedMessagesOnSubscription(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxUnackedMessagesOnSubscription(testTopic));
+    }
+
+    @Test
+    public void testDelayedDeliveryPolicyAuthz() throws Exception {
+        DelayedDeliveryPolicies policies = DelayedDeliveryPolicies.builder().build();
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setDelayedDeliveryPolicy(testTopic, policies);
+        tenantAdmin.topics().getDelayedDeliveryPolicy(testTopic);
+        tenantAdmin.topics().removeDelayedDeliveryPolicy(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getDelayedDeliveryPolicy(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setDelayedDeliveryPolicy(testTopic, policies));
+        assertFailsWith403(() -> basicUser.topics().removeDelayedDeliveryPolicy(testTopic));
+    }
+
+    @Test
+    public void testBacklogQuotaAuthz() throws Exception {
+        BacklogQuota backlogQuota = BacklogQuota.builder().build();
+        BacklogQuota.BacklogQuotaType backlogQuotaType = BacklogQuota.BacklogQuotaType.destination_storage;
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setBacklogQuota(testTopic, backlogQuota, backlogQuotaType);
+        tenantAdmin.topics().getBacklogQuotaMap(testTopic).get(backlogQuotaType);
+        tenantAdmin.topics().removeBacklogQuota(testTopic, backlogQuotaType);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getBacklogQuotaMap(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setBacklogQuota(testTopic, backlogQuota, backlogQuotaType));
+        assertFailsWith403(() -> basicUser.topics().removeBacklogQuota(testTopic, backlogQuotaType));
+    }
+
+    @Test
+    public void testMessageTTLAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMessageTTL(testTopic, 1);
+        tenantAdmin.topics().getMessageTTL(testTopic);
+        tenantAdmin.topics().removeMessageTTL(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMessageTTL(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMessageTTL(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMessageTTL(testTopic));
+    }
+
+    @Test
+    public void testDeduplicationStatusAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setDeduplicationStatus(testTopic, true);
+        tenantAdmin.topics().getDeduplicationStatus(testTopic);
+        tenantAdmin.topics().removeDeduplicationStatus(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getDeduplicationStatus(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setDeduplicationStatus(testTopic, true));
+        assertFailsWith403(() -> basicUser.topics().removeDeduplicationStatus(testTopic));
+    }
+
+    @Test
+    public void testRetentionAuthz() throws Exception {
+        RetentionPolicies policies = new RetentionPolicies(1, 1);
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setRetention(testTopic, policies);
+        tenantAdmin.topics().getRetention(testTopic);
+        tenantAdmin.topics().removeRetention(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getRetention(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setRetention(testTopic, policies));
+        assertFailsWith403(() -> basicUser.topics().removeRetention(testTopic));
+    }
+
+    @Test
+    public void testPersistenceAuthz() throws Exception {
+        PersistencePolicies policies = new PersistencePolicies(3, 2, 1, 0);
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setPersistence(testTopic, policies);
+        tenantAdmin.topics().getPersistence(testTopic);
+        tenantAdmin.topics().removePersistence(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getPersistence(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setPersistence(testTopic, policies));
+        assertFailsWith403(() -> basicUser.topics().removePersistence(testTopic));
+    }
+
+    @Test
+    public void testMaxSubscriptionsPerTopicAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxSubscriptionsPerTopic(testTopic, 1);
+        tenantAdmin.topics().getMaxSubscriptionsPerTopic(testTopic);
+        tenantAdmin.topics().removeMaxSubscriptionsPerTopic(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxSubscriptionsPerTopic(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxSubscriptionsPerTopic(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxSubscriptionsPerTopic(testTopic));
+    }
+
+    @Test
+    public void testReplicatorDispatchRateAuthz() throws Exception {
+        DispatchRate rate = DispatchRate.builder().build();
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setReplicatorDispatchRate(testTopic, rate);
+        tenantAdmin.topics().getReplicatorDispatchRate(testTopic);
+        tenantAdmin.topics().removeReplicatorDispatchRate(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getReplicatorDispatchRate(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setReplicatorDispatchRate(testTopic, rate));
+        assertFailsWith403(() -> basicUser.topics().removeReplicatorDispatchRate(testTopic));
+    }
+
+    @Test
+    public void testMaxProducersAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxProducers(testTopic, 1);
+        tenantAdmin.topics().getMaxProducers(testTopic);
+        tenantAdmin.topics().removeMaxProducers(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxProducers(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxProducers(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxProducers(testTopic));
+    }
+
+    @Test
+    public void testMaxConsumersAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxConsumers(testTopic, 1);
+        tenantAdmin.topics().getMaxConsumers(testTopic);
+        tenantAdmin.topics().removeMaxConsumers(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxConsumers(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxConsumers(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxConsumers(testTopic));
+    }
+
+    @Test
+    public void testMaxMessageSizeAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxMessageSize(testTopic, 1);
+        tenantAdmin.topics().getMaxMessageSize(testTopic);
+        tenantAdmin.topics().removeMaxMessageSize(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxMessageSize(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxMessageSize(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxMessageSize(testTopic));
+    }
+
+    @Test
+    public void testDispatchRateAuthz() throws Exception {
+        DispatchRate rate = DispatchRate.builder().build();
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setDispatchRate(testTopic, rate);
+        tenantAdmin.topics().getDispatchRate(testTopic);
+        tenantAdmin.topics().removeDispatchRate(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getDispatchRate(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setDispatchRate(testTopic, rate));
+        assertFailsWith403(() -> basicUser.topics().removeDispatchRate(testTopic));
+    }
+
+    @Test
+    public void testSubscriptionDispatchRateAuthz() throws Exception {
+        DispatchRate rate = DispatchRate.builder().build();
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setSubscriptionDispatchRate(testTopic, rate);
+        tenantAdmin.topics().getSubscriptionDispatchRate(testTopic);
+        tenantAdmin.topics().removeSubscriptionDispatchRate(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getSubscriptionDispatchRate(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setSubscriptionDispatchRate(testTopic, rate));
+        assertFailsWith403(() -> basicUser.topics().removeSubscriptionDispatchRate(testTopic));
+    }
+
+    @Test
+    public void testCompactionThresholdAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setCompactionThreshold(testTopic, 1);
+        tenantAdmin.topics().getCompactionThreshold(testTopic);
+        tenantAdmin.topics().removeCompactionThreshold(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getCompactionThreshold(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setCompactionThreshold(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeCompactionThreshold(testTopic));
+    }
+
+    @Test
+    public void testMaxConsumersPerSubscriptionAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setMaxConsumersPerSubscription(testTopic, 1);
+        tenantAdmin.topics().getMaxConsumersPerSubscription(testTopic);
+        tenantAdmin.topics().removeMaxConsumersPerSubscription(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getMaxConsumersPerSubscription(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setMaxConsumersPerSubscription(testTopic, 1));
+        assertFailsWith403(() -> basicUser.topics().removeMaxConsumersPerSubscription(testTopic));
+    }
+
+    @Test
+    public void testPublishRateAuthz() throws Exception {
+        PublishRate rate = new PublishRate(1, 1);
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setPublishRate(testTopic, rate);
+        tenantAdmin.topics().getPublishRate(testTopic);
+        tenantAdmin.topics().removePublishRate(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getPublishRate(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setPublishRate(testTopic, rate));
+        assertFailsWith403(() -> basicUser.topics().removePublishRate(testTopic));
+    }
+
+    @Test
+    public void testSubscriptionTypesEnabledAuthz() throws Exception {
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setSubscriptionTypesEnabled(testTopic, Sets.newHashSet());
+        tenantAdmin.topics().getSubscriptionTypesEnabled(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getSubscriptionTypesEnabled(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setSubscriptionTypesEnabled(testTopic, Sets.newHashSet()));
+    }
+
+    @Test
+    public void testSubscribeRateAuthz() throws Exception {
+        SubscribeRate rate = new SubscribeRate(1, 1);
+        // Perform all ops. Don't worry about resulting values, as this class is _only_ testing permission
+        tenantAdmin.topics().setSubscribeRate(testTopic, rate);
+        tenantAdmin.topics().getSubscribeRate(testTopic);
+        tenantAdmin.topics().removeSubscribeRate(testTopic);
+
+        // Perform all ops and expect all to fail.
+        assertFailsWith403(() -> basicUser.topics().getSubscribeRate(testTopic));
+        assertFailsWith403(() -> basicUser.topics().setSubscribeRate(testTopic, rate));
+        assertFailsWith403(() -> basicUser.topics().removeSubscribeRate(testTopic));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
@@ -33,7 +33,10 @@ import org.slf4j.LoggerFactory;
 
 public class MockAuthentication implements Authentication {
     private static final Logger log = LoggerFactory.getLogger(MockAuthentication.class);
-    private final String user;
+    private String user;
+
+    public MockAuthentication() {
+    }
 
     public MockAuthentication(String user) {
         this.user = user;
@@ -71,6 +74,7 @@ public class MockAuthentication implements Authentication {
 
     @Override
     public void configure(Map<String, String> authParams) {
+        this.user = authParams.get("user");
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyName.java
@@ -50,5 +50,6 @@ public enum PolicyName {
     ENCRYPTION,
     TTL,
     MAX_TOPICS,
-    RESOURCEGROUP
+    RESOURCEGROUP,
+    MAX_MESSAGE_SIZE,
 }


### PR DESCRIPTION
### Motivation

There are several calls in the v2/PeristentTopics endpoint class that are supposed to require tenant admin permission but only verify LOOKUP permission. These endpoints are all annotated with `@ApiResponse(code = 403, message = "Don't have admin permission")`. It seems to me that these should properly verify tenant admin privileges.

### Modifications

* Update the `preValidation` method in the `PersistentTopicsBase` class to run the `validatePoliciesReadOnlyAccess()` for all write operations and to run an appropriate `validateTopicPolicyOperation(topicName, policyName, policyOperation)` check for all methods.
    * When reading through these changes, please make sure that the `PolicyName` and the `PolicyOperation` make sense for the method.
* Remove the few pre-existing authz checks to prevent duplicate checks for authz.
* Add new `PolicyName` for `MAX_MESSAGE_SIZE`.

### Verifying this change

I verified this bug against a pulsar 2.8.0 broker. The broker authenticates the user, but only requires lookup permission, not tenant admin privilege.

I added new tests to cover these changes.

### Does this pull request potentially affect one of the following parts:

This change will introduce authorization checks that require tenant admin privilege instead of just produce/consumer permission. It is a correction in the behavior, as these checks were supposed to take place already (at least the annotations indicate that).

### Documentation

I don't believe any documentation is required, as this only corrects behavior. It would be good to include this fix in the release notes.