### PR TITLE
Use equals to compare string in CmdGenerateDocs

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
@@ -117,7 +117,7 @@ public class CmdGenerateDocs {
         }
         sb.append(module);
         if (cmd.getObjects().size() > 0
-                && cmd.getObjects().get(0).getClass().getName() == "com.beust.jcommander.JCommander") {
+                && cmd.getObjects().get(0).getClass().getName().equals("com.beust.jcommander.JCommander")) {
             JCommander cmdObj = (JCommander) cmd.getObjects().get(0);
             sb.append(" subcommand").append("\n```").append("\n\n");
             for (String s : cmdObj.getCommands().keySet()) {


### PR DESCRIPTION
### Modifications
Use equals to compare string in CmdGenerateDocs

### Documentation
  
- [ ] no-need-doc 
  
 It's just a little code optimization, don't need doc


