### PR TITLE
Use Lombok's @Builder.Default annotation to set defaults on fields in…

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -45,30 +45,33 @@ import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 @Setter
 public class TopicPolicies {
 
+    @Builder.Default
     private Map<String, BacklogQuotaImpl> backLogQuotaMap = Maps.newHashMap();
-    private PersistencePolicies persistence = null;
-    private RetentionPolicies retentionPolicies = null;
-    private Boolean deduplicationEnabled = null;
-    private Integer messageTTLInSeconds = null;
-    private Integer maxProducerPerTopic = null;
-    private Integer maxConsumerPerTopic = null;
-    private Integer maxConsumersPerSubscription = null;
-    private Integer maxUnackedMessagesOnConsumer = null;
-    private Integer maxUnackedMessagesOnSubscription = null;
-    private Long delayedDeliveryTickTimeMillis = null;
-    private Boolean delayedDeliveryEnabled = null;
-    private OffloadPoliciesImpl offloadPolicies;
-    private InactiveTopicPolicies inactiveTopicPolicies = null;
-    private DispatchRateImpl dispatchRate = null;
-    private DispatchRateImpl subscriptionDispatchRate = null;
-    private Long compactionThreshold = null;
-    private PublishRate publishRate = null;
-    private SubscribeRate subscribeRate = null;
-    private Integer deduplicationSnapshotIntervalSeconds = null;
-    private Integer maxMessageSize = null;
-    private Integer maxSubscriptionsPerTopic = null;
-    private DispatchRateImpl replicatorDispatchRate = null;
+    @Builder.Default
     private List<SubType> subscriptionTypesEnabled = new ArrayList<>();
+
+    private PersistencePolicies persistence;
+    private RetentionPolicies retentionPolicies;
+    private Boolean deduplicationEnabled;
+    private Integer messageTTLInSeconds;
+    private Integer maxProducerPerTopic;
+    private Integer maxConsumerPerTopic;
+    private Integer maxConsumersPerSubscription;
+    private Integer maxUnackedMessagesOnConsumer;
+    private Integer maxUnackedMessagesOnSubscription;
+    private Long delayedDeliveryTickTimeMillis;
+    private Boolean delayedDeliveryEnabled;
+    private OffloadPoliciesImpl offloadPolicies;
+    private InactiveTopicPolicies inactiveTopicPolicies;
+    private DispatchRateImpl dispatchRate;
+    private DispatchRateImpl subscriptionDispatchRate;
+    private Long compactionThreshold;
+    private PublishRate publishRate;
+    private SubscribeRate subscribeRate;
+    private Integer deduplicationSnapshotIntervalSeconds;
+    private Integer maxMessageSize;
+    private Integer maxSubscriptionsPerTopic;
+    private DispatchRateImpl replicatorDispatchRate;
 
     public boolean isReplicatorDispatchRateSet() {
         return replicatorDispatchRate != null;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Actions.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Actions.java
@@ -38,8 +38,10 @@ public class Actions {
     @Builder(toBuilder=true)
     public static class Action {
         private String actionName;
+        @Builder.Default
         private int numRetries = 1;
         private Supplier<ActionResult> supplier;
+        @Builder.Default
         private long sleepBetweenInvocationsMs = 500;
         private Boolean continueOn;
         private Consumer<ActionResult> onFail;


### PR DESCRIPTION
… TopicPolicies and Actions classes

### Motivation

When using the `@Builder` annotation, default values must be annotated with the `@Builder.Default` annotation in order to get set to the default if not set by the code calling the builder methods. The modified code had some defaults that were getting ignored and some defaults that were unnecessary (setting objects to null).

I found these issues when running `errorprone`. Here was the message: `java: @Builder will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add @Builder.Default. If it is not supposed to be settable during building, make the field final.`

### Modifications

* Update the `Actions` class to ensure that the defaults are set properly on `sleepBetweenInvocationsMs` and `numRetries`. The previous defaults would have been `0` for each field.
* Update the `TopicPolicies` class in two ways. First, set ensure that the `backLogQuotaMap` and the `subscriptionTypesEnabled` are properly defaulted. There is code that could have resulted in an NPE without this fix. However that method isn't called right now, so this just  preventative. Second, remove the unnecessary assignment of objects to `null`. The builder will do this automatically if the field is not explicitly set.

### Verifying this change

This is a trivial change. I am assuming that the values in the classes are correct and the right defaults to use.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change. It might change some behaviors, that will only be a change to the defaults.

### Documentation

No doc updates required.