### PR TITLE
[pulsar-perf] Make it possible to disable poolMessages

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -176,11 +176,11 @@ public class PerformanceConsumer {
         @Parameter(names = {"-ioThreads", "--num-io-threads"}, description = "Set the number of threads to be " +
                 "used for handling connections to brokers, default is 1 thread")
         public int ioThreads = 1;
-    
+
         @Parameter(names = {"--batch-index-ack" }, description = "Enable or disable the batch index acknowledgment")
         public boolean batchIndexAck = false;
 
-        @Parameter(names = { "-pm", "--pool-messages" }, description = "Use the pooled message")
+        @Parameter(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = 1)
         private boolean poolMessages = true;
 
         @Parameter(names = {"-bw", "--busy-wait"}, description = "Enable Busy-Wait on the Pulsar client")


### PR DESCRIPTION
### Motivation

In Pulsar 2.8.0 with pulsar-perf, I hit the bug #11824 where the `pulsar-perf consume` stops consuming some partitions.

As a workaround, I tried to pass `-pm false` or `--pool-messages false` on the command line, but this resulted in error message:
`The size of topics list should be equal to --num-topics`

The problem is that JCommander doesn't expect arguments to boolean parameters by default. 
This is explained [in the JCommander manual](http://jcommander.org/#_boolean) and issue comment https://github.com/cbeust/jcommander/issues/129#issuecomment-7402874 .

### Modifications

- add `arity = 1` to the JCommander Parameter annotation.
  - JCommander requires specifying `arity = 1` to boolean parameters that have a default value of true.