### PR TITLE
Print position info when can't find next valid position.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3281,7 +3281,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         } catch (NullPointerException e) {
             next = lastConfirmedEntry.getNext();
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Can't find next valid position, fall back to the next position of the last position.", name, e);
+                log.debug("[{}] Can't find next valid position : {}, fall back to the next position of the last position : {}.", position, name, next, e);
             }
         }
         return next;


### PR DESCRIPTION
## Motivation
When the user reset the cursor and does not find the next valid one, the original log does'nt print position info.
```
12:13:36.676 [pulsar-web-67-14] INFO  org.apache.pulsar.broker.service.persistent.PersistentSubscription - [persistent://public/default/test][sub] Successfully disconnected consumers from subscription, proceeding with cursor reset
12:13:36.676 [bookkeeper-ml-workers-OrderedExecutor-2-0] ERROR org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/test] Can't find next valid position, fail back to the next position of the last position.
java.lang.NullPointerException: null
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.getNextValidPositionInternal(ManagedLedgerImpl.java:3031) ~[io.streamnative-managed-ledger-2.7.2.10.jar:2.7.2.10]
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.getNextValidPosition(ManagedLedgerImpl.java:3018) ~[io.streamnative-managed-ledger-2.7.2.10.jar:2.7.2.10]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.lambda$asyncResetCursor$6(ManagedCursorImpl.java:1086) ~[io.streamnative-managed-ledger-2.7.2.10.jar:2.7.2.10]
	at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) [io.streamnative-managed-ledger-2.7.2.10.jar:2.7.2.10]
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [org.apache.bookkeeper-bookkeeper-common-4.12.0.jar:4.12.0]
	at org.apache.bookkeeper.common.util.OrderedExecutor$TimedRunnable.run(OrderedExecutor.java:203) [org.apache.bookkeeper-bookkeeper-common-4.12.0.jar:4.12.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_281]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_281]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.60.Final.jar:4.1.60.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_281]
```

So it's better to add position info to the log.
