### PR TITLE
Fix flaky test ManagedLedgerTest#testMaximumRolloverTime

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1773,7 +1773,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 1);
 
-        Thread.sleep(2000);
+        Thread.sleep(1500);
 
         ledger.addEntry("data".getBytes());
         ledger.addEntry("data".getBytes());


### PR DESCRIPTION
Master Issue: [#ISSUE-12019](https://github.com/streamnative/pulsar/issues/3045)

### Motivation


*Fix flaky test ManagedLedgerTest#testMaximumRolloverTime.*

### Modifications

*Here should sleep within 2 seconds to prevent more than two times rolls of ledger.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
Need to update docs? 
- [ ] doc-required   
- [x] no-need-doc 
- [ ] doc 



