### PR TITLE
[WebSite]Increase website build memory

### DIFF
--- a/site2/tools/build-site.sh
+++ b/site2/tools/build-site.sh
@@ -58,7 +58,7 @@ function workaround_crowdin_problem_by_copying_files() {
 
 set -x -e
 
-export NODE_OPTIONS="--max-old-space-size=2048" #increase to 2gb, default is 512mb
+export NODE_OPTIONS="--max-old-space-size=4096" #increase to 4GB, default is 512MB
 ${ROOT_DIR}/site2/tools/generate-api-docs.sh
 cd ${ROOT_DIR}/site2/website
 yarn


### PR DESCRIPTION
### Motivation
The website build failed by js OOM
```
2021-09-21T12:19:12.6116189Z [BABEL] Note: The code generator has deoptimised the styling of /pulsar/site2/website/node_modules/docusaurus/lib/core/metadata.js as it exceeds the max of 500KB.
2021-09-21T12:19:42.8916075Z 
2021-09-21T12:19:42.8929409Z <--- Last few GCs --->
2021-09-21T12:19:42.8929752Z 
2021-09-21T12:19:42.8930962Z [1659:0x51a7d00]   188975 ms: Mark-sweep (reduce) 2034.5 (2050.8) -> 2033.9 (2052.6) MB, 2855.8 / 0.0 ms  (average mu = 0.088, current mu = 0.001) allocation failure scavenge might not succeed
2021-09-21T12:19:42.8939667Z 
2021-09-21T12:19:42.8940242Z 
2021-09-21T12:19:42.8942348Z <--- JS stacktrace --->
2021-09-21T12:19:42.8944881Z 
2021-09-21T12:19:42.8947877Z FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
2021-09-21T12:19:42.8949798Z  1: 0xa25510 node::Abort() [/usr/bin/node]
2021-09-21T12:19:42.8952964Z  2: 0x9664d3 node::FatalError(char const*, char const*) [/usr/bin/node]
2021-09-21T12:19:42.8953981Z  3: 0xb9a8ee v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/usr/bin/node]
2021-09-21T12:19:42.8955393Z  4: 0xb9ac67 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/usr/bin/node]
2021-09-21T12:19:42.8957640Z  5: 0xd56cd5  [/usr/bin/node]
2021-09-21T12:19:42.8958145Z  6: 0xd5785f  [/usr/bin/node]
2021-09-21T12:19:42.8964881Z  7: 0xd6569b v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/usr/bin/node]
2021-09-21T12:19:42.8970008Z  8: 0xd6925c v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/usr/bin/node]
2021-09-21T12:19:42.8974798Z  9: 0xd3793b v8::internal::Factory::NewFillerObject(int, bool, v8::internal::AllocationType, v8::internal::AllocationOrigin) [/usr/bin/node]
2021-09-21T12:19:42.8981048Z 10: 0x107fc1f v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [/usr/bin/node]
2021-09-21T12:19:42.8986456Z 11: 0x1426939  [/usr/bin/node]
2021-09-21T12:19:43.2932456Z Aborted (core dumped)
2021-09-21T12:19:43.3056391Z error Command failed with exit code 134.
2021-09-21T12:19:43.3057237Z info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2021-09-21T12:19:43.4983397Z ##[error]Process completed with exit code 134.
```

### Modification
1. Increase the memory from 2GB to 4GB.