### PR TITLE
[Branch-2.6]Forbid to read other topic's data in managedLedger layer

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1586,8 +1586,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (!ledgers.containsKey(position.getLedgerId())) {
             log.error("[{}] Failed to get message with ledger {}:{} the ledgerId does not belong to this topic.",
                 name, position.getLedgerId(), position.getEntryId());
-            callback.readEntryFailed(new ManagedLedgerException("Message not found, the ledgerId does not " +
-                "belong to this topic"), ctx);
+            callback.readEntryFailed(new ManagedLedgerException.NonRecoverableLedgerException("Message not found, "
+                + "the ledgerId does not belong to this topic or has been deleted"), ctx);
             return;
         }
         if (position.getLedgerId() == currentLedger.getId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1583,6 +1583,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Reading entry ledger {}: {}", name, position.getLedgerId(), position.getEntryId());
         }
+        if (!ledgers.containsKey(position.getLedgerId())) {
+            log.error("[{}] Failed to get message with ledger {}:{} the ledgerId does not belong to this topic.",
+                name, position.getLedgerId(), position.getEntryId());
+            callback.readEntryFailed(new ManagedLedgerException("Message not found, the ledgerId does not " +
+                "belong to this topic"), ctx);
+            return;
+        }
         if (position.getLedgerId() == currentLedger.getId()) {
             asyncReadEntry(currentLedger, position, callback, ctx);
         } else {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2875,7 +2875,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             Assert.fail();
         } catch (Exception e) {
             assertEquals(e.getCause().getMessage(),
-                "Message not found, the ledgerId does not belong to this topic");
+                "Message not found, the ledgerId does not belong to this topic or has been deleted");
         }
 
         managedLedgerA.close();


### PR DESCRIPTION
### Motivation
Related to #11852 #11894 #11814

If we use another topic to find the message, it will return the message

### Modification
1. Check the requested ledgerId whether belongs to the current topic before execute read operation in managedLedger layer.