### PR TITLE
[feature] Strict bookie affinity group strategy

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1430,3 +1430,6 @@ tlsEnabled=false
 # Enable Key_Shared subscription (default is enabled)
 # @deprecated since 2.8.0 subscriptionTypesEnabled is preferred over subscriptionKeySharedEnable.
 subscriptionKeySharedEnable=true
+
+#enable or disable strict bookie affinity
+strictBookieAffinityEnabled=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1389,6 +1389,8 @@ packagesManagementLedgerRootPath=/ledgers
 
 ### --- Packages management service configuration variables (end) --- ###
 
+#enable or disable strict bookie affinity
+strictBookieAffinityEnabled=false
 
 ### --- Deprecated settings --- ###
 
@@ -1430,6 +1432,3 @@ tlsEnabled=false
 # Enable Key_Shared subscription (default is enabled)
 # @deprecated since 2.8.0 subscriptionTypesEnabled is preferred over subscriptionKeySharedEnable.
 subscriptionKeySharedEnable=true
-
-#enable or disable strict bookie affinity
-strictBookieAffinityEnabled=false

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -58,7 +58,7 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
 
     private MetadataCache<BookiesRackConfiguration> bookieMappingCache;
 
-    private static final String PULSAR_METADATA_ISOLATION_GROUP = "*";
+    private static final String PULSAR_SYSTEM_TOPIC_ISOLATION_GROUP = "*";
 
 
     public IsolatedBookieEnsemblePlacementPolicy() {
@@ -223,7 +223,7 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
     private Set<BookieId> getBlacklistedBookiesWithIsolationGroups(int ensembleSize,
         Pair<Set<String>, Set<String>> isolationGroups) {
         Set<BookieId> blacklistedBookies = new HashSet<>();
-        if (isolationGroups != null && isolationGroups.getLeft().contains(PULSAR_METADATA_ISOLATION_GROUP))  {
+        if (isolationGroups != null && isolationGroups.getLeft().contains(PULSAR_SYSTEM_TOPIC_ISOLATION_GROUP))  {
             return blacklistedBookies;
         }
         try {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1250,6 +1250,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean enableNamespaceIsolationUpdateOnTime = false;
 
+    @FieldContext(category = CATEGORY_SERVER, doc = "Enable or disable strict bookie affinity.")
+    private boolean strictBookieAffinityEnabled = false;
+
     /***** --- TLS. --- ****/
     @FieldContext(
         category = CATEGORY_TLS,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -43,6 +43,7 @@ public class BaseResources<T> {
 
     protected static final String BASE_POLICIES_PATH = "/admin/policies";
     protected static final String BASE_CLUSTERS_PATH = "/admin/clusters";
+    protected static final String LOCAL_POLICIES_ROOT = "/admin/local-policies";
 
     @Getter
     private final MetadataStore store;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
@@ -33,8 +33,6 @@ import org.apache.zookeeper.KeeperException;
 
 public class LocalPoliciesResources extends BaseResources<LocalPolicies> {
 
-    private static final String LOCAL_POLICIES_ROOT = "/admin/local-policies";
-
     public LocalPoliciesResources(MetadataStore localStore, int operationTimeoutSec) {
         super(localStore, LocalPolicies.class, operationTimeoutSec);
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -143,6 +143,11 @@ public class NamespaceResources extends BaseResources<Policies> {
                 && path.substring(BASE_POLICIES_PATH.length() + 1).contains("/");
     }
 
+    public static boolean pathIsNamespaceLocalPolicies(String path) {
+        return path.startsWith(LOCAL_POLICIES_ROOT + "/")
+                && path.substring(LOCAL_POLICIES_ROOT.length() + 1).contains("/");
+    }
+
     // clear resource of `/namespace/{namespaceName}` for zk-node
     public CompletableFuture<Void> deleteNamespaceAsync(NamespaceName ns) {
         final String namespacePath = joinPath(NAMESPACE_BASE_PATH, ns.toString());
@@ -157,6 +162,10 @@ public class NamespaceResources extends BaseResources<Policies> {
 
     public static NamespaceName namespaceFromPath(String path) {
         return NamespaceName.get(path.substring(BASE_POLICIES_PATH.length() + 1));
+    }
+
+    public static NamespaceName namespaceFromLocalPoliciesPath(String path) {
+        return NamespaceName.get(path.substring(LOCAL_POLICIES_ROOT.length() + 1));
     }
 
     public static class IsolationPolicyResources extends BaseResources<Map<String, NamespaceIsolationDataImpl>> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -158,7 +158,6 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FieldParser;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.RateLimiter;
 import org.apache.pulsar.common.util.RestException;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2374,6 +2374,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return retentionTime < 0 || (System.nanoTime() - lastActive) < retentionTime;
     }
 
+    public CompletableFuture<Void> onLocalPoliciesUpdate() {
+        return checkPersistencePolicies();
+    }
+
     @Override
     public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
         if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -264,6 +264,169 @@ public class BrokerBookieIsolationTest {
     }
 
     /**
+     * Validate that broker can support tenant based strict bookie isolation.
+     *
+     * <pre>
+     * 1. create one bookie-info group : isolated-group
+     * 2. namespace ns1 : has none group
+     *    validate: bookie-ensemble for ns1-topics's ledger will be from bookies don't belongs to any group
+     *    if bookies don't belongs to any group are not enough, then, throw #BKNotEnoughBookiesException
+     * 3. namespace ns2,ns3,ns4: uses isolated-group
+     *    validate: bookie-ensemble for above namespace-topics's ledger will try to select from isolated-group firstly
+     *    if bookies belongs to isolated-group are not enough
+     *    then, bookies from secondary isolation group will be selected (if secondary isolation group set)
+     *    if bookies still are not enough, then, bookies don't belongs to any group will be selected.
+     * </pre>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testStrictBookieIsolation() throws Exception {
+        final String tenant1 = "tenant1";
+        final String cluster = "use";
+        final String ns1 = String.format("%s/%s/%s", tenant1, cluster, "ns1");
+        final String ns2 = String.format("%s/%s/%s", tenant1, cluster, "ns2");
+        final String ns3 = String.format("%s/%s/%s", tenant1, cluster, "ns3");
+        final String ns4 = String.format("%s/%s/%s", tenant1, cluster, "ns4");
+        final int totalPublish = 100;
+
+        final String brokerBookkeeperClientIsolationGroups = "default-group";
+        final String tenantNamespaceIsolationGroups = "tenant1-isolation";
+
+        BookieServer[] bookies = bkEnsemble.getBookies();
+        ZooKeeper zkClient = bkEnsemble.getZkClient();
+
+        Set<BookieId> defaultBookies = Sets.newHashSet(bookies[0].getBookieId(),
+                bookies[1].getBookieId());
+        Set<BookieId> isolatedBookies = Sets.newHashSet(bookies[2].getBookieId(),
+                bookies[3].getBookieId());
+
+        setDefaultIsolationGroup(tenantNamespaceIsolationGroups, zkClient, isolatedBookies);
+
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+        config.setClusterName(cluster);
+        config.setWebServicePort(Optional.of(0));
+        config.setZookeeperServers("127.0.0.1" + ":" + bkEnsemble.getZookeeperPort());
+        config.setBrokerShutdownTimeoutMs(0L);
+        config.setBrokerServicePort(Optional.of(0));
+        config.setAdvertisedAddress("localhost");
+        config.setStrictBookieAffinityEnabled(true);
+        config.setBookkeeperClientIsolationGroups(brokerBookkeeperClientIsolationGroups);
+
+        config.setManagedLedgerDefaultEnsembleSize(2);
+        config.setManagedLedgerDefaultWriteQuorum(2);
+        config.setManagedLedgerDefaultAckQuorum(2);
+
+        config.setAllowAutoTopicCreationType("non-partitioned");
+
+        int totalEntriesPerLedger = 20;
+        int totalLedgers = totalPublish / totalEntriesPerLedger;
+        config.setManagedLedgerMaxEntriesPerLedger(totalEntriesPerLedger);
+        config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        pulsarService = new PulsarService(config);
+        pulsarService.start();
+
+
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
+
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        admin.clusters().createCluster(cluster, clusterData);
+        TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
+        admin.tenants().createTenant(tenant1, tenantInfo);
+        admin.namespaces().createNamespace(ns1);
+        admin.namespaces().createNamespace(ns2);
+        admin.namespaces().createNamespace(ns3);
+        admin.namespaces().createNamespace(ns4);
+        admin.namespaces().setBookieAffinityGroup(ns2,
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+        admin.namespaces().setBookieAffinityGroup(ns3,
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+        admin.namespaces().setBookieAffinityGroup(ns4,
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns2),
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns3),
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+        assertEquals(admin.namespaces().getBookieAffinityGroup(ns4),
+                BookieAffinityGroupData.builder()
+                        .bookkeeperAffinityGroupPrimary(tenantNamespaceIsolationGroups)
+                        .build());
+
+        try {
+            admin.namespaces().getBookieAffinityGroup(ns1);
+        } catch (PulsarAdminException.NotFoundException e) {
+            // Ok
+        }
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(pulsarService.getBrokerServiceUrl())
+                .statsInterval(-1, TimeUnit.SECONDS).build();
+
+        PersistentTopic topic1 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns1, "topic1", totalPublish);
+        PersistentTopic topic2 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns2, "topic1", totalPublish);
+        PersistentTopic topic3 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns3, "topic1", totalPublish);
+        PersistentTopic topic4 = (PersistentTopic) createTopicAndPublish(pulsarClient, ns4, "topic1", totalPublish);
+
+        Bookie bookie1 = bookies[0].getBookie();
+        Field ledgerManagerField = Bookie.class.getDeclaredField("ledgerManager");
+        ledgerManagerField.setAccessible(true);
+        LedgerManager ledgerManager = (LedgerManager) ledgerManagerField.get(bookie1);
+
+        // namespace: ns1
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) topic1.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), defaultBookies);
+
+        // namespace: ns2
+        ml = (ManagedLedgerImpl) topic2.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), isolatedBookies);
+
+        // namespace: ns3
+        ml = (ManagedLedgerImpl) topic3.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), isolatedBookies);
+
+        // namespace: ns4
+        ml = (ManagedLedgerImpl) topic4.getManagedLedger();
+        assertEquals(ml.getLedgersInfoAsList().size(), totalLedgers);
+        // validate ledgers' ensemble with affinity bookies
+        assertAffinityBookies(ledgerManager, ml.getLedgersInfoAsList(), isolatedBookies);
+
+        ManagedLedgerClientFactory mlFactory =
+                (ManagedLedgerClientFactory) pulsarService.getManagedLedgerClientFactory();
+        Map<EnsemblePlacementPolicyConfig, BookKeeper> bkPlacementPolicyToBkClientMap = mlFactory
+                .getBkEnsemblePolicyToBookKeeperMap();
+
+        // broker should create only 1 bk-client and factory per isolation-group
+        assertEquals(bkPlacementPolicyToBkClientMap.size(), 2);
+
+        // make sure bk-isolation group also configure REPP_DNS_RESOLVER_CLASS as ZkBookieRackAffinityMapping to
+        // configure rack-aware policy with in isolated group
+        Map<EnsemblePlacementPolicyConfig, BookKeeper> bkMap = mlFactory.getBkEnsemblePolicyToBookKeeperMap();
+        BookKeeper bk = bkMap.values().iterator().next();
+        Method getConf = BookKeeper.class.getDeclaredMethod("getConf");
+        getConf.setAccessible(true);
+        ClientConfiguration clientConf = (ClientConfiguration) getConf.invoke(bk);
+        assertEquals(clientConf.getProperty(REPP_DNS_RESOLVER_CLASS), BookieRackAffinityMapping.class.getName());
+    }
+
+    /**
      * It verifies that "ZkIsolatedBookieEnsemblePlacementPolicy" considers secondary affinity-group if primary group
      * doesn't have enough non-faulty bookies.
      *

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -205,6 +205,7 @@ public class BrokerBookieIsolationTest {
 
         try {
             admin.namespaces().getBookieAffinityGroup(ns1);
+            fail("ns1 should have no bookie affinity group set");
         } catch (PulsarAdminException.NotFoundException e) {
             // Ok
         }
@@ -315,6 +316,7 @@ public class BrokerBookieIsolationTest {
 
         try {
             admin.namespaces().getBookieAffinityGroup(ns2);
+            fail("ns2 should have no bookie affinity group set");
         } catch (PulsarAdminException.NotFoundException e) {
             // Ok
         }
@@ -485,6 +487,7 @@ public class BrokerBookieIsolationTest {
 
         try {
             admin.namespaces().getBookieAffinityGroup(ns1);
+            fail("ns1 should have no bookie affinity group set");
         } catch (PulsarAdminException.NotFoundException e) {
             // Ok
         }
@@ -644,6 +647,7 @@ public class BrokerBookieIsolationTest {
 
         try {
             admin.namespaces().getBookieAffinityGroup(ns1);
+            fail("ns1 should have no bookie affinity group set");
         } catch (PulsarAdminException.NotFoundException e) {
             // Ok
         }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -378,6 +378,7 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 | additionalServletDirectory | Location of broker additional servlet NAR directory | ./brokerAdditionalServlet |
 | brokerEntryMetadataInterceptors | Set broker entry metadata interceptors.<br /><br />Multiple interceptors should be separated by commas. <br /><br />Available values:<li>org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor</li><li>org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor</li> <br /><br />Example<br />brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor, org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor|N/A |
 | enableExposingBrokerEntryMetadataToClient|Whether to expose broker entry metadata to client or not.<br /><br />Available values:<li>true</li><li>false</li><br />Example<br />enableExposingBrokerEntryMetadataToClient=true  | false |
+| strictBookieAffinityEnabled | Enable or disable the strict bookie isolation strategy. If enabled, <br /> - `bookie-ensemble` first tries to choose bookies that belong to a namespace's affinity group. If the number of bookies is not enough, then the rest bookies are chosen. <br /> - If namespace has no affinity group, `bookie-ensemble` only chooses bookies that belong to no region. If the number of bookies is not enough, `BKNotEnoughBookiesException` is thrown.| false |
 
 
 #### Deprecated parameters of Broker


### PR DESCRIPTION
### Motivation
1、Suppose We have three bookies, `b1, b2, b3`,
b1 and b2 are in region `test-region`, b3 doesn't belongs to any region.
Namespace `public/test` has set-affinity-group `test-region`.
When produce msg to topic under ` public/test` the bookie b3 will also be selected as ensemble, I think it's a violation of isolation.

2、namespace public/default doesn't set any affinity-group, when produce msg to topic under ` public/default`, 
the bookie b1 and b2  which have been isolated will  be selected as ensemble. I think it's also a violation of isolation.


### Modifications

ignore the bookies which have not been divided into any region, when using  `ZkIsolatedBookieEnsemblePlacementPolicy.java`

when region is set, those namespaces not belongs to any affinity group will not send its traffic to bookies in region
 
### Verifying this change

This change added tests and can be verified as follows:
testNonRegionBookie


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API: (yes / no) no
  - The schema: (yes / no / don't know) no
  - The default values of configurations: (yes / no) no
  - The wire protocol: (yes / no) no
  - The rest endpoints: (yes / no) no
  - The admin cli options: (yes / no) no 
  - Anything that affects deployment: (yes / no / don't know)no 

### Documentation
no need docs


