### PR TITLE
[Issue #11799][logging] PIP-89: Enum based logging

### DIFF
--- a/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/EventGroup.java
+++ b/structured-event-log/src/main/java/org/apache/pulsar/structuredeventlog/EventGroup.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.structuredeventlog;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(value=RetentionPolicy.RUNTIME)
+public @interface EventGroup {
+    String component();
+}

--- a/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
+++ b/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig ;
 import org.apache.logging.log4j.core.layout.JsonLayout;
 import org.apache.pulsar.structuredeventlog.Event;
+import org.apache.pulsar.structuredeventlog.EventGroup;
 import org.apache.pulsar.structuredeventlog.EventResources;
 import org.apache.pulsar.structuredeventlog.StructuredEventLog;
 import org.testng.annotations.BeforeMethod;
@@ -354,6 +355,23 @@ public class StructuredEventLogTest {
         assertThat(logged.get(0).get("message"), equalTo("timed"));
         assertThat(contextMapField(logged.get(0), "startTimestamp"), equalTo("1970-01-02T03:46:40Z"));
         assertThat(contextMapField(logged.get(0), "durationMs"), equalTo("1234"));
+    }
+
+    @EventGroup(component="foobar")
+    public enum Events {
+        TEST_EVENT
+    }
+
+    @Test
+    public void testEventGroups() throws Exception {
+        StructuredEventLog log = StructuredEventLog.newLogger();
+        log.newRootEvent().log(Events.TEST_EVENT);
+
+        List<Map<String, Object>> logged = getLogged();
+        System.out.println(logged);
+        assertThat(logged.get(0).get("message"), equalTo("TEST_EVENT"));
+        assertThat(logged.get(0).get("loggerName"), equalTo("stevlog.foobar.TEST_EVENT"));
+        assertThat(contextMapField(logged.get(0), "component"), equalTo("foobar"));
     }
 
     @SuppressWarnings("unchecked")

--- a/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
+++ b/structured-event-log/src/test/java/org/apache/pulsar/structuredeventlog/slf4j/StructuredEventLogTest.java
@@ -374,6 +374,22 @@ public class StructuredEventLogTest {
         assertThat(contextMapField(logged.get(0), "component"), equalTo("foobar"));
     }
 
+    public enum BareEvents {
+        BARE_EVENT
+    }
+
+    @Test
+    public void testBareEnum() throws Exception {
+        StructuredEventLog log = StructuredEventLog.newLogger();
+        log.newRootEvent().log(BareEvents.BARE_EVENT);
+
+        List<Map<String, Object>> logged = getLogged();
+        System.out.println(logged);
+        assertThat(logged.get(0).get("message"), equalTo("BARE_EVENT"));
+        assertThat(logged.get(0).get("loggerName"), equalTo("stevlog.BARE_EVENT"));
+        assertThat(contextMapField(logged.get(0), "component"), nullValue());
+    }
+
     @SuppressWarnings("unchecked")
     private Object contextMapField(Map<String, Object> map, String field) {
         return ((Map<String, Object>)map.get("contextMap")).get(field);


### PR DESCRIPTION
Log an enum constant rather than a raw string. This allows component
annotation and javadoc to be attached to the log event.


