### PR TITLE
Force Python CI to use earlier version of Protobuf which supports Python2

### DIFF
--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -64,6 +64,10 @@ if [ $RES -eq 0 ]; then
     WHEEL_FILE=$(ls dist/ | grep whl)
     echo "${WHEEL_FILE}"
     echo "dist/${WHEEL_FILE}[all]"
+    # Protobuf 3.18 only works with Python3. Since we're still using Python2 in CI, 
+    # let's pin the Python version to the previous one
+    pip install protobuf==3.17.3
+
     pip install dist/${WHEEL_FILE}[all]
 
     echo "---- Running Python unit tests"


### PR DESCRIPTION
### Motivation

The C++/Python CI job is currently broken after a Protobuf update was pushed to PyPI: https://pypi.org/project/protobuf/#history

Protobuf 3.18 doesn't work anymore on Py2 and our CI for Python is still running on Py2. For now, let's pin the Protobuf version, later we need to eradicate Py2 from the codebase.