### PR TITLE
[FEATURE] support for resetting logger level in runtime

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -33,7 +33,7 @@ Configuration:
       - name: "pulsar.log.appender"
         value: "RoutingAppender"
       - name: "pulsar.log.root.level"
-        value: "debug"
+        value: "info"
       - name: "pulsar.log.level"
         value: "info"
       - name: "pulsar.routing.appender.default"

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -134,7 +134,6 @@ Configuration:
       additivity: true
       AppenderRef:
         - ref: "${sys:pulsar.log.appender}"
-          level: "${sys:pulsar.log.level}"
         - ref: Prometheus
           level: info
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -42,7 +42,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -472,7 +471,7 @@ public class BrokersBase extends PulsarWebResource {
                 try {
                     logger = rawLogger.trim();
                     Class.forName(logger);
-                } catch(ClassNotFoundException e) {
+                } catch (ClassNotFoundException e) {
                     // Logger not found
                     throw new RestException(Status.NOT_FOUND, "Logger not found.");
                 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Brokers.java
@@ -295,4 +295,22 @@ public interface Brokers {
      * @return version of broker.
      */
     String getVersion() throws PulsarAdminException;
+
+    /**
+     * Reset logger level dynamically in runtime.
+     *
+     * @param logger
+     * @param level
+     * @throws PulsarAdminException
+     */
+    void resetLoggerLevel(String logger, String level) throws PulsarAdminException;
+
+    /**
+     * Reset logger level dynamically in runtime asynchronously.
+     *
+     * @param logger
+     * @param level
+     * @return
+     */
+    CompletableFuture<Void> resetLoggerLevelAsync(String logger, String level);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BrokersImpl.java
@@ -431,4 +431,25 @@ public class BrokersImpl extends BaseResource implements Brokers {
             throw new PulsarAdminException.TimeoutException(e);
         }
     }
+
+    @Override
+    public void resetLoggerLevel(String logger, String level) throws PulsarAdminException {
+        try {
+            resetLoggerLevelAsync(logger, level).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> resetLoggerLevelAsync(String logger, String level) {
+        WebTarget path = adminBrokers.path("configuration").path("log4j").path(logger).path(level);
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -139,6 +139,9 @@ public class PulsarAdminToolTest {
 
         brokers.run(split("version"));
         verify(mockBrokers).getVersion();
+
+        brokers.run(split("reset-logger-level --logger root --level DEBUG"));
+        verify(mockBrokers).resetLoggerLevel("root", "DEBUG");
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBrokers.java
@@ -159,6 +159,21 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Reset logger level dynamically in runtime")
+    private class ResetLoggerLevelCmd extends CliCommand {
+
+        @Parameter(names = "--logger",
+                description = "logger name, \"root\" for rootLogger specifically", required = true)
+        private String logger;
+        @Parameter(names = "--level", description = "log level", required = true)
+        private String level;
+
+        @Override
+        void run() throws Exception {
+            getAdmin().brokers().resetLoggerLevel(logger, level);
+        }
+    }
+
     public CmdBrokers(Supplier<PulsarAdmin> admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
@@ -173,5 +188,6 @@ public class CmdBrokers extends CmdBase {
         jcommander.addCommand("healthcheck", new HealthcheckCmd());
         jcommander.addCommand("backlog-quota-check", new BacklogQuotaCheckCmd());
         jcommander.addCommand("version", new PulsarVersion());
+        jcommander.addCommand("reset-logger-level", new ResetLoggerLevelCmd());
     }
 }


### PR DESCRIPTION
### Motivation
This PR supplements a useful feature that enable users to reset logger level in runtime. It is very meaningful for developers to dynamically adjust the log level in the production environment, especially in the case of tracing online problems and unable to restart the broker process.

### Modifications

- add an REST endpoint for resetting (/brokers/configuration/log4j/{logger}/{level})
- add a companion admin cmd under `broker` (bin/pulsar-admin brokers reset-logger-level)

### Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *Run`bin/pulsar-admin brokers reset-logger-level --level debug --logger root` after broker start to check log level*
  - *Run`bin/pulsar-admin brokers reset-logger-level --level info --logger root` to restore*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - `The rest endpoints: yes`
  - `The admin cli options: yes`
  - Anything that affects deployment: no

### Documentation

- [x] doc-required 


