### PR TITLE
Fix messages in TopicPolicies will never be cleaned up

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -98,8 +98,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             } else {
                 PulsarEvent event = getPulsarEvent(topicName, actionType, policies);
                 CompletableFuture<MessageId> actionFuture =
-                        ActionType.DELETE.equals(actionType)
-                                ? writer.deleteAsync(event) : writer.writeAsync(event);
+                        ActionType.DELETE.equals(actionType) ? writer.deleteAsync(event) : writer.writeAsync(event);
                 actionFuture.whenComplete(((messageId, e) -> {
                             if (e != null) {
                                 result.completeExceptionally(e);
@@ -342,6 +341,16 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     break;
                 case UPDATE:
                     policiesCache.put(topicName, event.getPolicies());
+                    break;
+                case DELETE:
+                    // Since PR #11928, this branch is no longer needed.
+                    // However, due to compatibility, it is temporarily retained here
+                    // and can be deleted in the future.
+                    policiesCache.remove(topicName);
+                    SystemTopicClient<PulsarEvent> systemTopicClient = namespaceEventsSystemTopicFactory
+                            .createTopicPoliciesSystemTopicClient(topicName.getNamespaceObject());
+                    systemTopicClient.newWriterAsync().thenAccept(writer
+                            -> writer.deleteAsync(getPulsarEvent(topicName, ActionType.DELETE, null)));
                     break;
                 case NONE:
                     break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -350,7 +350,12 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     SystemTopicClient<PulsarEvent> systemTopicClient = namespaceEventsSystemTopicFactory
                             .createTopicPoliciesSystemTopicClient(topicName.getNamespaceObject());
                     systemTopicClient.newWriterAsync().thenAccept(writer
-                            -> writer.deleteAsync(getPulsarEvent(topicName, ActionType.DELETE, null)));
+                            -> writer.deleteAsync(getPulsarEvent(topicName, ActionType.DELETE, null))
+                            .whenComplete((result, e) -> writer.closeAsync().whenComplete((res, ex) -> {
+                                if (ex != null) {
+                                    log.error("close writer failed ", ex);
+                                }
+                            })));
                     break;
                 case NONE:
                     break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -129,16 +129,16 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     private PulsarEvent getPulsarEvent(TopicName topicName, ActionType actionType, TopicPolicies policies) {
         return PulsarEvent.builder()
                 .actionType(actionType)
-        .eventType(EventType.TOPIC_POLICY)
-        .topicPoliciesEvent(
-            TopicPoliciesEvent.builder()
-                .domain(topicName.getDomain().toString())
-                .tenant(topicName.getTenant())
-                .namespace(topicName.getNamespaceObject().getLocalName())
-                .topic(TopicName.get(topicName.getPartitionedTopicName()).getLocalName())
-                .policies(policies)
-                .build())
-        .build();
+                .eventType(EventType.TOPIC_POLICY)
+                .topicPoliciesEvent(
+                        TopicPoliciesEvent.builder()
+                                .domain(topicName.getDomain().toString())
+                                .tenant(topicName.getTenant())
+                                .namespace(topicName.getNamespaceObject().getLocalName())
+                                .topic(TopicName.get(topicName.getPartitionedTopicName()).getLocalName())
+                                .policies(policies)
+                                .build())
+                .build();
     }
 
     private void notifyListener(Message<PulsarEvent> msg) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -106,6 +106,25 @@ public interface SystemTopicClient<T> {
         CompletableFuture<MessageId> writeAsync(T t);
 
         /**
+         * Delete event in the system topic.
+         * @param t pulsar event
+         * @return message id
+         * @throws PulsarClientException exception while write event cause
+         */
+        default MessageId delete(T t) throws PulsarClientException {
+            throw new UnsupportedOperationException("Unsupported operation");
+        }
+
+        /**
+         * Async delete event in the system topic.
+         * @param t pulsar event
+         * @return message id future
+         */
+        default CompletableFuture<MessageId> deleteAsync(T t) {
+            throw new UnsupportedOperationException("Unsupported operation");
+        }
+
+        /**
          * Close the system topic writer.
          */
         void close() throws IOException;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.events.ActionType;
 import org.apache.pulsar.common.events.PulsarEvent;
 import org.apache.pulsar.common.naming.TopicName;
 import org.slf4j.Logger;
@@ -88,6 +89,18 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
             return producer.newMessage().key(getEventKey(event)).value(event).sendAsync();
         }
 
+        @Override
+        public MessageId delete(PulsarEvent event) throws PulsarClientException {
+            validateActionType(event);
+            return producer.newMessage().key(getEventKey(event)).value(null).send();
+        }
+
+        @Override
+        public CompletableFuture<MessageId> deleteAsync(PulsarEvent event) {
+            validateActionType(event);
+            return producer.newMessage().key(getEventKey(event)).value(null).sendAsync();
+        }
+
         private String getEventKey(PulsarEvent event) {
             return TopicName.get(event.getTopicPoliciesEvent().getDomain(),
                 event.getTopicPoliciesEvent().getTenant(),
@@ -112,6 +125,12 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
         @Override
         public SystemTopicClient<PulsarEvent> getSystemTopicClient() {
             return systemTopicClient;
+        }
+    }
+
+    private static void validateActionType(PulsarEvent event) {
+        if (event == null || !ActionType.DELETE.equals(event.getActionType())) {
+            throw new UnsupportedOperationException("The only supported ActionType is DELETE");
         }
     }
 


### PR DESCRIPTION
### Motivation
The current Topic Policies use compaction topic.
When a compaction topic deletes a message, the body of the message must be null.
Now, even if policies are being deleted, the body of the message is not null.
This will cause some messages in compaction topic never be cleaned up.

### Modifications
1）When deleting policies, set the message body to null
2）Add a delete API instead of modifying write API




