### PR TITLE
Fixed NPE in ProxyConnection with no auth data

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -92,6 +92,8 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
     private String proxyToBrokerUrl;
     private HAProxyMessage haProxyMessage;
 
+    private static final byte[] EMPTY_CREDENTIALS = new byte[0];
+
     enum State {
         Init,
 
@@ -315,7 +317,7 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
                 return;
             }
 
-            AuthData clientData = AuthData.of(connect.hasAuthData() ? connect.getAuthData() : null);
+            AuthData clientData = AuthData.of(connect.hasAuthData() ? connect.getAuthData() : EMPTY_CREDENTIALS);
             if (connect.hasAuthMethodName()) {
                 authMethod = connect.getAuthMethodName();
             } else if (connect.hasAuthMethod()) {


### PR DESCRIPTION
### Motivation

In #12057 there was a fix for missing authdata, but `AuthData.of()` is expecting a valid `byte[]` instance, empty if there are no credentials. 