### PR TITLE
[PIP-92] Part-1: Separate Topic Policies into a separate class

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -132,7 +132,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .build();
         log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
 
-        admin.topics().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
+        admin.topicPolicies().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
         log.info("Backlog quota set success on topic: {}", testTopic);
 
         Awaitility.await()
@@ -156,7 +156,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
                 .build();
 
-        admin.topics().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.message_age);
+        admin.topicPolicies().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.message_age);
 
         Awaitility.await()
                 .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
@@ -2194,34 +2194,34 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
 
-        assertNull(admin.topics().getReplicatorDispatchRate(topic));
+        assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic));
 
         DispatchRate dispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(100)
                 .dispatchThrottlingRateInByte(200)
                 .ratePeriodInSecond(10)
                 .build();
-        admin.topics().setReplicatorDispatchRate(topic, dispatchRate);
+        admin.topicPolicies().setReplicatorDispatchRate(topic, dispatchRate);
         Awaitility.await().untilAsserted(()
-                -> assertEquals(admin.topics().getReplicatorDispatchRate(topic), dispatchRate));
+                -> assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic), dispatchRate));
 
-        admin.topics().removeReplicatorDispatchRate(topic);
+        admin.topicPolicies().removeReplicatorDispatchRate(topic);
         Awaitility.await().untilAsserted(()
-                -> assertNull(admin.topics().getReplicatorDispatchRate(topic)));
+                -> assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic)));
     }
 
     @Test(timeOut = 20000)
     public void testGetReplicatorRateApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        assertNull(admin.topics().getReplicatorDispatchRate(topic));
+        assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic));
         assertNull(admin.namespaces().getReplicatorDispatchRate(myNamespace));
         DispatchRate brokerDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(pulsar.getConfiguration().getDispatchThrottlingRatePerReplicatorInMsg())
                 .dispatchThrottlingRateInByte(pulsar.getConfiguration().getDispatchThrottlingRatePerReplicatorInByte())
                 .ratePeriodInSecond(1)
                 .build();
-        assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), brokerDispatchRate);
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), brokerDispatchRate);
         DispatchRate namespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
@@ -2230,22 +2230,22 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         admin.namespaces().setReplicatorDispatchRate(myNamespace, namespaceDispatchRate);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getReplicatorDispatchRate(myNamespace)));
-        assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), namespaceDispatchRate);
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), namespaceDispatchRate);
 
         DispatchRate topicDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(20)
                 .dispatchThrottlingRateInByte(21)
                 .ratePeriodInSecond(22)
                 .build();
-        admin.topics().setReplicatorDispatchRate(topic, topicDispatchRate);
-        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topics().getReplicatorDispatchRate(topic)));
-        assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), topicDispatchRate);
+        admin.topicPolicies().setReplicatorDispatchRate(topic, topicDispatchRate);
+        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topicPolicies().getReplicatorDispatchRate(topic)));
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), topicDispatchRate);
 
         admin.namespaces().removeReplicatorDispatchRate(myNamespace);
-        admin.topics().removeReplicatorDispatchRate(topic);
+        admin.topicPolicies().removeReplicatorDispatchRate(topic);
         Awaitility.await().untilAsserted(() -> assertNull(admin.namespaces().getReplicatorDispatchRate(myNamespace)));
-        Awaitility.await().untilAsserted(() -> assertNull(admin.topics().getReplicatorDispatchRate(topic)));
-        assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), brokerDispatchRate);
+        Awaitility.await().untilAsserted(() -> assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic)));
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), brokerDispatchRate);
     }
 
     @Test(timeOut = 30000)
@@ -2257,7 +2257,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().createPartitionedTopic(topic, 3);
         pulsarClient.newProducer().topic(topic).create().close();
         //should not fail
-        assertNull(admin.topics().getMessageTTL(topic));
+        assertNull(admin.topicPolicies().getMessageTTL(topic));
     }
 
     @Test
@@ -2267,8 +2267,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         pulsarClient.newConsumer().topic(topic).subscriptionName("test").subscribe().close();
         Set<SubscriptionType> subscriptionTypeSet = new HashSet<>();
         subscriptionTypeSet.add(SubscriptionType.Key_Shared);
-        admin.topics().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
-        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topics().getSubscriptionTypesEnabled(topic)));
+        admin.topicPolicies().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
+        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topicPolicies().getSubscriptionTypesEnabled(topic)));
 
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
                 .getTopicReference(TopicName.get(topic).getPartition(0).toString()).get();
@@ -2288,15 +2288,15 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().createNonPartitionedTopic(topic);
         // use broker.conf
         pulsarClient.newConsumer().topic(topic).subscriptionName("test").subscribe().close();
-        assertNull(admin.topics().getSubscriptionTypesEnabled(topic));
+        assertNull(admin.topicPolicies().getSubscriptionTypesEnabled(topic));
         // set enable failover sub type
         Set<SubscriptionType> subscriptionTypeSet = new HashSet<>();
         subscriptionTypeSet.add(SubscriptionType.Failover);
-        admin.topics().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
+        admin.topicPolicies().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
 
         Awaitility.await().until(()
                 -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
-        subscriptionTypeSet = admin.topics().getSubscriptionTypesEnabled(topic);
+        subscriptionTypeSet = admin.topicPolicies().getSubscriptionTypesEnabled(topic);
         assertTrue(subscriptionTypeSet.contains(SubscriptionType.Failover));
         assertFalse(subscriptionTypeSet.contains(SubscriptionType.Shared));
         assertEquals(subscriptionTypeSet.size(), 1);
@@ -2310,7 +2310,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         // add shared type
         subscriptionTypeSet.add(SubscriptionType.Shared);
-        admin.topics().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
+        admin.topicPolicies().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
         pulsarClient.newConsumer().topic(topic)
                 .subscriptionType(SubscriptionType.Shared).subscriptionName("test").subscribe().close();
 
@@ -2320,7 +2320,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         subscriptionTypeSet.clear();
         subscriptionTypeSet.add(SubscriptionType.Failover);
-        admin.topics().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
+        admin.topicPolicies().setSubscriptionTypesEnabled(topic, subscriptionTypeSet);
 
         try {
             pulsarClient.newConsumer().topic(topic)
@@ -2367,10 +2367,10 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         }
 
         //set topic policy
-        admin.topics().setMaxConsumersPerSubscription(topic, maxConsumerPerSubInTopic);
+        admin.topicPolicies().setMaxConsumersPerSubscription(topic, maxConsumerPerSubInTopic);
         Awaitility.await().untilAsserted(() -> {
-            assertNotNull(admin.topics().getMaxConsumersPerSubscription(topic));
-            assertEquals(admin.topics().getMaxConsumersPerSubscription(topic).intValue(), maxConsumerPerSubInTopic);
+            assertNotNull(admin.topicPolicies().getMaxConsumersPerSubscription(topic));
+            assertEquals(admin.topicPolicies().getMaxConsumersPerSubscription(topic).intValue(), maxConsumerPerSubInTopic);
         });
         Consumer consumer3 = builder.subscribe();
         try {
@@ -2389,26 +2389,26 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetCompactionThresholdApplied() throws Exception {
         final String topic = testTopic + UUID.randomUUID();
         pulsarClient.newProducer().topic(topic).create().close();
-        assertNull(admin.topics().getCompactionThreshold(topic));
+        assertNull(admin.topicPolicies().getCompactionThreshold(topic));
         assertNull(admin.namespaces().getCompactionThreshold(myNamespace));
         long brokerPolicy = pulsar.getConfiguration().getBrokerServiceCompactionThresholdInBytes();
-        assertEquals(admin.topics().getCompactionThreshold(topic, true).longValue(), brokerPolicy);
+        assertEquals(admin.topicPolicies().getCompactionThreshold(topic, true).longValue(), brokerPolicy);
         long namespacePolicy = 10L;
 
         admin.namespaces().setCompactionThreshold(myNamespace, namespacePolicy);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getCompactionThreshold(myNamespace)));
-        assertEquals(admin.topics().getCompactionThreshold(topic, true).longValue(), namespacePolicy);
+        assertEquals(admin.topicPolicies().getCompactionThreshold(topic, true).longValue(), namespacePolicy);
 
         long topicPolicy = 20L;
-        admin.topics().setCompactionThreshold(topic, topicPolicy);
-        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topics().getCompactionThreshold(topic)));
-        assertEquals(admin.topics().getCompactionThreshold(topic, true).longValue(), topicPolicy);
+        admin.topicPolicies().setCompactionThreshold(topic, topicPolicy);
+        Awaitility.await().untilAsserted(() -> assertNotNull(admin.topicPolicies().getCompactionThreshold(topic)));
+        assertEquals(admin.topicPolicies().getCompactionThreshold(topic, true).longValue(), topicPolicy);
 
         admin.namespaces().removeCompactionThreshold(myNamespace);
-        admin.topics().removeCompactionThreshold(topic);
+        admin.topicPolicies().removeCompactionThreshold(topic);
         Awaitility.await().untilAsserted(() -> assertNull(admin.namespaces().getCompactionThreshold(myNamespace)));
-        Awaitility.await().untilAsserted(() -> assertNull(admin.topics().getCompactionThreshold(topic)));
-        assertEquals(admin.topics().getCompactionThreshold(topic, true).longValue(), brokerPolicy);
+        Awaitility.await().untilAsserted(() -> assertNull(admin.topicPolicies().getCompactionThreshold(topic)));
+        assertEquals(admin.topicPolicies().getCompactionThreshold(topic, true).longValue(), brokerPolicy);
     }
 
     @Test(timeOut = 30000)
@@ -2444,7 +2444,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .build();
         log.info("Backlog quota: {} will set to the topic: {}", backlogQuota, testTopic);
 
-        admin.topics().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
+        admin.topicPolicies().setBacklogQuota(testTopic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
         log.info("Backlog quota set success on topic: {}", testTopic);
 
         Awaitility.await()
@@ -2457,7 +2457,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         long previousCompactedLedgerId = internalStats.compactedLedger.ledgerId;
 
         Awaitility.await()
-                .untilAsserted(() -> Assert.assertEquals(admin.topics().getBacklogQuotaMap(testTopic)
+                .untilAsserted(() -> Assert.assertEquals(admin.topicPolicies().getBacklogQuotaMap(testTopic)
                         .get(BacklogQuota.BacklogQuotaType.destination_storage), backlogQuota));
 
         pulsar.getBrokerService().checkCompaction();
@@ -2483,7 +2483,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         // set and check retention policy on topic level
         RetentionPolicies topicRetentionPolicies = new RetentionPolicies(2, -1);
-        admin.topics().setRetention(testTopic, topicRetentionPolicies);
+        admin.topicPolicies().setRetention(testTopic, topicRetentionPolicies);
         Awaitility.await().untilAsserted(() -> {
             ManagedLedgerConfig config = pulsar.getBrokerService().getManagedLedgerConfig(topicName).get();
             Assert.assertEquals(config.getRetentionTimeMillis(),
@@ -2502,7 +2502,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                         .isNull());
 
         int maxConsumersPerSubscription = 10;
-        admin.topics().setMaxConsumersPerSubscription(topic, maxConsumersPerSubscription);
+        admin.topicPolicies().setMaxConsumersPerSubscription(topic, maxConsumersPerSubscription);
 
         Awaitility.await().untilAsserted(() ->
                 Assertions.assertThat(pulsar.getBrokerService().getTopic(topic, false).get().isPresent()).isTrue());
@@ -2529,7 +2529,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                         .isNull());
 
         int maxConsumersPerSubscription = 10;
-        admin.topics().setMaxConsumersPerSubscription(topic, maxConsumersPerSubscription);
+        admin.topicPolicies().setMaxConsumersPerSubscription(topic, maxConsumersPerSubscription);
 
         Awaitility.await().untilAsserted(() ->
                 Assertions.assertThat(pulsar.getBrokerService().getTopic(topic, false).get().isPresent()).isTrue());
@@ -2539,7 +2539,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         InactiveTopicPolicies inactiveTopicPolicies =
                 new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 3, true);
-        admin.topics().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
+        admin.topicPolicies().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
 
         Thread.sleep(4_000L);
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -75,6 +75,18 @@ public interface PulsarAdmin extends Closeable {
     Topics topics();
 
     /**
+     * Get the topic policies management object
+     * @return the topic policies management object
+     */
+    TopicPolicies topicPolicies();
+
+    /**
+     * Get the local/global topic policies management object
+     * @return the topic policies management object
+     */
+    TopicPolicies topicPolicies(boolean isGlobal);
+
+    /**
      * @return the bookies management object
      */
     Bookies bookies();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
@@ -1,0 +1,1661 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
+import org.apache.pulsar.common.policies.data.PublishRate;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
+
+/**
+ * Admin interface for topic policies management.
+ */
+public interface TopicPolicies {
+
+    /**
+     * Get backlog quota map for a topic.
+     * @param topic Topic name
+     * @throws PulsarAdminException.NotFoundException Topic does not exist
+     * @throws PulsarAdminException Unexpected error
+     */
+    Map<BacklogQuota.BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic)
+            throws PulsarAdminException;
+
+    /**
+     * Get applied backlog quota map for a topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    Map<BacklogQuota.BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic, boolean applied)
+            throws PulsarAdminException;
+
+    /**
+     * Set a backlog quota for a topic.
+     * @param topic
+     *            Topic name
+     * @param backlogQuota
+     *            the new BacklogQuota
+     * @param backlogQuotaType
+     *
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setBacklogQuota(String topic, BacklogQuota backlogQuota,
+                         BacklogQuota.BacklogQuotaType backlogQuotaType) throws PulsarAdminException;
+
+    default void setBacklogQuota(String topic, BacklogQuota backlogQuota) throws PulsarAdminException {
+        setBacklogQuota(topic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
+    }
+
+    /**
+     * Remove a backlog quota policy from a topic.
+     * The namespace backlog policy will fall back to the default.
+     *
+     * @param topic
+     *            Topic name
+     * @param backlogQuotaType
+     *
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeBacklogQuota(String topic, BacklogQuota.BacklogQuotaType backlogQuotaType) throws PulsarAdminException;
+
+    default void removeBacklogQuota(String topic)
+            throws PulsarAdminException {
+        removeBacklogQuota(topic, BacklogQuota.BacklogQuotaType.destination_storage);
+    }
+
+    /**
+     * Get the delayed delivery policy applied for a specified topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic
+            , boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the delayed delivery policy applied for a specified topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic
+            , boolean applied);
+    /**
+     * Get the delayed delivery policy for a specified topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the delayed delivery policy for a specified topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic);
+
+    /**
+     * Set the delayed delivery policy for a specified topic.
+     * @param topic
+     * @param delayedDeliveryPolicies
+     * @throws PulsarAdminException
+     */
+    void setDelayedDeliveryPolicy(String topic
+            , DelayedDeliveryPolicies delayedDeliveryPolicies) throws PulsarAdminException;
+
+    /**
+     * Set the delayed delivery policy for a specified topic asynchronously.
+     * @param topic
+     * @param delayedDeliveryPolicies
+     * @return
+     */
+    CompletableFuture<Void> setDelayedDeliveryPolicyAsync(String topic
+            , DelayedDeliveryPolicies delayedDeliveryPolicies);
+
+    /**
+     * Remove the delayed delivery policy for a specified topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeDelayedDeliveryPolicyAsync(String topic);
+
+    /**
+     * Remove the delayed delivery policy for a specified topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeDelayedDeliveryPolicy(String topic) throws PulsarAdminException;
+
+    /**
+     * Set message TTL for a topic.
+     *
+     * @param topic
+     *          Topic name
+     * @param messageTTLInSecond
+     *          Message TTL in second.
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setMessageTTL(String topic, int messageTTLInSecond) throws PulsarAdminException;
+
+    /**
+     * Get message TTL for a topic.
+     *
+     * @param topic
+     * @return Message TTL in second.
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Integer getMessageTTL(String topic) throws PulsarAdminException;
+
+    /**
+     * Get message TTL applied for a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMessageTTL(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Remove message TTL for a topic.
+     *
+     * @param topic
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeMessageTTL(String topic) throws PulsarAdminException;
+
+    /**
+     * Set the retention configuration on a topic.
+     * <p/>
+     * Set the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException;
+
+    /**
+     * Set the retention configuration for all the topics on a topic asynchronously.
+     * <p/>
+     * Set the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> setRetentionAsync(String topic, RetentionPolicies retention);
+
+    /**
+     * Get the retention configuration for a topic.
+     * <p/>
+     * Get the retention configuration for a topic.
+     * <p/>
+     * Response example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    RetentionPolicies getRetention(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the retention configuration for a topic asynchronously.
+     * <p/>
+     * Get the retention configuration for a topic.
+     * <p/>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<RetentionPolicies> getRetentionAsync(String topic);
+
+    /**
+     * Get the applied retention configuration for a topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    RetentionPolicies getRetention(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the applied retention configuration for a topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<RetentionPolicies> getRetentionAsync(String topic, boolean applied);
+
+    /**
+     * Remove the retention configuration for all the topics on a topic.
+     * <p/>
+     * Remove the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws ConflictException
+     *             Concurrent modification
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeRetention(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the retention configuration for all the topics on a topic asynchronously.
+     * <p/>
+     * Remove the retention configuration on a topic. This operation requires Pulsar super-user access.
+     * <p/>
+     * Request parameter example:
+     * <p/>
+     *
+     * <pre>
+     * <code>
+     * {
+     *     "retentionTimeInMinutes" : 60,            // how long to retain messages
+     *     "retentionSizeInMB" : 1024,              // retention backlog limit
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> removeRetentionAsync(String topic);
+
+    /**
+     * get max unacked messages on consumer of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException;
+
+    /**
+     * get max unacked messages on consumer of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic);
+
+    /**
+     * get applied max unacked messages on consumer of a topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxUnackedMessagesOnConsumer(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * get applied max unacked messages on consumer of a topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic, boolean applied);
+
+    /**
+     * set max unacked messages on consumer of a topic.
+     * @param topic
+     * @param maxNum
+     * @throws PulsarAdminException
+     */
+    void setMaxUnackedMessagesOnConsumer(String topic, int maxNum) throws PulsarAdminException;
+
+    /**
+     * set max unacked messages on consumer of a topic asynchronously.
+     * @param topic
+     * @param maxNum
+     * @return
+     */
+    CompletableFuture<Void> setMaxUnackedMessagesOnConsumerAsync(String topic, int maxNum);
+
+    /**
+     * remove max unacked messages on consumer of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException;
+
+    /**
+     * remove max unacked messages on consumer of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeMaxUnackedMessagesOnConsumerAsync(String topic);
+
+    /**
+     * Get inactive topic policies applied for a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get inactive topic policies applied for a topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic, boolean applied);
+    /**
+     * get inactive topic policies of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * get inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic);
+
+    /**
+     * set inactive topic policies of a topic.
+     * @param topic
+     * @param inactiveTopicPolicies
+     * @throws PulsarAdminException
+     */
+    void setInactiveTopicPolicies(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException;
+
+    /**
+     * set inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @param inactiveTopicPolicies
+     * @return
+     */
+    CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic, InactiveTopicPolicies inactiveTopicPolicies);
+
+    /**
+     * remove inactive topic policies of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeInactiveTopicPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * remove inactive topic policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeInactiveTopicPoliciesAsync(String topic);
+
+    /**
+     * get offload policies of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    OffloadPolicies getOffloadPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * get offload policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic);
+
+    /**
+     * get applied offload policies of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    OffloadPolicies getOffloadPolicies(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * get applied offload policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic, boolean applied);
+
+    /**
+     * set offload policies of a topic.
+     * @param topic
+     * @param offloadPolicies
+     * @throws PulsarAdminException
+     */
+    void setOffloadPolicies(String topic, OffloadPolicies offloadPolicies) throws PulsarAdminException;
+
+    /**
+     * set offload policies of a topic asynchronously.
+     * @param topic
+     * @param offloadPolicies
+     * @return
+     */
+    CompletableFuture<Void> setOffloadPoliciesAsync(String topic, OffloadPolicies offloadPolicies);
+
+    /**
+     * remove offload policies of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeOffloadPolicies(String topic) throws PulsarAdminException;
+
+    /**
+     * remove offload policies of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeOffloadPoliciesAsync(String topic);
+
+    /**
+     * get max unacked messages on subscription of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException;
+
+    /**
+     * get max unacked messages on subscription of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic);
+
+    /**
+     * get max unacked messages on subscription of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxUnackedMessagesOnSubscription(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * get max unacked messages on subscription of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic, boolean applied);
+
+    /**
+     * set max unacked messages on subscription of a topic.
+     * @param topic
+     * @param maxNum
+     * @throws PulsarAdminException
+     */
+    void setMaxUnackedMessagesOnSubscription(String topic, int maxNum) throws PulsarAdminException;
+
+    /**
+     * set max unacked messages on subscription of a topic asynchronously.
+     * @param topic
+     * @param maxNum
+     * @return
+     */
+    CompletableFuture<Void> setMaxUnackedMessagesOnSubscriptionAsync(String topic, int maxNum);
+
+    /**
+     * remove max unacked messages on subscription of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException;
+
+    /**
+     * remove max unacked messages on subscription of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeMaxUnackedMessagesOnSubscriptionAsync(String topic);
+
+    /**
+     * Set the configuration of persistence policies for specified topic.
+     *
+     * @param topic Topic name
+     * @param persistencePolicies Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setPersistence(String topic, PersistencePolicies persistencePolicies) throws PulsarAdminException;
+
+    /**
+     * Set the configuration of persistence policies for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @param persistencePolicies Configuration of bookkeeper persistence policies
+     */
+    CompletableFuture<Void> setPersistenceAsync(String topic, PersistencePolicies persistencePolicies);
+
+    /**
+     * Get the configuration of persistence policies for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    PersistencePolicies getPersistence(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the configuration of persistence policies for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic);
+
+    /**
+     * Get the applied configuration of persistence policies for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    PersistencePolicies getPersistence(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the applied configuration of persistence policies for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic, boolean applied);
+
+    /**
+     * Remove the configuration of persistence policies for specified topic.
+     *
+     * @param topic Topic name
+     * @throws PulsarAdminException Unexpected error
+     */
+    void removePersistence(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the configuration of persistence policies for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<Void> removePersistenceAsync(String topic);
+
+    /**
+     * get deduplication enabled of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Boolean getDeduplicationStatus(String topic) throws PulsarAdminException;
+
+    /**
+     * get deduplication enabled of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic);
+    /**
+     * get applied deduplication enabled of a topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Boolean getDeduplicationStatus(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * get applied deduplication enabled of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic, boolean applied);
+
+    /**
+     * set deduplication enabled of a topic.
+     * @param topic
+     * @param enabled
+     * @throws PulsarAdminException
+     */
+    void setDeduplicationStatus(String topic, boolean enabled) throws PulsarAdminException;
+
+    /**
+     * set deduplication enabled of a topic asynchronously.
+     * @param topic
+     * @param enabled
+     * @return
+     */
+    CompletableFuture<Void> setDeduplicationStatusAsync(String topic, boolean enabled);
+
+    /**
+     * remove deduplication enabled of a topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeDeduplicationStatus(String topic) throws PulsarAdminException;
+
+    /**
+     * remove deduplication enabled of a topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeDeduplicationStatusAsync(String topic);
+
+    /**
+     * Set message-dispatch-rate (topic can dispatch this many messages per second).
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set message-dispatch-rate asynchronously.
+     * <p/>
+     * topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Get message-dispatch-rate (topic can dispatch this many messages per second).
+     *
+     * @param topic
+     * @returns messageRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Get message-dispatch-rate asynchronously.
+     * <p/>
+     * Topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns messageRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getDispatchRateAsync(String topic);
+
+    /**
+     * Get applied message-dispatch-rate (topic can dispatch this many messages per second).
+     *
+     * @param topic
+     * @returns messageRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getDispatchRate(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get applied message-dispatch-rate asynchronously.
+     * <p/>
+     * Topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns messageRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getDispatchRateAsync(String topic, boolean applied);
+
+    /**
+     * Remove message-dispatch-rate.
+     * <p/>
+     * Remove topic message dispatch rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    void removeDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove message-dispatch-rate asynchronously.
+     * <p/>
+     * Remove topic message dispatch rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    CompletableFuture<Void> removeDispatchRateAsync(String topic) throws PulsarAdminException;
+
+    /**
+     * Set subscription-message-dispatch-rate for the topic.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set subscription-message-dispatch-rate for the topic asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Get applied subscription-message-dispatch-rate.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @returns DispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getSubscriptionDispatchRate(String namespace, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get applied subscription-message-dispatch-rate asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @returns DispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String namespace, boolean applied);
+
+    /**
+     * Get subscription-message-dispatch-rate for the topic.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns DispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getSubscriptionDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Get subscription-message-dispatch-rate asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns DispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String topic);
+
+    /**
+     * Remove subscription-message-dispatch-rate for a topic.
+     * @param topic
+     *            Topic name
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    void removeSubscriptionDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove subscription-message-dispatch-rate for a topic asynchronously.
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> removeSubscriptionDispatchRateAsync(String topic);
+
+    /**
+     * Set replicatorDispatchRate for the topic.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set replicatorDispatchRate for the topic asynchronously.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Get replicatorDispatchRate for the topic.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns DispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getReplicatorDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Get replicatorDispatchRate asynchronously.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @returns DispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic);
+
+    /**
+     * Get applied replicatorDispatchRate for the topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    DispatchRate getReplicatorDispatchRate(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get applied replicatorDispatchRate asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, boolean applied);
+
+    /**
+     * Remove replicatorDispatchRate for a topic.
+     * @param topic
+     *            Topic name
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    void removeReplicatorDispatchRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove replicatorDispatchRate for a topic asynchronously.
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic);
+
+    /**
+     * Get the compactionThreshold for a topic. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>10000000</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Long getCompactionThreshold(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the compactionThreshold for a topic asynchronously. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>10000000</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Long> getCompactionThresholdAsync(String topic);
+
+    /**
+     * Get the compactionThreshold for a topic. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * @param topic Topic name
+     * @throws NotAuthorizedException Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException Namespace does not exist
+     * @throws PulsarAdminException Unexpected error
+     */
+    Long getCompactionThreshold(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the compactionThreshold for a topic asynchronously. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * @param topic Topic name
+     */
+    CompletableFuture<Long> getCompactionThresholdAsync(String topic, boolean applied);
+
+    /**
+     * Set the compactionThreshold for a topic. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>10000000</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @param compactionThreshold
+     *            maximum number of backlog bytes before compaction is triggered
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setCompactionThreshold(String topic, long compactionThreshold) throws PulsarAdminException;
+
+    /**
+     * Set the compactionThreshold for a topic asynchronously. The maximum number of bytes
+     * can have before compaction is triggered. 0 disables.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>10000000</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @param compactionThreshold
+     *            maximum number of backlog bytes before compaction is triggered
+     */
+    CompletableFuture<Void> setCompactionThresholdAsync(String topic, long compactionThreshold);
+
+    /**
+     * Remove the compactionThreshold for a topic.
+     * @param topic
+     *            Topic name
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    void removeCompactionThreshold(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the compactionThreshold for a topic asynchronously.
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> removeCompactionThresholdAsync(String topic);
+
+    /**
+     * Set message-publish-rate (topics can publish this many messages per second).
+     *
+     * @param topic
+     * @param publishMsgRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setPublishRate(String topic, PublishRate publishMsgRate) throws PulsarAdminException;
+
+    /**
+     * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
+     *
+     * @param topic
+     * @param publishMsgRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishMsgRate);
+
+    /**
+     * Get message-publish-rate (topics can publish this many messages per second).
+     *
+     * @param topic
+     * @return number of messages per second
+     * @throws PulsarAdminException Unexpected error
+     */
+    PublishRate getPublishRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Get message-publish-rate (topics can publish this many messages per second) asynchronously.
+     *
+     * @param topic
+     * @return number of messages per second
+     */
+    CompletableFuture<PublishRate> getPublishRateAsync(String topic);
+
+    /**
+     * Remove message-publish-rate.
+     * <p/>
+     * Remove topic message publish rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    void removePublishRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove message-publish-rate asynchronously.
+     * <p/>
+     * Remove topic message publish rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    CompletableFuture<Void> removePublishRateAsync(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the maxConsumersPerSubscription for a topic.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>0</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Integer getMaxConsumersPerSubscription(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the maxConsumersPerSubscription for a topic asynchronously.
+     * <p/>
+     * Response example:
+     *
+     * <pre>
+     * <code>0</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Integer> getMaxConsumersPerSubscriptionAsync(String topic);
+
+    /**
+     * Set maxConsumersPerSubscription for a topic.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>10</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @param maxConsumersPerSubscription
+     *            maxConsumersPerSubscription value for a namespace
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setMaxConsumersPerSubscription(String topic, int maxConsumersPerSubscription) throws PulsarAdminException;
+
+    /**
+     * Set maxConsumersPerSubscription for a topic asynchronously.
+     * <p/>
+     * Request example:
+     *
+     * <pre>
+     * <code>10</code>
+     * </pre>
+     *
+     * @param topic
+     *            Topic name
+     * @param maxConsumersPerSubscription
+     *            maxConsumersPerSubscription value for a namespace
+     */
+    CompletableFuture<Void> setMaxConsumersPerSubscriptionAsync(String topic, int maxConsumersPerSubscription);
+
+    /**
+     * Remove the maxConsumersPerSubscription for a topic.
+     * @param topic
+     *            Topic name
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    void removeMaxConsumersPerSubscription(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the maxConsumersPerSubscription for a topic asynchronously.
+     * @param topic
+     *            Topic name
+     */
+    CompletableFuture<Void> removeMaxConsumersPerSubscriptionAsync(String topic);
+
+    /**
+     * Get the max number of producer for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    Integer getMaxProducers(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the max number of producer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Integer> getMaxProducersAsync(String topic);
+
+    /**
+     * Get the max number of producer applied for specified topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxProducers(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the max number of producer applied for specified topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<Integer> getMaxProducersAsync(String topic, boolean applied);
+
+
+    /**
+     * Set the max number of producer for specified topic.
+     *
+     * @param topic Topic name
+     * @param maxProducers Max number of producer
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setMaxProducers(String topic, int maxProducers) throws PulsarAdminException;
+
+    /**
+     * Set the max number of producer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @param maxProducers Max number of producer
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Void> setMaxProducersAsync(String topic, int maxProducers);
+
+    /**
+     * Remove the max number of producer for specified topic.
+     *
+     * @param topic Topic name
+     * @throws PulsarAdminException Unexpected error
+     */
+    void removeMaxProducers(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the max number of producer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<Void> removeMaxProducersAsync(String topic);
+
+    /**
+     * Get the max number of subscriptions for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    Integer getMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the max number of subscriptions for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Integer> getMaxSubscriptionsPerTopicAsync(String topic);
+
+
+    /**
+     * Set the max number of subscriptions for specified topic.
+     *
+     * @param topic Topic name
+     * @param maxSubscriptionsPerTopic Max number of subscriptions
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setMaxSubscriptionsPerTopic(String topic, int maxSubscriptionsPerTopic) throws PulsarAdminException;
+
+    /**
+     * Set the max number of subscriptions for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @param maxSubscriptionsPerTopic Max number of subscriptions
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Void> setMaxSubscriptionsPerTopicAsync(String topic, int maxSubscriptionsPerTopic);
+
+    /**
+     * Remove the max number of subscriptions for specified topic.
+     *
+     * @param topic Topic name
+     * @throws PulsarAdminException Unexpected error
+     */
+    void removeMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the max number of subscriptions for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<Void> removeMaxSubscriptionsPerTopicAsync(String topic);
+
+    /**
+     * Get the max message size for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    Integer getMaxMessageSize(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the max message size for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Integer> getMaxMessageSizeAsync(String topic);
+
+
+    /**
+     * Set the max message size for specified topic.
+     *
+     * @param topic Topic name
+     * @param maxMessageSize Max message size of producer
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setMaxMessageSize(String topic, int maxMessageSize) throws PulsarAdminException;
+
+    /**
+     * Set the max message size for specified topic asynchronously.0 disables.
+     *
+     * @param topic Topic name
+     * @param maxMessageSize Max message size of topic
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Void> setMaxMessageSizeAsync(String topic, int maxMessageSize);
+
+    /**
+     * Remove the max message size for specified topic.
+     *
+     * @param topic Topic name
+     * @throws PulsarAdminException Unexpected error
+     */
+    void removeMaxMessageSize(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the max message size for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<Void> removeMaxMessageSizeAsync(String topic);
+
+    /**
+     * Get the max number of consumer for specified topic.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    Integer getMaxConsumers(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the max number of consumer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @return Configuration of bookkeeper persistence policies
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Integer> getMaxConsumersAsync(String topic);
+
+    /**
+     * Get the max number of consumer applied for specified topic.
+     * @param topic
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getMaxConsumers(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get the max number of consumer applied for specified topic asynchronously.
+     * @param topic
+     * @param applied
+     * @return
+     */
+    CompletableFuture<Integer> getMaxConsumersAsync(String topic, boolean applied);
+
+    /**
+     * Set the max number of consumer for specified topic.
+     *
+     * @param topic Topic name
+     * @param maxConsumers Max number of consumer
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setMaxConsumers(String topic, int maxConsumers) throws PulsarAdminException;
+
+    /**
+     * Set the max number of consumer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     * @param maxConsumers Max number of consumer
+     * @throws PulsarAdminException Unexpected error
+     */
+    CompletableFuture<Void> setMaxConsumersAsync(String topic, int maxConsumers);
+
+    /**
+     * Remove the max number of consumer for specified topic.
+     *
+     * @param topic Topic name
+     * @throws PulsarAdminException Unexpected error
+     */
+    void removeMaxConsumers(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the max number of consumer for specified topic asynchronously.
+     *
+     * @param topic Topic name
+     */
+    CompletableFuture<Void> removeMaxConsumersAsync(String topic);
+
+    /**
+     * Get the deduplication snapshot interval for specified topic.
+     * @param topic
+     * @return
+     * @throws PulsarAdminException
+     */
+    Integer getDeduplicationSnapshotInterval(String topic) throws PulsarAdminException;
+
+    /**
+     * Get the deduplication snapshot interval for specified topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Integer> getDeduplicationSnapshotIntervalAsync(String topic);
+
+    /**
+     * Set the deduplication snapshot interval for specified topic.
+     * @param topic
+     * @param interval
+     * @throws PulsarAdminException
+     */
+    void setDeduplicationSnapshotInterval(String topic, int interval) throws PulsarAdminException;
+
+    /**
+     * Set the deduplication snapshot interval for specified topic asynchronously.
+     * @param topic
+     * @param interval
+     * @return
+     */
+    CompletableFuture<Void> setDeduplicationSnapshotIntervalAsync(String topic, int interval);
+
+    /**
+     * Remove the deduplication snapshot interval for specified topic.
+     * @param topic
+     * @throws PulsarAdminException
+     */
+    void removeDeduplicationSnapshotInterval(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove the deduplication snapshot interval for specified topic asynchronously.
+     * @param topic
+     * @return
+     */
+    CompletableFuture<Void> removeDeduplicationSnapshotIntervalAsync(String topic);
+
+    /**
+     * Set is enable sub types.
+     *
+     * @param topic
+     * @param subscriptionTypesEnabled
+     *            is enable subTypes
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscriptionTypesEnabled(String topic,
+                                     Set<SubscriptionType> subscriptionTypesEnabled) throws PulsarAdminException;
+
+    /**
+     * Set is enable sub types asynchronously.
+     *
+     * @param topic
+     * @param subscriptionTypesEnabled
+     *            is enable subTypes
+     */
+    CompletableFuture<Void> setSubscriptionTypesEnabledAsync(String topic,
+                                                             Set<SubscriptionType> subscriptionTypesEnabled);
+
+    /**
+     * Get is enable sub types.
+     *
+     * @param topic
+     *            is topic for get is enable sub types
+     * @return set of enable sub types {@link Set <SubscriptionType>}
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Set<SubscriptionType> getSubscriptionTypesEnabled(String topic) throws PulsarAdminException;
+
+    /**
+     * Get is enable sub types asynchronously.
+     *
+     * @param topic
+     *            is topic for get is enable sub types
+     */
+    CompletableFuture<Set<SubscriptionType>> getSubscriptionTypesEnabledAsync(String topic);
+
+    /**
+     * Set topic-subscribe-rate (topic will limit by subscribeRate).
+     *
+     * @param topic
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException;
+
+    /**
+     * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
+     *
+     * @param topic
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     */
+    CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate);
+
+    /**
+     * Get topic-subscribe-rate (topics allow subscribe times per consumer in a period).
+     *
+     * @param topic
+     * @returns subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    SubscribeRate getSubscribeRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Get topic-subscribe-rate asynchronously.
+     * <p/>
+     * Topic allow subscribe times per consumer in a period.
+     *
+     * @param topic
+     * @returns subscribeRate
+     */
+    CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic);
+
+    /**
+     * Get applied topic-subscribe-rate (topics allow subscribe times per consumer in a period).
+     *
+     * @param topic
+     * @returns subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    SubscribeRate getSubscribeRate(String topic, boolean applied) throws PulsarAdminException;
+
+    /**
+     * Get applied topic-subscribe-rate asynchronously.
+     *
+     * @param topic
+     * @returns subscribeRate
+     */
+    CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic, boolean applied);
+
+    /**
+     * Remove topic-subscribe-rate.
+     * <p/>
+     * Remove topic subscribe rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    void removeSubscribeRate(String topic) throws PulsarAdminException;
+
+    /**
+     * Remove topic-subscribe-rate asynchronously.
+     * <p/>
+     * Remove topic subscribe rate
+     *
+     * @param topic
+     * @throws PulsarAdminException
+     *              unexpected error
+     */
+    CompletableFuture<Void> removeSubscribeRateAsync(String topic) throws PulsarAdminException;
+
+
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1606,6 +1606,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     Map<BacklogQuota.BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic)
             throws PulsarAdminException;
 
@@ -1616,6 +1617,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Map<BacklogQuota.BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic, boolean applied)
             throws PulsarAdminException;
 
@@ -1649,9 +1651,11 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setBacklogQuota(String topic, BacklogQuota backlogQuota,
                          BacklogQuota.BacklogQuotaType backlogQuotaType) throws PulsarAdminException;
 
+    @Deprecated
     default void setBacklogQuota(String topic, BacklogQuota backlogQuota) throws PulsarAdminException {
         setBacklogQuota(topic, backlogQuota, BacklogQuota.BacklogQuotaType.destination_storage);
     }
@@ -1671,8 +1675,10 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void removeBacklogQuota(String topic, BacklogQuota.BacklogQuotaType backlogQuotaType) throws PulsarAdminException;
 
+    @Deprecated
     default void removeBacklogQuota(String topic)
             throws PulsarAdminException {
         removeBacklogQuota(topic, BacklogQuota.BacklogQuotaType.destination_storage);
@@ -1685,6 +1691,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic
             , boolean applied) throws PulsarAdminException;
 
@@ -1694,6 +1701,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic
             , boolean applied);
     /**
@@ -1702,6 +1710,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic) throws PulsarAdminException;
 
     /**
@@ -1709,6 +1718,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic);
 
     /**
@@ -1717,6 +1727,7 @@ public interface Topics {
      * @param delayedDeliveryPolicies
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setDelayedDeliveryPolicy(String topic
             , DelayedDeliveryPolicies delayedDeliveryPolicies) throws PulsarAdminException;
 
@@ -1726,6 +1737,7 @@ public interface Topics {
      * @param delayedDeliveryPolicies
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setDelayedDeliveryPolicyAsync(String topic
             , DelayedDeliveryPolicies delayedDeliveryPolicies);
 
@@ -1734,6 +1746,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeDelayedDeliveryPolicyAsync(String topic);
 
     /**
@@ -1741,6 +1754,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeDelayedDeliveryPolicy(String topic) throws PulsarAdminException;
 
     /**
@@ -1757,6 +1771,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setMessageTTL(String topic, int messageTTLInSecond) throws PulsarAdminException;
 
     /**
@@ -1771,6 +1786,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     Integer getMessageTTL(String topic) throws PulsarAdminException;
 
     /**
@@ -1779,6 +1795,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMessageTTL(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -1792,6 +1809,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void removeMessageTTL(String topic) throws PulsarAdminException;
 
     /**
@@ -1823,6 +1841,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException;
 
     /**
@@ -1845,6 +1864,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> setRetentionAsync(String topic, RetentionPolicies retention);
 
     /**
@@ -1875,6 +1895,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     RetentionPolicies getRetention(String topic) throws PulsarAdminException;
 
     /**
@@ -1886,6 +1907,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<RetentionPolicies> getRetentionAsync(String topic);
 
     /**
@@ -1895,6 +1917,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     RetentionPolicies getRetention(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -1903,6 +1926,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<RetentionPolicies> getRetentionAsync(String topic, boolean applied);
 
     /**
@@ -1925,6 +1949,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void removeRetention(String topic) throws PulsarAdminException;
 
     /**
@@ -1947,6 +1972,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeRetentionAsync(String topic);
 
     /**
@@ -1955,6 +1981,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException;
 
     /**
@@ -1962,6 +1989,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic);
 
     /**
@@ -1971,6 +1999,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxUnackedMessagesOnConsumer(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -1979,6 +2008,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic, boolean applied);
 
     /**
@@ -1987,6 +2017,7 @@ public interface Topics {
      * @param maxNum
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setMaxUnackedMessagesOnConsumer(String topic, int maxNum) throws PulsarAdminException;
 
     /**
@@ -1995,6 +2026,7 @@ public interface Topics {
      * @param maxNum
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setMaxUnackedMessagesOnConsumerAsync(String topic, int maxNum);
 
     /**
@@ -2002,6 +2034,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException;
 
     /**
@@ -2009,6 +2042,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxUnackedMessagesOnConsumerAsync(String topic);
 
     /**
@@ -2017,6 +2051,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2025,6 +2060,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic, boolean applied);
     /**
      * get inactive topic policies of a topic.
@@ -2032,6 +2068,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException;
 
     /**
@@ -2039,6 +2076,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic);
 
     /**
@@ -2047,6 +2085,7 @@ public interface Topics {
      * @param inactiveTopicPolicies
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setInactiveTopicPolicies(String topic
             , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException;
 
@@ -2056,6 +2095,7 @@ public interface Topics {
      * @param inactiveTopicPolicies
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic, InactiveTopicPolicies inactiveTopicPolicies);
 
     /**
@@ -2063,6 +2103,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeInactiveTopicPolicies(String topic) throws PulsarAdminException;
 
     /**
@@ -2070,6 +2111,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeInactiveTopicPoliciesAsync(String topic);
 
     /**
@@ -2078,6 +2120,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     OffloadPolicies getOffloadPolicies(String topic) throws PulsarAdminException;
 
     /**
@@ -2085,6 +2128,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic);
 
     /**
@@ -2093,6 +2137,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     OffloadPolicies getOffloadPolicies(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2100,6 +2145,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic, boolean applied);
 
     /**
@@ -2108,6 +2154,7 @@ public interface Topics {
      * @param offloadPolicies
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setOffloadPolicies(String topic, OffloadPolicies offloadPolicies) throws PulsarAdminException;
 
     /**
@@ -2116,6 +2163,7 @@ public interface Topics {
      * @param offloadPolicies
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setOffloadPoliciesAsync(String topic, OffloadPolicies offloadPolicies);
 
     /**
@@ -2123,6 +2171,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeOffloadPolicies(String topic) throws PulsarAdminException;
 
     /**
@@ -2130,6 +2179,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeOffloadPoliciesAsync(String topic);
 
     /**
@@ -2138,6 +2188,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException;
 
     /**
@@ -2145,6 +2196,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic);
 
     /**
@@ -2153,6 +2205,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxUnackedMessagesOnSubscription(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2160,6 +2213,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic, boolean applied);
 
     /**
@@ -2168,6 +2222,7 @@ public interface Topics {
      * @param maxNum
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setMaxUnackedMessagesOnSubscription(String topic, int maxNum) throws PulsarAdminException;
 
     /**
@@ -2176,6 +2231,7 @@ public interface Topics {
      * @param maxNum
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setMaxUnackedMessagesOnSubscriptionAsync(String topic, int maxNum);
 
     /**
@@ -2183,6 +2239,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException;
 
     /**
@@ -2190,6 +2247,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxUnackedMessagesOnSubscriptionAsync(String topic);
 
     /**
@@ -2199,6 +2257,7 @@ public interface Topics {
      * @param persistencePolicies Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void setPersistence(String topic, PersistencePolicies persistencePolicies) throws PulsarAdminException;
 
     /**
@@ -2207,6 +2266,7 @@ public interface Topics {
      * @param topic Topic name
      * @param persistencePolicies Configuration of bookkeeper persistence policies
      */
+    @Deprecated
     CompletableFuture<Void> setPersistenceAsync(String topic, PersistencePolicies persistencePolicies);
 
     /**
@@ -2216,6 +2276,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     PersistencePolicies getPersistence(String topic) throws PulsarAdminException;
 
     /**
@@ -2223,6 +2284,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic);
 
     /**
@@ -2232,6 +2294,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     PersistencePolicies getPersistence(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2239,6 +2302,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic, boolean applied);
 
     /**
@@ -2247,6 +2311,7 @@ public interface Topics {
      * @param topic Topic name
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void removePersistence(String topic) throws PulsarAdminException;
 
     /**
@@ -2254,6 +2319,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removePersistenceAsync(String topic);
 
     /**
@@ -2279,6 +2345,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Boolean getDeduplicationStatus(String topic) throws PulsarAdminException;
 
     /**
@@ -2286,6 +2353,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic);
     /**
      * get applied deduplication enabled of a topic.
@@ -2293,6 +2361,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Boolean getDeduplicationStatus(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2300,6 +2369,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic, boolean applied);
 
     /**
@@ -2326,6 +2396,7 @@ public interface Topics {
      * @param enabled
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setDeduplicationStatus(String topic, boolean enabled) throws PulsarAdminException;
 
     /**
@@ -2334,6 +2405,7 @@ public interface Topics {
      * @param enabled
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setDeduplicationStatusAsync(String topic, boolean enabled);
 
     /**
@@ -2357,6 +2429,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeDeduplicationStatus(String topic) throws PulsarAdminException;
 
     /**
@@ -2364,6 +2437,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeDeduplicationStatusAsync(String topic);
 
     /**
@@ -2375,6 +2449,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2386,6 +2461,7 @@ public interface Topics {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate);
 
     /**
@@ -2397,6 +2473,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     DispatchRate getDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2408,6 +2485,7 @@ public interface Topics {
      * @returns messageRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getDispatchRateAsync(String topic);
 
     /**
@@ -2419,6 +2497,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     DispatchRate getDispatchRate(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2430,6 +2509,7 @@ public interface Topics {
      * @returns messageRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getDispatchRateAsync(String topic, boolean applied);
 
     /**
@@ -2441,6 +2521,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     void removeDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2452,6 +2533,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> removeDispatchRateAsync(String topic) throws PulsarAdminException;
 
     /**
@@ -2465,6 +2547,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2476,6 +2559,7 @@ public interface Topics {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate);
 
     /**
@@ -2489,6 +2573,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     DispatchRate getSubscriptionDispatchRate(String namespace, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2500,6 +2585,7 @@ public interface Topics {
      * @returns DispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String namespace, boolean applied);
 
     /**
@@ -2513,6 +2599,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     DispatchRate getSubscriptionDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2524,6 +2611,7 @@ public interface Topics {
      * @returns DispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String topic);
 
     /**
@@ -2533,6 +2621,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *            Unexpected error
      */
+    @Deprecated
     void removeSubscriptionDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2540,6 +2629,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeSubscriptionDispatchRateAsync(String topic);
 
     /**
@@ -2553,6 +2643,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2564,6 +2655,7 @@ public interface Topics {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate);
 
     /**
@@ -2577,6 +2669,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     DispatchRate getReplicatorDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2588,6 +2681,7 @@ public interface Topics {
      * @returns DispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic);
 
     /**
@@ -2597,6 +2691,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     DispatchRate getReplicatorDispatchRate(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2605,6 +2700,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, boolean applied);
 
     /**
@@ -2614,6 +2710,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *            Unexpected error
      */
+    @Deprecated
     void removeReplicatorDispatchRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2621,6 +2718,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic);
 
     /**
@@ -2643,6 +2741,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     Long getCompactionThreshold(String topic) throws PulsarAdminException;
 
     /**
@@ -2658,6 +2757,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Long> getCompactionThresholdAsync(String topic);
 
     /**
@@ -2668,6 +2768,7 @@ public interface Topics {
      * @throws NotFoundException Namespace does not exist
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     Long getCompactionThreshold(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2675,6 +2776,7 @@ public interface Topics {
      * can have before compaction is triggered. 0 disables.
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Long> getCompactionThresholdAsync(String topic, boolean applied);
 
     /**
@@ -2699,6 +2801,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setCompactionThreshold(String topic, long compactionThreshold) throws PulsarAdminException;
 
     /**
@@ -2716,6 +2819,7 @@ public interface Topics {
      * @param compactionThreshold
      *            maximum number of backlog bytes before compaction is triggered
      */
+    @Deprecated
     CompletableFuture<Void> setCompactionThresholdAsync(String topic, long compactionThreshold);
 
     /**
@@ -2725,6 +2829,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *            Unexpected error
      */
+    @Deprecated
     void removeCompactionThreshold(String topic) throws PulsarAdminException;
 
     /**
@@ -2732,6 +2837,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeCompactionThresholdAsync(String topic);
 
     /**
@@ -2743,6 +2849,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setPublishRate(String topic, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
@@ -2752,6 +2859,7 @@ public interface Topics {
      * @param publishMsgRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishMsgRate);
 
     /**
@@ -2761,6 +2869,7 @@ public interface Topics {
      * @return number of messages per second
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     PublishRate getPublishRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2769,6 +2878,7 @@ public interface Topics {
      * @param topic
      * @return number of messages per second
      */
+    @Deprecated
     CompletableFuture<PublishRate> getPublishRateAsync(String topic);
 
     /**
@@ -2780,6 +2890,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     void removePublishRate(String topic) throws PulsarAdminException;
 
     /**
@@ -2791,6 +2902,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> removePublishRateAsync(String topic) throws PulsarAdminException;
 
     /**
@@ -2812,6 +2924,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     Integer getMaxConsumersPerSubscription(String topic) throws PulsarAdminException;
 
     /**
@@ -2826,6 +2939,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxConsumersPerSubscriptionAsync(String topic);
 
     /**
@@ -2849,6 +2963,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setMaxConsumersPerSubscription(String topic, int maxConsumersPerSubscription) throws PulsarAdminException;
 
     /**
@@ -2865,6 +2980,7 @@ public interface Topics {
      * @param maxConsumersPerSubscription
      *            maxConsumersPerSubscription value for a namespace
      */
+    @Deprecated
     CompletableFuture<Void> setMaxConsumersPerSubscriptionAsync(String topic, int maxConsumersPerSubscription);
 
     /**
@@ -2874,6 +2990,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *            Unexpected error
      */
+    @Deprecated
     void removeMaxConsumersPerSubscription(String topic) throws PulsarAdminException;
 
     /**
@@ -2881,6 +2998,7 @@ public interface Topics {
      * @param topic
      *            Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxConsumersPerSubscriptionAsync(String topic);
 
     /**
@@ -2890,6 +3008,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     Integer getMaxProducers(String topic) throws PulsarAdminException;
 
     /**
@@ -2899,6 +3018,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxProducersAsync(String topic);
 
     /**
@@ -2908,6 +3028,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxProducers(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -2916,6 +3037,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxProducersAsync(String topic, boolean applied);
 
 
@@ -2926,6 +3048,7 @@ public interface Topics {
      * @param maxProducers Max number of producer
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void setMaxProducers(String topic, int maxProducers) throws PulsarAdminException;
 
     /**
@@ -2935,6 +3058,7 @@ public interface Topics {
      * @param maxProducers Max number of producer
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> setMaxProducersAsync(String topic, int maxProducers);
 
     /**
@@ -2943,6 +3067,7 @@ public interface Topics {
      * @param topic Topic name
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void removeMaxProducers(String topic) throws PulsarAdminException;
 
     /**
@@ -2950,6 +3075,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxProducersAsync(String topic);
 
     /**
@@ -2959,6 +3085,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     Integer getMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException;
 
     /**
@@ -2968,6 +3095,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxSubscriptionsPerTopicAsync(String topic);
 
 
@@ -2978,6 +3106,7 @@ public interface Topics {
      * @param maxSubscriptionsPerTopic Max number of subscriptions
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void setMaxSubscriptionsPerTopic(String topic, int maxSubscriptionsPerTopic) throws PulsarAdminException;
 
     /**
@@ -2987,6 +3116,7 @@ public interface Topics {
      * @param maxSubscriptionsPerTopic Max number of subscriptions
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> setMaxSubscriptionsPerTopicAsync(String topic, int maxSubscriptionsPerTopic);
 
     /**
@@ -2995,6 +3125,7 @@ public interface Topics {
      * @param topic Topic name
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void removeMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException;
 
     /**
@@ -3002,6 +3133,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxSubscriptionsPerTopicAsync(String topic);
 
     /**
@@ -3011,6 +3143,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     Integer getMaxMessageSize(String topic) throws PulsarAdminException;
 
     /**
@@ -3020,6 +3153,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxMessageSizeAsync(String topic);
 
 
@@ -3030,6 +3164,7 @@ public interface Topics {
      * @param maxMessageSize Max message size of producer
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void setMaxMessageSize(String topic, int maxMessageSize) throws PulsarAdminException;
 
     /**
@@ -3039,6 +3174,7 @@ public interface Topics {
      * @param maxMessageSize Max message size of topic
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> setMaxMessageSizeAsync(String topic, int maxMessageSize);
 
     /**
@@ -3047,6 +3183,7 @@ public interface Topics {
      * @param topic Topic name
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void removeMaxMessageSize(String topic) throws PulsarAdminException;
 
     /**
@@ -3054,6 +3191,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxMessageSizeAsync(String topic);
 
     /**
@@ -3063,6 +3201,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     Integer getMaxConsumers(String topic) throws PulsarAdminException;
 
     /**
@@ -3072,6 +3211,7 @@ public interface Topics {
      * @return Configuration of bookkeeper persistence policies
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxConsumersAsync(String topic);
 
     /**
@@ -3081,6 +3221,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getMaxConsumers(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -3089,6 +3230,7 @@ public interface Topics {
      * @param applied
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getMaxConsumersAsync(String topic, boolean applied);
 
     /**
@@ -3098,6 +3240,7 @@ public interface Topics {
      * @param maxConsumers Max number of consumer
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void setMaxConsumers(String topic, int maxConsumers) throws PulsarAdminException;
 
     /**
@@ -3107,6 +3250,7 @@ public interface Topics {
      * @param maxConsumers Max number of consumer
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> setMaxConsumersAsync(String topic, int maxConsumers);
 
     /**
@@ -3115,6 +3259,7 @@ public interface Topics {
      * @param topic Topic name
      * @throws PulsarAdminException Unexpected error
      */
+    @Deprecated
     void removeMaxConsumers(String topic) throws PulsarAdminException;
 
     /**
@@ -3122,6 +3267,7 @@ public interface Topics {
      *
      * @param topic Topic name
      */
+    @Deprecated
     CompletableFuture<Void> removeMaxConsumersAsync(String topic);
 
     /**
@@ -3130,6 +3276,7 @@ public interface Topics {
      * @return
      * @throws PulsarAdminException
      */
+    @Deprecated
     Integer getDeduplicationSnapshotInterval(String topic) throws PulsarAdminException;
 
     /**
@@ -3137,6 +3284,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Integer> getDeduplicationSnapshotIntervalAsync(String topic);
 
     /**
@@ -3145,6 +3293,7 @@ public interface Topics {
      * @param interval
      * @throws PulsarAdminException
      */
+    @Deprecated
     void setDeduplicationSnapshotInterval(String topic, int interval) throws PulsarAdminException;
 
     /**
@@ -3153,6 +3302,7 @@ public interface Topics {
      * @param interval
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> setDeduplicationSnapshotIntervalAsync(String topic, int interval);
 
     /**
@@ -3160,6 +3310,7 @@ public interface Topics {
      * @param topic
      * @throws PulsarAdminException
      */
+    @Deprecated
     void removeDeduplicationSnapshotInterval(String topic) throws PulsarAdminException;
 
     /**
@@ -3167,6 +3318,7 @@ public interface Topics {
      * @param topic
      * @return
      */
+    @Deprecated
     CompletableFuture<Void> removeDeduplicationSnapshotIntervalAsync(String topic);
 
     /**
@@ -3178,6 +3330,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setSubscriptionTypesEnabled(String topic,
                                      Set<SubscriptionType> subscriptionTypesEnabled) throws PulsarAdminException;
 
@@ -3188,6 +3341,7 @@ public interface Topics {
      * @param subscriptionTypesEnabled
      *            is enable subTypes
      */
+    @Deprecated
     CompletableFuture<Void> setSubscriptionTypesEnabledAsync(String topic,
                                                              Set<SubscriptionType> subscriptionTypesEnabled);
 
@@ -3200,6 +3354,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     Set<SubscriptionType> getSubscriptionTypesEnabled(String topic) throws PulsarAdminException;
 
     /**
@@ -3208,6 +3363,7 @@ public interface Topics {
      * @param topic
      *            is topic for get is enable sub types
      */
+    @Deprecated
     CompletableFuture<Set<SubscriptionType>> getSubscriptionTypesEnabledAsync(String topic);
 
     /**
@@ -3219,6 +3375,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
@@ -3228,6 +3385,7 @@ public interface Topics {
      * @param subscribeRate
      *            consumer subscribe limit by this subscribeRate
      */
+    @Deprecated
     CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate);
 
     /**
@@ -3238,6 +3396,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     SubscribeRate getSubscribeRate(String topic) throws PulsarAdminException;
 
     /**
@@ -3248,6 +3407,7 @@ public interface Topics {
      * @param topic
      * @returns subscribeRate
      */
+    @Deprecated
     CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic);
 
     /**
@@ -3258,6 +3418,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     SubscribeRate getSubscribeRate(String topic, boolean applied) throws PulsarAdminException;
 
     /**
@@ -3266,6 +3427,7 @@ public interface Topics {
      * @param topic
      * @returns subscribeRate
      */
+    @Deprecated
     CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic, boolean applied);
 
     /**
@@ -3277,6 +3439,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     void removeSubscribeRate(String topic) throws PulsarAdminException;
 
     /**
@@ -3288,6 +3451,7 @@ public interface Topics {
      * @throws PulsarAdminException
      *              unexpected error
      */
+    @Deprecated
     CompletableFuture<Void> removeSubscribeRateAsync(String topic) throws PulsarAdminException;
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.client.admin.Sinks;
 import org.apache.pulsar.client.admin.Source;
 import org.apache.pulsar.client.admin.Sources;
 import org.apache.pulsar.client.admin.Tenants;
+import org.apache.pulsar.client.admin.TopicPolicies;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.Worker;
@@ -87,6 +88,8 @@ public class PulsarAdminImpl implements PulsarAdmin {
     private final Namespaces namespaces;
     private final Bookies bookies;
     private final TopicsImpl topics;
+    private final TopicPolicies localTopicPolicies;
+    private final TopicPolicies globalTopicPolicies;
     private final NonPersistentTopics nonPersistentTopics;
     private final ResourceQuotas resourceQuotas;
     private final ClientConfigurationData clientConfigData;
@@ -209,6 +212,8 @@ public class PulsarAdminImpl implements PulsarAdmin {
         this.properties = new TenantsImpl(root, auth, readTimeoutMs);
         this.namespaces = new NamespacesImpl(root, auth, readTimeoutMs);
         this.topics = new TopicsImpl(root, auth, readTimeoutMs);
+        this.localTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, false);
+        this.globalTopicPolicies = new TopicPoliciesImpl(root, auth, readTimeoutMs, true);
         this.nonPersistentTopics = new NonPersistentTopicsImpl(root, auth, readTimeoutMs);
         this.resourceQuotas = new ResourceQuotasImpl(root, auth, readTimeoutMs);
         this.lookups = new LookupImpl(root, auth, useTls, readTimeoutMs, topics);
@@ -332,6 +337,16 @@ public class PulsarAdminImpl implements PulsarAdmin {
 
     public Topics topics() {
         return topics;
+    }
+
+    @Override
+    public TopicPolicies topicPolicies() {
+        return localTopicPolicies;
+    }
+
+    @Override
+    public TopicPolicies topicPolicies(boolean isGlobal) {
+        return isGlobal ? globalTopicPolicies : localTopicPolicies;
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -1,0 +1,1929 @@
+package org.apache.pulsar.client.admin.internal;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.TopicPolicies;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
+import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.ErrorData;
+import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
+import org.apache.pulsar.common.policies.data.PublishRate;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
+
+public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
+    private final WebTarget adminTopics;
+    private final WebTarget adminV2Topics;
+    private final boolean isGlobal;
+
+    protected TopicPoliciesImpl(WebTarget web, Authentication auth, long readTimeoutMs, boolean isGlobal) {
+        super(auth, readTimeoutMs);
+        this.adminTopics = web.path("/admin");
+        this.adminV2Topics = web.path("/admin/v2");
+        this.isGlobal = isGlobal;
+    }
+
+    public WebTarget addGlobalIfNeeded(WebTarget path) {
+        return isGlobal ? path.queryParam("isGlobal", true) : path;
+    }
+
+    @Override
+    public Map<BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic) throws PulsarAdminException {
+        return getBacklogQuotaMap(topic, false);
+    }
+
+    @Override
+    public Map<BacklogQuotaType, BacklogQuota> getBacklogQuotaMap(String topic, boolean applied)
+            throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuotaMap");
+            path = path.queryParam("applied", applied);
+            return request(path).get(new GenericType<Map<BacklogQuotaType, BacklogQuota>>() {
+            });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+
+    @Override
+    public void setBacklogQuota(String topic, BacklogQuota backlogQuota) throws PulsarAdminException {
+        TopicPolicies.super.setBacklogQuota(topic, backlogQuota);
+    }
+
+
+    @Override
+    public void removeBacklogQuota(String topic) throws PulsarAdminException {
+        TopicPolicies.super.removeBacklogQuota(topic);
+    }
+
+    @Override
+    public void setBacklogQuota(String topic, BacklogQuota backlogQuota,
+                                BacklogQuotaType backlogQuotaType) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuota");
+            request(path.queryParam("backlogQuotaType", backlogQuotaType.toString()))
+                    .post(Entity.entity(backlogQuota, MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void removeBacklogQuota(String topic, BacklogQuotaType backlogQuotaType) throws PulsarAdminException {
+        try {
+            TopicName tn = validateTopic(topic);
+            WebTarget path = topicPath(tn, "backlogQuota");
+            request(path.queryParam("backlogQuotaType", backlogQuotaType.toString()))
+                    .delete(ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public Integer getMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException {
+        return getMaxUnackedMessagesOnConsumer(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic) {
+        return getMaxUnackedMessagesOnConsumerAsync(topic, false);
+    }
+
+    @Override
+    public Integer getMaxUnackedMessagesOnConsumer(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getMaxUnackedMessagesOnConsumerAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxUnackedMessagesOnConsumerAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnConsumer");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<Integer>() {
+            @Override
+            public void completed(Integer maxNum) {
+                future.complete(maxNum);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxUnackedMessagesOnConsumerAsync(String topic, int maxNum) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnConsumer");
+
+        return asyncPostRequest(path, Entity.entity(maxNum, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void setMaxUnackedMessagesOnConsumer(String topic, int maxNum) throws PulsarAdminException {
+        try {
+            setMaxUnackedMessagesOnConsumerAsync(topic, maxNum)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxUnackedMessagesOnConsumerAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnConsumer");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void removeMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException {
+        try {
+            removeMaxUnackedMessagesOnConsumerAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getInactiveTopicPoliciesAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<InactiveTopicPolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<InactiveTopicPolicies>() {
+            @Override
+            public void completed(InactiveTopicPolicies inactiveTopicPolicies) {
+                future.complete(inactiveTopicPolicies);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public InactiveTopicPolicies getInactiveTopicPolicies(String topic) throws PulsarAdminException {
+        return getInactiveTopicPolicies(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<InactiveTopicPolicies> getInactiveTopicPoliciesAsync(String topic) {
+        return getInactiveTopicPoliciesAsync(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Void> setInactiveTopicPoliciesAsync(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
+        return asyncPostRequest(path, Entity.entity(inactiveTopicPolicies, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void setInactiveTopicPolicies(String topic
+            , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException {
+        try {
+            setInactiveTopicPoliciesAsync(topic, inactiveTopicPolicies)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeInactiveTopicPoliciesAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "inactiveTopicPolicies");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void removeInactiveTopicPolicies(String topic) throws PulsarAdminException {
+        try {
+            removeInactiveTopicPoliciesAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic
+            , boolean applied) throws PulsarAdminException {
+        try {
+            return getDelayedDeliveryPolicyAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic
+            , boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "delayedDelivery");
+        path = path.queryParam("applied", applied);
+
+        final CompletableFuture<DelayedDeliveryPolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<DelayedDeliveryPolicies>() {
+            @Override
+            public void completed(DelayedDeliveryPolicies delayedDeliveryPolicies) {
+                future.complete(delayedDeliveryPolicies);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic) throws PulsarAdminException {
+        return getDelayedDeliveryPolicy(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<DelayedDeliveryPolicies> getDelayedDeliveryPolicyAsync(String topic) {
+        return getDelayedDeliveryPolicyAsync(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeDelayedDeliveryPolicyAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "delayedDelivery");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void removeDelayedDeliveryPolicy(String topic) throws PulsarAdminException {
+        try {
+            removeDelayedDeliveryPolicyAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setDelayedDeliveryPolicyAsync(String topic
+            , DelayedDeliveryPolicies delayedDeliveryPolicies) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "delayedDelivery");
+        return asyncPostRequest(path, Entity.entity(delayedDeliveryPolicies, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void setDelayedDeliveryPolicy(String topic
+            , DelayedDeliveryPolicies delayedDeliveryPolicies) throws PulsarAdminException {
+        try {
+            setDelayedDeliveryPolicyAsync(topic, delayedDeliveryPolicies)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public Boolean getDeduplicationStatus(String topic) throws PulsarAdminException {
+        return getDeduplicationStatus(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic) {
+        return getDeduplicationStatusAsync(topic, false);
+    }
+
+    @Override
+    public Boolean getDeduplicationStatus(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getDeduplicationStatusAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> getDeduplicationStatusAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "deduplicationEnabled");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Boolean> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<Boolean>() {
+            @Override
+            public void completed(Boolean enabled) {
+                future.complete(enabled);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    private CompletableFuture<Void> enableDeduplicationAsync(String topic, boolean enabled) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "deduplicationEnabled");
+        return asyncPostRequest(path, Entity.entity(enabled, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void setDeduplicationStatus(String topic, boolean enabled) throws PulsarAdminException {
+        try {
+            enableDeduplicationAsync(topic, enabled).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setDeduplicationStatusAsync(String topic, boolean enabled) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "deduplicationEnabled");
+        return asyncPostRequest(path, Entity.entity(enabled, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeDeduplicationStatus(String topic) throws PulsarAdminException {
+        try {
+            removeDeduplicationStatusAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeDeduplicationStatusAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "deduplicationEnabled");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public OffloadPolicies getOffloadPolicies(String topic) throws PulsarAdminException {
+        return getOffloadPolicies(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic) {
+        return getOffloadPoliciesAsync(topic, false);
+    }
+
+    @Override
+    public OffloadPolicies getOffloadPolicies(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getOffloadPoliciesAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<OffloadPolicies> getOffloadPoliciesAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "offloadPolicies");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<OffloadPolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<OffloadPoliciesImpl>() {
+            @Override
+            public void completed(OffloadPoliciesImpl offloadPolicies) {
+                future.complete(offloadPolicies);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public void setOffloadPolicies(String topic, OffloadPolicies offloadPolicies) throws PulsarAdminException {
+        try {
+            setOffloadPoliciesAsync(topic, offloadPolicies).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setOffloadPoliciesAsync(String topic, OffloadPolicies offloadPolicies) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "offloadPolicies");
+        return asyncPostRequest(path, Entity.entity((OffloadPoliciesImpl) offloadPolicies, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeOffloadPolicies(String topic) throws PulsarAdminException {
+        try {
+            removeOffloadPoliciesAsync(topic).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeOffloadPoliciesAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "offloadPolicies");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException {
+        return getMaxUnackedMessagesOnSubscription(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic) {
+        return getMaxUnackedMessagesOnSubscriptionAsync(topic, false);
+    }
+
+    @Override
+    public Integer getMaxUnackedMessagesOnSubscription(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getMaxUnackedMessagesOnSubscriptionAsync(topic, applied).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxUnackedMessagesOnSubscriptionAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnSubscription");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path, new InvocationCallback<Integer>() {
+            @Override
+            public void completed(Integer maxNum) {
+                future.complete(maxNum);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                future.completeExceptionally(getApiException(throwable.getCause()));
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public void setMaxUnackedMessagesOnSubscription(String topic, int maxNum) throws PulsarAdminException {
+        try {
+            setMaxUnackedMessagesOnSubscriptionAsync(topic, maxNum).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxUnackedMessagesOnSubscriptionAsync(String topic, int maxNum) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnSubscription");
+        return asyncPostRequest(path, Entity.entity(maxNum, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException {
+        try {
+            removeMaxUnackedMessagesOnSubscriptionAsync(topic).
+                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxUnackedMessagesOnSubscriptionAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxUnackedMessagesOnSubscription");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void setMessageTTL(String topic, int messageTTLInSecond) throws PulsarAdminException {
+        try {
+            TopicName topicName = validateTopic(topic);
+            WebTarget path = topicPath(topicName, "messageTTL");
+            request(path.queryParam("messageTTL", messageTTLInSecond)).
+                    post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public Integer getMessageTTL(String topic) throws PulsarAdminException {
+        return getMessageTTL(topic, false);
+    }
+
+    @Override
+    public Integer getMessageTTL(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            TopicName topicName = validateTopic(topic);
+            WebTarget path = topicPath(topicName, "messageTTL");
+            path = path.queryParam("applied", applied);
+            return request(path).get(new GenericType<Integer>() {});
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void removeMessageTTL(String topic) throws PulsarAdminException {
+        try {
+            TopicName topicName = validateTopic(topic);
+            WebTarget path = topicPath(topicName, "messageTTL");
+            request(path.queryParam("messageTTL", 0)).delete(ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException {
+        try {
+            setRetentionAsync(topic, retention).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setRetentionAsync(String topic, RetentionPolicies retention) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        return asyncPostRequest(path, Entity.entity(retention, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public RetentionPolicies getRetention(String topic) throws PulsarAdminException {
+        return getRetention(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<RetentionPolicies> getRetentionAsync(String topic) {
+        return getRetentionAsync(topic, false);
+    }
+
+    @Override
+    public RetentionPolicies getRetention(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getRetentionAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<RetentionPolicies> getRetentionAsync(String topic, boolean applied) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<RetentionPolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<RetentionPolicies>() {
+                    @Override
+                    public void completed(RetentionPolicies retentionPolicies) {
+                        future.complete(retentionPolicies);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void removeRetention(String topic) throws PulsarAdminException {
+        try {
+            removeRetentionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeRetentionAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "retention");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void setPersistence(String topic, PersistencePolicies persistencePolicies) throws PulsarAdminException {
+        try {
+            setPersistenceAsync(topic, persistencePolicies).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setPersistenceAsync(String topic, PersistencePolicies persistencePolicies) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "persistence");
+        return asyncPostRequest(path, Entity.entity(persistencePolicies, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public PersistencePolicies getPersistence(String topic) throws PulsarAdminException {
+        return getPersistence(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic) {
+        return getPersistenceAsync(topic, false);
+    }
+
+    @Override
+    public PersistencePolicies getPersistence(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getPersistenceAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<PersistencePolicies> getPersistenceAsync(String topic, boolean applied) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "persistence");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<PersistencePolicies> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<PersistencePolicies>() {
+                    @Override
+                    public void completed(PersistencePolicies persistencePolicies) {
+                        future.complete(persistencePolicies);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void removePersistence(String topic) throws PulsarAdminException {
+        try {
+            removePersistenceAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removePersistenceAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "persistence");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public DispatchRate getDispatchRate(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getDispatchRateAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "dispatchRate");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<DispatchRate>() {
+                    @Override
+                    public void completed(DispatchRate dispatchRate) {
+                        future.complete(dispatchRate);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public DispatchRate getDispatchRate(String topic) throws PulsarAdminException {
+        return getDispatchRate(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getDispatchRateAsync(String topic) {
+        return getDispatchRateAsync(topic, false);
+    }
+
+    @Override
+    public void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
+        try {
+            setDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "dispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeDispatchRate(String topic) throws PulsarAdminException {
+        try {
+            removeDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeDispatchRateAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "dispatchRate");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public DispatchRate getSubscriptionDispatchRate(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getSubscriptionDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<DispatchRate>() {
+                    @Override
+                    public void completed(DispatchRate dispatchRate) {
+                        future.complete(dispatchRate);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public DispatchRate getSubscriptionDispatchRate(String topic) throws PulsarAdminException {
+        return getSubscriptionDispatchRate(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getSubscriptionDispatchRateAsync(String topic) {
+        return getSubscriptionDispatchRateAsync(topic, false);
+    }
+
+    @Override
+    public void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
+        try {
+            setSubscriptionDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeSubscriptionDispatchRate(String topic) throws PulsarAdminException {
+        try {
+            removeSubscriptionDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeSubscriptionDispatchRateAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Long getCompactionThreshold(String topic) throws PulsarAdminException {
+        return getCompactionThreshold(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Long> getCompactionThresholdAsync(String topic) {
+        return getCompactionThresholdAsync(topic, false);
+    }
+
+    @Override
+    public Long getCompactionThreshold(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getCompactionThresholdAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Long> getCompactionThresholdAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "compactionThreshold");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Long> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Long>() {
+                    @Override
+                    public void completed(Long compactionThreshold) {
+                        future.complete(compactionThreshold);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setCompactionThreshold(String topic, long compactionThreshold) throws PulsarAdminException {
+        try {
+            setCompactionThresholdAsync(topic, compactionThreshold).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setCompactionThresholdAsync(String topic, long compactionThreshold) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "compactionThreshold");
+        return asyncPostRequest(path, Entity.entity(compactionThreshold, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeCompactionThreshold(String topic) throws PulsarAdminException {
+        try {
+            removeCompactionThresholdAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeCompactionThresholdAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "compactionThreshold");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public PublishRate getPublishRate(String topic) throws PulsarAdminException {
+        try {
+            return getPublishRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<PublishRate> getPublishRateAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "publishRate");
+        final CompletableFuture<PublishRate> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<PublishRate>() {
+                    @Override
+                    public void completed(PublishRate publishRate) {
+                        future.complete(publishRate);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setPublishRate(String topic, PublishRate publishRate) throws PulsarAdminException {
+        try {
+            setPublishRateAsync(topic, publishRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "publishRate");
+        return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removePublishRate(String topic) throws PulsarAdminException {
+        try {
+            removePublishRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removePublishRateAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "publishRate");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxConsumersPerSubscription(String topic) throws PulsarAdminException {
+        try {
+            return getMaxConsumersPerSubscriptionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxConsumersPerSubscriptionAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxConsumersPerSubscription");
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer maxConsumersPerSubscription) {
+                        future.complete(maxConsumersPerSubscription);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setMaxConsumersPerSubscription(String topic, int maxConsumersPerSubscription)
+            throws PulsarAdminException {
+        try {
+            setMaxConsumersPerSubscriptionAsync(topic, maxConsumersPerSubscription)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxConsumersPerSubscriptionAsync(String topic, int maxConsumersPerSubscription) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxConsumersPerSubscription");
+        return asyncPostRequest(path, Entity.entity(maxConsumersPerSubscription, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxConsumersPerSubscription(String topic) throws PulsarAdminException {
+        try {
+            removeMaxConsumersPerSubscriptionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxConsumersPerSubscriptionAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "maxConsumersPerSubscription");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxProducers(String topic) throws PulsarAdminException {
+        return getMaxProducers(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxProducersAsync(String topic) {
+        return getMaxProducersAsync(topic, false);
+    }
+
+    @Override
+    public Integer getMaxProducers(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getMaxProducersAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxProducersAsync(String topic, boolean applied) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxProducers");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer maxProducers) {
+                        future.complete(maxProducers);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setMaxProducers(String topic, int maxProducers) throws PulsarAdminException {
+        try {
+            setMaxProducersAsync(topic, maxProducers).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxProducersAsync(String topic, int maxProducers) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxProducers");
+        return asyncPostRequest(path, Entity.entity(maxProducers, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxProducers(String topic) throws PulsarAdminException {
+        try {
+            removeMaxProducersAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxProducersAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxProducers");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException {
+        try {
+            return getMaxSubscriptionsPerTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxSubscriptionsPerTopicAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxSubscriptionsPerTopic");
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer maxSubscriptionsPerTopic) {
+                        future.complete(maxSubscriptionsPerTopic);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setMaxSubscriptionsPerTopic(String topic, int maxSubscriptionsPerTopic) throws PulsarAdminException {
+        try {
+            setMaxSubscriptionsPerTopicAsync(topic, maxSubscriptionsPerTopic)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxSubscriptionsPerTopicAsync(String topic, int maxSubscriptionsPerTopic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxSubscriptionsPerTopic");
+        return asyncPostRequest(path, Entity.entity(maxSubscriptionsPerTopic, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException {
+        try {
+            removeMaxSubscriptionsPerTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxSubscriptionsPerTopicAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxSubscriptionsPerTopic");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxMessageSize(String topic) throws PulsarAdminException {
+        try {
+            return getMaxMessageSizeAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxMessageSizeAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxMessageSize");
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer maxMessageSize) {
+                        future.complete(maxMessageSize);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setMaxMessageSize(String topic, int maxMessageSize) throws PulsarAdminException {
+        try {
+            setMaxMessageSizeAsync(topic, maxMessageSize).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxMessageSizeAsync(String topic, int maxMessageSize) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxMessageSize");
+        return asyncPostRequest(path, Entity.entity(maxMessageSize, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxMessageSize(String topic) throws PulsarAdminException {
+        try {
+            removeMaxMessageSizeAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxMessageSizeAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxMessageSize");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public Integer getMaxConsumers(String topic) throws PulsarAdminException {
+        return getMaxConsumers(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxConsumersAsync(String topic) {
+        return getMaxConsumersAsync(topic, false);
+    }
+
+    @Override
+    public Integer getMaxConsumers(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getMaxConsumersAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getMaxConsumersAsync(String topic, boolean applied) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxConsumers");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer maxProducers) {
+                        future.complete(maxProducers);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setMaxConsumers(String topic, int maxConsumers) throws PulsarAdminException {
+        try {
+            setMaxConsumersAsync(topic, maxConsumers).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setMaxConsumersAsync(String topic, int maxConsumers) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxConsumers");
+        return asyncPostRequest(path, Entity.entity(maxConsumers, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeMaxConsumers(String topic) throws PulsarAdminException {
+        try {
+            removeMaxConsumersAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeMaxConsumersAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "maxConsumers");
+        return asyncDeleteRequest(path);
+    }
+
+
+    @Override
+    public Integer getDeduplicationSnapshotInterval(String topic) throws PulsarAdminException {
+        try {
+            return getDeduplicationSnapshotIntervalAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> getDeduplicationSnapshotIntervalAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "deduplicationSnapshotInterval");
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Integer>() {
+                    @Override
+                    public void completed(Integer interval) {
+                        future.complete(interval);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setDeduplicationSnapshotInterval(String topic, int interval) throws PulsarAdminException {
+        try {
+            setDeduplicationSnapshotIntervalAsync(topic, interval).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setDeduplicationSnapshotIntervalAsync(String topic, int interval) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "deduplicationSnapshotInterval");
+        return asyncPostRequest(path, Entity.entity(interval, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeDeduplicationSnapshotInterval(String topic) throws PulsarAdminException {
+        try {
+            removeDeduplicationSnapshotIntervalAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeDeduplicationSnapshotIntervalAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "deduplicationSnapshotInterval");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void setSubscriptionTypesEnabled(
+            String topic, Set<SubscriptionType>
+            subscriptionTypesEnabled) throws PulsarAdminException {
+        try {
+            setSubscriptionTypesEnabledAsync(topic, subscriptionTypesEnabled)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscriptionTypesEnabledAsync(String topic,
+                                                                    Set<SubscriptionType> subscriptionTypesEnabled) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "subscriptionTypesEnabled");
+        return asyncPostRequest(path, Entity.entity(subscriptionTypesEnabled, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public Set<SubscriptionType> getSubscriptionTypesEnabled(String topic) throws PulsarAdminException {
+        try {
+            return getSubscriptionTypesEnabledAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Set<SubscriptionType>> getSubscriptionTypesEnabledAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscriptionTypesEnabled");
+        final CompletableFuture<Set<SubscriptionType>> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<Set<SubscriptionType>>() {
+                    @Override
+                    public void completed(Set<SubscriptionType> subscriptionTypesEnabled) {
+                        future.complete(subscriptionTypesEnabled);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public SubscribeRate getSubscribeRate(String topic) throws PulsarAdminException {
+        return getSubscribeRate(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic) {
+        return getSubscribeRateAsync(topic, false);
+    }
+
+    @Override
+    public SubscribeRate getSubscribeRate(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getSubscribeRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<SubscribeRate> getSubscribeRateAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscribeRate");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<SubscribeRate> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<SubscribeRate>() {
+                    @Override
+                    public void completed(SubscribeRate subscribeRate) {
+                        future.complete(subscribeRate);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException {
+        try {
+            setSubscribeRateAsync(topic, subscribeRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscribeRate");
+        return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeSubscribeRate(String topic) throws PulsarAdminException {
+        try {
+            removeSubscribeRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeSubscribeRateAsync(String topic) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscribeRate");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public DispatchRate getReplicatorDispatchRate(String topic) throws PulsarAdminException {
+        return getReplicatorDispatchRate(topic, false);
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic) {
+        return getReplicatorDispatchRateAsync(topic, false);
+    }
+
+    @Override
+    public DispatchRate getReplicatorDispatchRate(String topic, boolean applied) throws PulsarAdminException {
+        try {
+            return getReplicatorDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, boolean applied) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "replicatorDispatchRate");
+        path = path.queryParam("applied", applied);
+        final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
+        asyncGetRequest(path,
+                new InvocationCallback<DispatchRate>() {
+                    @Override
+                    public void completed(DispatchRate dispatchRate) {
+                        future.complete(dispatchRate);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
+        try {
+            setReplicatorDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeReplicatorDispatchRate(String topic) throws PulsarAdminException {
+        try {
+            removeReplicatorDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        return asyncDeleteRequest(path);
+    }
+
+    /*
+     * returns topic name with encoded Local Name
+     */
+    private TopicName validateTopic(String topic) {
+        // Parsing will throw exception if name is not valid
+        return TopicName.get(topic);
+    }
+
+    private WebTarget topicPath(TopicName topic, String... parts) {
+        final WebTarget base = topic.isV2() ? adminV2Topics : adminTopics;
+        WebTarget topicPath = base.path(topic.getRestPath());
+        topicPath = WebTargets.addParts(topicPath, parts);
+        topicPath = addGlobalIfNeeded(topicPath);
+        return topicPath;
+    }
+}


### PR DESCRIPTION
### Motivation
When setting the topic policy for a geo-replicated cluster, some policies want to affect the whole geo-replicated cluster but some only want to affect the local cluster. 
https://github.com/apache/pulsar/wiki/PIP-92%3A-Topic-policy-across-multiple-clusters

And I address penghui‘s comment
https://lists.apache.org/thread.html/r1c4be3c3b97618625cc7b3410634b43704e0a290df21b7356a491152%40%3Cdev.pulsar.apache.org%3E

### Modifications
Separate Topic Policies into a separate class

### Verifying this change

### Documentation
doc-required 
  

