### PR TITLE
Update the default log pattern

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.tests;
 
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.LockInfo;
@@ -68,7 +70,8 @@ public class ThreadDumpUtil {
         // fallback to using JMX for creating the thread dump
         StringBuilder dump = new StringBuilder();
 
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        DateFormat dateFormat = new SimpleDateFormat(
+            FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
         dump.append(String.format("Timestamp: %s", dateFormat.format(new Date())));
         dump.append("\n\n");
 

--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level [%t{12}] %c{1.}@%L - %msg %X%n" />
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.}@%L - %msg %X%n" />
         </Console>
     </Appenders>
     <Loggers>

--- a/conf/functions_log4j2.xml
+++ b/conf/functions_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -54,7 +54,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
 
     # Rolling file appender configuration
     RollingFile:
@@ -63,7 +63,7 @@ Configuration:
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
       immediateFlush: false
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.util.DirectMemoryUtils;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -316,7 +317,8 @@ public class PulsarBrokerStarter {
 
 
     public static void main(String[] args) throws Exception {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        DateFormat dateFormat = new SimpleDateFormat(
+            FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
         Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
             System.out.println(String.format("%s [%s] error Uncaught exception in thread %s: %s",
                     dateFormat.format(new Date()), thread.getContextClassLoader(),

--- a/pulsar-client-cpp/include/pulsar/ConsoleLoggerFactory.h
+++ b/pulsar-client-cpp/include/pulsar/ConsoleLoggerFactory.h
@@ -29,10 +29,10 @@ class ConsoleLoggerFactoryImpl;
  * The default LoggerFactory of Client if `USE_LOG4CXX` macro was not defined during compilation.
  *
  *
- * The log format is "yyyy-mm-dd hh:MM:ss.xxx <level> <thread-id> <file>:<line> | <msg>", like
+ * The log format is "yyyy-MM-dd HH:mm:ss,SSS Z <level> <thread-id> <file>:<line> | <msg>", like
  *
  * ```
- * 2021-03-24 17:35:46.571 INFO  [0x10a951e00] ConnectionPool:85 | Created connection for ...
+ * 2021-03-24 17:35:46,571 +0800 INFO  [0x10a951e00] ConnectionPool:85 | Created connection for ...
  * ```
  *
  * It uses `std::cout` to prints logs to standard output. You can use this factory class to change your log

--- a/pulsar-client-cpp/include/pulsar/FileLoggerFactory.h
+++ b/pulsar-client-cpp/include/pulsar/FileLoggerFactory.h
@@ -28,10 +28,10 @@ class FileLoggerFactoryImpl;
 /**
  * A logger factory that is appending logs to a single file.
  *
- * The log format is "yyyy-mm-dd hh:MM:ss.xxx <level> <thread-id> <file>:<line> | <msg>", like
+ * The log format is "yyyy-MM-dd HH:mm:ss,SSS Z <level> <thread-id> <file>:<line> | <msg>", like
  *
  * ```
- * 2021-03-24 17:35:46.571 INFO  [0x10a951e00] ConnectionPool:85 | Created connection for ...
+ * 2021-03-24 17:35:46,571 +0800 INFO  [0x10a951e00] ConnectionPool:85 | Created connection for ...
  * ```
  *
  * Example:

--- a/pulsar-client-cpp/lib/Log4cxxLogger.cc
+++ b/pulsar-client-cpp/lib/Log4cxxLogger.cc
@@ -66,7 +66,7 @@ std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create() {
     if (!LogManager::getLoggerRepository()->isConfigured()) {
         LogManager::getLoggerRepository()->setConfigured(true);
         LoggerPtr root = log4cxx::Logger::getRootLogger();
-        static const LogString TTCC_CONVERSION_PATTERN(LOG4CXX_STR("%d{HH:mm:ss.SSS} [%t] %-5p %l - %m%n"));
+        static const LogString TTCC_CONVERSION_PATTERN(LOG4CXX_STR("%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%t] %-5p %l - %m%n"));
         LayoutPtr layout(new PatternLayout(TTCC_CONVERSION_PATTERN));
         AppenderPtr appender(new ConsoleAppender(layout));
         root->setLevel(log4cxx::Level::getInfo());

--- a/pulsar-client-cpp/lib/Log4cxxLogger.cc
+++ b/pulsar-client-cpp/lib/Log4cxxLogger.cc
@@ -66,7 +66,8 @@ std::unique_ptr<LoggerFactory> Log4CxxLoggerFactory::create() {
     if (!LogManager::getLoggerRepository()->isConfigured()) {
         LogManager::getLoggerRepository()->setConfigured(true);
         LoggerPtr root = log4cxx::Logger::getRootLogger();
-        static const LogString TTCC_CONVERSION_PATTERN(LOG4CXX_STR("%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%t] %-5p %l - %m%n"));
+        static const LogString TTCC_CONVERSION_PATTERN(
+            LOG4CXX_STR("%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%t] %-5p %l - %m%n"));
         LayoutPtr layout(new PatternLayout(TTCC_CONVERSION_PATTERN));
         AppenderPtr appender(new ConsoleAppender(layout));
         root->setLevel(log4cxx::Level::getInfo());

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -156,6 +156,10 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
 
   </dependencies>
 </project>

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceStarter.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceStarter.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.util.CmdGenerateDocs;
 import org.apache.pulsar.discovery.service.DiscoveryService;
@@ -65,7 +66,8 @@ public class DiscoveryServiceStarter {
         removeHandlersForRootLogger();
         install();
 
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        DateFormat dateFormat = new SimpleDateFormat(
+            FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
         Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
             System.out.println(String.format("%s [%s] error Uncaught exception in thread %s: %s", dateFormat.format(new Date()), thread.getContextClassLoader(), thread.getName(), exception.getMessage()));
         });

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -36,7 +36,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>canal.client</artifactId>
             <version>1.1.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalStringSource.java
+++ b/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalStringSource.java
@@ -29,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import com.alibaba.fastjson.JSON;
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 
@@ -55,7 +56,8 @@ public class CanalStringSource extends CanalAbstractSource<CanalMessage> {
         String messages = JSON.toJSONString(flatMessages, SerializerFeature.WriteMapNullValue);
         CanalMessage canalMessage = new CanalMessage();
         Date date = new Date();
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat(
+            FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
         canalMessage.setTimestamp(dateFormat.format(date));
         canalMessage.setId(this.messageId);
         canalMessage.setMessage(messages);

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -174,6 +174,10 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+      </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -27,6 +27,7 @@ import static org.slf4j.bridge.SLF4JBridgeHandler.install;
 import static org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
@@ -103,7 +104,8 @@ public class ProxyServiceStarter {
             removeHandlersForRootLogger();
             install();
 
-            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+            DateFormat dateFormat = new SimpleDateFormat(
+                FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
             Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
                 System.out.println(String.format("%s [%s] error Uncaught exception in thread %s: %s", dateFormat.format(new Date()), thread.getContextClassLoader(), thread.getName(), exception.getMessage()));
             });

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -683,7 +683,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -692,7 +692,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -725,7 +725,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -830,7 +830,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/site2/website/versioned_docs/version-2.7.2/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.7.2/functions-develop.md
@@ -684,7 +684,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -693,7 +693,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -726,7 +726,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -831,7 +831,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/site2/website/versioned_docs/version-2.7.3/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.7.3/functions-develop.md
@@ -684,7 +684,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -693,7 +693,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -726,7 +726,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -831,7 +831,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/site2/website/versioned_docs/version-2.8.0/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-develop.md
@@ -684,7 +684,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -693,7 +693,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -726,7 +726,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -831,7 +831,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/site2/website/versioned_docs/version-2.8.1/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.8.1/functions-develop.md
@@ -684,7 +684,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -693,7 +693,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -726,7 +726,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -831,7 +831,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/site2/website/versioned_docs/version-2.8.2/functions-develop.md
+++ b/site2/website/versioned_docs/version-2.8.2/functions-develop.md
@@ -684,7 +684,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -693,7 +693,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -726,7 +726,7 @@ To customize the function log level, create or update `functions_log4j2.xml` in 
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -831,7 +831,7 @@ The `<AppenderRef>` is defined in the `<Appenders>` section, such as:
   <name>Console</name>
   <target>SYSTEM_OUT</target>
   <PatternLayout>
-    <Pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Pattern>
+    <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
   </PatternLayout>
 </Console>
 ```

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,7 +33,7 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C@%L] %-5level %logger{36} - %msg%n"
     File:
       name: File
       fileName: ${filename}


### PR DESCRIPTION
Master Issue: [#8298](https://github.com/apache/pulsar/issues/8298)

### Motivation

To make it easy to track problems and resolve them, we should add date for the logs by default.

### Modifications

Updated the default logs pattern, added date.

### Verifying this change

No tests involved.

Before the change:
![before-change](https://user-images.githubusercontent.com/55134131/132304198-6544bcc7-25c1-43eb-adad-518114c1a2b5.jpg)

After the change:
![after-change](https://user-images.githubusercontent.com/55134131/132339368-94b1ace6-7ae2-4275-8536-d6393a325947.jpg)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [ ] doc-required 
- [x] no-need-doc 
- [ ] doc 



