### PR TITLE
[Java Client] Fix JavaDoc for closeAsync: remove documented exception…

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -272,8 +272,7 @@ public interface PulsarClient extends Closeable {
      * this client has currently active. That implies that close and wait, asynchronously, until all pending producer
      * send requests are persisted.
      *
-     * @throws PulsarClientException
-     *             if the close operation fails
+     * @return a future that can be used to track the completion of the operation
      */
     CompletableFuture<Void> closeAsync();
 


### PR DESCRIPTION
… that isn't thrown

## Motivation

Fix JavaDoc on the PulsarClient interface.

## Changes

* Switch `throws` to `return` as the method does not actually throw the checked exception

## Testing

No tests needed, as this change just updates the documentation to align with the code.

## Documentation

This is fixing documentation. The website does not need to be updated.

