### PR TITLE
[Standalone] Fix the assignment of a custom stream-storage-port number

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -129,7 +129,7 @@ public class LocalBookkeeperEnsemble {
                                    String bkDataDirName,
                                    boolean clearOldData,
                                    String advertisedAddress) {
-        this(numberOfBookies, zkPort, 4181, zkDataDirName, bkDataDirName, clearOldData, advertisedAddress,
+        this(numberOfBookies, zkPort, streamStoragePort, zkDataDirName, bkDataDirName, clearOldData, advertisedAddress,
                 new BasePortManager(bkBasePort));
     }
 


### PR DESCRIPTION
### Motivation

- The stream storage port passed on the command line with `--stream-storage-port` argument is ignored. 4181 will always be used.

### Modifications

- fix the issue where the streamStoragePort parameter was ignored and hard coded to 4181