### PR TITLE
[Issue-11966][pulsar-proxy] set default http proxy request timeout

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -95,6 +95,8 @@ class AdminProxyHandler extends ProxyServlet {
                 : config.getBrokerWebServiceURL();
         this.functionWorkerWebServiceUrl = config.isTlsEnabledWithBroker() ? config.getFunctionWorkerWebServiceURLTLS()
                 : config.getFunctionWorkerWebServiceURL();
+
+        super.setTimeout(config.getHttpProxyTimeout());
     }
 
     @Override
@@ -135,11 +137,6 @@ class AdminProxyHandler extends ProxyServlet {
         if (value == null)
             value = "30000";
         client.setIdleTimeout(Long.parseLong(value));
-
-        value = config.getInitParameter("connectTimeout");
-        if (value == null)
-            value = "30000";
-        client.setConnectTimeout(Long.parseLong(value));
 
         value = config.getInitParameter("requestBufferSize");
         if (value != null)

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -136,6 +136,11 @@ class AdminProxyHandler extends ProxyServlet {
             value = "30000";
         client.setIdleTimeout(Long.parseLong(value));
 
+        value = config.getInitParameter("connectTimeout");
+        if (value == null)
+            value = "30000";
+        client.setConnectTimeout(Long.parseLong(value));
+
         value = config.getInitParameter("requestBufferSize");
         if (value != null)
             client.setRequestBufferSize(Integer.parseInt(value));

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -491,6 +491,14 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private int httpInputMaxReplayBufferSize = 5 * 1024 * 1024;
 
     @FieldContext(
+            minValue = 1,
+            category = CATEGORY_HTTP,
+            doc = "Http proxy timeout.\n\n"
+                    + "The timeout value for HTTP proxy is in millisecond."
+    )
+    private int httpProxyTimeout = 30 * 1000;
+
+    @FieldContext(
            minValue = 1,
            category = CATEGORY_HTTP,
            doc = "Number of threads to use for HTTP requests processing"


### PR DESCRIPTION
Fixes #11966

Address missing http proxy request timeout in issue #11966

### Motivation
Set http proxy request timeout in pulsar-proxy

### Modifications

Set default http proxy request timeout in pulsar-proxy as 30 seconds

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: introduced a new default of proxy HTTP connect timeout
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no



