### PR TITLE
[broker] add setting to enable CORS

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -33,6 +33,9 @@ webServicePort=8080
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
 
+# comma separated list of origins that are allowed for CORS
+allowedOrigins=
+
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
 advertisedAddress=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -33,7 +33,7 @@ webServicePort=8080
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
 
-# comma separated list of origins that are allowed for CORS
+# comma separated list of origins that are allowed for CORS, i.e.: http://localhost:3333,http://localhost:1234
 allowedOrigins=
 
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -148,6 +148,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String bindAddress = "0.0.0.0";
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Origins that are allowed to do Cross-Origin Resource Sharing (CORS) (as a comma-separated list)"
+    )
+    private Optional<String> allowedOrigins = Optional.empty();
+
+    @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Hostname or IP address the service advertises to the outside world."
             + " If not set, the value of `InetAddress.getLocalHost().getHostname()` is used."

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/CorsFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/CorsFilter.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.web;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
+
+/**
+ * This class separates the CORS handling into an own place.
+ * However, it requires quite some code and inheritance, so I think it is harder to reason about.
+ * Personally I would go with the approach shown in WebService.class
+ */
+
+public class CorsFilter extends CrossOriginFilter {
+
+    private final String allowedOrigins;
+
+    public CorsFilter(String allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    @Override
+    public void init(FilterConfig arg) throws ServletException {
+        super.init(new CorsFilterConfig(allowedOrigins, arg));
+    }
+
+    public static final class CorsFilterConfig implements FilterConfig {
+
+        private final String filterName;
+        private final ServletContext servletContext;
+        private final Map<String, String> map = new HashMap<>();
+
+        public CorsFilterConfig(String allowedOrigins, FilterConfig filterConfig) {
+            this.filterName = filterConfig.getFilterName();
+            this.servletContext = filterConfig.getServletContext();
+
+            map.put(ALLOWED_ORIGINS_PARAM, allowedOrigins);
+            map.put(ALLOWED_METHODS_PARAM, "POST,GET,OPTIONS,PUT,DELETE,HEAD");
+            map.put(ALLOWED_HEADERS_PARAM, "Origin, X-Requested-With, Content-Type, Accept");
+            map.put(PREFLIGHT_MAX_AGE_PARAM, "86400"); // 24 hours
+            map.put(ALLOW_CREDENTIALS_PARAM, "true");
+        }
+
+        @Override
+        public String getFilterName() {
+            return filterName;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return servletContext;
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            return map.get(s);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return Collections.enumeration(this.map.keySet());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation


I want to develop an own frontend (SPA) for Pulsar, similar to Pulsar Manager. The frontend should be able to make REST calls directly to a (local) broker. Currently, the browser blocks the requests, due to different origins for front- and backend (CORS policy). I know it could be worked around with a reverse proxy, but I would like to keep the setup simple.

See also 
- https://github.com/apache/pulsar-manager/issues/219
- https://github.com/streamnative/pulsar-manager/issues/26

### Modifications

Add a servlet Filter that adds the required CORS headers, if `allowedOrigins` are configured.

### Verifying this change

This change added tests and can be verified as follows:

Since CORS is a security measure that requires a browser, I am not sure how this can be tested best in your CI. Maybe just test that the header is present if the setting is active? Would need some guidance on this. 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no - value is empty by default
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Need to update docs? 
  
- [ x ] no-need-doc 
  
Looks like doc for `ServiceConfiguration` is generated from the annotation.


