### PR TITLE
Fix permissions of docker images scripts packaged in source tar ball

### DIFF
--- a/src/assembly-source-package.xml
+++ b/src/assembly-source-package.xml
@@ -106,6 +106,7 @@
       <outputDirectory>/docker/pulsar/scripts</outputDirectory>
       <includes>
         <include>*.sh</include>
+        <include>*.py</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>


### PR DESCRIPTION
### Motivation

The `/pulsar/bin/apply-config-from-env.py` script doesn't have execution permission when the docker image is built from the source tar ball.

Building the docker image 2.8.1-rc3 from the **source tar ball** leads to images having too strict permissions for python scripts in `docker/pulsar/scripts`.

I have generated the pulsar docker images from the source tar ball using the commands:

```
mvn clean install -DskipTests
mvn package -Pdocker,-main -am -pl docker/pulsar-all -DskipTests
```

And then pushed the images to a docker hub [repo](https://hub.docker.com/layers/165949556/massimilianomirelli/pulsar-all/2.8.1-rc3/images/sha256-8766ee21375d0264f92bb12849b6fcba36e3bba1aaa015c75c2196195c860410?context=repo), which is then used in the `pulsar-values.yaml` to deploy the cluster.

The error 

`sh: 1: bin/apply-config-from-env.py: Permission denied`

manifests when installing the k8s cluster via the command:

`helm install  --namespace mypulsar --wait --debug --timeout 1200s mypulsar datastax-pulsar/pulsar --values pulsar-values.yaml`

on pods:

* `pulsar-function`
* `pulsar-zookeeper`
* `pulsar-autorecovery`



### Modifications

Adding exec permissions to the python scripts in `/docker/pulsar/scripts`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: yes

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
- [x] no-need-doc 
  
  It is just a small fix only impacting deployment on kubernetes.
  
- [ ] doc 

