### PR TITLE
[pulsar-broker] Improve JwtParser build

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
@@ -276,8 +276,9 @@ public class TokensCliUtils {
 
             // Validate the token
             @SuppressWarnings("unchecked")
-            Jwt<?, Claims> jwt = Jwts.parser()
+            Jwt<?, Claims> jwt = Jwts.parserBuilder()
                     .setSigningKey(validationKey)
+                    .build()
                     .parse(token);
 
             System.out.println(jwt.getBody());


### PR DESCRIPTION
### Motivation
The method `parser` is deprecated to create `JwtParser` , we will use the static method `parserBuilder` to build it.

### Verifying this change
- Use static method instead of build a `JwtParser` object.
- I updated all uses of `JwtParser`.

### Documentation
- no-need-doc 


