### PR TITLE
Replace newInstance() with getDeclaredConstructor().newInstance()

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloaderUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloaderUtils.java
@@ -71,7 +71,7 @@ public class OffloaderUtils {
             Thread loadingThread = new Thread(() -> {
                 Thread.currentThread().setContextClassLoader(ncl);
                 try {
-                    Object offloader = factoryClass.newInstance();
+                    Object offloader = factoryClass.getDeclaredConstructor().newInstance();
                     if (!(offloader instanceof LedgerOffloaderFactory)) {
                         throw new IOException("Class " + conf.getOffloaderFactoryClass() + " does not implement interface "
                             + LedgerOffloaderFactory.class.getName());

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -55,7 +55,7 @@ public class AuthenticationService implements Closeable {
                     if (className.isEmpty()) {
                         continue;
                     }
-                    AuthenticationProvider provider = (AuthenticationProvider) Class.forName(className).newInstance();
+                    AuthenticationProvider provider = (AuthenticationProvider) Class.forName(className).getDeclaredConstructor().newInstance();
 
                     List<AuthenticationProvider> providerList = providerMap.get(provider.getAuthMethodName());
                     if (null == providerList) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -55,7 +55,8 @@ public class AuthenticationService implements Closeable {
                     if (className.isEmpty()) {
                         continue;
                     }
-                    AuthenticationProvider provider = (AuthenticationProvider) Class.forName(className).getDeclaredConstructor().newInstance();
+                    AuthenticationProvider provider = (AuthenticationProvider) Class.forName(className)
+                            .getDeclaredConstructor().newInstance();
 
                     List<AuthenticationProvider> providerList = providerMap.get(provider.getAuthMethodName());
                     if (null == providerList) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -62,7 +62,7 @@ public class AuthorizationService {
         try {
             final String providerClassname = conf.getAuthorizationProvider();
             if (StringUtils.isNotBlank(providerClassname)) {
-                provider = (AuthorizationProvider) Class.forName(providerClassname).newInstance();
+                provider = (AuthorizationProvider) Class.forName(providerClassname).getDeclaredConstructor().newInstance();
                 provider.initialize(conf, pulsarResources);
                 log.info("{} has been loaded.", providerClassname);
             } else {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -62,7 +62,8 @@ public class AuthorizationService {
         try {
             final String providerClassname = conf.getAuthorizationProvider();
             if (StringUtils.isNotBlank(providerClassname)) {
-                provider = (AuthorizationProvider) Class.forName(providerClassname).getDeclaredConstructor().newInstance();
+                provider = (AuthorizationProvider) Class.forName(providerClassname)
+                        .getDeclaredConstructor().newInstance();
                 provider.initialize(conf, pulsarResources);
                 log.info("{} has been loaded.", providerClassname);
             } else {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
@@ -132,7 +132,7 @@ public class AdditionalServletUtils {
 
         try {
             Class additionalServletClass = ncl.loadClass(def.getAdditionalServletClass());
-            Object additionalServlet = additionalServletClass.newInstance();
+            Object additionalServlet = additionalServletClass.getDeclaredConstructor().newInstance();
             if (!(additionalServlet instanceof AdditionalServlet)) {
                 throw new IOException("Class " + def.getAdditionalServletClass()
                         + " does not implement additional servlet interface");

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -98,7 +98,8 @@ public class PulsarConfigurationLoader {
             configuration = (T) clazz.getDeclaredConstructor().newInstance();
             configuration.setProperties(properties);
             update((Map) properties, configuration);
-        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException
+                | NoSuchMethodException | InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to instantiate " + clazz.getName(), e);
         }
         return configuration;
@@ -178,7 +179,8 @@ public class PulsarConfigurationLoader {
      */
     public static ServiceConfiguration convertFrom(PulsarConfiguration conf, boolean ignoreNonExistMember) throws RuntimeException {
         try {
-            final ServiceConfiguration convertedConf = ServiceConfiguration.class.getDeclaredConstructor().newInstance();
+            final ServiceConfiguration convertedConf = ServiceConfiguration.class
+                    .getDeclaredConstructor().newInstance();
             Field[] confFields = conf.getClass().getDeclaredFields();
             Arrays.stream(confFields).forEach(confField -> {
                 try {
@@ -197,14 +199,9 @@ public class PulsarConfigurationLoader {
                 }
             });
             return convertedConf;
-        } catch (InstantiationException e) {
-            throw new RuntimeException("InstantiationException caused while converting configuration: " + e.getMessage());
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException("IllegalAccessException caused while converting configuration: " + e.getMessage());
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException("InvocationTargetException caused while converting configuration: " + e.getMessage());
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("NoSuchMethodException caused while converting configuration: " + e.getMessage());
+        } catch (InstantiationException | IllegalAccessException
+                | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException("Exception caused while converting configuration: " + e.getMessage());
         }
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Map;
@@ -94,10 +95,10 @@ public class PulsarConfigurationLoader {
         checkNotNull(properties);
         T configuration = null;
         try {
-            configuration = (T) clazz.newInstance();
+            configuration = (T) clazz.getDeclaredConstructor().newInstance();
             configuration.setProperties(properties);
             update((Map) properties, configuration);
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new IllegalArgumentException("Failed to instantiate " + clazz.getName(), e);
         }
         return configuration;
@@ -177,7 +178,7 @@ public class PulsarConfigurationLoader {
      */
     public static ServiceConfiguration convertFrom(PulsarConfiguration conf, boolean ignoreNonExistMember) throws RuntimeException {
         try {
-            final ServiceConfiguration convertedConf = ServiceConfiguration.class.newInstance();
+            final ServiceConfiguration convertedConf = ServiceConfiguration.class.getDeclaredConstructor().newInstance();
             Field[] confFields = conf.getClass().getDeclaredFields();
             Arrays.stream(confFields).forEach(confField -> {
                 try {
@@ -197,9 +198,13 @@ public class PulsarConfigurationLoader {
             });
             return convertedConf;
         } catch (InstantiationException e) {
-            throw new RuntimeException("Exception caused while converting configuration: " + e.getMessage());
+            throw new RuntimeException("InstantiationException caused while converting configuration: " + e.getMessage());
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("Exception caused while converting configuration: " + e.getMessage());
+            throw new RuntimeException("IllegalAccessException caused while converting configuration: " + e.getMessage());
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException("InvocationTargetException caused while converting configuration: " + e.getMessage());
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("NoSuchMethodException caused while converting configuration: " + e.getMessage());
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1260,7 +1260,7 @@ public class PulsarService implements AutoCloseable {
 
     private SchemaStorage createAndStartSchemaStorage() throws Exception {
         final Class<?> storageClass = Class.forName(config.getSchemaRegistryStorageClassName());
-        Object factoryInstance = storageClass.newInstance();
+        Object factoryInstance = storageClass.getDeclaredConstructor().newInstance();
         Method createMethod = storageClass.getMethod("create", PulsarService.class);
         SchemaStorage schemaStorage = (SchemaStorage) createMethod.invoke(factoryInstance, this);
         schemaStorage.start();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerLoader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerLoader.java
@@ -30,7 +30,7 @@ public class DelayedDeliveryTrackerLoader {
         Class<?> factoryClass;
         try {
             factoryClass = Class.forName(conf.getDelayedDeliveryTrackerFactoryClassName());
-            Object obj = factoryClass.newInstance();
+            Object obj = factoryClass.getDeclaredConstructor().newInstance();
             checkArgument(obj instanceof DelayedDeliveryTrackerFactory,
                     "The factory has to be an instance of " + DelayedDeliveryTrackerFactory.class.getName());
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
@@ -130,7 +130,7 @@ public class BrokerInterceptorUtils {
 
         try {
             Class interceptorClass = ncl.loadClass(def.getInterceptorClass());
-            Object interceptor = interceptorClass.newInstance();
+            Object interceptor = interceptorClass.getDeclaredConstructor().newInstance();
             if (!(interceptor instanceof BrokerInterceptor)) {
                 throw new IOException("Class " + def.getInterceptorClass()
                         + " does not implement broker interceptor interface");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -130,7 +130,7 @@ public interface LoadManager {
             final ServiceConfiguration conf = pulsar.getConfiguration();
             final Class<?> loadManagerClass = Class.forName(conf.getLoadManagerClassName());
             // Assume there is a constructor with one argument of PulsarService.
-            final Object loadManagerInstance = loadManagerClass.newInstance();
+            final Object loadManagerInstance = loadManagerClass.getDeclaredConstructor().newInstance();
             if (loadManagerInstance instanceof LoadManager) {
                 final LoadManager casted = (LoadManager) loadManagerInstance;
                 casted.initialize(pulsar);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -291,7 +291,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, Consumer<Noti
     private LoadSheddingStrategy createLoadSheddingStrategy() {
         try {
             Class<?> loadSheddingClass = Class.forName(conf.getLoadBalancerLoadSheddingStrategy());
-            Object loadSheddingInstance = loadSheddingClass.newInstance();
+            Object loadSheddingInstance = loadSheddingClass.getDeclaredConstructor().newInstance();
             if (loadSheddingInstance instanceof LoadSheddingStrategy) {
                 return (LoadSheddingStrategy) loadSheddingInstance;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
@@ -130,7 +130,7 @@ class ProtocolHandlerUtils {
 
         try {
             Class handlerClass = ncl.loadClass(phDef.getHandlerClass());
-            Object handler = handlerClass.newInstance();
+            Object handler = handlerClass.getDeclaredConstructor().newInstance();
             if (!(handler instanceof ProtocolHandler)) {
                 throw new IOException("Class " + phDef.getHandlerClass()
                     + " does not implement protocol handler interface");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -35,7 +35,8 @@ public interface SchemaRegistryService extends SchemaRegistry {
         Map<SchemaType, SchemaCompatibilityCheck> checkers = Maps.newHashMap();
         for (String className : checkerClasses) {
             final Class<?> checkerClass = Class.forName(className);
-            SchemaCompatibilityCheck instance = (SchemaCompatibilityCheck) checkerClass.getDeclaredConstructor().newInstance();
+            SchemaCompatibilityCheck instance = (SchemaCompatibilityCheck) checkerClass
+                    .getDeclaredConstructor().newInstance();
             checkers.put(instance.getSchemaType(), instance);
         }
         return checkers;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -35,7 +35,7 @@ public interface SchemaRegistryService extends SchemaRegistry {
         Map<SchemaType, SchemaCompatibilityCheck> checkers = Maps.newHashMap();
         for (String className : checkerClasses) {
             final Class<?> checkerClass = Class.forName(className);
-            SchemaCompatibilityCheck instance = (SchemaCompatibilityCheck) checkerClass.newInstance();
+            SchemaCompatibilityCheck instance = (SchemaCompatibilityCheck) checkerClass.getDeclaredConstructor().newInstance();
             checkers.put(instance.getSchemaType(), instance);
         }
         return checkers;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
@@ -93,7 +93,7 @@ public interface ManagedLedgerStorage extends AutoCloseable {
                                        BookKeeperClientFactory bkProvider,
                                        EventLoopGroup eventLoopGroup) throws Exception {
         final Class<?> storageClass = Class.forName(conf.getManagedLedgerStorageClassName());
-        final ManagedLedgerStorage storage = (ManagedLedgerStorage) storageClass.newInstance();
+        final ManagedLedgerStorage storage = (ManagedLedgerStorage) storageClass.getDeclaredConstructor().newInstance();
         storage.initialize(conf, metadataStore, zkClient, bkProvider, eventLoopGroup);
         return storage;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferProvider.java
@@ -40,7 +40,7 @@ public interface TransactionBufferProvider {
         Class<?> providerClass;
         try {
             providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.newInstance();
+            Object obj = providerClass.getDeclaredConstructor().newInstance();
             checkArgument(obj instanceof TransactionBufferProvider,
                 "The factory has to be an instance of "
                     + TransactionBufferProvider.class.getName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/TransactionPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/TransactionPendingAckStoreProvider.java
@@ -38,7 +38,7 @@ public interface TransactionPendingAckStoreProvider {
         Class<?> providerClass;
         try {
             providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.newInstance();
+            Object obj = providerClass.getDeclaredConstructor().newInstance();
             checkArgument(obj instanceof TransactionPendingAckStoreProvider,
                     "The factory has to be an instance of "
                             + TransactionPendingAckStoreProvider.class.getName());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -630,7 +630,7 @@ public class PulsarFunctionLocalRunTest {
         int totalMsgs = 5;
         Method setBaseValueMethod = avroTestObjectClass.getMethod("setBaseValue", new Class[]{int.class});
         for (int i = 0; i < totalMsgs; i++) {
-            Object avroTestObject = avroTestObjectClass.newInstance();
+            Object avroTestObject = avroTestObjectClass.getDeclaredConstructor().newInstance();
             setBaseValueMethod.invoke(avroTestObject, i);
             producer.newMessage().property(propertyKey, propertyValue)
                     .value(avroTestObject).send();
@@ -672,7 +672,7 @@ public class PulsarFunctionLocalRunTest {
                 .brokerServiceUrl(pulsar.getBrokerServiceUrlTls()).build();
         localRunner.start(false);
 
-        producer.newMessage().property(propertyKey, propertyValue).value(avroTestObjectClass.newInstance()).send();
+        producer.newMessage().property(propertyKey, propertyValue).value(avroTestObjectClass.getDeclaredConstructor().newInstance()).send();
         Message<GenericRecord> msg = consumer.receive(2, TimeUnit.SECONDS);
         Assert.assertNull(msg);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -672,7 +672,8 @@ public class PulsarFunctionLocalRunTest {
                 .brokerServiceUrl(pulsar.getBrokerServiceUrlTls()).build();
         localRunner.start(false);
 
-        producer.newMessage().property(propertyKey, propertyValue).value(avroTestObjectClass.getDeclaredConstructor().newInstance()).send();
+        producer.newMessage().property(propertyKey, propertyValue).value(avroTestObjectClass
+                .getDeclaredConstructor().newInstance()).send();
         Message<GenericRecord> msg = consumer.receive(2, TimeUnit.SECONDS);
         Assert.assertNull(msg);
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/utils/DefaultImplementation.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/utils/DefaultImplementation.java
@@ -40,7 +40,7 @@ public class DefaultImplementation {
                     LongRunningProcessStatus.Status.class, String.class, MessageId.class);
 
     public static PulsarAdminBuilder newAdminClientBuilder() {
-        return ReflectionUtils.catchExceptions(() -> ADMIN_CLIENT_BUILDER_IMPL.newInstance());
+        return ReflectionUtils.catchExceptions(() -> ADMIN_CLIENT_BUILDER_IMPL.getDeclaredConstructor().newInstance());
     }
 
     public static OffloadProcessStatus newOffloadProcessStatus(LongRunningProcessStatus.Status status, String lastError

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AuthenticationUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AuthenticationUtil.java
@@ -71,7 +71,7 @@ public class AuthenticationUtil {
         try {
             if (isNotBlank(authPluginClassName)) {
                 Class<?> authClass = Class.forName(authPluginClassName);
-                Authentication auth = (Authentication) authClass.newInstance();
+                Authentication auth = (Authentication) authClass.getDeclaredConstructor().newInstance();
                 if (auth instanceof EncodedAuthenticationParameterSupport) {
                     // Parse parameters on plugin side.
                     ((EncodedAuthenticationParameterSupport) auth).configure(authParamsString);
@@ -104,7 +104,7 @@ public class AuthenticationUtil {
         try {
             if (isNotBlank(authPluginClassName)) {
                 Class<?> authClass = Class.forName(authPluginClassName);
-                Authentication auth = (Authentication) authClass.newInstance();
+                Authentication auth = (Authentication) authClass.getDeclaredConstructor().newInstance();
                 auth.configure(authParams);
                 return auth;
             } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/PulsarURLStreamHandlerFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/PulsarURLStreamHandlerFactory.java
@@ -45,7 +45,8 @@ public class PulsarURLStreamHandlerFactory implements URLStreamHandlerFactory {
             } else {
                 urlStreamHandler = null;
             }
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+        } catch (InstantiationException | IllegalAccessException
+                | InvocationTargetException | NoSuchMethodException e) {
             urlStreamHandler = null;
         }
         return urlStreamHandler;

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/PulsarURLStreamHandlerFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/api/url/PulsarURLStreamHandlerFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api.url;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.util.HashMap;
@@ -40,13 +41,11 @@ public class PulsarURLStreamHandlerFactory implements URLStreamHandlerFactory {
         try {
             Class<? extends URLStreamHandler> handler = handlers.get(protocol);
             if (handler != null) {
-                urlStreamHandler = handler.newInstance();
+                urlStreamHandler = handler.getDeclaredConstructor().newInstance();
             } else {
                 urlStreamHandler = null;
             }
-        } catch (InstantiationException e) {
-            urlStreamHandler = null;
-        } catch (IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             urlStreamHandler = null;
         }
         return urlStreamHandler;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.intercept;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.pulsar.common.util.ClassLoaderUtils;
@@ -41,8 +42,8 @@ public class BrokerEntryMetadataUtils {
                     Class<BrokerEntryMetadataInterceptor> clz = (Class<BrokerEntryMetadataInterceptor>) ClassLoaderUtils
                             .loadClass(interceptorName, classLoader);
                     try {
-                        interceptors.add(clz.newInstance());
-                    } catch (InstantiationException | IllegalAccessException e) {
+                        interceptors.add(clz.getDeclaredConstructor().newInstance());
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                         log.error("Create new BrokerEntryMetadataInterceptor instance for {} failed.",
                                 interceptorName, e);
                         throw new RuntimeException(e);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/BrokerEntryMetadataUtils.java
@@ -43,7 +43,8 @@ public class BrokerEntryMetadataUtils {
                             .loadClass(interceptorName, classLoader);
                     try {
                         interceptors.add(clz.getDeclaredConstructor().newInstance());
-                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    } catch (InstantiationException | IllegalAccessException
+                            | InvocationTargetException | NoSuchMethodException e) {
                         log.error("Create new BrokerEntryMetadataInterceptor instance for {} failed.",
                                 interceptorName, e);
                         throw new RuntimeException(e);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
@@ -71,7 +71,7 @@ public class JvmMetrics {
         JvmGCMetricsLogger gcLoggerImpl = null;
         if (StringUtils.isNotBlank(gcLoggerImplClassName)) {
             try {
-                gcLoggerImpl = (JvmGCMetricsLogger) Class.forName(gcLoggerImplClassName).newInstance();
+                gcLoggerImpl = (JvmGCMetricsLogger) Class.forName(gcLoggerImplClassName).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 log.error("Failed to initialize jvmGCMetricsLogger {} due to {}", jvmGCMetricsLoggerClassName,
                         e.getMessage(), e);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
@@ -71,7 +71,8 @@ public class JvmMetrics {
         JvmGCMetricsLogger gcLoggerImpl = null;
         if (StringUtils.isNotBlank(gcLoggerImplClassName)) {
             try {
-                gcLoggerImpl = (JvmGCMetricsLogger) Class.forName(gcLoggerImplClassName).getDeclaredConstructor().newInstance();
+                gcLoggerImpl = (JvmGCMetricsLogger) Class.forName(gcLoggerImplClassName)
+                        .getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 log.error("Failed to initialize jvmGCMetricsLogger {} due to {}", jvmGCMetricsLoggerClassName,
                         e.getMessage(), e);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -118,7 +118,7 @@ public class SecurityUtility {
     private static Provider loadConscryptProvider() {
         Provider provider;
         try {
-            provider = (Provider) Class.forName(CONSCRYPT_PROVIDER_CLASS).newInstance();
+            provider = (Provider) Class.forName(CONSCRYPT_PROVIDER_CLASS).getDeclaredConstructor().newInstance();
         } catch (ReflectiveOperationException e) {
             log.warn("Unable to get security provider for class {}", CONSCRYPT_PROVIDER_CLASS, e);
             return null;
@@ -179,7 +179,7 @@ public class SecurityUtility {
             clazz = Class.forName(BC_FIPS_PROVIDER_CLASS);
         }
 
-        Provider provider = (Provider) clazz.newInstance();
+        Provider provider = (Provider) clazz.getDeclaredConstructor().newInstance();
         Security.addProvider(provider);
         if (log.isDebugEnabled()) {
             log.debug("Found and Instantiated Bouncy Castle provider in classpath {}", provider.getName());

--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
@@ -95,7 +95,7 @@ public class ConfigValidation {
                     if (hasConstructor(clazz, Map.class)) {
                         o = clazz.getConstructor(Map.class).newInstance(params);
                     } else { //If not call default constructor
-                        o = clazz.newInstance();
+                        o = clazz.getDeclaredConstructor().newInstance();
                     }
                     o.validateField(fieldName, value);
                 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
@@ -85,7 +85,7 @@ public class WorkerServiceLoader {
 
         try {
             Class handlerClass = ncl.loadClass(phDef.getHandlerClass());
-            Object handler = handlerClass.newInstance();
+            Object handler = handlerClass.getDeclaredConstructor().newInstance();
             if (!(handler instanceof WorkerService)) {
                 throw new IOException("Class " + phDef.getHandlerClass()
                     + " does not implement worker service interface");

--- a/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/node/Application.java
+++ b/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/node/Application.java
@@ -217,7 +217,7 @@ public class Application {
                     //Not a known type, use FQCN
                     klass = (Class<? extends MonitorService>) Class.forName(monitorType);
                 }
-                this.monitorServer = klass.newInstance();
+                this.monitorServer = klass.getDeclaredConstructor().newInstance();
                 Context context = new Context();
                 for (String key : keys) {
                     if (key.startsWith(CONF_MONITOR_PREFIX)) {

--- a/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/node/PropertiesFileConfigurationProvider.java
+++ b/pulsar-io/flume/src/main/java/org/apache/pulsar/io/flume/node/PropertiesFileConfigurationProvider.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -190,7 +191,7 @@ public class PropertiesFileConfigurationProvider extends
                     DEFAULT_PROPERTIES_IMPLEMENTATION);
             Class<? extends Properties> propsclass = Class.forName(resolverClassName)
                     .asSubclass(Properties.class);
-            Properties properties = propsclass.newInstance();
+            Properties properties = propsclass.getDeclaredConstructor().newInstance();
             properties.load(reader);
             return new FlumeConfiguration(toMap(properties));
         } catch (IOException ex) {
@@ -202,6 +203,10 @@ public class PropertiesFileConfigurationProvider extends
             LOGGER.error("Instantiation exception", e);
         } catch (IllegalAccessException e) {
             LOGGER.error("Illegal access exception", e);
+        } catch (InvocationTargetException e) {
+            LOGGER.error("Invocation target exception", e);
+        } catch (NoSuchMethodException e) {
+            LOGGER.error("No such method exception", e);
         } finally {
             if (reader != null) {
                 try {

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorageProvider.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/PackagesStorageProvider.java
@@ -36,7 +36,7 @@ public interface PackagesStorageProvider {
         Class<?> providerClass;
         try {
             providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.newInstance();
+            Object obj = providerClass.getDeclaredConstructor().newInstance();
             checkArgument(obj instanceof PackagesStorageProvider,
                 "The package storage provider has to be an instance of " + PackagesStorageProvider.class.getName());
             return (PackagesStorageProvider) obj;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -484,7 +484,7 @@ public class PerformanceProducer {
         try {
             ClassLoader classLoader = PerformanceProducer.class.getClassLoader();
             Class clz = classLoader.loadClass(formatterClass);
-            return (IMessageFormatter) clz.newInstance();
+            return (IMessageFormatter) clz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             return null;
         }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProvider.java
@@ -41,7 +41,7 @@ public interface TransactionMetadataStoreProvider {
         Class<?> providerClass;
         try {
             providerClass = Class.forName(providerClassName);
-            Object obj = providerClass.newInstance();
+            Object obj = providerClass.getDeclaredConstructor().newInstance();
             checkArgument(obj instanceof TransactionMetadataStoreProvider,
                 "The factory has to be an instance of "
                     + TransactionMetadataStoreProvider.class.getName());


### PR DESCRIPTION
### Motivation
The method `newInstance()` is deprecated in Class since java9, and it is recommended to use `getDeclaredConstructor().newInstance()` instead. As follow:
```java
    /**
     * Creates a new instance of the class represented by this {@code Class}
     * object.  The class is instantiated as if by a {@code new}
     * expression with an empty argument list.  The class is initialized if it
     * has not already been initialized.
     *
     * @deprecated This method propagates any exception thrown by the
     * nullary constructor, including a checked exception.  Use of
     * this method effectively bypasses the compile-time exception
     * checking that would otherwise be performed by the compiler.
     * The {@link
     * java.lang.reflect.Constructor#newInstance(java.lang.Object...)
     * Constructor.newInstance} method avoids this problem by wrapping
     * any exception thrown by the constructor in a (checked) {@link
     * java.lang.reflect.InvocationTargetException}.
     *
     * <p>The call
     *
     * <pre>{@code
     * clazz.newInstance()
     * }</pre>
     *
     * can be replaced by
     *
     * <pre>{@code
     * clazz.getDeclaredConstructor().newInstance()
     * }</pre>
     *
     * The latter sequence of calls is inferred to be able to throw
     * the additional exception types {@link
     * InvocationTargetException} and {@link
     * NoSuchMethodException}. Both of these exception types are
     * subclasses of {@link ReflectiveOperationException}.
     *
     * @return  a newly allocated instance of the class represented by this
     *          object.
     * @throws  IllegalAccessException  if the class or its nullary
     *          constructor is not accessible.
     * @throws  InstantiationException
     *          if this {@code Class} represents an abstract class,
     *          an interface, an array class, a primitive type, or void;
     *          or if the class has no nullary constructor;
     *          or if the instantiation fails for some other reason.
     * @throws  ExceptionInInitializerError if the initialization
     *          provoked by this method fails.
     * @throws  SecurityException
     *          If a security manager, <i>s</i>, is present and
     *          the caller's class loader is not the same as or an
     *          ancestor of the class loader for the current class and
     *          invocation of {@link SecurityManager#checkPackageAccess
     *          s.checkPackageAccess()} denies access to the package
     *          of this class.
     */
    @CallerSensitive
    @Deprecated(since="9")
    public T newInstance()
        throws InstantiationException, IllegalAccessException
```

### Modifications
- Use `getDeclaredConstructor().newInstance()` instead of new a Clazz.
- I updated all uses of `clazz.newInstance()`.

### Documentation
- no-need-doc 
