### PR TITLE
[Broker] Only store authentication data after authentication is complete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -801,7 +801,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             }
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
-            authenticationData = authState.getAuthDataSource();
 
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Authenticate role : {}", remoteAddress,


### PR DESCRIPTION
### Motivation

The `ServerCnx` class stores the most recent `AuthenticationDataSource` for a connection in the `authenticationData` field. This should not be stored until the authentication state `isComplete` has returned `true`. Since the `ServerCnx` state does not go to `Connected` until after the auth state has completed, this is really just a cosmetic change.

For historical context, it looks like this line was added a while ago here: https://github.com/apache/pulsar/pull/5462. At that time, the `doAuthentication` method did not set the `authenticationState` field. The method now sets that field, so I think we should remove this line. https://github.com/apache/pulsar/blob/fb76b23be6a1b8334225d4be55f93e02626ccec5/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L623-L632

### Modifications

* Remove the premature setting of authentication data in `ServerCnx`

### Verifying this change

This change is mostly cosmetic. The `authenticationData` field is only used when the class's state is `Connected`, and that only happens after the authentication state has returned true for `isComplete`. As such, I think tests passing will be enough to ensure correctness.

### Does this pull request potentially affect one of the following parts:

This change is not breaking.

### Documentation
No docs required.