### PR TITLE
 [pulsar admin] getPartitionedTopicMetada method support setting auto create topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -786,7 +786,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is check configuration required to automatically create topic")
             @QueryParam("checkAllowAutoCreation") @DefaultValue("false") boolean checkAllowAutoCreation) {
         validateTopicName(tenant, namespace, encodedTopic);
-        if (checkAllowAutoCreation) {
+        if (authoritative && checkAllowAutoCreation) {
             validateTopicPolicyOperation(topicName, PolicyName.PARTITION, PolicyOperation.WRITE);
         }
         return internalGetPartitionedMetadata(authoritative, checkAllowAutoCreation);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -786,7 +786,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is check configuration required to automatically create topic")
             @QueryParam("checkAllowAutoCreation") @DefaultValue("false") boolean checkAllowAutoCreation) {
         validateTopicName(tenant, namespace, encodedTopic);
-        if (authoritative && checkAllowAutoCreation) {
+        if (checkAllowAutoCreation) {
             validateTopicPolicyOperation(topicName, PolicyName.PARTITION, PolicyOperation.WRITE);
         }
         return internalGetPartitionedMetadata(authoritative, checkAllowAutoCreation);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -786,6 +786,9 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Is check configuration required to automatically create topic")
             @QueryParam("checkAllowAutoCreation") @DefaultValue("false") boolean checkAllowAutoCreation) {
         validateTopicName(tenant, namespace, encodedTopic);
+        if (checkAllowAutoCreation) {
+            validateTopicPolicyOperation(topicName, PolicyName.PARTITION, PolicyOperation.WRITE);
+        }
         return internalGetPartitionedMetadata(authoritative, checkAllowAutoCreation);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -397,11 +397,19 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         String testLocalTopicName = "test-topic";
 
-        // 1) Auto create non-partitioned topic.
+        // 1. Not auto create topic.
+        try {
+            persistentTopics.getPartitionedMetadata(testTenant, testNamespace, testLocalTopicName, true, false);
+            Assert.fail("Should fail topic not exit exception");
+        } catch (RestException e) {
+            Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), e.getResponse().getStatus());
+        }
+
+        // 2. Auto create non-partitioned topic.
         PartitionedTopicMetadata partitionedMetadata = persistentTopics.getPartitionedMetadata(testTenant, testNamespace, testLocalTopicName, true, true);
         Assert.assertEquals(0, partitionedMetadata.partitions);
 
-        // 2. Add validate policy assert.
+        // 3. Add validate policy assert.
         doThrow(new RestException(Response.Status.FORBIDDEN, "mock message"))
                 .when(persistentTopics).validateTopicPolicyOperation(persistentTopics.topicName, PolicyName.PARTITION, PolicyOperation.WRITE);
         try {
@@ -410,7 +418,6 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus());
         }
-
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -482,6 +482,21 @@ public interface Topics {
     PartitionedTopicMetadata getPartitionedTopicMetadata(String topic) throws PulsarAdminException;
 
     /**
+     * Get metadata of a partitioned topic.
+     * <p/>
+     * Get metadata of a partitioned topic.
+     * <p/>
+     *
+     * @param topic
+     *            Topic name
+     * @param checkAllowAutoCreation
+     * @return Partitioned topic metadata
+     * @throws PulsarAdminException
+     */
+    PartitionedTopicMetadata getPartitionedTopicMetadata(String topic, boolean checkAllowAutoCreation)
+            throws PulsarAdminException;
+
+    /**
      * Get metadata of a partitioned topic asynchronously.
      * <p/>
      * Get metadata of a partitioned topic asynchronously.
@@ -492,6 +507,20 @@ public interface Topics {
      * @return a future that can be used to track when the partitioned topic metadata is returned
      */
     CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String topic);
+
+    /**
+     * Get metadata of a partitioned topic asynchronously.
+     * <p/>
+     * Get metadata of a partitioned topic asynchronously.
+     * <p/>
+     *
+     * @param topic
+     *            Topic name
+     * @return a future that can be used to track when the partitioned topic metadata is returned
+     */
+    CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String topic,
+                                                                                 boolean checkAllowAutoCreation);
+
 
     /**
      * Delete a partitioned topic.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -486,8 +486,15 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PartitionedTopicMetadata getPartitionedTopicMetadata(String topic) throws PulsarAdminException {
+        return getPartitionedTopicMetadata(topic, false);
+    }
+
+    @Override
+    public PartitionedTopicMetadata getPartitionedTopicMetadata(String topic, boolean checkAllowAutoCreation)
+            throws PulsarAdminException {
         try {
-            return getPartitionedTopicMetadataAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+            return getPartitionedTopicMetadataAsync(topic, checkAllowAutoCreation)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw (PulsarAdminException) e.getCause();
         } catch (InterruptedException e) {
@@ -500,8 +507,14 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String topic) {
+        return getPartitionedTopicMetadataAsync(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(
+            String topic, boolean checkAllowAutoCreation) {
         TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn, "partitions");
+        WebTarget path = topicPath(tn, "partitions").queryParam("checkAllowAutoCreation", checkAllowAutoCreation);
         final CompletableFuture<PartitionedTopicMetadata> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<PartitionedTopicMetadata>() {

--- a/pulsar-client-cpp/pulsar-test-service-start.sh
+++ b/pulsar-client-cpp/pulsar-test-service-start.sh
@@ -107,7 +107,7 @@ $PULSAR_DIR/bin/pulsar-admin namespaces grant-permission public/default-4 \
 $PULSAR_DIR/bin/pulsar-admin namespaces set-encryption-required public/default-4 -e
 
 # Create "private" tenant
-$PULSAR_DIR/bin/pulsar-admin tenants create private -r "" -c "standalone"
+$PULSAR_DIR/bin/pulsar-admin tenants create private -r "token-principal" -c "standalone"
 
 # Create "private/auth" with required authentication
 $PULSAR_DIR/bin/pulsar-admin namespaces create private/auth --clusters standalone

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1138,7 +1138,7 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
-When topic auto-creation is enabled by broker, you can set param `checkAllowAutoCreation = true` to auto create topic.
+When enabling topic auto-creation, you can set the parameter `checkAllowAutoCreation = true` to automatically create a topic.
 
 {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -1138,12 +1138,18 @@ $ pulsar-admin topics get-partitioned-topic-metadata \
 ```
 
 <!--REST API-->
+When topic auto-creation is enabled by broker, you can set param `checkAllowAutoCreation = true` to auto create topic.
+
 {@inject: endpoint|GET|/admin/v2/:schema/:tenant/:namespace/:topic/partitions|operation/getPartitionedMetadata?version=[[pulsar:version_number]]}
 
 <!--Java-->
+When topic auto-creation is enabled by broker, you can set param `checkAllowAutoCreation = true` to auto create topic.
+
 ```java
 String topicName = "persistent://my-tenant/my-namespace/my-topic";
 admin.topics().getPartitionedTopicMetadata(topicName);
+// or
+admin.topics().getPartitionedTopicMetadata(topicName, true);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
#11923 

### Motivation

https://github.com/streamnative/pulsar-flink/issues/398

### Modifications


1.  Add validateTopicPolicyOperation to PersistentTopic#getPartitionedMetadata
2.  `Topics#getPartitionedTopicMetadata` add parameter `checkAllowAutoCreation`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- `PersistentTopicsTest#testGetPartitionedMetadata`

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: **yes**
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: **yes**
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Need to update docs? 

- [x] doc-required 
- [ ] no-need-doc 
- [ ] doc 

