### PR TITLE
Fixed used after recycle issue in OpAddEntry

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -277,18 +277,19 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
     /**
      * It handles add failure on the given ledger. it can be triggered when add-entry fails or times out.
      * 
-     * @param ledger
+     * @param lh
      */
-    void handleAddFailure(final LedgerHandle ledger) {
+    void handleAddFailure(final LedgerHandle lh) {
         // If we get a write error, we will try to create a new ledger and re-submit the pending writes. If the
-        // ledger creation fails (persistent bk failure, another instanche owning the ML, ...), then the writes will
+        // ledger creation fails (persistent bk failure, another instance owning the ML, ...), then the writes will
         // be marked as failed.
-        ml.mbean.recordAddEntryError();
+        ManagedLedgerImpl finalMl = this.ml;
+        finalMl.mbean.recordAddEntryError();
 
-        ml.getExecutor().executeOrdered(ml.getName(), SafeRun.safeRun(() -> {
+        finalMl.getExecutor().executeOrdered(finalMl.getName(), SafeRun.safeRun(() -> {
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock
             // from a BK callback.
-            ml.ledgerClosed(ledger);
+            finalMl.ledgerClosed(lh);
         }));
     }
 


### PR DESCRIPTION
### Motivation

After a write failure, a task is scheduled in background to force close the ledger and trigger the creation of a new one. If the the `OpAddEntry` instance is already recycled, that could lead to either a NPE or undefined behavior.

### Modifications

Copy the reference to a final variable so the background task will not be dependent on the lifecycle of `OpAddEntry` instance.