### PR TITLE
[Branch-2.7]Forbid to read other topic's data in managedLedger layer

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1660,8 +1660,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (!ledgers.containsKey(position.getLedgerId())) {
             log.error("[{}] Failed to get message with ledger {}:{} the ledgerId does not belong to this topic.",
                 name, position.getLedgerId(), position.getEntryId());
-            callback.readEntryFailed(new ManagedLedgerException("Message not found, the ledgerId does not " +
-                "belong to this topic"), ctx);
+            callback.readEntryFailed(new ManagedLedgerException.NonRecoverableLedgerException("Message not found, "
+                + "the ledgerId does not belong to this topic or has been deleted"), ctx);
             return;
         }
         if (position.getLedgerId() == currentLedger.getId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1657,6 +1657,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Reading entry ledger {}: {}", name, position.getLedgerId(), position.getEntryId());
         }
+        if (!ledgers.containsKey(position.getLedgerId())) {
+            log.error("[{}] Failed to get message with ledger {}:{} the ledgerId does not belong to this topic.",
+                name, position.getLedgerId(), position.getEntryId());
+            callback.readEntryFailed(new ManagedLedgerException("Message not found, the ledgerId does not " +
+                "belong to this topic"), ctx);
+            return;
+        }
         if (position.getLedgerId() == currentLedger.getId()) {
             asyncReadEntry(currentLedger, position, callback, ctx);
         } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3010,7 +3010,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             Assert.fail();
         } catch (Exception e) {
             assertEquals(e.getCause().getMessage(),
-                "Message not found, the ledgerId does not belong to this topic");
+                "Message not found, the ledgerId does not belong to this topic or has been deleted");
         }
 
         managedLedgerA.close();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2966,4 +2966,55 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         cursor3.close();
         ledger.close();
     }
+
+    @Test(timeOut = 30000)
+    public void testReadOtherManagedLedgersEntry() throws Exception {
+        ManagedLedgerImpl managedLedgerA = (ManagedLedgerImpl) factory.open("my_test_ledger_a");
+        ManagedLedgerImpl managedLedgerB = (ManagedLedgerImpl) factory.open("my_test_ledger_b");
+
+        PositionImpl pa = (PositionImpl) managedLedgerA.addEntry("dummy-entry-a".getBytes(Encoding));
+        PositionImpl pb = (PositionImpl) managedLedgerB.addEntry("dummy-entry-b".getBytes(Encoding));
+
+        // read managedLegerA's entry using managedLedgerA
+        CompletableFuture<byte[]> completableFutureA = new CompletableFuture<>();
+        managedLedgerA.asyncReadEntry(pa, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                completableFutureA.complete(entry.getData());
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                completableFutureA.completeExceptionally(exception.getCause());
+            }
+        }, null);
+
+        assertEquals("dummy-entry-a".getBytes(Encoding), completableFutureA.get());
+
+        // read managedLedgerB's entry using managedLedgerA
+        CompletableFuture<byte[]> completableFutureB = new CompletableFuture<>();
+        managedLedgerA.asyncReadEntry(pb, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                completableFutureB.complete(entry.getData());
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                completableFutureB.completeExceptionally(exception);
+            }
+        }, null);
+
+        try {
+            completableFutureB.get();
+            Assert.fail();
+        } catch (Exception e) {
+            assertEquals(e.getCause().getMessage(),
+                "Message not found, the ledgerId does not belong to this topic");
+        }
+
+        managedLedgerA.close();
+        managedLedgerB.close();
+
+    }
 }


### PR DESCRIPTION
### Motivation
Related to #11852 #11894 #11814

If we use another topic to find the message, it will return the message

### Modification
1. Check the requested ledgerId whether belongs to the current topic before execute read operation in managedLedger layer.