### PR TITLE
[Issue 12040][broker] Multiple bind addresses for Pulsar protocol

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -33,6 +33,9 @@ webServicePort=8080
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
 
+# Extra bind addresses for protocol handlers: <listener_name>:<scheme>://<host>:<port>,[...]
+bindAddresses=
+
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
 advertisedAddress=
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -121,13 +121,18 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String configurationStoreServers;
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving binary protobuf requests"
+        doc = "The port for serving binary protobuf requests."
+            + "If set, defines a server binding for bindAddress:brokerServicePort"
+            + "without an associated advertised listener."
+            + "The Default value is 6650."
     )
 
     private Optional<Integer> brokerServicePort = Optional.of(6650);
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving tls secured binary protobuf requests"
+        doc = "The port for serving TLS-secured binary protobuf requests."
+            + "If set, defines a server binding for bindAddress:brokerServicePortTls"
+            + "without an associated advertised listener."
     )
     private Optional<Integer> brokerServicePortTls = Optional.empty();
     @FieldContext(
@@ -167,6 +172,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "The listener name must contain in the advertisedListeners."
                     + "The Default value is absent, the broker uses the first listener as the internal listener.")
     private String internalListenerName;
+
+    @FieldContext(category=CATEGORY_SERVER,
+            doc = "Used to specify additional bind addresses for the broker."
+                    + "The value must format as <listener_name>:pulsar://<host>:<port>,"
+                    + "multiple bind addresses should separate with commas."
+                    + "Associates each bind address with an advertised listener."
+                    + "Use 'pulsar+ssl' scheme to define a TLS-protected channel."
+                    + "Note that brokerServicePort and brokerServicePortTls define additional bindings."
+                    + ".")
+    private String bindAddresses;
 
     @FieldContext(category=CATEGORY_SERVER,
             doc = "Enable or disable the proxy protocol.")

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -175,11 +175,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(category=CATEGORY_SERVER,
             doc = "Used to specify additional bind addresses for the broker."
-                    + "The value must format as <listener_name>:pulsar://<host>:<port>,"
-                    + "multiple bind addresses should separate with commas."
-                    + "Associates each bind address with an advertised listener."
-                    + "Use 'pulsar+ssl' scheme to define a TLS-protected channel."
-                    + "Note that brokerServicePort and brokerServicePortTls define additional bindings."
+                    + "The value must format as <listener_name>:<scheme>://<host>:<port>,"
+                    + "multiple bind addresses should be separated with commas."
+                    + "Associates each bind address with an advertised listener and protocol handler."
+                    + "Note that the brokerServicePort, brokerServicePortTls, webServicePort, and "
+                    + "webServicePortTls properties define additional bindings."
                     + ".")
     private String bindAddresses;
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -80,4 +80,11 @@ public class ServiceConfigurationUtils {
         return getDefaultOrConfiguredAddress(advertisedAddress);
     }
 
+    public static String brokerUrl(String host, int port) {
+        return String.format("pulsar://%s:%d", host, port);
+    }
+
+    public static String brokerUrlTls(String host, int port) {
+        return String.format("pulsar+ssl://%s:%d", host, port);
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -87,4 +87,12 @@ public class ServiceConfigurationUtils {
     public static String brokerUrlTls(String host, int port) {
         return String.format("pulsar+ssl://%s:%d", host, port);
     }
+
+    public static String webServiceUrl(String host, int port) {
+        return String.format("http://%s:%d", host, port);
+    }
+
+    public static String webServiceUrlTls(String host, int port) {
+        return String.format("https://%s:%d", host, port);
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.validator;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.ArrayList;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
+import org.apache.pulsar.common.configuration.BindAddress;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Validates bind address configurations.
+ */
+public class BindAddressValidator {
+
+    private static final Pattern bindAddress = Pattern.compile("(?<name>\\w+):(?<url>.+)$");
+
+    /**
+     * Validate the configuration of `bindAddresses`.
+     * @param config the pulsar broker configure.
+     * @return a list of bind addresses.
+     */
+    public static List<BindAddress> validateBindAddresses(ServiceConfiguration config) {
+        // migrate the existing configuration properties
+        List<BindAddress> addresses = migrateBindAddresses(config);
+        if (StringUtils.isBlank(config.getBindAddresses())) {
+            return addresses;
+        }
+
+        // parse the list of additional bind addresses
+        Arrays
+                .stream(StringUtils.split(config.getBindAddresses(), ","))
+                .map(bindAddress::matcher)
+                .filter(Matcher::matches)
+                .map(m -> new BindAddress(m.group("name"), URI.create(m.group("url"))))
+                .filter(m -> StringUtils.equalsAnyIgnoreCase(m.getAddress().getScheme(), "pulsar", "pulsar+ssl"))
+                .forEach(addresses::add);
+
+        return addresses;
+    }
+
+    /**
+     * Generates bind addresses based on legacy configuration.
+     * When no bind addresses are defined:
+     * - generate a bind address for the internal listener
+     *   on bindAddress:brokerServicePort and/or bindAddress:brokerServicePortTls.
+     */
+    private static List<BindAddress> migrateBindAddresses(ServiceConfiguration config) {
+        List<BindAddress> addresses = new ArrayList<>(2);
+        if (config.getBrokerServicePort().isPresent()) {
+            addresses.add(new BindAddress(null, URI.create(
+                    ServiceConfigurationUtils.brokerUrl(config.getBindAddress(), config.getBrokerServicePort().get()))));
+        }
+        if (config.getBrokerServicePortTls().isPresent()) {
+            addresses.add(new BindAddress(null, URI.create(
+                    ServiceConfigurationUtils.brokerUrlTls(config.getBindAddress(), config.getBrokerServicePortTls().get()))));
+        }
+        return addresses;
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
@@ -66,10 +66,7 @@ public class BindAddressValidator {
     }
 
     /**
-     * Generates bind addresses based on legacy configuration.
-     * When no bind addresses are defined:
-     * - generate a bind address for the internal listener
-     *   on bindAddress:brokerServicePort and/or bindAddress:brokerServicePortTls.
+     * Generates bind addresses based on legacy configuration properties.
      */
     private static List<BindAddress> migrateBindAddresses(ServiceConfiguration config) {
         List<BindAddress> addresses = new ArrayList<>(2);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import java.net.URI;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A bind address for the broker as a non-TLS and TLS pair.
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class BindAddress {
+
+    @Getter
+    @Setter
+    // the listener name associated with the bind address, or null if no listener is associated.
+    private String listenerName;
+
+    @Getter
+    @Setter
+    @NonNull
+    // the broker bind address
+    private URI address;
+
+    /**
+     * A convenience method indicating whether the bind address should have TLS.
+     */
+    public boolean isTLS() {
+        return StringUtils.equalsIgnoreCase(this.address.getScheme(), "pulsar+ssl");
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
@@ -27,7 +27,6 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A bind address for the broker as a non-TLS and TLS pair.
@@ -39,21 +38,18 @@ import org.apache.commons.lang3.StringUtils;
 @ToString
 public class BindAddress {
 
+    /**
+     * The listener name associated with the bind address, or null if no listener is associated.
+     */
     @Getter
     @Setter
-    // the listener name associated with the bind address, or null if no listener is associated.
     private String listenerName;
 
+    /**
+     * The bind address.
+     */
     @Getter
     @Setter
     @NonNull
-    // the broker bind address
     private URI address;
-
-    /**
-     * A convenience method indicating whether the bind address should have TLS.
-     */
-    public boolean isTLS() {
-        return StringUtils.equalsIgnoreCase(this.address.getScheme(), "pulsar+ssl");
-    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -35,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class BindAddress {
 
     @Getter

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.validator;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.configuration.BindAddress;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * testcase for BindAddressValidator.
+ */
+public class BindAddressValidatorTest {
+
+    @Test
+    public void testInvalidScheme() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,internal:invalid://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+    }
+
+    @Test
+    public void testMalformed() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBindAddresses("internal:");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(0, addresses.size());
+    }
+
+    @Test
+    public void testOneListenerMultipleAddresses() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,internal:pulsar+ssl://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(1));
+    }
+
+    @Test
+    public void testMultiListener() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,external:pulsar+ssl://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(1));
+    }
+
+    @Test
+    public void testMigrationNonTls() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.empty());
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+    }
+
+    @Test
+    public void testMigrationNonTlsWithExtra() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("extra:pulsar://0.0.0.0:6652");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652")), addresses.get(1));
+    }
+
+    @Test
+    public void testMigrationTls() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.of(6651));
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(0));
+    }
+
+    @Test
+    public void testMigrationTlsWithExtra() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setBindAddresses("extra:pulsar://0.0.0.0:6652");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(0));
+        assertEquals(new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652")), addresses.get(1));
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1459,7 +1459,7 @@ public class PulsarService implements AutoCloseable {
     }
 
     public static String brokerUrl(String host, int port) {
-        return String.format("pulsar://%s:%d", host, port);
+        return ServiceConfigurationUtils.brokerUrl(host, port);
     }
 
     public String brokerUrlTls(ServiceConfiguration config) {
@@ -1472,7 +1472,7 @@ public class PulsarService implements AutoCloseable {
     }
 
     public static String brokerUrlTls(String host, int port) {
-        return String.format("pulsar+ssl://%s:%d", host, port);
+        return ServiceConfigurationUtils.brokerUrlTls(host, port);
     }
 
     public String webAddress(ServiceConfiguration config) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -30,11 +31,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
 public class TopicLookup extends TopicLookupBase {
+
+    static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
 
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
@@ -45,8 +49,12 @@ public class TopicLookup extends TopicLookupBase {
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @Suspended AsyncResponse asyncResponse,
-            @QueryParam("listenerName") String listenerName) {
+            @QueryParam("listenerName") String listenerName,
+            @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
         TopicName topicName = getTopicName(topicDomain, tenant, namespace, encodedTopic);
+        if (StringUtils.isEmpty(listenerName)) {
+            listenerName = listenerNameHeader;
+        }
         internalLookupTopicAsync(topicName, authoritative, asyncResponse, listenerName);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -23,7 +23,6 @@ import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -31,14 +30,11 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
 public class TopicLookup extends TopicLookupBase {
-
-    static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
 
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
@@ -49,12 +45,8 @@ public class TopicLookup extends TopicLookupBase {
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @Suspended AsyncResponse asyncResponse,
-            @QueryParam("listenerName") String listenerName,
-            @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
+            @QueryParam("listenerName") String listenerName) {
         TopicName topicName = getTopicName(topicDomain, tenant, namespace, encodedTopic);
-        if (StringUtils.isEmpty(listenerName)) {
-            listenerName = listenerNameHeader;
-        }
         internalLookupTopicAsync(topicName, authoritative, asyncResponse, listenerName);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -47,6 +47,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -414,7 +415,8 @@ public class BrokerService implements Closeable {
                 PRODUCER_NAME_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
 
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
-        List<BindAddress> bindAddresses = BindAddressValidator.validateBindAddresses(serviceConfig);
+        List<BindAddress> bindAddresses = BindAddressValidator.validateBindAddresses(serviceConfig,
+                Arrays.asList("pulsar", "pulsar+ssl"));
         String internalListenerName = serviceConfig.getInternalListenerName();
 
         // create a channel for each bind address

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -73,10 +73,10 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
             protected BrokerService newBrokerService(PulsarService pulsar) throws Exception {
                 BrokerService broker = new BrokerService(this, ioEventLoopGroup);
                 broker.setPulsarChannelInitializerFactory(
-                        (_pulsar, tls) -> {
-                            return new PulsarChannelInitializer(_pulsar, tls) {
+                        (_pulsar, opts) -> {
+                            return new PulsarChannelInitializer(_pulsar, opts) {
                                 @Override
-                                protected ServerCnx newServerCnx(PulsarService pulsar) throws Exception {
+                                protected ServerCnx newServerCnx(PulsarService pulsar, String listenerName) throws Exception {
                                     return new ServerCnx(pulsar) {
 
                                         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
@@ -79,10 +79,10 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
             protected BrokerService newBrokerService(PulsarService pulsar) throws Exception {
                 BrokerService broker = new BrokerService(this, ioEventLoopGroup);
                 broker.setPulsarChannelInitializerFactory(
-                        (_pulsar, tls) -> {
-                            return new PulsarChannelInitializer(_pulsar, tls) {
+                        (_pulsar, opts) -> {
+                            return new PulsarChannelInitializer(_pulsar, opts) {
                                 @Override
-                                protected ServerCnx newServerCnx(PulsarService pulsar) throws Exception {
+                                protected ServerCnx newServerCnx(PulsarService pulsar, String listenerName) throws Exception {
                                     connectionsCreated.incrementAndGet();
                                     return new ErrorByTopicServerCnx(pulsar, failureMap);
                                 }


### PR DESCRIPTION
Master Issue: #12040

### Motivation

Add a new configuration setting `bindAddresses` to open additional server ports on the broker.  Note that these are in addition to `brokerServicePort` / `brokerServicePortTls` for compatibility reasons.

Each new-style bind address is associated with an advertised listener, to be used as the default listener for topic lookup requests.   See #12040 for details.  A given listener may be associated with numerous bindings.

The scheme indicates the protocol handler and whether to use TLS on the server channel.  This PR is focused on the Pulsar protocol handler, but it is anticipated that other protocols may be supported in future.

For example:
```
bindAddresses=external:pulsar://0.0.0.0:6652,external:pulsar+ssl://0.0.0.0:6653
bindAddress=0.0.0.0
brokerServicePort=6650
brokerServicePortTls=6651
advertisedListeners=cluster:pulsar://broker-1.local:6650,cluster:pulsar+ssl://broker-1.local:6651,external:pulsar://broker-1.example.dev:6652,external:pulsar+ssl://broker-1.example.dev:6653
internalListenerName=cluster
```

The above would produce three server sockets, with `6650` having no associated listener name (thus retaining existing lookup behavior of returning the internal listener), and with `6652` and `6653` having an association with listener name `external`.  Given a lookup request on `6652` or `6653`, the `external` listener address would be returned.

### Modifications

- added configuration property `bindAddresses`
- implementing parsing and validation logic
- factored some utility code for formatting broker/web addresses

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
- [ ] Adhoc testing as outlined in PIP 95.

This change added tests and can be verified as follows:

- Added unit tests for configuration validation logic.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [X] doc-required 
  
