### PR TITLE
make partitioned-lookup result more readable

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -80,55 +80,62 @@ public class TopicLookupBase extends PulsarWebResource {
             return;
         }
 
-        CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                .getBrokerServiceUrlAsync(topicName,
-                        LookupOptions.builder().advertisedListenerName(listenerName)
-                                .authoritative(authoritative).loadTopicsInBundle(false).build());
-
-        lookupFuture.thenAccept(optionalResult -> {
-            if (optionalResult == null || !optionalResult.isPresent()) {
-                log.warn("No broker was found available for topic {}", topicName);
-                completeLookupResponseExceptionally(asyncResponse,
-                        new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
+        pulsar().getNamespaceService().checkTopicExists(topicName).thenAccept(exist -> {
+            if (!exist) {
+                completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,
+                        "Topic not found."));
                 return;
             }
+            CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
+                    .getBrokerServiceUrlAsync(topicName,
+                            LookupOptions.builder().advertisedListenerName(listenerName)
+                                    .authoritative(authoritative).loadTopicsInBundle(false).build());
 
-            LookupResult result = optionalResult.get();
-            // We have found either a broker that owns the topic, or a broker to which we should redirect the client to
-            if (result.isRedirect()) {
-                boolean newAuthoritative = result.isAuthoritativeRedirect();
-                URI redirect;
-                try {
-                    String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
-                            : result.getLookupData().getHttpUrl();
-                    checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
-                    String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
-                    String path = String.format("%s%s%s?authoritative=%s",
-                            redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
-                    path = listenerName == null ? path : path + "&listenerName=" + listenerName;
-                    redirect = new URI(path);
-                } catch (URISyntaxException | NullPointerException e) {
-                    log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
-                    completeLookupResponseExceptionally(asyncResponse, e);
+            lookupFuture.thenAccept(optionalResult -> {
+                if (optionalResult == null || !optionalResult.isPresent()) {
+                    log.warn("No broker was found available for topic {}", topicName);
+                    completeLookupResponseExceptionally(asyncResponse,
+                            new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
                     return;
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
-                }
-                completeLookupResponseExceptionally(asyncResponse,
-                        new WebApplicationException(Response.temporaryRedirect(redirect).build()));
 
-            } else {
-                // Found broker owning the topic
-                if (log.isDebugEnabled()) {
-                    log.debug("Lookup succeeded for topic {} -- broker: {}", topicName, result.getLookupData());
+                LookupResult result = optionalResult.get();
+                // We have found either a broker that owns the topic, or a broker to which we should redirect the client to
+                if (result.isRedirect()) {
+                    boolean newAuthoritative = result.isAuthoritativeRedirect();
+                    URI redirect;
+                    try {
+                        String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
+                                : result.getLookupData().getHttpUrl();
+                        checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
+                        String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
+                        String path = String.format("%s%s%s?authoritative=%s",
+                                redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
+                        path = listenerName == null ? path : path + "&listenerName=" + listenerName;
+                        redirect = new URI(path);
+                    } catch (URISyntaxException | NullPointerException e) {
+                        log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
+                        completeLookupResponseExceptionally(asyncResponse, e);
+                        return;
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
+                    }
+                    completeLookupResponseExceptionally(asyncResponse,
+                            new WebApplicationException(Response.temporaryRedirect(redirect).build()));
+
+                } else {
+                    // Found broker owning the topic
+                    if (log.isDebugEnabled()) {
+                        log.debug("Lookup succeeded for topic {} -- broker: {}", topicName, result.getLookupData());
+                    }
+                    completeLookupResponseSuccessfully(asyncResponse, result.getLookupData());
                 }
-                completeLookupResponseSuccessfully(asyncResponse, result.getLookupData());
-            }
-        }).exceptionally(exception -> {
-            log.warn("Failed to lookup broker for topic {}: {}", topicName, exception.getMessage(), exception);
-            completeLookupResponseExceptionally(asyncResponse, exception);
-            return null;
+            }).exceptionally(exception -> {
+                log.warn("Failed to lookup broker for topic {}: {}", topicName, exception.getMessage(), exception);
+                completeLookupResponseExceptionally(asyncResponse, exception);
+                return null;
+            });
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.lookup.http;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -49,6 +50,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.mockito.ArgumentCaptor;
@@ -124,7 +126,44 @@ public class HttpTopicLookupv2Test {
         WebApplicationException wae = (WebApplicationException) arg.getValue();
         assertEquals(wae.getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
     }
-    
+
+    @Test
+    public void testLookupTopicNotExist() throws Exception {
+
+        MockTopicLookup destLookup = spy(new MockTopicLookup());
+        doReturn(false).when(destLookup).isRequestHttps();
+        destLookup.setPulsar(pulsar);
+        doReturn("null").when(destLookup).clientAppId();
+        Field uriField = PulsarWebResource.class.getDeclaredField("uri");
+        uriField.setAccessible(true);
+        UriInfo uriInfo = mock(UriInfo.class);
+        uriField.set(destLookup, uriInfo);
+        URI uri = URI.create("http://localhost:8080/lookup/v2/destination/topic/myprop/usc/ns2/topic1");
+        doReturn(uri).when(uriInfo).getRequestUri();
+        doReturn(true).when(config).isAuthorizationEnabled();
+
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        future.complete(false);
+        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
+
+        AsyncResponse asyncResponse1 = mock(AsyncResponse.class);
+        destLookup.lookupTopicAsync(TopicDomain.persistent.value(), "myprop", "usc", "ns2", "topic_not_exist", false,
+                asyncResponse1, null, null);
+
+        ArgumentCaptor<Throwable> arg = ArgumentCaptor.forClass(Throwable.class);
+        verify(asyncResponse1).resume(arg.capture());
+        assertEquals(arg.getValue().getClass(), RestException.class);
+        RestException restException = (RestException) arg.getValue();
+        assertEquals(restException.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
+    }
+
+    static class MockTopicLookup extends TopicLookup {
+        @Override
+        protected void validateClusterOwnership(String s) {
+            // do nothing
+        }
+    }
     
     @Test
     public void testNotEnoughLookupPermits() throws Exception {


### PR DESCRIPTION
Fixes #12026 

### Motivation
Currently we get the broker URL for each partition of a patitioned topic by `partitioned-lookup` command , and the result displayed like 

```bash
"persistent://t/ns/t-partition-0    pulsar://broker2:6650"
"persistent://t/ns/t-partition-1    pulsar://broker2:6650"
"persistent://t/ns/t-partition-2    pulsar://broker1:6650"
"persistent://t/ns/t-partition-3    pulsar://broker1:6650"
"persistent://t/ns/t-partition-4    pulsar://broker2:6650"
```
As desceibe in #12026 , if a partitioned-topic has lots of partitions(may be 1000 or more), the`partitioned-lookup` command will print lots of content which contains a mapping for every partition and we can't get the brokerUrl easily.

And in the product environment, partitions usually are much more than brokers, so, print the result of `partitioned-lookpup` using brokerUrl as key can make this result much more  simpler and readable.

This pull request modified the result of `partitiond-lookup`, and return a `Map<brokerUrl, List<partitioin>>`  which is more readable from user side.

After this change, partitioned-lookup will like
```shell
"pulsar://broker1:6660    [persistent://t/ns/topic-partition-2, persistent://t/ns/topic-partition-3]"
"pulsar://broker2:6650    [persistent://t/ns/topic-partition-0, persistent://t/ns/topic-partition-1, persistent://t/ns/topic-partition-4]"
```

### Modifications

Modidy the result of `partitioned-lookup` from `Map<partition, brokerUrl>` to `Map<brokerUrl, List<partitioin>>`

### Verifying this change
This change is already covered by existing tests, such as *AdminApiTest.testPulsarAdminForUriAndUrlEncoding * and *TopicOwnerTest.testLookupPartitionedTopic*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no)
  - The default values of configurations: ( no)
  - The wire protocol: ( no)
  - The rest endpoints: ( no)
  - The admin cli options: ( no)
  - Anything that affects deployment: ( no)

### Documentation

no-need-doc 

