### PR TITLE
Remove deprecated netty allocator tiny size

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -76,7 +76,6 @@ public class EntryCacheImpl implements EntryCache {
             PooledByteBufAllocator.defaultNumDirectArena(), // nDirectArena
             PooledByteBufAllocator.defaultPageSize(), // pageSize
             PooledByteBufAllocator.defaultMaxOrder(), // maxOrder
-            PooledByteBufAllocator.defaultTinyCacheSize(), // tinyCacheSize
             PooledByteBufAllocator.defaultSmallCacheSize(), // smallCacheSize
             PooledByteBufAllocator.defaultNormalCacheSize(), // normalCacheSize,
             true // Use cache for all threads

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/AllocatorStatsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/AllocatorStatsGenerator.java
@@ -34,7 +34,7 @@ import org.apache.pulsar.common.stats.AllocatorStats.PoolSubpageStats;
 
 public class AllocatorStatsGenerator {
     public static AllocatorStats generate(String allocatorName) {
-        PooledByteBufAllocator allocator = null;
+        PooledByteBufAllocator allocator;
         if ("default".equals(allocatorName)) {
             allocator = PooledByteBufAllocator.DEFAULT;
         } else if ("ml-cache".equals(allocatorName)) {
@@ -56,19 +56,14 @@ public class AllocatorStatsGenerator {
         stats.numThreadLocalCaches = allocator.metric().numThreadLocalCaches();
         stats.normalCacheSize = allocator.metric().normalCacheSize();
         stats.smallCacheSize = allocator.metric().smallCacheSize();
-        stats.tinyCacheSize = allocator.metric().tinyCacheSize();
         return stats;
     }
 
     private static PoolArenaStats newPoolArenaStats(PoolArenaMetric m) {
         PoolArenaStats stats = new PoolArenaStats();
-        stats.numTinySubpages = m.numTinySubpages();
         stats.numSmallSubpages = m.numSmallSubpages();
         stats.numChunkLists = m.numChunkLists();
 
-        stats.tinySubpages = m.tinySubpages().stream()
-            .map(AllocatorStatsGenerator::newPoolSubpageStats)
-            .collect(Collectors.toList());
         stats.smallSubpages = m.smallSubpages().stream()
             .map(AllocatorStatsGenerator::newPoolSubpageStats)
             .collect(Collectors.toList());
@@ -77,17 +72,14 @@ public class AllocatorStatsGenerator {
             .collect(Collectors.toList());
 
         stats.numAllocations = m.numAllocations();
-        stats.numTinyAllocations = m.numTinyAllocations();
         stats.numSmallAllocations = m.numSmallAllocations();
         stats.numNormalAllocations = m.numNormalAllocations();
         stats.numHugeAllocations = m.numHugeAllocations();
         stats.numDeallocations = m.numDeallocations();
-        stats.numTinyDeallocations = m.numTinyDeallocations();
         stats.numSmallDeallocations = m.numSmallDeallocations();
         stats.numNormalDeallocations = m.numNormalDeallocations();
         stats.numHugeDeallocations = m.numHugeDeallocations();
         stats.numActiveAllocations = m.numActiveAllocations();
-        stats.numActiveTinyAllocations = m.numActiveTinyAllocations();
         stats.numActiveSmallAllocations = m.numActiveSmallAllocations();
         stats.numActiveNormalAllocations = m.numActiveNormalAllocations();
         stats.numActiveHugeAllocations = m.numActiveHugeAllocations();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerCacheMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerCacheMetrics.java
@@ -56,7 +56,6 @@ public class ManagedLedgerCacheMetrics extends AbstractMetrics {
 
         PooledByteBufAllocator allocator = EntryCacheImpl.ALLOCATOR;
         long activeAllocations = 0;
-        long activeAllocationsTiny = 0;
         long activeAllocationsSmall = 0;
         long activeAllocationsNormal = 0;
         long activeAllocationsHuge = 0;
@@ -65,7 +64,6 @@ public class ManagedLedgerCacheMetrics extends AbstractMetrics {
 
         for (PoolArenaMetric arena : allocator.metric().directArenas()) {
             activeAllocations += arena.numActiveAllocations();
-            activeAllocationsTiny += arena.numActiveTinyAllocations();
             activeAllocationsSmall += arena.numActiveSmallAllocations();
             activeAllocationsNormal += arena.numActiveNormalAllocations();
             activeAllocationsHuge += arena.numActiveHugeAllocations();
@@ -84,7 +82,6 @@ public class ManagedLedgerCacheMetrics extends AbstractMetrics {
         m.put("brk_ml_cache_pool_allocated", totalAllocated);
         m.put("brk_ml_cache_pool_used", totalUsed);
         m.put("brk_ml_cache_pool_active_allocations", activeAllocations);
-        m.put("brk_ml_cache_pool_active_allocations_tiny", activeAllocationsTiny);
         m.put("brk_ml_cache_pool_active_allocations_small", activeAllocationsSmall);
         m.put("brk_ml_cache_pool_active_allocations_normal", activeAllocationsNormal);
         m.put("brk_ml_cache_pool_active_allocations_huge", activeAllocationsHuge);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
@@ -63,7 +63,6 @@ public class BookieClientsStatsGeneratorTest extends BrokerTestBase {
                 1, // nDirectArena
                 8192, // pageSize
                 11, // maxOrder
-                64, // tinyCacheSize
                 32, // smallCacheSize
                 8, // normalCacheSize
                 true // Cache all threads

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AllocatorStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AllocatorStats.java
@@ -29,7 +29,6 @@ public class AllocatorStats {
     public int numThreadLocalCaches;
     public int normalCacheSize;
     public int smallCacheSize;
-    public int tinyCacheSize;
 
     public List<PoolArenaStats> directArenas;
     public List<PoolArenaStats> heapArenas;
@@ -38,25 +37,20 @@ public class AllocatorStats {
      * Pool arena statistics.
      */
     public static class PoolArenaStats {
-        public int numTinySubpages;
         public int numSmallSubpages;
         public int numChunkLists;
 
-        public List<PoolSubpageStats> tinySubpages;
         public List<PoolSubpageStats> smallSubpages;
         public List<PoolChunkListStats> chunkLists;
         public long numAllocations;
-        public long numTinyAllocations;
         public long numSmallAllocations;
         public long numNormalAllocations;
         public long numHugeAllocations;
         public long numDeallocations;
-        public long numTinyDeallocations;
         public long numSmallDeallocations;
         public long numNormalDeallocations;
         public long numHugeDeallocations;
         public long numActiveAllocations;
-        public long numActiveTinyAllocations;
         public long numActiveSmallAllocations;
         public long numActiveNormalAllocations;
         public long numActiveHugeAllocations;

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -243,7 +243,6 @@ All the ManagedLedgerCache metrics are labelled with the following labels:
 | pulsar_ml_cache_pool_active_allocations_huge | Gauge | The number of currently active huge allocation in direct arena |
 | pulsar_ml_cache_pool_active_allocations_normal | Gauge | The number of currently active normal allocations in direct arena |
 | pulsar_ml_cache_pool_active_allocations_small | Gauge | The number of currently active small allocations in direct arena |
-| pulsar_ml_cache_pool_active_allocations_tiny | Gauge | The number of currently active tiny allocations in direct arena |
 | pulsar_ml_cache_pool_allocated | Gauge | The total allocated memory of chunk lists in direct arena |
 | pulsar_ml_cache_pool_used | Gauge | The total used memory of chunk lists in direct arena |
 | pulsar_ml_cache_used_size | Gauge | The size in byte used to store the entries payloads |


### PR DESCRIPTION
### Motivation
https://github.com/netty/netty/pull/10267

Netty has removed tiny size, now netty only have small, normal and huge size.

### Modifications

Remove the tiny size use.

### Documentation

It only affetcs a metric, I change the `reference-metrics.md`


