### PR TITLE
Remove unnecessary creation of JsonParser object per deprecation doc

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -301,8 +301,7 @@ public final class SchemaUtils {
     }
 
     public static JsonObject toJsonObject(String json) {
-        JsonParser parser = new JsonParser();
-        return parser.parse(json).getAsJsonObject();
+        return JsonParser.parseString(json).getAsJsonObject();
     }
 
     private static class SchemaInfoToStringAdapter implements JsonSerializer<SchemaInfo> {

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -547,7 +547,7 @@ public class LocalRunner implements AutoCloseable {
                     for (index = 0; index < futures.length; ++index) {
                         String json = futures[index].get();
                         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                        log.info(gson.toJson(new JsonParser().parse(json)));
+                        log.info(gson.toJson(JsonParser.parseString(json)));
                     }
                 } catch (TimeoutException | InterruptedException | ExecutionException e) {
                     log.error("Could not get status from all local instances");

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
@@ -143,8 +143,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 				commandData = authData.getHttpHeader("BasicAuthentication");
 			}
 
-			JsonParser parser = new JsonParser();
-			JsonObject element = parser.parse(commandData).getAsJsonObject();
+			JsonObject element = JsonParser.parseString(commandData).getAsJsonObject();
 			long expiryTimeInMillis = Long.parseLong(element.get("expiryTime").getAsString());
 			long currentTimeInMillis = System.currentTimeMillis();
 			if (expiryTimeInMillis < currentTimeInMillis) {


### PR DESCRIPTION
### Motivation

The modified `JsonParser` is deprecated. The library includes java docs (copied below) indicating how to fix. This PR follows those instructions. As a result, we will use the static method and prevent the creation of the `JsonParser` object.

```java
  /** @deprecated No need to instantiate this class, use the static methods instead. */
  @Deprecated
  public JsonParser() {}
```

```java
  /** @deprecated Use {@link JsonParser#parseString} */
  @Deprecated
  public JsonElement parse(String json) throws JsonSyntaxException {
    return parseString(json);
  }
```

### Modifications

* Use static method instead of creating a `JsonParser` object.
* I updated all uses of `JsonParser`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No.

### Documentation

No doc updates needed.


