### PR TITLE
[Issue 11846][Java client] Create a consumer in the paused state

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -775,8 +775,9 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> negativeAckRedeliveryBackoff(NegativeAckRedeliveryBackoff negativeAckRedeliveryBackoff);
 
     /**
-     * Start the consumer in a paused state. When enabled, the consumer will not immediately fetch messages when
-     * {@link #subscribe()} is called. Instead, the consumer will wait to fetch messages until {@link Consumer#resume()} is called.
+     * Start the consumer in a paused state. When enabled, the consumer does not immediately fetch messages when
+     * {@link #subscribe()} is called. Instead, the consumer waits to fetch messages until {@link Consumer#resume()} is
+     * called.
      * <p/>
      * See also {@link Consumer#pause()}.
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -780,6 +780,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * called.
      * <p/>
      * See also {@link Consumer#pause()}.
+     * @default false
      */
-    ConsumerBuilder<T> paused(boolean paused);
+    ConsumerBuilder<T> startPaused(boolean paused);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -773,4 +773,12 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * </pre>
      */
     ConsumerBuilder<T> negativeAckRedeliveryBackoff(NegativeAckRedeliveryBackoff negativeAckRedeliveryBackoff);
+
+    /**
+     * Start the consumer in a paused state. When enabled, the consumer will not immediately fetch messages when
+     * {@link #subscribe()} is called. Instead, the consumer will wait to fetch messages until {@link Consumer#resume()} is called.
+     * <p/>
+     * See also {@link Consumer#pause()}.
+     */
+    ConsumerBuilder<T> paused(boolean paused);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -502,4 +502,10 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         conf.setNegativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
         return this;
     }
+
+    @Override
+    public ConsumerBuilder<T> paused(boolean paused) {
+        conf.setStartPaused(paused);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -504,7 +504,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> paused(boolean paused) {
+    public ConsumerBuilder<T> startPaused(boolean paused) {
         conf.setStartPaused(paused);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -266,6 +266,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.expireTimeOfIncompleteChunkedMessageMillis = conf.getExpireTimeOfIncompleteChunkedMessageMillis();
         this.autoAckOldestChunkedMessageOnQueueFull = conf.isAutoAckOldestChunkedMessageOnQueueFull();
         this.poolMessages = conf.isPoolMessages();
+        this.paused = conf.isStartPaused();
 
         if (client.getConfiguration().getStatsIntervalSeconds() > 0) {
             stats = new ConsumerStatsRecorderImpl(client, conf, this);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -149,6 +149,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         this.allTopicPartitionsNumber = new AtomicInteger(0);
         this.startMessageId = startMessageId != null ? new BatchMessageIdImpl(MessageIdImpl.convertToMessageIdImpl(startMessageId)) : null;
         this.startMessageRollbackDurationInSec = startMessageRollbackDurationInSec;
+        this.paused = conf.isStartPaused();
 
         if (conf.getAckTimeoutMillis() != 0) {
             if (conf.getTickDurationMillis() > 0) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -508,6 +508,7 @@ public class PulsarClientImpl implements PulsarClient {
 
                 List<String> topicsList = topicsPatternFilter(topics, conf.getTopicsPattern());
                 conf.getTopicNames().addAll(topicsList);
+                // todo
                 ConsumerBase<T> consumer = new PatternMultiTopicsConsumerImpl<>(conf.getTopicsPattern(),
                         PulsarClientImpl.this,
                         conf,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -508,7 +508,6 @@ public class PulsarClientImpl implements PulsarClient {
 
                 List<String> topicsList = topicsPatternFilter(topics, conf.getTopicsPattern());
                 conf.getTopicNames().addAll(topicsList);
-                // todo
                 ConsumerBase<T> consumer = new PatternMultiTopicsConsumerImpl<>(conf.getTopicsPattern(),
                         PulsarClientImpl.this,
                         conf,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -160,6 +160,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     @JsonIgnore
     private transient MessagePayloadProcessor payloadProcessor = null;
 
+    private boolean startPaused = false;
+
     public void setAutoUpdatePartitionsIntervalSeconds(int interval, TimeUnit timeUnit) {
         checkArgument(interval > 0, "interval needs to be > 0");
         this.autoUpdatePartitionsIntervalSeconds = timeUnit.toSeconds(interval);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -37,8 +37,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Unit tests of {@link ConsumerBuilderImpl}.
@@ -309,5 +311,11 @@ public class ConsumerBuilderImplTest {
                 .minNackTimeMs(1000)
                 .maxNackTimeMs(10 * 1000)
                 .build());
+    }
+
+    @Test
+    public void testStartPaused() {
+        consumerBuilderImpl.startPaused(true);
+        verify(consumerBuilderImpl.getConf()).setStartPaused(true);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -199,5 +200,22 @@ public class ConsumerImplTest {
             checkException = e;
         }
         Assert.assertNull(checkException);
+    }
+
+    @Test
+    public void testConsumerCreatedWhilePaused() throws InterruptedException {
+        PulsarClientImpl client = ClientTestFixtures.createPulsarClientMock(executorProvider, internalExecutor);
+        ClientConfigurationData clientConf = client.getConfiguration();
+        clientConf.setOperationTimeoutMs(100);
+        clientConf.setStatsIntervalSeconds(0);
+        String topic = "non-persistent://tenant/ns1/my-topic";
+
+        consumerConf.setStartPaused(true);
+
+        consumer = ConsumerImpl.newConsumerImpl(client, topic, consumerConf,
+                executorProvider, -1, false, new CompletableFuture<>(), null, null, null,
+                true);
+
+        Assert.assertTrue(consumer.paused);
     }
 }


### PR DESCRIPTION
Fixes #11846 

### Motivation

Control the message flow when creating a consumer. Before this change, consumers would immediately send flow permits to the broker upon `.subscribe()`. Now, consumers can connect (which validates configuration/authentication) immediately, but wait to process messages until `.resume()` is called.

### Modifications

* Add a field `private boolean startPaused` to `ConsumerConfigurationData`
* Use that boolean to set `paused` in the `ConsumerImpl`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
  - *Added a unit test that confirms the paused state of the consumer based on the ConsumerConfigurationData*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
     - There is a new option `paused(boolean)` on the `ConsumerBuilder`
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] no-need-doc 
  
  This PR adds Javadoc to the new ConsumerBuilder option. There's no existing documentation I can find on the site for `paused` so this seems sufficient.
  
- [ ] doc 
  
  (If this PR contains doc changes)


