### PR TITLE
Remove unused variable and unneccessary box in NamespaceBundleFactory

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -92,7 +92,6 @@ public class NamespaceBundleFactory {
         CompletableFuture<NamespaceBundles> future = new CompletableFuture<>();
         // Read the static bundle data from the policies
         pulsar.getLocalMetadataStore().get(path).thenAccept(result -> {
-            NamespaceBundles namespaceBundles;
 
             if (result.isPresent()) {
                 try {
@@ -278,9 +277,9 @@ public class NamespaceBundleFactory {
                     splitPartition = i;
                     Long maxVal = sourceBundle.partitions[i + 1];
                     Long minVal = sourceBundle.partitions[i];
-                    Long segSize = splitBoundary == null ? (maxVal - minVal) / numBundles : splitBoundary - minVal;
+                    long segSize = splitBoundary == null ? (maxVal - minVal) / numBundles : splitBoundary - minVal;
                     partitions[pos++] = minVal;
-                    Long curPartition = minVal + segSize;
+                    long curPartition = minVal + segSize;
                     for (int j = 0; j < numBundles - 1; j++) {
                         partitions[pos++] = curPartition;
                         curPartition += segSize;


### PR DESCRIPTION
### Modifications

Clean up. Remove unused variable and unneccessary box in NamespaceBundleFactory

### Documentation
  
- [ ] no-need-doc 

internal clean up, no need doc.


