### PR TITLE
Fixed ZKSessionTest.testReacquireLocksAfterSessionLost

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -107,6 +107,9 @@ class LockManagerImpl<T> implements LockManager<T> {
         if (se == SessionEvent.SessionReestablished) {
             log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
             locks.values().forEach(ResourceLockImpl::revalidate);
+        } else if (se == SessionEvent.Reconnected) {
+            log.info("Metadata store connection has been re-established. Revalidating locks that were pending.");
+            locks.values().forEach(ResourceLockImpl::revalidateIfNeededAfterReconnection);
         }
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -114,6 +114,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
 
         ResourceLock<String> lock = lm1.acquireLock(path, "value-1").join();
 
+
         zks.expireSession(((ZKMetadataStore) store).getZkSessionId());
 
         SessionEvent e = sessionEvents.poll(5, TimeUnit.SECONDS);
@@ -127,11 +128,8 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
 
-        Awaitility.waitAtMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertFalse(lock.getLockExpiredFuture().isDone());
-        });
-
-        assertTrue(store.get(path).join().isPresent());
+        Awaitility.await().untilAsserted(() -> assertTrue(store.get(path).join().isPresent()));
+        assertFalse(lock.getLockExpiredFuture().isDone());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Fixes the flakiness in `ZKSessionTest.testReacquireLocksAfterSessionLost` test:

```
Error:  testReacquireLocksAfterSessionLost(org.apache.pulsar.metadata.ZKSessionTest)  Time elapsed: 22.547 s  <<< FAILURE!
java.lang.AssertionError: expected [Reconnected] but found [null]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
	at org.testng.Assert.assertEquals(Assert.java:122)
	at org.testng.Assert.assertEquals(Assert.java:617)
	at org.apache.pulsar.metadata.ZKSessionTest.testReacquireLocksAfterSessionLost(ZKSessionTest.java:126)
```

The root cause for the test failing is that, when the session is forcefully expired, we're also getting a watch triggered for the deletion of the ephemeral node.  That means that, depending on the timing of the watch, we can end up trying to revalidate the lock while we're not connected to ZK. 

When that happens, we should expire the lock, instead we only expire it if we get a BadVersion on the put operation, which means that someone else took the lock over.

This way, we can retry the validation when we're finally reconnected to ZK.

