### PR TITLE
[Issue 9772][Go Functions]Allow User Metrics

### DIFF
--- a/pulsar-function-go/examples/userMetricsFunc/userMetricsFunc.go
+++ b/pulsar-function-go/examples/userMetricsFunc/userMetricsFunc.go
@@ -1,0 +1,39 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"context"
+
+	"github.com/apache/pulsar/pulsar-function-go/pf"
+)
+
+func metricRecorderFunction(ctx context.Context, in []byte) error {
+	inputstr := string(in)
+	ctx.RecordMetric("hit-count", 1)
+	if string == "eleven" {
+		ctx.RecordMetric("elevens-count", 1)
+	}
+	return nil
+}
+
+func main() {
+	pf.Start(metricRecorderFunction)
+}

--- a/pulsar-function-go/examples/userMetricsFunc/userMetricsFunc.go
+++ b/pulsar-function-go/examples/userMetricsFunc/userMetricsFunc.go
@@ -21,15 +21,20 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	"github.com/apache/pulsar/pulsar-function-go/pf"
 )
 
 func metricRecorderFunction(ctx context.Context, in []byte) error {
 	inputstr := string(in)
-	ctx.RecordMetric("hit-count", 1)
-	if string == "eleven" {
-		ctx.RecordMetric("elevens-count", 1)
+	fctx, ok := pf.FromContext(ctx)
+	if !ok {
+		return errors.New("get Go Functions Context error")
+	}
+	fctx.RecordMetric("hit-count", 1)
+	if inputstr == "eleven" {
+		fctx.RecordMetric("elevens-count", 1)
 	}
 	return nil
 }

--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -36,6 +36,7 @@ type FunctionContext struct {
 	userConfigs   map[string]interface{}
 	logAppender   *LogAppender
 	outputMessage func(topic string) pulsar.Producer
+	recordMetric  func(metricName string, metricValue float64)
 	record        pulsar.Message
 }
 
@@ -172,6 +173,11 @@ func (c *FunctionContext) GetCurrentRecord() pulsar.Message {
 //GetMetricsPort returns the port the pulsar function metrics listen on
 func (c *FunctionContext) GetMetricsPort() int {
 	return c.instanceConf.metricsPort
+}
+
+//RecordMetric records an observation to the user_metric summary with the provided value
+func (c *FunctionContext) RecordMetric(metricName string, metricValue float64) {
+	c.recordMetric(metricName, metricValue)
 }
 
 // An unexported type to be used as the key for types in this package. This

--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"math"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -32,7 +31,6 @@ import (
 
 	log "github.com/apache/pulsar/pulsar-function-go/logutil"
 	pb "github.com/apache/pulsar/pulsar-function-go/pb"
-	"github.com/prometheus/client_golang/prometheus"
 	prometheus_client "github.com/prometheus/client_model/go"
 )
 
@@ -77,20 +75,9 @@ func newGoInstance() *goInstance {
 		return producer
 	}
 
-	metricsLabels := goInstance.getMetricsLabels()
-
-	var userMetrics sync.Map
-	goInstance.context.recordMetric = func(metricName string, metricValue float64) {
-		v, ok := userMetrics.Load(metricName)
-		if !ok {
-			v, _ = userMetrics.LoadOrStore(metricName, userMetricSummary.WithLabelValues(append(metricsLabels, metricName)...))
-		}
-		v.(prometheus.Observer).Observe(metricValue)
-	}
-
 	goInstance.lastHealthCheckTs = now.UnixNano()
 	goInstance.properties = make(map[string]string)
-	goInstance.stats = NewStatWithLabelValues(metricsLabels...)
+	goInstance.stats = NewStatWithLabelValues(goInstance.getMetricsLabels()...)
 	return goInstance
 }
 
@@ -520,6 +507,7 @@ func (gi *goInstance) getMetrics() *pb.MetricsData {
 	totalUserExceptions1min := gi.getTotalUserExceptions1min()
 	totalSysExceptions1min := gi.getTotalSysExceptions1min()
 	//avg_process_latency_ms_1min := gi.get_avg_process_latency_1min()
+	userMetricsMap := gi.getUserMetricsMap()
 
 	metricsData := pb.MetricsData{}
 	// total metrics
@@ -534,6 +522,9 @@ func (gi *goInstance) getMetrics() *pb.MetricsData {
 	metricsData.ProcessedSuccessfullyTotal_1Min = int64(totalProcessedSuccessfully1min)
 	metricsData.SystemExceptionsTotal_1Min = int64(totalSysExceptions1min)
 	metricsData.UserExceptionsTotal_1Min = int64(totalUserExceptions1min)
+
+	// user metrics
+	metricsData.UserMetrics = userMetricsMap
 
 	return &metricsData
 }
@@ -559,6 +550,13 @@ func (gi *goInstance) getMatchingMetricFunc() func(lbl *prometheus_client.LabelP
 }
 
 func (gi *goInstance) getMatchingMetricFromRegistry(metricName string) prometheus_client.Metric {
+	filteredMetricFamilies := gi.getFilteredMetricFamilies(metricName)
+	metricFunc := gi.getMatchingMetricFunc()
+	matchingMetric := getFirstMatch(filteredMetricFamilies[0].Metric, metricFunc)
+	return *matchingMetric
+}
+
+func (gi *goInstance) getFilteredMetricFamilies(metricName string) []*prometheus_client.MetricFamily {
 	metricFamilies, err := reg.Gather()
 	if err != nil {
 		log.Errorf("Something went wrong when calling reg.Gather(), the metricName is: %s", metricName)
@@ -571,9 +569,7 @@ func (gi *goInstance) getMatchingMetricFromRegistry(metricName string) prometheu
 		// handle this.
 		log.Errorf("Too many metric families for metricName: %s " + metricName)
 	}
-	metricFunc := gi.getMatchingMetricFunc()
-	matchingMetric := getFirstMatch(filteredMetricFamilies[0].Metric, metricFunc)
-	return *matchingMetric
+	return filteredMetricFamilies
 }
 
 func (gi *goInstance) getTotalReceived() float32 {
@@ -648,4 +644,40 @@ func (gi *goInstance) getTotalReceived1min() float32 {
 	// "pulsar_function_" +  "received_total_1min", GaugeVec
 	val := metric.GetGauge().Value
 	return float32(*val)
+}
+
+func (gi *goInstance) getUserMetricsMap() map[string]float64 {
+	userMetricMap := map[string]float64{}
+	filteredMetricFamilies := gi.getFilteredMetricFamilies(PulsarFunctionMetricsPrefix + UserMetric)
+	for _, m := range filteredMetricFamilies[0].GetMetric() {
+		var isFuncMetric bool
+		var userLabelName string
+	VERIFY_USER_METRIC:
+		for _, l := range m.GetLabel() {
+			switch l.GetName() {
+			case "fqfn":
+				if l.GetValue() == gi.context.GetTenantAndNamespaceAndName() {
+					isFuncMetric = true
+					if userLabelName != "" {
+						break VERIFY_USER_METRIC
+					}
+				}
+			case "metric":
+				userLabelName = l.GetValue()
+				if isFuncMetric {
+					break VERIFY_USER_METRIC
+				}
+			}
+		}
+		if isFuncMetric && userLabelName != "" {
+			summary := m.GetSummary()
+			count := summary.GetSampleCount()
+			if count <= 0 {
+				userMetricMap[userLabelName] = 0
+			} else {
+				userMetricMap[userLabelName] = float64(summary.GetSampleSum()) / float64(count)
+			}
+		}
+	}
+	return userMetricMap
 }

--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -675,7 +675,7 @@ func (gi *goInstance) getUserMetricsMap() map[string]float64 {
 			if count <= 0 {
 				userMetricMap[userLabelName] = 0
 			} else {
-				userMetricMap[userLabelName] = float64(summary.GetSampleSum()) / float64(count)
+				userMetricMap[userLabelName] = summary.GetSampleSum() / float64(count)
 			}
 		}
 	}

--- a/pulsar-function-go/pf/stats.go
+++ b/pulsar-function-go/pf/stats.go
@@ -356,7 +356,9 @@ func (s *MetricsServicer) serve() {
 		// create a listener on metrics port
 		log.Infof("Starting metrics server on port %d", s.goInstance.context.GetMetricsPort())
 		err := s.server.ListenAndServe()
-		if err != nil {
+		switch err {
+		case nil, http.ErrServerClosed:
+		default:
 			log.Fatalf("failed to start metrics server: %v", err)
 		}
 	}()

--- a/pulsar-function-go/pf/stats.go
+++ b/pulsar-function-go/pf/stats.go
@@ -130,7 +130,14 @@ var (
 	userMetricSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: PulsarFunctionMetricsPrefix + UserMetric,
-			Help: "Pulsar Function user defined metric"}, userMetricLabelNames)
+			Help: "User defined metric.",
+			Objectives: map[float64]float64{
+				0.5:   0.01,
+				0.9:   0.01,
+				0.99:  0.01,
+				0.999: 0.01,
+			},
+		}, userMetricLabelNames)
 )
 
 type MetricsServicer struct {

--- a/pulsar-function-go/pf/stats.go
+++ b/pulsar-function-go/pf/stats.go
@@ -35,6 +35,8 @@ var (
 	metricsLabelNames          = []string{"tenant", "namespace", "name", "instance_id", "cluster", "fqfn"}
 	exceptionLabelNames        = []string{"error"}
 	exceptionMetricsLabelNames = append(metricsLabelNames, exceptionLabelNames...)
+	userLabelNames             = []string{"metric"}
+	userMetricLabelNames       = append(metricsLabelNames, userLabelNames...)
 )
 
 const (
@@ -52,6 +54,8 @@ const (
 	TotalUserExceptions1min        = "user_exceptions_total_1min"
 	ProcessLatencyMs1min           = "process_latency_ms_1min"
 	TotalReceived1min              = "received_total_1min"
+
+	UserMetric = "user_metric"
 )
 
 // Declare Prometheus
@@ -122,6 +126,11 @@ var (
 		prometheus.GaugeOpts{
 			Name: PulsarFunctionMetricsPrefix + "system_exception",
 			Help: "Exception from system code."}, exceptionMetricsLabelNames)
+
+	userMetricSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: PulsarFunctionMetricsPrefix + UserMetric,
+			Help: "Pulsar Function user defined metric"}, userMetricLabelNames)
 )
 
 type MetricsServicer struct {
@@ -146,6 +155,7 @@ func init() {
 	reg.MustRegister(statTotalReceived1min)
 	reg.MustRegister(userExceptions)
 	reg.MustRegister(systemExceptions)
+	reg.MustRegister(userMetricSummary)
 
 }
 

--- a/pulsar-function-go/pf/stats_test.go
+++ b/pulsar-function-go/pf/stats_test.go
@@ -213,6 +213,8 @@ func TestMetricsServer(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.NotEmpty(t, body)
 	resp.Body.Close()
+	gi.close()
+	metricsServicer.close()
 }
 
 // nolint
@@ -246,10 +248,12 @@ func TestUserMetrics(t *testing.T) {
 	assert.NotEmpty(t, body)
 
 	for labelname, value := range testUserMetricValues {
-		for _, quantile := range []string{"0.5", "0.9", "0.99", "0.999", "balls"} {
+		for _, quantile := range []string{"0.5", "0.9", "0.99", "0.999"} {
 			assert.Containsf(t, string(body), fmt.Sprintf("\n"+`pulsar_function_user_metric{cluster="pulsar-function-go",fqfn="//go-function",instance_id="pulsar-function",metric="%s",name="go-function",namespace="/",tenant="",quantile="%s"} %d`+"\n", labelname, quantile, value), "user metric %q quantile %s not found with value %d", labelname, quantile, value)
 		}
 	}
 
 	resp.Body.Close()
+	gi.close()
+	metricsServicer.close()
 }

--- a/pulsar-function-go/pf/stats_test.go
+++ b/pulsar-function-go/pf/stats_test.go
@@ -189,67 +189,66 @@ func TestExampleSummaryVec_Pulsar(t *testing.T) {
 	assert.Equal(t, 2000, int(*count))
 }
 
-func TestMetricsServer(t *testing.T) {
-	gi := newGoInstance()
-	metricsServicer := NewMetricsServicer(gi)
-	metricsServicer.serve()
-	gi.stats.incrTotalReceived()
-	time.Sleep(time.Second * 1)
-
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", gi.context.GetMetricsPort()))
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, nil, err)
-	assert.NotEmpty(t, body)
-	resp.Body.Close()
-
-	resp, err = http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err = ioutil.ReadAll(resp.Body)
-	assert.Equal(t, nil, err)
-	assert.NotEmpty(t, body)
-	resp.Body.Close()
-}
-
 // nolint
-func TestUserMetrics(t *testing.T) {
+func TestMetrics(t *testing.T) {
 	gi := newGoInstance()
 	metricsServicer := NewMetricsServicer(gi)
 	metricsServicer.serve()
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, nil, err)
-	assert.NotEmpty(t, body)
-	assert.NotContainsf(t, string(body), "pulsar_function_user_metric", "user metric should not appear yet")
+	t.Run("Test Metrics Server", func(t *testing.T) {
+		gi.stats.incrTotalReceived()
+		time.Sleep(time.Second * 1)
 
-	testUserMetricValues := map[string]int{"test": 1, "test2": 2}
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", gi.context.GetMetricsPort()))
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.Equal(t, nil, err)
+		assert.NotEmpty(t, body)
+		resp.Body.Close()
 
-	for labelname, value := range testUserMetricValues {
-		gi.context.RecordMetric(labelname, float64(value))
-	}
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		body, err = ioutil.ReadAll(resp.Body)
+		assert.Equal(t, nil, err)
+		assert.NotEmpty(t, body)
+		resp.Body.Close()
+	})
 
-	time.Sleep(time.Second * 1)
-	resp, err = http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err = ioutil.ReadAll(resp.Body)
-	assert.Equal(t, nil, err)
-	assert.NotEmpty(t, body)
+	t.Run("Test User Metrics", func(t *testing.T) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.Equal(t, nil, err)
+		assert.NotEmpty(t, body)
+		assert.NotContainsf(t, string(body), "pulsar_function_user_metric", "user metric should not appear yet")
 
-	for labelname, value := range testUserMetricValues {
-		for _, quantile := range []string{"0.5", "0.9", "0.99", "0.999", "balls"} {
-			assert.Containsf(t, string(body), fmt.Sprintf("\n"+`pulsar_function_user_metric{cluster="pulsar-function-go",fqfn="//go-function",instance_id="pulsar-function",metric="%s",name="go-function",namespace="/",tenant="",quantile="%s"} %d`+"\n", labelname, quantile, value), "user metric %q quantile %s not found with value %d", labelname, quantile, value)
+		testUserMetricValues := map[string]int{"test": 1, "test2": 2}
+
+		for labelname, value := range testUserMetricValues {
+			gi.context.RecordMetric(labelname, float64(value))
 		}
-	}
 
-	resp.Body.Close()
+		time.Sleep(time.Second * 1)
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, resp)
+		assert.Equal(t, 200, resp.StatusCode)
+		body, err = ioutil.ReadAll(resp.Body)
+		assert.Equal(t, nil, err)
+		assert.NotEmpty(t, body)
+
+		for labelname, value := range testUserMetricValues {
+			for _, quantile := range []string{"0.5", "0.9", "0.99", "0.999"} {
+				assert.Containsf(t, string(body), fmt.Sprintf("\n"+`pulsar_function_user_metric{cluster="pulsar-function-go",fqfn="//go-function",instance_id="pulsar-function",metric="%s",name="go-function",namespace="/",tenant="",quantile="%s"} %d`+"\n", labelname, quantile, value), "user metric %q quantile %s not found with value %d", labelname, quantile, value)
+			}
+		}
+
+		resp.Body.Close()
+	})
 }

--- a/pulsar-function-go/pf/stats_test.go
+++ b/pulsar-function-go/pf/stats_test.go
@@ -214,3 +214,42 @@ func TestMetricsServer(t *testing.T) {
 	assert.NotEmpty(t, body)
 	resp.Body.Close()
 }
+
+// nolint
+func TestUserMetrics(t *testing.T) {
+	gi := newGoInstance()
+	metricsServicer := NewMetricsServicer(gi)
+	metricsServicer.serve()
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, nil, err)
+	assert.NotEmpty(t, body)
+	assert.NotContainsf(t, string(body), "pulsar_function_user_metric", "user metric should not appear yet")
+
+	testUserMetricValues := map[string]int{"test": 1, "test2": 2}
+
+	for labelname, value := range testUserMetricValues {
+		gi.context.RecordMetric(labelname, float64(value))
+	}
+
+	time.Sleep(time.Second * 1)
+	resp, err = http.Get(fmt.Sprintf("http://localhost:%d/metrics", gi.context.GetMetricsPort()))
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.Equal(t, nil, err)
+	assert.NotEmpty(t, body)
+
+	for labelname, value := range testUserMetricValues {
+		for _, quantile := range []string{"0.5", "0.9", "0.99", "0.999", "balls"} {
+			assert.Containsf(t, string(body), fmt.Sprintf("\n"+`pulsar_function_user_metric{cluster="pulsar-function-go",fqfn="//go-function",instance_id="pulsar-function",metric="%s",name="go-function",namespace="/",tenant="",quantile="%s"} %d`+"\n", labelname, quantile, value), "user metric %q quantile %s not found with value %d", labelname, quantile, value)
+		}
+	}
+
+	resp.Body.Close()
+}

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -1011,9 +1011,13 @@ The Go SDK [`Context`](#context) object enables you to record metrics on a per-k
 ```go
 func metricRecorderFunction(ctx context.Context, in []byte) error {
 	inputstr := string(in)
-	ctx.RecordMetric("hit-count", 1)
-	if string == "eleven" {
-		ctx.RecordMetric("elevens-count", 1)
+	fctx, ok := pf.FromContext(ctx)
+	if !ok {
+		return errors.New("get Go Functions Context error")
+	}
+	fctx.RecordMetric("hit-count", 1)
+	if inputstr == "eleven" {
+		fctx.RecordMetric("elevens-count", 1)
 	}
 	return nil
 }

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -1006,7 +1006,18 @@ class MetricRecorderFunction(Function):
             context.record_metric('elevens-count', 1)
 ```
 <!--Go-->
-Currently, the feature is not available in Go.
+The Go SDK [`Context`](#context) object enables you to record petrics on a per-key basis. For example, you can set a metric for the `process-count` key and a different metric for the `elevens-count` key every time the function processes a message:
+
+```go
+func metricRecorderFunction(ctx context.Context, in []byte) error {
+	inputstr := string(in)
+	ctx.RecordMetric("hit-count", 1)
+	if string == "eleven" {
+		ctx.RecordMetric("elevens-count", 1)
+	}
+	return nil
+}
+```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/site2/docs/functions-develop.md
+++ b/site2/docs/functions-develop.md
@@ -1006,7 +1006,7 @@ class MetricRecorderFunction(Function):
             context.record_metric('elevens-count', 1)
 ```
 <!--Go-->
-The Go SDK [`Context`](#context) object enables you to record petrics on a per-key basis. For example, you can set a metric for the `process-count` key and a different metric for the `elevens-count` key every time the function processes a message:
+The Go SDK [`Context`](#context) object enables you to record metrics on a per-key basis. For example, you can set a metric for the `process-count` key and a different metric for the `elevens-count` key every time the function processes a message:
 
 ```go
 func metricRecorderFunction(ctx context.Context, in []byte) error {


### PR DESCRIPTION
Fixes #9772

### Motivation
#9772

### Modifications

Add context `RecordMetric(metricName string, metricValue float64)`

### Verifying this change

The current testing framework doesn't exercise pfunc metrics at all. If there are integration tests elsewhere that can verify this, let me know, but I have tested it in my environment and it works as intended.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API: **yes** (pulsar function SDK only)
    - It brings the context object in-line with the other two frameworks, however it follows the same signature.
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [X] doc 

EDIT: I have removed the erroneous doc-required checkbox. This PR includes documentation.

