### PR TITLE
[Docs] Update instructions about Gradle Nar plugin

### DIFF
--- a/site2/docs/io-develop.md
+++ b/site2/docs/io-develop.md
@@ -298,7 +298,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website-next/docs/io-develop.md
+++ b/site2/website-next/docs/io-develop.md
@@ -318,7 +318,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 :::tip
 

--- a/site2/website-next/versioned_docs/version-2.7.3/io-develop.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/io-develop.md
@@ -223,7 +223,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 :::tip
 

--- a/site2/website-next/versioned_docs/version-2.8.0/io-develop.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/io-develop.md
@@ -319,7 +319,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 :::tip
 

--- a/site2/website/versioned_docs/version-2.5.0/io-develop.md
+++ b/site2/website/versioned_docs/version-2.5.0/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.5.1/io-develop.md
+++ b/site2/website/versioned_docs/version-2.5.1/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.5.2/io-develop.md
+++ b/site2/website/versioned_docs/version-2.5.2/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.6.0/io-develop.md
+++ b/site2/website/versioned_docs/version-2.6.0/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.6.1/io-develop.md
+++ b/site2/website/versioned_docs/version-2.6.1/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.6.2/io-develop.md
+++ b/site2/website/versioned_docs/version-2.6.2/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.6.3/io-develop.md
+++ b/site2/website/versioned_docs/version-2.6.3/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.6.4/io-develop.md
+++ b/site2/website/versioned_docs/version-2.6.4/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.7.0/io-develop.md
+++ b/site2/website/versioned_docs/version-2.7.0/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.7.1/io-develop.md
+++ b/site2/website/versioned_docs/version-2.7.1/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.7.2/io-develop.md
+++ b/site2/website/versioned_docs/version-2.7.2/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.7.3/io-develop.md
+++ b/site2/website/versioned_docs/version-2.7.3/io-develop.md
@@ -203,7 +203,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.8.0/io-develop.md
+++ b/site2/website/versioned_docs/version-2.8.0/io-develop.md
@@ -299,7 +299,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.8.1/io-develop.md
+++ b/site2/website/versioned_docs/version-2.8.1/io-develop.md
@@ -299,7 +299,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 

--- a/site2/website/versioned_docs/version-2.8.2/io-develop.md
+++ b/site2/website/versioned_docs/version-2.8.2/io-develop.md
@@ -299,7 +299,7 @@ sourceClass: fully qualified class name (only if source connector)
 sinkClass: fully qualified class name (only if sink connector)
 ```
 
-If you are using the [Gradle NiFi plugin](https://github.com/sponiro/gradle-nar-plugin) you might need to create a directive to ensure your pulsar-io.yaml is [copied into the NAR file correctly](https://github.com/sponiro/gradle-nar-plugin/issues/5).
+For Gradle users, there is a [Gradle Nar plugin available on the Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin).
 
 > #### Tip
 > 


### PR DESCRIPTION
### Motivation

https://github.com/sponiro/gradle-nar-plugin is no more available since it was published on Bintray. [The original author doesn't maintain the plugin anymore](https://github.com/sponiro/gradle-nar-plugin/issues/8#issuecomment-831447590). The new location for the plugin is https://plugins.gradle.org/plugin/io.github.lhotari.gradle-nar-plugin (for the plugin page) and source repository is https://github.com/lhotari/gradle-nar-plugin . 
The issue mentioned in the docs has been fixed in the maintained plugin version 0.5.1 .

### Modifications

- update docs to point to maintained Gradle Nar plugin