### PR TITLE
[Issue #11799][logging] PIP-89: Timed log events

### DIFF
--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/slf4j/Slf4jStructuredEventLog.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/slf4j/Slf4jStructuredEventLog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.structuredeventlog.slf4j;
 
+import java.time.Clock;
+
 import org.apache.pulsar.structuredeventlog.Event;
 import org.apache.pulsar.structuredeventlog.EventResources;
 import org.apache.pulsar.structuredeventlog.EventResourcesImpl;
@@ -25,10 +27,12 @@ import org.apache.pulsar.structuredeventlog.StructuredEventLog;
 
 public class Slf4jStructuredEventLog implements StructuredEventLog {
     public static Slf4jStructuredEventLog INSTANCE = new Slf4jStructuredEventLog();
+    // Visible for testing
+    Clock clock = Clock.systemUTC();
 
     @Override
     public Event newRootEvent() {
-        return new Slf4jEvent(null).traceId(Slf4jEvent.randomId());
+        return new Slf4jEvent(clock, null).traceId(Slf4jEvent.randomId());
     }
 
     @Override


### PR DESCRIPTION
Allow log events to be timed. When the user marks an event as timed,
the duration between the marking and the logging will be added to the
final log event.

