### PR TITLE
Fixed KCA Sink handling of Json and Avro; support for kafka connectors that overload task.preCommit() directly

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/schema/KafkaConnectData.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/schema/KafkaConnectData.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.kafka.connect.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import org.apache.avro.generic.GenericData;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaConnectData {
+    public static Object getKafkaConnectData(Object nativeObject, Schema kafkaSchema) {
+        if (kafkaSchema == null) {
+            return nativeObject;
+        }
+
+        if (nativeObject == null) {
+            return defaultOrThrow(kafkaSchema);
+        }
+
+        if (nativeObject instanceof JsonNode) {
+            JsonNode node = (JsonNode) nativeObject;
+            return jsonAsConnectData(node, kafkaSchema);
+        } else if (nativeObject instanceof GenericData.Record) {
+            GenericData.Record avroRecord = (GenericData.Record) nativeObject;
+            return avroAsConnectData(avroRecord, kafkaSchema);
+        }
+
+        return nativeObject;
+    }
+
+    static Object avroAsConnectData(GenericData.Record avroRecord, Schema kafkaSchema) {
+        if (kafkaSchema == null) {
+            if (avroRecord == null) {
+                return null;
+            }
+            throw new DataException("Don't know how to convert " + avroRecord + " to Connect data (schema is null).");
+        }
+
+        Struct struct = new Struct(kafkaSchema);
+        for (Field field : kafkaSchema.fields()) {
+            struct.put(field, getKafkaConnectData(avroRecord.get(field.name()), field.schema()));
+        }
+        return struct;
+    }
+
+    // with some help of
+    // https://github.com/apache/kafka/blob/trunk/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+    static Object jsonAsConnectData(JsonNode jsonNode, Schema kafkaSchema) {
+        if (kafkaSchema == null) {
+            if (jsonNode == null || jsonNode.isNull()) {
+                return null;
+            }
+            switch (jsonNode.getNodeType()) {
+                case BINARY:
+                    try {
+                        return jsonNode.binaryValue();
+                    } catch (IOException e) {
+                        throw new DataException("Cannot get binary value for " + jsonNode);
+                    }
+                case BOOLEAN:
+                    return jsonNode.booleanValue();
+                case NUMBER:
+                    jsonNode.doubleValue();
+                case STRING:
+                    jsonNode.textValue();
+                default:
+                    throw new DataException("Don't know how to convert " + jsonNode +
+                            " to Connect data (schema is null).");
+            }
+        }
+
+        if (jsonNode == null || jsonNode.isNull()) {
+            return defaultOrThrow(kafkaSchema);
+        }
+
+        switch (kafkaSchema.type()) {
+            case INT8:
+                return (byte)jsonNode.shortValue();
+            case INT16:
+                return jsonNode.shortValue();
+            case INT32:
+                return jsonNode.intValue();
+            case INT64:
+                return  jsonNode.longValue();
+            case FLOAT32:
+                return jsonNode.floatValue();
+            case FLOAT64:
+                return jsonNode.doubleValue();
+            case BOOLEAN:
+                return jsonNode.booleanValue();
+            case STRING:
+                return jsonNode.textValue();
+            case BYTES:
+                try {
+                    return jsonNode.binaryValue();
+                } catch (IOException e) {
+                    throw new DataException("Cannot get binary value for " + jsonNode + " with schema " + kafkaSchema);
+                }
+            case ARRAY:
+                List<Object> list = new ArrayList<>();
+                Preconditions.checkArgument(jsonNode.isArray(), "jsonNode has to be an array");
+                for (Iterator<JsonNode> it = jsonNode.elements(); it.hasNext(); ) {
+                    list.add(jsonAsConnectData(it.next(), kafkaSchema.valueSchema()));
+                }
+                return list;
+            case MAP:
+                Map<String, Object> map = new HashMap<>();
+                for (Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
+                    Map.Entry<String, JsonNode> elem = it.next();
+                    map.put(elem.getKey(), jsonAsConnectData(elem.getValue(), kafkaSchema.valueSchema()));
+                }
+                return map;
+            case STRUCT:
+                Struct struct = new Struct(kafkaSchema);
+                for (Field field: kafkaSchema.fields()) {
+                    struct.put(field, jsonAsConnectData(jsonNode.get(field.name()), field.schema()));
+                }
+                return struct;
+            default:
+                throw new DataException("Unknown schema type " + kafkaSchema.type());
+        }
+    }
+
+    private static Object defaultOrThrow(Schema kafkaSchema) {
+        if (kafkaSchema.defaultValue() != null) {
+            return kafkaSchema.defaultValue(); // any logical type conversions should already have been applied
+        }
+        if (kafkaSchema.isOptional()) {
+            return null;
+        }
+        throw new DataException("Invalid null value for required " + kafkaSchema.type() + " field");
+    }
+}

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -20,9 +20,13 @@
 package org.apache.pulsar.io.kafka.connect;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericData;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
@@ -34,13 +38,17 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.util.MessageIdUtils;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.core.KeyValue;
 import org.apache.pulsar.io.core.SinkContext;
+import org.apache.pulsar.io.kafka.connect.schema.KafkaConnectData;
+import org.apache.pulsar.io.kafka.connect.schema.PulsarSchemaToKafkaSchema;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -124,7 +132,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         final GenericRecord rec = getGenericRecord("value", Schema.STRING);
         Message msg = mock(MessageImpl.class);
         when(msg.getValue()).thenReturn(rec);
-        when(msg.getMessageId()).thenReturn(new MessageIdImpl(0, 0, 0));
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
 
         final AtomicInteger status = new AtomicInteger(0);
         Record<GenericObject> record = PulsarRecord.<String>builder()
@@ -230,11 +238,11 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
     }
 
-    private void recordSchemaTest(Object value, Schema schema, Object expected, String expectedSchema) throws Exception {
-        recordSchemaTest(value, schema, "key",  "STRING", expected, expectedSchema);
+    private SinkRecord recordSchemaTest(Object value, Schema schema, Object expected, String expectedSchema) throws Exception {
+        return recordSchemaTest(value, schema, "key",  "STRING", expected, expectedSchema);
     }
 
-    private void recordSchemaTest(Object value, Schema schema, Object expectedKey, String expectedKeySchema,
+    private SinkRecord recordSchemaTest(Object value, Schema schema, Object expectedKey, String expectedKeySchema,
                                   Object expected, String expectedSchema) throws Exception {
         props.put("kafkaConnectorSinkClass", SchemaedFileStreamSinkConnector.class.getCanonicalName());
 
@@ -246,7 +254,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         when(msg.getValue()).thenReturn(rec);
         when(msg.getKey()).thenReturn("key");
         when(msg.hasKey()).thenReturn(true);
-        when(msg.getMessageId()).thenReturn(new MessageIdImpl(0, 0, 0));
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
 
         final AtomicInteger status = new AtomicInteger(0);
         Record<GenericObject> record = PulsarRecord.<String>builder()
@@ -256,6 +264,8 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
                 .ackFunction(status::incrementAndGet)
                 .failFunction(status::decrementAndGet)
                 .build();
+
+        org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema.getKafkaConnectSchema(schema);
 
         sink.write(record);
         sink.flush();
@@ -272,6 +282,9 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         assertEquals(result.get("value"), expected);
         assertEquals(result.get("keySchema"), expectedKeySchema);
         assertEquals(result.get("valueSchema"), expectedSchema);
+
+        SinkRecord sinkRecord = sink.toSinkRecord(record);
+        return sinkRecord;
     }
 
     private GenericRecord getGenericRecord(Object value, Schema schema) {
@@ -289,50 +302,69 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
 
     @Test
     public void bytesRecordSchemaTest() throws Exception {
-        recordSchemaTest("val".getBytes(StandardCharsets.US_ASCII), Schema.BYTES, "val", "BYTES");
+        byte[] in = "val".getBytes(StandardCharsets.US_ASCII);
+        SinkRecord sinkRecord = recordSchemaTest(in, Schema.BYTES, "val", "BYTES");
+        byte[] out = (byte[]) sinkRecord.value();
+        Assert.assertEquals(out, in);
     }
 
     @Test
     public void stringRecordSchemaTest() throws Exception {
-        recordSchemaTest("val", Schema.STRING, "val", "STRING");
+        SinkRecord sinkRecord = recordSchemaTest("val", Schema.STRING, "val", "STRING");
+        String out = (String) sinkRecord.value();
+        Assert.assertEquals(out, "val");
     }
 
     @Test
     public void booleanRecordSchemaTest() throws Exception {
-        recordSchemaTest(true, Schema.BOOL, true, "BOOLEAN");
+        SinkRecord sinkRecord = recordSchemaTest(true, Schema.BOOL, true, "BOOLEAN");
+        boolean out = (boolean) sinkRecord.value();
+        Assert.assertEquals(out, true);
     }
 
     @Test
     public void byteRecordSchemaTest() throws Exception {
         // int 1 is coming back from ObjectMapper
-        recordSchemaTest((byte)1, Schema.INT8, 1, "INT8");
+        SinkRecord sinkRecord = recordSchemaTest((byte)1, Schema.INT8, 1, "INT8");
+        byte out = (byte) sinkRecord.value();
+        Assert.assertEquals(out, 1);
     }
 
     @Test
     public void shortRecordSchemaTest() throws Exception {
         // int 1 is coming back from ObjectMapper
-        recordSchemaTest((short)1, Schema.INT16, 1, "INT16");
+        SinkRecord sinkRecord = recordSchemaTest((short)1, Schema.INT16, 1, "INT16");
+        short out = (short) sinkRecord.value();
+        Assert.assertEquals(out, 1);
     }
 
     @Test
     public void integerRecordSchemaTest() throws Exception {
-        recordSchemaTest(Integer.MAX_VALUE, Schema.INT32, Integer.MAX_VALUE, "INT32");
+        SinkRecord sinkRecord = recordSchemaTest(Integer.MAX_VALUE, Schema.INT32, Integer.MAX_VALUE, "INT32");
+        int out = (int) sinkRecord.value();
+        Assert.assertEquals(out, Integer.MAX_VALUE);
     }
 
     @Test
     public void longRecordSchemaTest() throws Exception {
-        recordSchemaTest(Long.MAX_VALUE, Schema.INT64, Long.MAX_VALUE, "INT64");
+        SinkRecord sinkRecord = recordSchemaTest(Long.MAX_VALUE, Schema.INT64, Long.MAX_VALUE, "INT64");
+        long out = (long) sinkRecord.value();
+        Assert.assertEquals(out, Long.MAX_VALUE);
     }
 
     @Test
     public void floatRecordSchemaTest() throws Exception {
         // 1.0d is coming back from ObjectMapper
-        recordSchemaTest(1.0f, Schema.FLOAT, 1.0d, "FLOAT32");
+        SinkRecord sinkRecord = recordSchemaTest(1.0f, Schema.FLOAT, 1.0d, "FLOAT32");
+        float out = (float) sinkRecord.value();
+        Assert.assertEquals(out, 1.0d);
     }
 
     @Test
     public void doubleRecordSchemaTest() throws Exception {
-        recordSchemaTest(Double.MAX_VALUE, Schema.DOUBLE, Double.MAX_VALUE, "FLOAT64");
+        SinkRecord sinkRecord = recordSchemaTest(Double.MAX_VALUE, Schema.DOUBLE, Double.MAX_VALUE, "FLOAT64");
+        double out = (double) sinkRecord.value();
+        Assert.assertEquals(out, Double.MAX_VALUE);
     }
 
     @Test
@@ -347,13 +379,45 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         obj.setField2("test");
         obj.setField3(100L);
 
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.valueToTree(obj);
+
         Map<String, Object> expected = new LinkedHashMap<>();
         expected.put("field1", 10);
         expected.put("field2", "test");
         // integer is coming back from ObjectMapper
         expected.put("field3", 100);
 
-        recordSchemaTest(obj, jsonSchema, expected, "STRUCT");
+        SinkRecord sinkRecord = recordSchemaTest(jsonNode, jsonSchema, expected, "STRUCT");
+
+        Struct out = (Struct) sinkRecord.value();
+        Assert.assertEquals((int)out.get("field1"), 10);
+        Assert.assertEquals((String)out.get("field2"), "test");
+        Assert.assertEquals((long)out.get("field3"), 100L);
+    }
+
+    @Test
+    public void avroSchemaTest() throws Exception {
+        AvroSchema<PulsarSchemaToKafkaSchemaTest.StructWithAnnotations> pulsarAvroSchema
+                = AvroSchema.of(PulsarSchemaToKafkaSchemaTest.StructWithAnnotations.class);
+
+        final GenericData.Record obj = new GenericData.Record(pulsarAvroSchema.getAvroSchema());
+        obj.put("field1", 10);
+        obj.put("field2", "test");
+        obj.put("field3", 100L);
+
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("field1", 10);
+        expected.put("field2", "test");
+        // integer is coming back from ObjectMapper
+        expected.put("field3", 100);
+
+        SinkRecord sinkRecord = recordSchemaTest(obj, pulsarAvroSchema, expected, "STRUCT");
+
+        Struct out = (Struct) sinkRecord.value();
+        Assert.assertEquals((int)out.get("field1"), 10);
+        Assert.assertEquals((String)out.get("field2"), "test");
+        Assert.assertEquals((long)out.get("field3"), 100L);
     }
 
     @Test
@@ -390,7 +454,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
     @Test
     public void KeyValueSchemaTest() throws Exception {
         KeyValue<Integer, String> kv = new KeyValue<>(11, "value");
-        recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
+        SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
     }
 
     @Test

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -265,8 +265,6 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
                 .failFunction(status::decrementAndGet)
                 .build();
 
-        org.apache.kafka.connect.data.Schema kafkaSchema = PulsarSchemaToKafkaSchema.getKafkaConnectSchema(schema);
-
         sink.write(record);
         sink.flush();
 

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -455,6 +455,10 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
     public void KeyValueSchemaTest() throws Exception {
         KeyValue<Integer, String> kv = new KeyValue<>(11, "value");
         SinkRecord sinkRecord = recordSchemaTest(kv, Schema.KeyValue(Schema.INT32, Schema.STRING), 11, "INT32", "value", "STRING");
+        String val = (String) sinkRecord.value();
+        Assert.assertEquals(val, "value");
+        int key = (int) sinkRecord.key();
+        Assert.assertEquals(key, 11);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Kafka Connect Sink expects KC Data Struct instead of Avro or Json.
- at some version of Kafka Connect, tasks got `preCommit()` method with default implementation that simply calls `flush()`. Some tasks override `preCommit()` directly, now KCA Sink supports it.

### Modifications

- support for `preCommit()`
- Avro and Json remapped into Kafka's Struct for the sinks to handle the data correctly
- updated unit tests

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - updated tests in KafkaConnectSinkTest 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

No

### Documentation
  
- [X] no-need-doc 

no changes in API

