### PR TITLE
Optimize the memory usage of Cache Eviction

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2112,8 +2112,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private PositionImpl getEarlierReadPositionForActiveCursors() {
-        PositionImpl nonDurablePosition = (PositionImpl) nonDurableActiveCursors.getSlowestReader().getReadPosition();
-        PositionImpl durablePosition = (PositionImpl) activeCursors.getSlowestReader().getReadPosition();
+        PositionImpl nonDurablePosition = nonDurableActiveCursors.getSlowestReadPositionForActiveCursors();
+        PositionImpl durablePosition = activeCursors.getSlowestReadPositionForActiveCursors();
         if (nonDurablePosition == null) {
             return durablePosition;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2111,7 +2111,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private PositionImpl getEarlierReadPositionForActiveCursors() {
-        return (PositionImpl) (activeCursors.getSlowestReader()).getReadPosition();
+        return activeCursors.getSlowestReadPositionForActiveCursors();
     }
 
     void updateCursor(ManagedCursorImpl cursor, PositionImpl newPosition) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2097,6 +2097,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     void doCacheEviction(long maxTimestamp) {
+        if (entryCache.getSize() <= 0) {
+            return;
+        }
         // Always remove all entries already read by active cursors
         PositionImpl slowestReaderPos = getEarlierReadPositionForActiveCursors();
         if (slowestReaderPos != null) {
@@ -2108,17 +2111,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private PositionImpl getEarlierReadPositionForActiveCursors() {
-        PositionImpl smallest = null;
-        for (ManagedCursor cursor : activeCursors) {
-            PositionImpl p = (PositionImpl) cursor.getReadPosition();
-            if (smallest == null) {
-                smallest = p;
-            } else if (p.compareTo(smallest) < 0) {
-                smallest = p;
-            }
-        }
-
-        return smallest;
+        return (PositionImpl) (activeCursors.getSlowestReader()).getReadPosition();
     }
 
     void updateCursor(ManagedCursorImpl cursor, PositionImpl newPosition) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2112,7 +2112,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private PositionImpl getEarlierReadPositionForActiveCursors() {
-        return (PositionImpl) nonDurableActiveCursors.getSlowestReader().getReadPosition();
+        PositionImpl nonDurablePosition = (PositionImpl) nonDurableActiveCursors.getSlowestReader().getReadPosition();
+        PositionImpl durablePosition = (PositionImpl) activeCursors.getSlowestReader().getReadPosition();
+        if (nonDurablePosition == null) {
+            return durablePosition;
+        }
+        if (durablePosition == null) {
+            return nonDurablePosition;
+        }
+        return durablePosition.compareTo(nonDurablePosition) > 0 ? nonDurablePosition : durablePosition;
     }
 
     void updateCursor(ManagedCursorImpl cursor, PositionImpl newPosition) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -19,14 +19,12 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -404,14 +402,26 @@ public class ManagedCursorContainerTest {
         // Add no durable cursor
         position = PositionImpl.get(1,1);
         ManagedCursor cursor2 = spy(new MockManagedCursor(container, "test2", position));
-        doReturn(false).when(cursor1).isDurable();
+        doReturn(false).when(cursor2).isDurable();
         doReturn(position).when(cursor2).getReadPosition();
         container.add(cursor2);
         assertEquals(container.getSlowestReadPositionForActiveCursors(), new PositionImpl(1, 1));
 
-        // Remove cursor
-        container.removeCursor(cursor2.getName());
+        // Move forward cursor, cursor1 = 5:5 , cursor2 = 5:6, slowest is 5:5
+        position = PositionImpl.get(5,6);
+        container.cursorUpdated(cursor2, position);
+        doReturn(position).when(cursor2).getReadPosition();
         assertEquals(container.getSlowestReadPositionForActiveCursors(), new PositionImpl(5, 5));
+
+        // Move forward cursor, cursor1 = 5:8 , cursor2 = 5:6, slowest is 5:6
+        position = PositionImpl.get(5,8);
+        doReturn(position).when(cursor1).getReadPosition();
+        container.cursorUpdated(cursor1, position);
+        assertEquals(container.getSlowestReadPositionForActiveCursors(), new PositionImpl(5, 6));
+
+        // Remove cursor, only cursor1 left, cursor1 = 5:8
+        container.removeCursor(cursor2.getName());
+        assertEquals(container.getSlowestReadPositionForActiveCursors(), new PositionImpl(5, 8));
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -389,12 +389,14 @@ public class ManagedCursorContainerTest {
 
     @Test
     public void testSlowestReadPositionForActiveCursors() throws Exception {
-        ManagedCursorContainer container = new ManagedCursorContainer();
+        ManagedCursorContainer container =
+                new ManagedCursorContainer(ManagedCursorContainer.CursorType.NonDurableCursor);
         assertNull(container.getSlowestReadPositionForActiveCursors());
 
-        // Add durable cursor
+        // Add no durable cursor
         PositionImpl position = PositionImpl.get(5,5);
         ManagedCursor cursor1 = spy(new MockManagedCursor(container, "test1", position));
+        doReturn(false).when(cursor1).isDurable();
         doReturn(position).when(cursor1).getReadPosition();
         container.add(cursor1);
         assertEquals(container.getSlowestReadPositionForActiveCursors(), new PositionImpl(5, 5));


### PR DESCRIPTION
### Motivation
Cache Eviction is executed every 100ms by default, and the frequency is very high. I have observed that it produces a lot of garbage
![image](https://user-images.githubusercontent.com/9758905/133396233-b149f4f7-2607-4dc6-a9fa-b28d475b97df.png)

The optimized memory is as follow:
![image](https://user-images.githubusercontent.com/9758905/133396367-2d5d54bd-d5df-426b-b85c-99832995e34a.png)


### Modifications
1）When there is no cache, no longer check
2）Avoid traversing all cursors

### Documentation

no-need-doc 


