### PR TITLE
Fixed merge conflict on MetadataStoreTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -300,9 +300,9 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void testDeleteRecursive(String provider, String url) throws Exception {
+    public void testDeleteRecursive(String provider,  Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         String prefix = newKey();
 


### PR DESCRIPTION
### Motivation

After merging #11867 and #11778 got independently merged on master, there is a conflict that makes the test to fail since the parameter signature has changed.