### PR TITLE
[Broker Auth SASL] Remove unnecessary authenticate method definition

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -52,11 +52,18 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetrics;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.sasl.JAASCredentialsContainer;
 import org.apache.pulsar.common.sasl.SaslConstants;
 
+/**
+ * Authentication Provider for SASL (Simple Authentication and Security Layer).
+ *
+ * Note: This provider does not override the default implementation for
+ * {@link AuthenticationProvider#authenticate(AuthenticationDataSource)}. As the Javadoc for the interface's method
+ * indicates, this method should only be implemented when using single stage authentication. In the case of this
+ * provider, the authentication is multi-stage.
+ */
 @Slf4j
 public class AuthenticationProviderSasl implements AuthenticationProvider {
 
@@ -96,22 +103,6 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
         }
 
         this.signer = new SaslRoleTokenSigner(Long.toString(new Random().nextLong()).getBytes());
-    }
-
-    @Override
-    public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
-        try {
-            if (authData instanceof SaslAuthenticationDataSource) {
-                AuthenticationMetrics.authenticateSuccess(getClass().getSimpleName(), getAuthMethodName());
-                return ((SaslAuthenticationDataSource) authData).getAuthorizationID();
-            } else {
-                throw new AuthenticationException("Not support authDataSource type, expect sasl.");
-            }
-        } catch (AuthenticationException exception) {
-            AuthenticationMetrics.authenticateFailure(getClass().getSimpleName(), getAuthMethodName(), exception.getMessage());
-            throw exception;
-        }
-
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Remove `AuthenticationProviderSasl`'s overridden method declaration for `authenticate`. The default implementation will be used, which always throws an `AuthenticationException`.

I remove it first because the `AuthenticationProvider` interface's Javadoc indicates that the method should not be implemented in the case of multi-stage authentication providers. In those cases, the authentication provider ought to implement the `AuthenticationState` class, which the `pulsar-broker-auth-sasl` module does do (`AuthenticationProviderSasl`). Here is a reference to the Javadoc: https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java#L54-L67

Second, this `authenticate` method is never called successfully. By removing it, it should make the implementation a bit easier to understand. Here is an enumeration of the method calls to `AuthenticationProvider#authenticate`:

1. https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java#L92
2. https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java#L113
3. https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java#L125
4. https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java#L46
5. https://github.com/apache/pulsar/blob/23ffdb778e25169bfc7343920912521b41bf95f5/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderList.java#L159

In case 1 above, the calling method `AuthenticationService#authenticate` is only called from the `DiscoveryService`'s class. This class does not create an `SaslAuthenticationDataSource`, so the call will fail. In cases 2 and 3 above, the `AuthenticationDataSource` that is passed in is always of type `AuthenticationDataHttps`, so the call will fail. In case 4 above, that is used in `OneStageAuthenticationState`, so it is never called when using sasl. In çase 5 above, the `AuthenticationProviderList` is recursively implementing the `authenticate` method, so it is covered by cases 1 through 4.

### Modifications

* Remove overriding of `authenticate` method in the sasl authentication provider implementation.
* Add Javadoc explaining why it is not overridden. 

### Verifying this change

* Tests pass for the `pulsar-broker-auth-sasl` module
* Since this change does not _actually_ change any behavior, I don't see any need to add more tests.

### Does this pull request potentially affect one of the following parts:

No.

### Documentation

This is an internal change. I did leave some comments for future reference. I don't believe any additional documentation is required.