### PR TITLE
[cli] Fix issue where pulsar-client command cannot consume v2 topics through WebSocket

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.client.internal.PulsarClientImplementationBindin
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.Gson;
@@ -365,30 +366,43 @@ public class CmdConsume {
     }
 
     @SuppressWarnings("deprecation")
+    @VisibleForTesting
+    public String getWebSocketConsumeUri(String topic) {
+        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
+                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
+
+        TopicName topicName = TopicName.get(topic);
+        String wsTopic;
+        if (topicName.isV2()) {
+            wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+                    topicName.getNamespacePortion(), topicName.getLocalName());
+        } else {
+            wsTopic = String.format("%s/%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+                    topicName.getCluster(), topicName.getNamespacePortion(), topicName.getLocalName());
+        }
+
+        String uriFormat = "%s/ws" + (topicName.isV2() ? "/v2/" : "/")
+                + "consumer/%s/%s?subscriptionType=%s&subscriptionMode=%s";
+        return String.format(uriFormat, serviceURLWithoutTrailingSlash, wsTopic, subscriptionName,
+                subscriptionType.toString(), subscriptionMode.toString());
+    }
+
+    @SuppressWarnings("deprecation")
     private int consumeFromWebSocket(String topic) {
         int numMessagesConsumed = 0;
         int returnCode = 0;
 
-        TopicName topicName = TopicName.get(topic);
+        URI consumerUri = URI.create(getWebSocketConsumeUri(topic));
 
-        String wsTopic = String.format(
-                "%s/%s/" + (StringUtils.isEmpty(topicName.getCluster()) ? "" : topicName.getCluster() + "/")
-                        + "%s/%s/%s?subscriptionType=%s&subscriptionMode=%s",
-                topicName.getDomain(), topicName.getTenant(), topicName.getNamespacePortion(), topicName.getLocalName(),
-                subscriptionName, subscriptionType.toString(), subscriptionMode.toString());
-
-        String consumerBaseUri = serviceURL + (serviceURL.endsWith("/") ? "" : "/") + "ws/consumer/" + wsTopic;
-        URI consumerUri = URI.create(consumerBaseUri);
-
-        WebSocketClient produceClient = new WebSocketClient(new SslContextFactory(true));
-        ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
+        WebSocketClient consumeClient = new WebSocketClient(new SslContextFactory(true));
+        ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
         try {
             if (authentication != null) {
                 authentication.start();
                 AuthenticationDataProvider authData = authentication.getAuthData();
                 if (authData.hasDataForHttp()) {
                     for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
-                        produceRequest.setHeader(kv.getKey(), kv.getValue());
+                        consumeRequest.setHeader(kv.getKey(), kv.getValue());
                     }
                 }
             }
@@ -399,7 +413,7 @@ public class CmdConsume {
         CompletableFuture<Void> connected = new CompletableFuture<>();
         ConsumerSocket consumerSocket = new ConsumerSocket(connected);
         try {
-            produceClient.start();
+            consumeClient.start();
         } catch (Exception e) {
             LOG.error("Failed to start websocket-client", e);
             return -1;
@@ -407,7 +421,7 @@ public class CmdConsume {
 
         try {
             LOG.info("Trying to create websocket session..{}",consumerUri);
-            produceClient.connect(consumerSocket, consumerUri, produceRequest);
+            consumeClient.connect(consumerSocket, consumerUri, consumeRequest);
             connected.get();
         } catch (Exception e) {
             LOG.error("Failed to create web-socket session", e);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -359,19 +359,22 @@ public class CmdProduce {
 
     @SuppressWarnings("deprecation")
     @VisibleForTesting
-    public String getProduceBaseEndPoint(String topic) {
+    public String getWebSocketProduceUri(String topic) {
+        String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
+                serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
+
         TopicName topicName = TopicName.get(topic);
-        String produceBaseEndPoint;
+        String wsTopic;
         if (topicName.isV2()) {
-            String wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+            wsTopic = String.format("%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
                     topicName.getNamespacePortion(), topicName.getLocalName());
-            produceBaseEndPoint = serviceURL + (serviceURL.endsWith("/") ? "" : "/") + "ws/v2/producer/" + wsTopic;
         } else {
-            String wsTopic = String.format("%s/%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
+            wsTopic = String.format("%s/%s/%s/%s/%s", topicName.getDomain(), topicName.getTenant(),
                     topicName.getCluster(), topicName.getNamespacePortion(), topicName.getLocalName());
-            produceBaseEndPoint = serviceURL + (serviceURL.endsWith("/") ? "" : "/") + "ws/producer/" + wsTopic;
         }
-        return produceBaseEndPoint;
+
+        String uriFormat = "%s/ws" + (topicName.isV2() ? "/v2/" : "/") + "producer/%s";
+        return String.format(uriFormat, serviceURLWithoutTrailingSlash, wsTopic);
     }
 
     @SuppressWarnings("deprecation")
@@ -379,7 +382,7 @@ public class CmdProduce {
         int numMessagesSent = 0;
         int returnCode = 0;
 
-        URI produceUri = URI.create(getProduceBaseEndPoint(topic));
+        URI produceUri = URI.create(getWebSocketProduceUri(topic));
 
         WebSocketClient produceClient = new WebSocketClient(new SslContextFactory(true));
         ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdConsume.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.testng.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestCmdConsume {
+
+    CmdConsume cmdConsume;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        cmdConsume = new CmdConsume();
+        cmdConsume.updateConfig(null, null, "ws://localhost:8080/");
+        Field subscriptionNameField = CmdConsume.class.getDeclaredField("subscriptionName");
+        subscriptionNameField.setAccessible(true);
+        subscriptionNameField.set(cmdConsume, "my-sub");
+    }
+
+    @Test
+    public void testGetWebSocketConsumeUri() {
+        String topicNameV1 = "persistent://public/cluster/default/issue-11067";
+        assertEquals(cmdConsume.getWebSocketConsumeUri(topicNameV1),
+                "ws://localhost:8080/ws/consumer/persistent/public/cluster/default/issue-11067/my-sub"
+                        + "?subscriptionType=Exclusive&subscriptionMode=Durable");
+        String topicNameV2 = "persistent://public/default/issue-11067";
+        assertEquals(cmdConsume.getWebSocketConsumeUri(topicNameV2),
+                "ws://localhost:8080/ws/v2/consumer/persistent/public/default/issue-11067/my-sub"
+                        + "?subscriptionType=Exclusive&subscriptionMode=Durable");
+    }
+
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
@@ -39,12 +39,12 @@ public class TestCmdProduce {
     }
 
     @Test
-    public void testGetProduceBaseEndPoint() {
+    public void testGetWebSocketProduceUri() {
         String topicNameV1 = "persistent://public/cluster/default/issue-11067";
-        assertEquals(cmdProduce.getProduceBaseEndPoint(topicNameV1),
+        assertEquals(cmdProduce.getWebSocketProduceUri(topicNameV1),
                 "ws://localhost:8080/ws/producer/persistent/public/cluster/default/issue-11067");
         String topicNameV2 = "persistent://public/default/issue-11067";
-        assertEquals(cmdProduce.getProduceBaseEndPoint(topicNameV2),
+        assertEquals(cmdProduce.getWebSocketProduceUri(topicNameV2),
                 "ws://localhost:8080/ws/v2/producer/persistent/public/default/issue-11067");
     }
 


### PR DESCRIPTION
### Motivation

Currently, the CLI `pulsar-client` command cannot consume v2 topics through WebSocket. This is because `/v2/` is not included in the path of the WebSocket URL even if the format of the specified topic is v2.
https://github.com/apache/pulsar/blob/683c2d6a5d39af852add27a93ebfedb0e6e4910b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java#L380

Related issue: https://github.com/apache/pulsar/issues/11067

### Modifications

Fixed the `CmdConsume` class so that it can construc the correct WebSocket URL even if a v2 topic name is specified.

### Verifying this change

- [x] Make sure that the change passes the CI checks.