### PR TITLE
Fix the Pulsar Proxy flaky test (Collector already registered that provides name: jvm_memory_direct_bytes_used)

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -103,14 +103,12 @@ function broker_flaky() {
 }
 
 function proxy() {
-  echo "::endgroup::"
-  echo "::group::Running quarantined pulsar-proxy tests"
-  $MVN_COMMAND test -pl pulsar-proxy -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false ||
-    print_testng_failures pulsar-proxy/target/surefire-reports/testng-failed.xml "Quarantined test failure in" "Quarantined test failures"
-  echo "::endgroup::"
-  echo "::group::Running pulsar-proxy tests"
-  $MVN_TEST_COMMAND -pl pulsar-proxy
-  echo "::endgroup::"
+    echo "::group::Running pulsar-proxy tests"
+    $MVN_TEST_COMMAND -pl pulsar-proxy -Dtest="org.apache.pulsar.proxy.server.ProxyServiceTlsStarterTest"
+    $MVN_TEST_COMMAND -pl pulsar-proxy -Dtest="org.apache.pulsar.proxy.server.ProxyServiceStarterTest"
+    $MVN_TEST_COMMAND -pl pulsar-proxy -Dexclude='org.apache.pulsar.proxy.server.ProxyServiceTlsStarterTest,
+                                                  org.apache.pulsar.proxy.server.ProxyServiceStarterTest'
+    echo "::endgroup::"
 }
 
 function other() {


### PR DESCRIPTION
### Motivation

Fix the failed test with `Collector already registered that provides name: jvm_memory_direct_bytes_used` in the Pulsar Proxy unit test. Here is the error log while executing the proxy unit test:

```
Error:  Tests run: 6, Failures: 3, Errors: 0, Skipped: 3, Time elapsed: 13.646 s <<< FAILURE! - in org.apache.pulsar.proxy.server.ProxyServiceStarterTest
  Error:  setup(org.apache.pulsar.proxy.server.ProxyServiceStarterTest)  Time elapsed: 2.323 s  <<< FAILURE!
  java.lang.IllegalArgumentException: Collector already registered that provides name: jvm_memory_direct_bytes_used
  	at io.prometheus.client.CollectorRegistry.register(CollectorRegistry.java:54)
  	at io.prometheus.client.Collector.register(Collector.java:139)
  	at org.apache.pulsar.proxy.server.ProxyServiceStarter.start(ProxyServiceStarter.java:183)
  	at org.apache.pulsar.proxy.server.ProxyServiceStarterTest.setup(ProxyServiceStarterTest.java:64)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
  	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
  	at org.testng.internal.MethodInvocationHelper.invokeMethodConsideringTimeout(MethodInvocationHelper.java:61)
  	at org.testng.internal.ConfigInvoker.invokeConfigurationMethod(ConfigInvoker.java:366)
  	at org.testng.internal.ConfigInvoker.invokeConfigurations(ConfigInvoker.java:320)
  	at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:176)
  	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:122)
  	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
  	at org.testng.TestRunner.privateRun(TestRunner.java:764)
  	at org.testng.TestRunner.run(TestRunner.java:585)
  	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
  	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
  	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
  	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
  	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
  	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
  	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
  	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
  	at org.testng.TestNG.runSuites(TestNG.java:1069)
  	at org.testng.TestNG.run(TestNG.java:1037)
  	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135)
  	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
  	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeLazy(TestNGDirectoryTestSuite.java:123)
  	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:90)
  	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146)
  	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
  	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
  	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
  	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```

Here is an example: https://github.com/apache/pulsar/runs/3495438512?check_suite_focus=true

### Changes

1. Removed the running quarantined group command since we don't have a test class with quarantined group in the Pulsar proxy module
2. Run ProxyServiceTlsStarterTest and ProxyServiceStarterTest to make sure they are not running in a single JVM.