### PR TITLE
Upgrade Netty to 4.1.67.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.66.Final</version>
+      <version>4.1.67.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,23 +352,23 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.66.Final.jar
-    - io.netty-netty-codec-4.1.66.Final.jar
-    - io.netty-netty-codec-dns-4.1.66.Final.jar
-    - io.netty-netty-codec-http-4.1.66.Final.jar
-    - io.netty-netty-codec-http2-4.1.66.Final.jar
-    - io.netty-netty-codec-socks-4.1.66.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.66.Final.jar
-    - io.netty-netty-common-4.1.66.Final.jar
-    - io.netty-netty-handler-4.1.66.Final.jar
-    - io.netty-netty-handler-proxy-4.1.66.Final.jar
-    - io.netty-netty-resolver-4.1.66.Final.jar
-    - io.netty-netty-resolver-dns-4.1.66.Final.jar
-    - io.netty-netty-transport-4.1.66.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.66.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.66.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.66.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.66.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.67.Final.jar
+    - io.netty-netty-codec-4.1.67.Final.jar
+    - io.netty-netty-codec-dns-4.1.67.Final.jar
+    - io.netty-netty-codec-http-4.1.67.Final.jar
+    - io.netty-netty-codec-http2-4.1.67.Final.jar
+    - io.netty-netty-codec-socks-4.1.67.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.67.Final.jar
+    - io.netty-netty-common-4.1.67.Final.jar
+    - io.netty-netty-handler-4.1.67.Final.jar
+    - io.netty-netty-handler-proxy-4.1.67.Final.jar
+    - io.netty-netty-resolver-4.1.67.Final.jar
+    - io.netty-netty-resolver-dns-4.1.67.Final.jar
+    - io.netty-netty-transport-4.1.67.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.67.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.67.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.67.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.40.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.66.Final</netty.version>
+    <netty.version>4.1.67.Final</netty.version>
     <netty-tc-native.version>2.0.40.Final</netty-tc-native.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -233,23 +233,23 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.66.Final.jar
-    - netty-codec-4.1.66.Final.jar
-    - netty-codec-dns-4.1.66.Final.jar
-    - netty-codec-http-4.1.66.Final.jar
-    - netty-codec-haproxy-4.1.66.Final.jar
-    - netty-codec-socks-4.1.66.Final.jar
-    - netty-handler-proxy-4.1.66.Final.jar
-    - netty-common-4.1.66.Final.jar
-    - netty-handler-4.1.66.Final.jar
+    - netty-buffer-4.1.67.Final.jar
+    - netty-codec-4.1.67.Final.jar
+    - netty-codec-dns-4.1.67.Final.jar
+    - netty-codec-http-4.1.67.Final.jar
+    - netty-codec-haproxy-4.1.67.Final.jar
+    - netty-codec-socks-4.1.67.Final.jar
+    - netty-handler-proxy-4.1.67.Final.jar
+    - netty-common-4.1.67.Final.jar
+    - netty-handler-4.1.67.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.66.Final.jar
-    - netty-resolver-dns-4.1.66.Final.jar
+    - netty-resolver-4.1.67.Final.jar
+    - netty-resolver-dns-4.1.67.Final.jar
     - netty-tcnative-boringssl-static-2.0.40.Final.jar
-    - netty-transport-4.1.66.Final.jar
-    - netty-transport-native-epoll-4.1.66.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.66.Final.jar
-    - netty-transport-native-unix-common-4.1.66.Final-linux-x86_64.jar
+    - netty-transport-4.1.67.Final.jar
+    - netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.67.Final.jar
+    - netty-transport-native-unix-common-4.1.67.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty


### PR DESCRIPTION
### Motivation

Before releasing 2.9.0, we would want to make sure to run the latest stable Netty release.
Summary of 4.1.67.Final from [Norman Maurer's tweet](https://twitter.com/normanmaurer/status/1427205629412847620):
"This is mostly a bug-fix release but also adds things like TCP FASTOPEN support for macOS. Please check our release notes for more details: https://netty.io/news/2021/08/16/4-1-67-Final.html"

### Modifications

Upgrade Netty dependency from 4.1.66.Final to 4.1.67.Final .