### PR TITLE
Fixed ResourceLockTest.revalidateLockOnDifferentSession()

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -37,7 +36,6 @@ import lombok.Cleanup;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
@@ -45,6 +43,7 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 public class LockManagerTest extends BaseMetadataStoreTest {
@@ -212,20 +211,23 @@ public class LockManagerTest extends BaseMetadataStoreTest {
             assertEquals(e.getCause().getClass(), LockBusyException.class);
         }
 
-        // Lock-1 should get notification of expiry
+        // Lock-1 should not get invalidated
         assertFalse(rl1.getLockExpiredFuture().isDone());
 
         assertEquals(new String(store1.get(path1).join().get().getValue()), "\"value-1\"");
 
         // Simulate existing lock with same content. The 2nd acquirer will steal the lock
         String path2 = newKey();
-        rl1 = lm1.acquireLock(path2, "value-1").join();
+        store1.put(path2, ObjectMapperFactory.getThreadLocal().writeValueAsBytes("value-1"), Optional.of(-1L));
 
         ResourceLock<String> rl2 = lm2.acquireLock(path2, "value-1").join();
 
-        assertFalse(rl1.getLockExpiredFuture().isDone());
         assertFalse(rl2.getLockExpiredFuture().isDone());
 
-        assertEquals(new String(store1.get(path2).join().get().getValue()), "\"value-1\"");
+        Awaitility.await().untilAsserted(() -> {
+            // On 'store1' we might see for a short amount of time an empty result still cached while the lock is
+            // being reacquired.
+            assertEquals(new String(store1.get(path2).join().get().getValue()), "\"value-1\"");
+        });
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.Cleanup;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;


### PR DESCRIPTION
### Motivation

Fixes #11690 

The main issue in the test is that there are 2 `ResourceLock` instances that are competing.

 * `RL_1` acquires the lock
 * `RL_2` tries to “steal” the lock
 * When `RL_2` deletes the existing lock, `RL_1` might get the notification fast and delete the lock after `RL_2` did acquire it.

That eventually lead in both locks getting expired:

```
10:22:34.784 INFO  [main] o.a.p.m.c.i.ResourceLockImpl@68 - CREATED RESOURCE LOCK [RL 1 ]  - 
10:22:34.807 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@184 - [RL 1 ]  - Acquired resource lock on /key-193314812191875
----------------------- START --------------------
10:22:34.807 INFO  [main] o.a.p.m.c.i.ResourceLockImpl@68 - CREATED RESOURCE LOCK [RL 2 ]  - 
10:22:34.831 WARN  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@149 - [RL 2 ] FAILED TO ACQUIRE LOCK WITH NO REVALIDATION: 
10:22:34.833 WARN  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@151 - [RL 2 ] REVALIDATING LOCK 
10:22:34.837 INFO  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@253 - [RL 2 ]  - Deleting stale lock at /key-193314812191875
10:22:34.862 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@205 -  [RL 1 ]  - Lock on resource /key-193314812191875 was invalidated
10:22:34.884 INFO  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@184 - [RL 2 ]  - Acquired resource lock on /key-193314812191875
10:22:34.884 INFO  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@258 - [RL 2 ]  - Successfully re-acquired stale lock at /key-193314812191875
----------------------- DONE --------------------
10:22:34.885 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@253 -  [RL 1 ]  - Deleting stale lock at /key-193314812191875
10:22:34.912 INFO  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@205 - [RL 2 ]  - Lock on resource /key-193314812191875 was invalidated
10:22:34.912 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@205 -  [RL 1 ]  - Lock on resource /key-193314812191875 was invalidated
10:22:34.942 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@184 -  [RL 1 ]  - Acquired resource lock on /key-193314812191875
10:22:34.943 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@258 -  [RL 1 ]  - Successfully re-acquired stale lock at /key-193314812191875
10:22:34.943 INFO  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@207 -  [RL 1 ]  - Successfully revalidated the lock on /key-193314812191875
10:22:34.963 WARN  [metadata-store-9-1] o.a.p.m.c.i.ResourceLockImpl@210 -  [RL 1 ]  - Failed to revalidate the lock at /key-193314812191875. Marked as expired
10:22:34.963 WARN  [metadata-store-11-1] o.a.p.m.c.i.ResourceLockImpl@210 - [RL 2 ]  - Failed to revalidate the lock at /key-193314812191875. Marked as expired
```

### Modification 
 * Avoid the competing ResourceLock instances. Instead simulate the case of existing lock left by previous broker instance.
