### PR TITLE
Remove python3 from vcpkg.json

### DIFF
--- a/pulsar-client-cpp/vcpkg.json
+++ b/pulsar-client-cpp/vcpkg.json
@@ -21,7 +21,6 @@
     "snappy",
     "zlib",
     "zstd",
-    "python3",
     "log4cxx",
     {
       "name": "dlfcn-win32",


### PR DESCRIPTION
### Motivation

The master CI is broken by the Windows C++ build if the C++ related code was changed. See https://github.com/apache/pulsar/pull/12076/checks?check_run_id=3639836198 for example.

It's because there's a bug in latest vcpkg for python3 build. See https://github.com/microsoft/vcpkg/issues/20242.

### Modifications

Remove the python3 dependency from vcpkg.json. Since the CI doesn't build Python wrapper, it won't affect the build.