### PR TITLE
[Python] Expose Client.shutdown() method

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -865,6 +865,15 @@ class Client:
         _check_type(str, topic, 'topic')
         return self._client.get_topic_partitions(topic)
 
+    def shutdown(self):
+        """
+        Perform immediate shutdown of Pulsar client.
+
+        Release all resources and close all producer, consumer, and readers without waiting
+        for ongoing operations to complete.
+        """
+        self._client.shutdown()
+
     def close(self):
         """
         Close the client and all the associated producers and consumers

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -1147,6 +1147,19 @@ class PulsarTest(TestCase):
         self.assertTrue(msg.topic_name() in partitions)
         client.close()
 
+    def test_shutdown_client(self):
+        client = Client(self.serviceUrl)
+        producer = client.create_producer('persistent://public/default/partitioned_topic_name_test')
+        producer.send(b'hello')
+        client.shutdown()
+
+        try:
+            producer.send(b'hello')
+            self.assertTrue(False)
+        except pulsar.PulsarException:
+            # Expected
+            pass
+
     def test_negative_acks(self):
         client = Client(self.serviceUrl)
         consumer = client.subscribe('test_negative_acks',


### PR DESCRIPTION
### Motivation

Similar to what we expose in Java and C++ client, we should expose the quick `shutdown()` method on the Python client.