### PR TITLE
Fix log placeholders not correct

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -146,7 +146,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic {
                 .getAsync(AdminResource.path(POLICIES, TopicName.get(topic).getNamespace()))
                 .thenAccept(optPolicies -> {
                     if (!optPolicies.isPresent()) {
-                        log.warn("[{}] Policies not present {} and isEncryptionRequired will be set to false", topic);
+                        log.warn("[{}] Policies not present and isEncryptionRequired will be set to false", topic);
                         isEncryptionRequired = false;
                     } else {
                         Policies policies = optPolicies.get();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
@@ -65,7 +65,7 @@ public class EventLoopUtil {
                     try {
                         CpuAffinity.acquireCore();
                     } catch (Throwable t) {
-                        log.warn("Failed to acquire CPU core for thread {}", Thread.currentThread().getName(),
+                        log.warn("Failed to acquire CPU core for thread {} {}", Thread.currentThread().getName(),
                                 t.getMessage(), t);
                     }
                 });

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -67,7 +67,7 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
         checkArgument(!isBlank(topic), "Offset storage topic must be specified");
         this.data = new HashMap<>();
 
-        log.info("Configure offset backing store on pulsar topic {} at cluster {}", topic);
+        log.info("Configure offset backing store on pulsar topic {}", topic);
     }
 
     void readToEnd(CompletableFuture<Void> future) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -206,7 +206,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                             // We failed to revalidate the lock due to connectivity issue
                             // Continue assuming we hold the lock, until we can revalidate it, either
                             // on Reconnected or SessionReestablished events.
-                            log.warn("Failed to revalidate the lock at {}. Retrying later on reconnection", path,
+                            log.warn("Failed to revalidate the lock at {}. Retrying later on reconnection {}", path,
                                     ex.getCause().getMessage());
                         }
                     }


### PR DESCRIPTION
### Motivation

Log placehodlers not correct. Cause some log info is missing or `{}` alone

### Modifications

Fix the placeholder, add `{}` or delete `{}`

### Documentation
  
- [ ] no-need-doc 
 this is an internal optimize, don't need doc.


