### PR TITLE
[pulsar-client]Add a optional params scope for pulsar oauth2 client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -46,7 +46,11 @@ public final class AuthenticationFactoryOAuth2 {
      * @param issuerUrl the issuer URL
      * @param credentialsUrl the credentials URL
      * @param audience the audience identifier
-     * @param scope the scope
+     * @param scope An optional field. The value of the scope parameter is expressed as a list of space-delimited,
+     *              case-sensitive strings.  The strings are defined by the authorization server.
+     *              If the value contains multiple space-delimited strings, their order does not matter,
+     *              and each string adds an additional access range to the requested scope.
+     *              From here: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2
      * @return an Authentication object
      */
     public static Authentication clientCredentials(URL issuerUrl, URL credentialsUrl, String audience, String scope) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -37,10 +37,24 @@ public final class AuthenticationFactoryOAuth2 {
      * @return an Authentication object
      */
     public static Authentication clientCredentials(URL issuerUrl, URL credentialsUrl, String audience) {
+        return clientCredentials(issuerUrl, credentialsUrl, audience, null);
+    }
+
+    /**
+     * Authenticate with client credentials.
+     *
+     * @param issuerUrl the issuer URL
+     * @param credentialsUrl the credentials URL
+     * @param audience the audience identifier
+     * @param scope the scope
+     * @return an Authentication object
+     */
+    public static Authentication clientCredentials(URL issuerUrl, URL credentialsUrl, String audience, String scope) {
         ClientCredentialsFlow flow = ClientCredentialsFlow.builder()
                 .issuerUrl(issuerUrl)
                 .privateKey(credentialsUrl.toExternalForm())
                 .audience(audience)
+                .scope(scope)
                 .build();
         return new AuthenticationOAuth2(flow, Clock.systemDefaultZone());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -46,21 +46,24 @@ class ClientCredentialsFlow extends FlowBase {
     public static final String CONFIG_PARAM_ISSUER_URL = "issuerUrl";
     public static final String CONFIG_PARAM_AUDIENCE = "audience";
     public static final String CONFIG_PARAM_KEY_FILE = "privateKey";
+    public static final String CONFIG_PARAM_SCOPE = "scope";
 
     private static final long serialVersionUID = 1L;
 
     private final String audience;
     private final String privateKey;
+    private final String scope;
 
     private transient ClientCredentialsExchanger exchanger;
 
     private boolean initialized = false;
 
     @Builder
-    public ClientCredentialsFlow(URL issuerUrl, String audience, String privateKey) {
+    public ClientCredentialsFlow(URL issuerUrl, String audience, String privateKey, String scope) {
         super(issuerUrl);
         this.audience = audience;
         this.privateKey = privateKey;
+        this.scope = scope;
     }
 
     @Override
@@ -87,6 +90,7 @@ class ClientCredentialsFlow extends FlowBase {
                 .clientId(keyFile.getClientId())
                 .clientSecret(keyFile.getClientSecret())
                 .audience(this.audience)
+                .scope(this.scope)
                 .build();
         TokenResult tr;
         if (!initialized) {
@@ -116,10 +120,13 @@ class ClientCredentialsFlow extends FlowBase {
         URL issuerUrl = parseParameterUrl(params, CONFIG_PARAM_ISSUER_URL);
         String audience = parseParameterString(params, CONFIG_PARAM_AUDIENCE);
         String privateKeyUrl = parseParameterString(params, CONFIG_PARAM_KEY_FILE);
+        // This is an optional parameter
+        String scope = params.get(CONFIG_PARAM_SCOPE);
         return ClientCredentialsFlow.builder()
                 .issuerUrl(issuerUrl)
                 .audience(audience)
                 .privateKey(privateKeyUrl)
+                .scope(scope)
                 .build();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/ClientCredentialsExchangeRequest.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/ClientCredentialsExchangeRequest.java
@@ -39,4 +39,7 @@ public class ClientCredentialsExchangeRequest {
 
     @JsonProperty("audience")
     private String audience;
+
+    @JsonProperty("scope")
+    private String scope;
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -27,6 +27,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.asynchttpclient.AsyncHttpClient;
@@ -76,6 +77,9 @@ public class TokenClient implements ClientCredentialsExchanger {
         bodyMap.put("client_id", req.getClientId());
         bodyMap.put("client_secret", req.getClientSecret());
         bodyMap.put("audience", req.getAudience());
+        if (!StringUtils.isBlank(req.getScope())) {
+            bodyMap.put("scope", req.getScope());
+        }
         String body = bodyMap.entrySet().stream()
                 .map(e -> {
                     try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -45,7 +45,7 @@ public class TokenClient implements ClientCredentialsExchanger {
     protected static final int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
 
     private final URL tokenUrl;
-    private final AsyncHttpClient httpClient;
+    AsyncHttpClient httpClient;
 
     public TokenClient(URL tokenUrl) {
         this.tokenUrl = tokenUrl;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -86,6 +86,7 @@ public class AuthenticationOAuth2Test {
         params.put("privateKey", "data:base64,e30=");
         params.put("issuerUrl", "http://localhost");
         params.put("audience", "http://localhost");
+        params.put("scope", "test-scope");
         ObjectMapper mapper = new ObjectMapper();
         String authParams = mapper.writeValueAsString(params);
         this.auth.configure(authParams);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -86,7 +86,6 @@ public class AuthenticationOAuth2Test {
         params.put("privateKey", "data:base64,e30=");
         params.put("issuerUrl", "http://localhost");
         params.put("audience", "http://localhost");
-        params.put("scope", "test-scope");
         ObjectMapper mapper = new ObjectMapper();
         String authParams = mapper.writeValueAsString(params);
         this.auth.configure(authParams);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -1,0 +1,132 @@
+package org.apache.pulsar.client.impl.auth.oauth2.protocol;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+
+/**
+ * Token client exchange token mock test.
+ */
+public class TokenClientTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void exchangeClientCredentialsSuccessByScopeTest() throws
+            IOException, TokenExchangeException, ExecutionException, InterruptedException {
+        DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
+        URL url = new URL("http://localhost");
+        TokenClient tokenClient = new TokenClient(url);
+        tokenClient.httpClient = defaultAsyncHttpClient;
+        Map<String, String> bodyMap = new TreeMap<>();
+        ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
+                .audience("test-audience")
+                .clientId("test-client-id")
+                .clientSecret("test-client-secret")
+                .scope("test-scope")
+                .build();
+        bodyMap.put("grant_type", "client_credentials");
+        bodyMap.put("client_id", request.getClientId());
+        bodyMap.put("client_secret", request.getClientSecret());
+        bodyMap.put("audience", request.getAudience());
+        if (!StringUtils.isBlank(request.getScope())) {
+            bodyMap.put("scope", request.getScope());
+        }
+        String body = bodyMap.entrySet().stream()
+            .map(e -> {
+                try {
+                    return URLEncoder.encode(
+                            e.getKey(),
+                            "UTF-8") + '=' + URLEncoder.encode(e.getValue(), "UTF-8");
+                } catch (UnsupportedEncodingException e1) {
+                    throw new RuntimeException(e1);
+                }
+            })
+        .collect(Collectors.joining("&"));
+        BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
+        Response response = mock(Response.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
+        when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(listenableFuture.get()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(200);
+        TokenResult tokenResult = new TokenResult();
+        tokenResult.setAccessToken("test-access-token");
+        tokenResult.setIdToken("test-id");
+        when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
+        TokenResult tr = tokenClient.exchangeClientCredentials(request);
+        Assert.assertNotNull(tr);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void exchangeClientCredentialsFailedByScopeTest() throws
+            IOException, TokenExchangeException, ExecutionException, InterruptedException {
+        DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
+        URL url = new URL("http://localhost");
+        TokenClient tokenClient = new TokenClient(url);
+        tokenClient.httpClient = defaultAsyncHttpClient;
+        Map<String, String> bodyMap = new TreeMap<>();
+        ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
+                .audience("test-audience")
+                .clientId("test-client-id")
+                .clientSecret("test-client-secret")
+                .scope("test-scope")
+                .build();
+        bodyMap.put("grant_type", "client_credentials");
+        bodyMap.put("client_id", request.getClientId());
+        bodyMap.put("client_secret", request.getClientSecret());
+        bodyMap.put("audience", request.getAudience());
+        String body = bodyMap.entrySet().stream()
+                .map(e -> {
+                    try {
+                        return URLEncoder.encode(
+                                e.getKey(),
+                                "UTF-8") + '=' + URLEncoder.encode(e.getValue(), "UTF-8");
+                    } catch (UnsupportedEncodingException e1) {
+                        throw new RuntimeException(e1);
+                    }
+                })
+                .collect(Collectors.joining("&"));
+        BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
+        Response response = mock(Response.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
+        when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(listenableFuture.get()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(200);
+        TokenResult tokenResult = new TokenResult();
+        tokenResult.setAccessToken("test-access-token");
+        tokenResult.setIdToken("test-id");
+        when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
+        try {
+            tokenClient.exchangeClientCredentials(request);
+            fail("Because the body is missing the scope parameter, it should fail.");
+        } catch (NullPointerException e) {
+            // Skip this exception
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
 
 /**
  * Token client exchange token mock test.
@@ -59,9 +60,7 @@ public class TokenClientTest {
         bodyMap.put("client_id", request.getClientId());
         bodyMap.put("client_secret", request.getClientSecret());
         bodyMap.put("audience", request.getAudience());
-        if (!StringUtils.isBlank(request.getScope())) {
-            bodyMap.put("scope", request.getScope());
-        }
+        bodyMap.put("scope", request.getScope());
         String body = tokenClient.buildClientCredentialsBody(bodyMap);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
@@ -113,6 +112,11 @@ public class TokenClientTest {
         tokenResult.setAccessToken("test-access-token");
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
-        tokenClient.exchangeClientCredentials(request);
+        try {
+            tokenClient.exchangeClientCredentials(request);
+            fail("Because the body is missing the scope parameter, it should fail.");
+        } catch (NullPointerException e) {
+            // Skip this exception
+        }
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.fail;
 
 /**
  * Token client exchange token mock test.
@@ -84,7 +83,7 @@ public class TokenClientTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void exchangeClientCredentialsFailedByScopeTest() throws
+    public void exchangeClientCredentialsSuccessByNoScopeTest() throws
             IOException, TokenExchangeException, ExecutionException, InterruptedException {
         DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
         URL url = new URL("http://localhost");
@@ -94,7 +93,6 @@ public class TokenClientTest {
                 .audience("test-audience")
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
-                .scope("test-scope")
                 .build();
         bodyMap.put("grant_type", "client_credentials");
         bodyMap.put("client_id", request.getClientId());
@@ -115,11 +113,6 @@ public class TokenClientTest {
         tokenResult.setAccessToken("test-access-token");
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
-        try {
-            tokenClient.exchangeClientCredentials(request);
-            fail("Because the body is missing the scope parameter, it should fail.");
-        } catch (NullPointerException e) {
-            // Skip this exception
-        }
+        tokenClient.exchangeClientCredentials(request);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl.auth.oauth2.protocol;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang3.StringUtils;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.ListenableFuture;
@@ -35,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.fail;
 
 /**
  * Token client exchange token mock test.
@@ -112,11 +110,7 @@ public class TokenClientTest {
         tokenResult.setAccessToken("test-access-token");
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
-        try {
-            tokenClient.exchangeClientCredentials(request);
-            fail("Because the body is missing the scope parameter, it should fail.");
-        } catch (NullPointerException e) {
-            // Skip this exception
-        }
+        TokenResult tr = tokenClient.exchangeClientCredentials(request);
+        Assert.assertNotNull(tr);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.client.impl.auth.oauth2.protocol;
 
 import com.google.gson.Gson;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -28,13 +28,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,8 +48,7 @@ public class TokenClientTest {
             IOException, TokenExchangeException, ExecutionException, InterruptedException {
         DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
         URL url = new URL("http://localhost");
-        TokenClient tokenClient = new TokenClient(url);
-        tokenClient.httpClient = defaultAsyncHttpClient;
+        TokenClient tokenClient = new TokenClient(url, defaultAsyncHttpClient);
         Map<String, String> bodyMap = new TreeMap<>();
         ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
                 .audience("test-audience")
@@ -67,17 +63,7 @@ public class TokenClientTest {
         if (!StringUtils.isBlank(request.getScope())) {
             bodyMap.put("scope", request.getScope());
         }
-        String body = bodyMap.entrySet().stream()
-            .map(e -> {
-                try {
-                    return URLEncoder.encode(
-                            e.getKey(),
-                            "UTF-8") + '=' + URLEncoder.encode(e.getValue(), "UTF-8");
-                } catch (UnsupportedEncodingException e1) {
-                    throw new RuntimeException(e1);
-                }
-            })
-        .collect(Collectors.joining("&"));
+        String body = tokenClient.buildClientCredentialsBody(bodyMap);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -102,8 +88,7 @@ public class TokenClientTest {
             IOException, TokenExchangeException, ExecutionException, InterruptedException {
         DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
         URL url = new URL("http://localhost");
-        TokenClient tokenClient = new TokenClient(url);
-        tokenClient.httpClient = defaultAsyncHttpClient;
+        TokenClient tokenClient = new TokenClient(url, defaultAsyncHttpClient);
         Map<String, String> bodyMap = new TreeMap<>();
         ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
                 .audience("test-audience")
@@ -115,17 +100,7 @@ public class TokenClientTest {
         bodyMap.put("client_id", request.getClientId());
         bodyMap.put("client_secret", request.getClientSecret());
         bodyMap.put("audience", request.getAudience());
-        String body = bodyMap.entrySet().stream()
-                .map(e -> {
-                    try {
-                        return URLEncoder.encode(
-                                e.getKey(),
-                                "UTF-8") + '=' + URLEncoder.encode(e.getValue(), "UTF-8");
-                    } catch (UnsupportedEncodingException e1) {
-                        throw new RuntimeException(e1);
-                    }
-                })
-                .collect(Collectors.joining("&"));
+        String body = tokenClient.buildClientCredentialsBody(bodyMap);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);


### PR DESCRIPTION
### Motivation

In some scenarios (e.g. azure cloud), when the client exchanges tokens with the server, an optional scope parameter is required, this pr fixes this issue, to ensure compatibility, when the user does not fill in this parameter, all behavior is the same as before.

### Modifications

* Add an optional parameter scope when exchanges token

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] doc-required 
https://github.com/apache/pulsar/issues/11932
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


