### PR TITLE
[Issue 12040][broker] Improved multi-listener in standalone mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -30,6 +30,7 @@ import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -296,11 +297,12 @@ public class PulsarStandalone implements AutoCloseable {
         broker.start();
 
         final String cluster = config.getClusterName();
-
         if (!config.isTlsEnabled()) {
-            URL webServiceUrl = new URL(
-                    String.format("http://%s:%d", config.getAdvertisedAddress(), config.getWebServicePort().get()));
-            String brokerServiceUrl = String.format("pulsar://%s:%d", config.getAdvertisedAddress(),
+            URL webServiceUrl = new URL(String.format("http://%s:%d",
+                    ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
+                    config.getWebServicePort().get()));
+            String brokerServiceUrl = String.format("pulsar://%s:%d",
+                    ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
                     config.getBrokerServicePort().get());
             admin = PulsarAdmin.builder().serviceHttpUrl(
                     webServiceUrl.toString()).authentication(
@@ -312,9 +314,11 @@ public class PulsarStandalone implements AutoCloseable {
                     .build();
             createSampleNameSpace(clusterData, cluster);
         } else {
-            URL webServiceUrlTls = new URL(
-                    String.format("https://%s:%d", config.getAdvertisedAddress(), config.getWebServicePortTls().get()));
-            String brokerServiceUrlTls = String.format("pulsar+ssl://%s:%d", config.getAdvertisedAddress(),
+            URL webServiceUrlTls = new URL(String.format("https://%s:%d",
+                    ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
+                    config.getWebServicePortTls().get()));
+            String brokerServiceUrlTls = String.format("pulsar+ssl://%s:%d",
+                    ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
                     config.getBrokerServicePortTls().get());
             PulsarAdminBuilder builder = PulsarAdmin.builder()
                     .serviceHttpUrl(webServiceUrlTls.toString())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -57,7 +57,7 @@ public class NoopLoadManager implements LoadManager {
 
         LocalBrokerData localData = new LocalBrokerData(pulsar.getSafeWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(),
-                pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+                pulsar.getSafeBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
         localData.setProtocols(pulsar.getProtocolDataToAdvertise());
         String brokerReportPath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -33,6 +33,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.web.PulsarWebResource;
@@ -294,9 +295,10 @@ public class TopicLookupBase extends PulsarWebResource {
                                                 newAuthoritative, LookupType.Redirect, requestId, false));
                             } else {
                                 // When running in standalone mode we want to redirect the client through the service
-                                // url, so that the advertised address configuration is not relevant anymore.
-                                boolean redirectThroughServiceUrl = pulsarService.getConfiguration()
-                                        .isRunningStandalone();
+                                // url, if the advertised address is localhost (per PulsarStandaloneStarter).
+                                ServiceConfiguration conf = pulsarService.getConfiguration();
+                                boolean isLocalhost = StringUtils.equals("localhost", conf.getAdvertisedAddress());
+                                boolean redirectThroughServiceUrl = conf.isRunningStandalone() && isLocalhost;
 
                                 lookupfuture.complete(newLookupResponse(lookupData.getBrokerUrl(),
                                         lookupData.getBrokerUrlTls(), true /* authoritative */, LookupType.Connect,


### PR DESCRIPTION
Master Issue: #12040

### Motivation

It should be possible to use the `advertisedListeners` configuration property in Pulsar standalone mode.   One reason is to support dev scenarios involving multiple listeners.  Another is to make standalone mode more consistent, e.g. to avoid special cases like seen [here](https://github.com/streamnative/rop/commit/3e59300628704e296f9a97870c7250ff616747ef).

### Modifications

- Fix `NoopLoadManager` to actually advertise the configured advertised listeners.
- Don't always force the 'proxy mode' in the lookup response; check that the `advertisedAddress` is `localhost`.
- Initialize the internal admin client to use the actual advertised address.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] no-need-doc 
  
  This PR addresses an undocumented limitation.


