### PR TITLE
[Python] Fix deadlock caused by ExecutorService::close

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -569,7 +569,11 @@ void ClientConnection::handleRead(const boost::system::error_code& err, size_t b
 
     if (err || bytesTransferred == 0) {
         if (err) {
-            LOG_ERROR(cnxString_ << "Read failed: " << err.message());
+            if (err == boost::asio::error::operation_aborted) {
+                LOG_DEBUG(cnxString_ << "Read failed: " << err.message());
+            } else {
+                LOG_ERROR(cnxString_ << "Read operation was cancelled");
+            }
         }  // else: bytesTransferred == 0, which means server has closed the connection
         close();
     } else if (bytesTransferred < minReadSize) {

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -73,11 +73,9 @@ void ExecutorService::close() {
 
     io_service_->stop();
     work_.reset();
-    // If this thread is attempting to join itself, do not. The destructor's
-    // call to close will handle joining if it does not occur here. This also ensures
-    // join is not called twice since it is not re-entrant on windows
-    if (std::this_thread::get_id() != worker_.get_id() && worker_.joinable()) {
-        worker_.join();
+    // Detach the worker thread instead of join to avoid potential deadlock
+    if (worker_.joinable()) {
+        worker_.detach();
     }
 }
 


### PR DESCRIPTION
Fixes #11847 

### Motivation

There's a deadlock that might happen when Python client enables custom logging. From stack traces of #11847, we can see there're 3 threads when the Python program hanged:
1. The thread to call `ExecutorServiceProvider::close`, which waits until all worker threads of `ExecutorService` completed by `std::thread::join`.
2. The thread to use Python object for logging. It stuck at `PyGILState_Ensure`, which tried to acquire Python GIL. It's called in `ClientConnection::handleRead`. Since all pending events were cancelled by `boost::asio::io_service::stop`, these callbacks were completed with `boost::asio::error::operation_aborted` immediately.
3. The worker thread of `ExecutorService`. It waited until all callbacks including `ClientConnection::handleRead` completed.

The root cause might be related to Python's GIL issues. It seems like CPython APIs might not work well in C++ destructors. It might be caused by some lifetime issues. But the direct cause is thread 1 was blocked by joining a worker thread.

### Modifications

Detach the worker thread instead of join in `ExecutorService::close` to avoid potential deadlock. The close method could be called in `ClientImpl`'s destructor, which calls `shutdown`. It's better to call these blocking methods in C++ destructors even without this issue.

In addition, this PR reduces the log level from error to debug for the `boost::asio::error::operation_aborted` error code, which means the registered event is cancelled by a close event of the event loop.