### PR TITLE
[pulsar-client] Fix NPE in pulsar bolt while publishing messages

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -284,7 +284,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     public Message<T> getMessage() {
         beforeSend();
-        return MessageImpl.create(msgMetadata, content, schema, producer.topic);
+        return MessageImpl.create(msgMetadata, content, schema, producer != null ? producer.getTopic() : null);
     }
 
     public long getPublishTime() {


### PR DESCRIPTION
### Motivation
Fix NPE when pulsar-storm bolt or any other client app tries to create message without initializing producer in it.
```
java.lang.NullPointerException
	at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.getMessage(TypedMessageBuilderImpl.java:285)
	:
	at org.apache.pulsar.storm.TupleToMessageMapper.toMessage(TupleToMessageMapper.java:50)
	at org.apache.pulsar.storm.PulsarBolt.execute(PulsarBolt.java:126)
```
