### PR TITLE
[Broker] Cleanup: remove unnecessary boxing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -275,8 +275,8 @@ public class NamespaceBundleFactory {
                 if (sourceBundle.partitions[i] == range.lowerEndpoint()
                         && (range.upperEndpoint() == sourceBundle.partitions[i + 1])) {
                     splitPartition = i;
-                    Long maxVal = sourceBundle.partitions[i + 1];
-                    Long minVal = sourceBundle.partitions[i];
+                    long maxVal = sourceBundle.partitions[i + 1];
+                    long minVal = sourceBundle.partitions[i];
                     long segSize = splitBoundary == null ? (maxVal - minVal) / numBundles : splitBoundary - minVal;
                     partitions[pos++] = minVal;
                     long curPartition = minVal + segSize;


### PR DESCRIPTION
### Motivation

When checking the latest merged commits in master branch, I noticed that the cleanup made in #11975 didn't cover all variables.

### Modifications

- remove unnecessary boxing for 2 variables
  - `sourceBundle.partitions` is a `long[]`