### PR TITLE
[PIP-82] [pulsar-broker] Add missing permission check, fail update on non-existent ResourceGroup

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
@@ -50,6 +50,7 @@ public abstract class ResourceGroupsBase extends AdminResource {
     protected ResourceGroup internalGetResourceGroup(String rgName) {
         try {
             final String resourceGroupPath = AdminResource.path(RESOURCEGROUPS, rgName);
+            validateSuperUserAccess();
             ResourceGroup resourceGroup = resourceGroupResources().get(resourceGroupPath)
                     .orElseThrow(() -> new RestException(Response.Status.NOT_FOUND, "ResourceGroup does not exist"));
             return resourceGroup;
@@ -161,6 +162,7 @@ public abstract class ResourceGroupsBase extends AdminResource {
          * need to walk the namespaces and make sure it is not in use
          */
         try {
+            validateSuperUserAccess();
             /*
              * walk the namespaces and make sure it is not in use.
              */

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ResourceGroup;
 import org.apache.pulsar.common.tls.NoopHostnameVerifier;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
@@ -169,6 +170,72 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
         try (PulsarAdmin admin = buildAdminClient("proxy")) {
             admin.tenants().getTenants();
             Assert.fail("Shouldn't be able to list tenants");
+        } catch (PulsarAdminException.NotAuthorizedException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testSuperUserCanGetResourceGroups() throws Exception {
+        try (PulsarAdmin admin = buildAdminClient("admin")) {
+            admin.resourcegroups().createResourceGroup("test-resource-group",
+                    new ResourceGroup());
+            admin.resourcegroups().getResourceGroup("test-resource-group");
+            Assert.assertEquals(ImmutableSet.of("test-resource-group"),
+                            admin.resourcegroups().getResourceGroups());
+            admin.resourcegroups().getResourceGroup("test-resource-group");
+        }
+    }
+
+    @Test
+    public void testSuperUserCanDeleteResourceGroups() throws Exception {
+        try (PulsarAdmin admin = buildAdminClient("admin")) {
+            admin.resourcegroups().createResourceGroup("test-resource-group",
+                    new ResourceGroup());
+            admin.resourcegroups().deleteResourceGroup("test-resource-group");
+        }
+    }
+
+    @Test
+    public void testProxyRoleCantDeleteResourceGroups() throws Exception {
+        try (PulsarAdmin admin = buildAdminClient("admin")) {
+            admin.resourcegroups().createResourceGroup("test-resource-group",
+                    new ResourceGroup());
+        }
+        try (PulsarAdmin admin = buildAdminClient("proxy")) {
+            admin.resourcegroups().deleteResourceGroup("test-resource-group");
+            Assert.fail("Shouldn't be able to delete ResourceGroup");
+        } catch (PulsarAdminException.NotAuthorizedException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testProxyRoleCantCreateResourceGroups() throws Exception {
+        try (PulsarAdmin admin = buildAdminClient("proxy")) {
+            admin.resourcegroups().createResourceGroup("test-resource-group",
+                    new ResourceGroup());
+            Assert.fail("Shouldn't be able to create ResourceGroup");
+        } catch (PulsarAdminException.NotAuthorizedException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testProxyRoleCantGetResourceGroups() throws Exception {
+        try (PulsarAdmin admin = buildAdminClient("admin")) {
+            admin.resourcegroups().createResourceGroup("test-resource-group",
+                    new ResourceGroup());
+        }
+        try (PulsarAdmin admin = buildAdminClient("proxy")) {
+            admin.resourcegroups().getResourceGroups();
+            Assert.fail("Shouldn't be able to list ResourceGroups");
+        } catch (PulsarAdminException.NotAuthorizedException e) {
+            // expected
+        }
+        try (PulsarAdmin admin = buildAdminClient("proxy")) {
+            admin.resourcegroups().getResourceGroup("test-resource-group");
+            Assert.fail("Shouldn't be able to get ResourceGroup");
         } catch (PulsarAdminException.NotAuthorizedException e) {
             // expected
         }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.ResourceGroups;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
+import org.apache.pulsar.common.util.RestException;
 
 
 public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
@@ -130,8 +131,9 @@ public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
     @Override
     public void updateResourceGroup(String name, ResourceGroup resourcegroup) throws PulsarAdminException {
         try {
+            getResourceGroup(name);
             updateResourceGroupAsync(name, resourcegroup).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | RestException e) {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION


### Motivation

Fix a few small issues found during testing and code inspection.


### Modifications

*Added missing check for permissions for certain ResourceGroup operations.
*Check if ResourceGroup exists before proceeding to update in pulsar-admin.


### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] tested manually


### Documentation
    
- [x] no-need-doc 
  

