### PR TITLE
[C++] Fixed attempting to connect to multiple IP addresses

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -544,7 +544,7 @@ void ClientConnection::handleResolve(const boost::system::error_code& err,
     if (endpointIterator != tcp::resolver::iterator()) {
         LOG_DEBUG(cnxString_ << "Resolved hostname " << endpointIterator->host_name()  //
                              << " to " << endpointIterator->endpoint());
-        socket_->async_connect(*endpointIterator++,
+        socket_->async_connect(*endpointIterator,
                                std::bind(&ClientConnection::handleTcpConnected, shared_from_this(),
                                          std::placeholders::_1, endpointIterator));
     } else {


### PR DESCRIPTION
### Motivation

Fix #11950

In #11557 there was a fix to advance the DNS resolver result iterator before attempting to reconnect to the subsequent IP results. 

The problem was that the 1st increment was not removed, so we were left to always skip the 2nd DNS result.