### PR TITLE
Fix k8s pulsar functions containers not exposing metrics port for scraping

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -1127,20 +1127,23 @@ public class KubernetesRuntime implements Runtime {
 
     private List<V1ContainerPort> getFunctionContainerPorts() {
         List<V1ContainerPort> ports = new ArrayList<>();
-        final V1ContainerPort port = new V1ContainerPort();
-        port.setName("grpc");
-        port.setContainerPort(grpcPort);
-        ports.add(port);
+        ports.add(getGRPCPort());
+        ports.add(getPrometheusPort());
         return ports;
     }
 
-    private List<V1ContainerPort> getPrometheusContainerPorts() {
-        List<V1ContainerPort> ports = new ArrayList<>();
+    private V1ContainerPort getGRPCPort() {
+        final V1ContainerPort port = new V1ContainerPort();
+        port.setName("grpc");
+        port.setContainerPort(grpcPort);
+        return port;
+    }
+
+    private V1ContainerPort getPrometheusPort() {
         final V1ContainerPort port = new V1ContainerPort();
         port.setName("prometheus");
         port.setContainerPort(metricsPort);
-        ports.add(port);
-        return ports;
+        return port;
     }
 
     public static String createJobName(Function.FunctionDetails functionDetails, String jobName) {


### PR DESCRIPTION
### Motivation
* We are currently unable to scrape metrics from pulsar functions pods on k8s because the metrics port is not exposed. 

### Modifications
* updates `getFunctionContainerPorts` to return both its grpc port as well as the metric port (currently the function returning the metrics port in its own list is not being called)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
* Deploy pulsar to k8s (or update the image of an existing deployment) w/ functions enabled
* inspect the functions pods to see that they now expose a metrics port along with their current grpc port

### Documentation

- [x] no-need-doc (minor fix for something that should already be enabled)
  