### PR TITLE
[ZK Tests] Add breaks to prevent fall through in MockZooKeeper

### DIFF
--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -931,12 +931,15 @@ public class MockZooKeeper extends ZooKeeper {
                 case ZooDefs.OpCode.create:
                     this.create(op.getPath(), ((org.apache.zookeeper.Op.Create)op).data, null, null);
                     res.add(new OpResult.CreateResult(op.getPath()));
+                    break;
                 case ZooDefs.OpCode.delete:
                     this.delete(op.getPath(), -1);
                     res.add(new OpResult.DeleteResult());
+                    break;
                 case ZooDefs.OpCode.setData:
                     this.create(op.getPath(), ((org.apache.zookeeper.Op.Create)op).data, null, null);
                     res.add(new OpResult.SetDataResult(null));
+                    break;
                 default:
             }
         }


### PR DESCRIPTION
### Motivation

With @lhotari's help, I ran the errorprone lombok check against Pulsar. It identified that the switch block modified here had potential fall through cases. Given the context of the method, it looks like the cases shouldn't allow the logic to fall through.

### Modifications

* Corrected the logic in `MockZooKeeper#multi` by adding `break;` lines.

### Verifying this change

This change is a trivial rework that does not require test coverage.

### Does this pull request potentially affect one of the following parts:

No

### Documentation
No doc updates required.