### PR TITLE
Remove the deprecated api usage in hdfs

### DIFF
--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
@@ -137,7 +137,7 @@ public abstract class AbstractHdfsConnector {
         }
         InetSocketAddress namenode = NetUtils.createSocketAddr(address, port);
         SocketFactory socketFactory = NetUtils.getDefaultSocketFactory(config);
-        try(Socket socket = socketFactory.createSocket()) {
+        try (Socket socket = socketFactory.createSocket()) {
             NetUtils.connect(socket, namenode, 1000); // 1 second timeout
         }
     }

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.SocketFactory;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -138,12 +137,8 @@ public abstract class AbstractHdfsConnector {
         }
         InetSocketAddress namenode = NetUtils.createSocketAddr(address, port);
         SocketFactory socketFactory = NetUtils.getDefaultSocketFactory(config);
-        Socket socket = null;
-        try {
-            socket = socketFactory.createSocket();
+        try(Socket socket = socketFactory.createSocket()) {
             NetUtils.connect(socket, namenode, 1000); // 1 second timeout
-        } finally {
-            IOUtils.closeQuietly(socket);
         }
     }
 

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsSequentialTextSink.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/seq/HdfsSequentialTextSink.java
@@ -60,7 +60,7 @@ public class HdfsSequentialTextSink extends HdfsAbstractSequenceFileSink<Long, S
 
     @Override
     public KeyValue<Long, String> extractKeyValue(Record<String> record) {
-       Long sequence = record.getRecordSequence().orElseGet(() -> new Long(counter.incrementAndGet()));
+       Long sequence = record.getRecordSequence().orElseGet(() -> counter.incrementAndGet());
        return new KeyValue<>(sequence, record.getValue());
     }
 

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.SocketFactory;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -138,12 +137,8 @@ public abstract class AbstractHdfsConnector {
         }
         InetSocketAddress namenode = NetUtils.createSocketAddr(address, port);
         SocketFactory socketFactory = NetUtils.getDefaultSocketFactory(config);
-        Socket socket = null;
-        try {
-            socket = socketFactory.createSocket();
+        try (Socket socket = socketFactory.createSocket()){
             NetUtils.connect(socket, namenode, 1000); // 1 second timeout
-        } finally {
-            IOUtils.closeQuietly(socket);
         }
     }
 

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialTextSink.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/seq/HdfsSequentialTextSink.java
@@ -60,7 +60,7 @@ public class HdfsSequentialTextSink extends HdfsAbstractSequenceFileSink<Long, S
 
     @Override
     public KeyValue<Long, String> extractKeyValue(Record<String> record) {
-       Long sequence = record.getRecordSequence().orElseGet(() -> new Long(counter.incrementAndGet()));
+       Long sequence = record.getRecordSequence().orElseGet(() -> counter.incrementAndGet());
        return new KeyValue<>(sequence, record.getValue());
     }
 


### PR DESCRIPTION
### Motivation
Remove the deprecated api usage in hdfs

### Modifications
Use try with resources instead of `closeQuitely`
Remove the Long constructor

### Documentation
  
- [ ] no-need-doc 
  
little internal optimization


