### PR TITLE
Forget to update memory usage on producer close

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -884,6 +884,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     format("The producer %s of the topic %s was already closed when closing the producers",
                         producerName, topic));
                 pendingMessages.forEach(msg -> {
+                    client.getMemoryLimitController().releaseMemory(msg.uncompressedSize);
                     msg.sendComplete(ex);
                     msg.cmd.release();
                     msg.recycle();
@@ -907,6 +908,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     log.info("[{}] [{}] Closed Producer", topic, producerName);
                     setState(State.Closed);
                     pendingMessages.forEach(msg -> {
+                        client.getMemoryLimitController().releaseMemory(msg.uncompressedSize);
                         msg.cmd.release();
                         msg.recycle();
                     });


### PR DESCRIPTION
### Motivation

The client doesn't upate the memory counter when producer close

### Modifications

When the producer close, update the memory usage too.

### Documentation

We don't need to update docs, because it's a bug fix.
