### PR TITLE
[Python] Ensure producer is keeping the client object alive

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -602,6 +602,7 @@ class Client:
         p = Producer()
         p._producer = self._client.create_producer(topic, conf)
         p._schema = schema
+        p._client = self._client
         return p
 
     def subscribe(self, topic, subscription_name,

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -1104,6 +1104,14 @@ class PulsarTest(TestCase):
         consumer.unsubscribe()
         client.close()
 
+    def test_client_reference_deleted(self):
+        def get_producer():
+            cl = Client(self.serviceUrl)
+            return cl.create_producer(topic='foobar')
+
+        producer = get_producer()
+        producer.send(b'test_payload')
+
     #####
 
     def test_get_topic_name(self):


### PR DESCRIPTION
### Motivation

Fix #6463. 

When a producer is created, keep a reference on the client object so that the Python GC will not destroy it. This is similar to what we were already doing for consumer and reader, were we had examples with listeners that need to keep the client/consumer alive.