### PR TITLE
[Issue 12040][web] Topic lookup with listener header

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -30,11 +31,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
 public class TopicLookup extends TopicLookupBase {
+
+    static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
 
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
@@ -45,8 +49,12 @@ public class TopicLookup extends TopicLookupBase {
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @Suspended AsyncResponse asyncResponse,
-            @QueryParam("listenerName") String listenerName) {
+            @QueryParam("listenerName") String listenerName,
+            @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
         TopicName topicName = getTopicName(topicDomain, tenant, namespace, encodedTopic);
+        if (StringUtils.isEmpty(listenerName)) {
+            listenerName = listenerNameHeader;
+        }
         internalLookupTopicAsync(topicName, authoritative, asyncResponse, listenerName);
     }
 


### PR DESCRIPTION

Master Issue: #12040

### Motivation

This PR introduces an optional HTTP header `X-Pulsar-ListenerName` to the `TopicLookup` operation of the Pulsar Admin API.  The header supplies the listener name to use when the broker has multiple advertised listeners.  Today the `TopicLookup` operation accepts a query parameter `listenerName` for that same purpose.

The motivation for adding a header-based alternative is to improve support smart listener selection via HTTP gateways or proxies that are capable of rewriting headers (see: [Istio virtual services](https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers)).

See #12040 for more background.

### Modifications

- Modify `TopicLookup` operation to use a header (query string takes precedence).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [ ] doc 
  
  (javadocs)

