### PR TITLE
[C++] Handle error when shutting down client after forks

### DIFF
--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -32,9 +32,7 @@ ExecutorService::ExecutorService()
       work_(new BackgroundWork(*io_service_)),
       worker_(std::bind(&ExecutorService::startWorker, this, io_service_)) {}
 
-ExecutorService::~ExecutorService() {
-    close();
-}
+ExecutorService::~ExecutorService() { close(); }
 
 void ExecutorService::startWorker(std::shared_ptr<boost::asio::io_service> io_service) { io_service_->run(); }
 
@@ -75,9 +73,9 @@ void ExecutorService::close() {
     if (worker_.joinable()) {
         try {
             worker_.detach();
-        } catch (const std::system_error& e) {
-            // This condition will happen if we're forking the process, therefore the thread was not ported to the
-            // child side of the fork and the detach would be failing.
+        } catch (const std::system_error &e) {
+            // This condition will happen if we're forking the process, therefore the thread was not ported to
+            // the child side of the fork and the detach would be failing.
             LOG_DEBUG("Failed to detach thread: " << e.what());
         }
     }

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -22,6 +22,9 @@
 #include <functional>
 #include <memory>
 
+#include "LogUtils.h"
+DECLARE_LOG_OBJECT()
+
 namespace pulsar {
 
 ExecutorService::ExecutorService()
@@ -31,11 +34,6 @@ ExecutorService::ExecutorService()
 
 ExecutorService::~ExecutorService() {
     close();
-    // If the worker_ is still not joinable at this point just detach
-    // the thread so its destructor does not terminate the app
-    if (worker_.joinable()) {
-        worker_.detach();
-    }
 }
 
 void ExecutorService::startWorker(std::shared_ptr<boost::asio::io_service> io_service) { io_service_->run(); }
@@ -75,7 +73,13 @@ void ExecutorService::close() {
     work_.reset();
     // Detach the worker thread instead of join to avoid potential deadlock
     if (worker_.joinable()) {
-        worker_.detach();
+        try {
+            worker_.detach();
+        } catch (const std::system_error& e) {
+            // This condition will happen if we're forking the process, therefore the thread was not ported to the
+            // child side of the fork and the detach would be failing.
+            LOG_DEBUG("Failed to detach thread: " << e.what());
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

Fix #11953

After a `fork()` call, the threads are not getting ported to the child process (at least not most of them). When we're shutting down the pulsar client, we should handle the exception

I didn't add a specific error check since there's no portable error code to be used.