### PR TITLE
[Tiered Storage] Fix read tiered storage ledger data again

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/BackedInputStream.java
@@ -27,4 +27,16 @@ import java.io.InputStream;
 public abstract class BackedInputStream extends InputStream {
     public abstract void seek(long position);
     public abstract void seekForward(long position) throws IOException;
+
+    /**
+     * Check whether the data stream have data to read or not.
+     *
+     * @return True indicate there are data could to be read.
+     */
+    public abstract boolean haveDataToRead();
+
+    /**
+     * Reset the data stream reader index.
+     */
+    public abstract void resetReaderIndex();
 }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -141,7 +141,7 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
     public boolean haveDataToRead() {
         log.debug("haveDataToRead cursor: {}, objectLen: {}, readableBytes: {}.",
                 cursor, objectLen, this.buffer.readableBytes());
-        return cursor >= objectLen && this.buffer.readableBytes() > 0;
+        return cursor < objectLen || this.buffer.readableBytes() > 0;
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -139,8 +139,10 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
 
     @Override
     public boolean haveDataToRead() {
-        log.debug("haveDataToRead cursor: {}, objectLen: {}, readableBytes: {}.",
-                cursor, objectLen, this.buffer.readableBytes());
+        if (log.isDebugEnabled()) {
+            log.debug("haveDataToRead cursor: {}, objectLen: {}, readableBytes: {}.",
+                    cursor, objectLen, this.buffer.readableBytes());
+        }
         return cursor < objectLen || this.buffer.readableBytes() > 0;
     }
 

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -116,8 +116,8 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
 
     @Override
     public void seek(long position) {
-        log.debug("Seeking to {} on {}/{}, current position {} (bufStart:{}, bufEnd:{})",
-                position, bucket, key, cursor, bufferOffsetStart, bufferOffsetEnd);
+        log.debug("Seeking to {} on {}/{}, current position {} (bufStart:{}, bufEnd:{}, objectLen: {})",
+                position, bucket, key, cursor, bufferOffsetStart, bufferOffsetEnd, objectLen);
         if (position >= bufferOffsetStart && position <= bufferOffsetEnd) {
             long newIndex = position - bufferOffsetStart;
             buffer.readerIndex((int) newIndex);
@@ -135,6 +135,18 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             throw new IOException(String.format("Error seeking, new position %d < current position %d",
                                                 position, cursor));
         }
+    }
+
+    @Override
+    public boolean haveDataToRead() {
+        log.debug("haveDataToRead cursor: {}, objectLen: {}, readableBytes: {}.",
+                cursor, objectLen, this.buffer.readableBytes());
+        return cursor >= objectLen && this.buffer.readableBytes() > 0;
+    }
+
+    @Override
+    public void resetReaderIndex() {
+        this.buffer.resetReaderIndex();
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -92,6 +92,9 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
         log.debug("Ledger {}: reading {} - {}", getId(), firstEntry, lastEntry);
+        if (!inputStream.haveDataToRead()) {
+            inputStream.resetReaderIndex();
+        }
         CompletableFuture<LedgerEntries> promise = new CompletableFuture<>();
         executor.submit(() -> {
                 if (firstEntry > lastEntry

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -92,12 +92,12 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
     @Override
     public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
         log.debug("Ledger {}: reading {} - {}", getId(), firstEntry, lastEntry);
-        if (!inputStream.haveDataToRead()) {
-            inputStream.resetReaderIndex();
-        }
         CompletableFuture<LedgerEntries> promise = new CompletableFuture<>();
         executor.submit(() -> {
-                if (firstEntry > lastEntry
+            if (!inputStream.haveDataToRead()) {
+                inputStream.resetReaderIndex();
+            }
+            if (firstEntry > lastEntry
                     || firstEntry < 0
                     || lastEntry > getLastAddConfirmed()) {
                     promise.completeExceptionally(new BKException.BKIncorrectParameterException());

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -139,6 +139,13 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             Assert.assertFalse(toWriteIter.hasNext());
             Assert.assertFalse(toTestIter.hasNext());
         }
+
+        try {
+            toTest.read(0, toWrite.getLastAddConfirmed());
+        } catch (Exception e) {
+            log.error("Failed to read offload data again.", e);
+            Assert.fail("Failed to read offload data again.");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Currently, the `BlobStoreBackedReadHandleImpl` couldn't read the ledger data again, if read to the end of the data stream, it can't reset the reader index. So the `ReadHandle`(BlobStoreBackedReadHandleImpl) of the ledger couldn't be reused.

**How to reproduce**
1. Create a consumer and consume offloaded data(don't ack messages).
2. Restart the consumer and read data from the earliest position.
3. We'll meet this issue.

**error logs**
```
2021-09-19T00:56:00,806+0800 [TestNG-method=testOffloadAndRead-1:org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloaderTest@146] ERROR org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloaderTest - Failed to read offload data again.
org.apache.bookkeeper.client.api.BKException: Unexpected condition
	at org.apache.bookkeeper.client.api.BKException.lambda$static$0(BKException.java:40) ~[bookkeeper-server-4.14.2.jar:4.14.2]
	at org.apache.bookkeeper.common.concurrent.FutureUtils.result(FutureUtils.java:77) ~[bookkeeper-common-4.14.2.jar:4.14.2]
	at org.apache.bookkeeper.client.api.ReadHandle.read(ReadHandle.java:58) ~[bookkeeper-server-4.14.2.jar:4.14.2]
	at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreManagedLedgerOffloaderTest.testOffloadAndRead(BlobStoreManagedLedgerOffloaderTest.java:144) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_261]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_261]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_261]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_261]
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132) [testng-7.3.0.jar:?]
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45) [testng-7.3.0.jar:?]
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73) [testng-7.3.0.jar:?]
	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11) [testng-7.3.0.jar:?]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266) [?:1.8.0_261]
	at java.util.concurrent.FutureTask.run(FutureTask.java) [?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_261]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_261]
Caused by: java.io.EOFException
	at java.io.DataInputStream.readInt(DataInputStream.java:392) ~[?:1.8.0_261]
	at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$1(BlobStoreBackedReadHandleImpl.java:111) ~[classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_261]
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125) ~[guava-30.1-jre.jar:?]
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69) ~[guava-30.1-jre.jar:?]
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78) ~[guava-30.1-jre.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_261]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266) ~[?:1.8.0_261]
	at java.util.concurrent.FutureTask.run(FutureTask.java) ~[?:1.8.0_261]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_261]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_261]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_261]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	... 1 more

```

### Modifications

Reset the buffer reader index if the reading progress reaches the end of the data stream.

### Verifying this change

Modify the test to verify reading tiered storage data again.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


