### PR TITLE
Added JLine 2.x for ZK CLI tool

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -65,6 +65,12 @@
     </dependency>
 
     <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>${jline.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-prometheus-metrics</artifactId>
       <version>${zookeeper.version}</version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -524,6 +524,7 @@ BSD 3-clause "New" or "Revised" License
     - com.google.auth-google-auth-library-oauth2-http-0.20.0.jar -- licenses/LICENSE-google-auth-library.txt
  * LevelDB -- (included in org.rocksdb.*.jar) -- licenses/LICENSE-LevelDB.txt
  * JSR305 -- com.google.code.findbugs-jsr305-3.0.2.jar -- licenses/LICENSE-JSR305.txt
+ * JLine -- jline-jline-2.14.6.jar -- licenses/LICENSE-JLine.txt
 
 BSD 2-Clause License
  * HdrHistogram -- org.hdrhistogram-HdrHistogram-2.1.9.jar -- licenses/LICENSE-HdrHistogram.txt

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@ flexible messaging model and an intuitive client API.</description>
     <javax.servlet-api>3.1.0</javax.servlet-api>
     <caffeine.version>2.9.1</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
+    <jline.version>2.14.6</jline.version>
     <hppc.version>0.7.3</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.18.1</assertj-core.version>


### PR DESCRIPTION
### Motivation

Added the JLine dependency into binary distribution so that the `zookeeper-shell` command will be easier to use with completion/history/etc.. 