### PR TITLE
[Zookeeper Client] Fix String formatting conversion in toString method

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -1172,7 +1172,7 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
 
             @Override
             public String toString() {
-                return String.format("setData (%s, mode = %d)", basePath, mode);
+                return String.format("setData (%s, mode = %s)", basePath, mode.name());
             }
         };
         // execute it immediately


### PR DESCRIPTION
### Motivation

The current `toString` implementation in `PulsarZooKeeperClient` is incorrect because it was using `%d` to interpolate an object. Instead, we should convert the enum to its string value and print that instead using `%s`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No.

### Documentation

No doc updates needed.