### PR TITLE
[Cherry-pick] [Functions] reorganize the context hierarchy for functions (#10631)

### DIFF
--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -84,7 +84,7 @@ public interface Producer extends Closeable {
     void flush() throws PulsarClientException;
 
     /**
-     * Flush all the messages buffered in the client and wait until all messages have been successfully persisted.
+     *  Flush all the messages buffered in the client asynchronously.
      *
      * @return a future that can be used to track when all the messages have been safely persisted.
      * @since 2.1.0

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.functions.api;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -31,7 +30,6 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
-import org.slf4j.Logger;
 
 /**
  * Context provides contextual information to the executing function.
@@ -41,14 +39,7 @@ import org.slf4j.Logger;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public interface Context {
-    /**
-     * Access the record associated with the current input value.
-     *
-     * @return
-     */
-    Record<?> getCurrentRecord();
-
+public interface Context extends BaseContext {
     /**
      * Get a list of all input topics.
      *
@@ -57,11 +48,18 @@ public interface Context {
     Collection<String> getInputTopics();
 
     /**
-     * Get the output topic of the function.
+     * Get the output topic of the source.
      *
      * @return output topic name
      */
     String getOutputTopic();
+
+    /**
+     * Access the record associated with the current input value.
+     *
+     * @return
+     */
+    Record<?> getCurrentRecord();
 
     /**
      * Get output schema builtin type or custom class name.
@@ -69,20 +67,6 @@ public interface Context {
      * @return output schema builtin type or custom class name
      */
     String getOutputSchemaType();
-
-    /**
-     * The tenant this function belongs to.
-     *
-     * @return the tenant this function belongs to
-     */
-    String getTenant();
-
-    /**
-     * The namespace this function belongs to.
-     *
-     * @return the namespace this function belongs to
-     */
-    String getNamespace();
 
     /**
      * The name of the function that we are executing.
@@ -99,138 +83,11 @@ public interface Context {
     String getFunctionId();
 
     /**
-     * The id of the instance that invokes this function.
-     *
-     * @return the instance id
-     */
-    int getInstanceId();
-
-    /**
-     * Get the number of instances that invoke this function.
-     *
-     * @return the number of instances that invoke this function.
-     */
-    int getNumInstances();
-
-    /**
      * The version of the function that we are executing.
      *
      * @return The version id
      */
     String getFunctionVersion();
-
-    /**
-     * The logger object that can be used to log in a function.
-     *
-     * @return the logger object
-     */
-    Logger getLogger();
-
-    /**
-     * Get the state store with the provided store name in the function tenant & namespace.
-     *
-     * @param name the state store name
-     * @param <S> the type of interface of the store to return
-     * @return the state store instance.
-     *
-     * @throws ClassCastException if the return type isn't a type
-     * or interface of the actual returned store.
-     */
-    <S extends StateStore> S getStateStore(String name);
-
-    /**
-     * Get the state store with the provided store name.
-     *
-     * @param tenant the state tenant name
-     * @param ns the state namespace name
-     * @param name the state store name
-     * @param <S> the type of interface of the store to return
-     * @return the state store instance.
-     *
-     * @throws ClassCastException if the return type isn't a type
-     * or interface of the actual returned store.
-     */
-    <S extends StateStore> S getStateStore(String tenant, String ns, String name);
-
-    /**
-     * Increment the builtin distributed counter referred by key.
-     *
-     * @param key    The name of the key
-     * @param amount The amount to be incremented
-     */
-    void incrCounter(String key, long amount);
-
-    /**
-     * Increment the builtin distributed counter referred by key
-     * but dont wait for the completion of the increment operation
-     *
-     * @param key    The name of the key
-     * @param amount The amount to be incremented
-     */
-    CompletableFuture<Void> incrCounterAsync(String key, long amount);
-
-    /**
-     * Retrieve the counter value for the key.
-     *
-     * @param key name of the key
-     * @return the amount of the counter value for this key
-     */
-    long getCounter(String key);
-
-    /**
-     * Retrieve the counter value for the key, but don't wait
-     * for the operation to be completed
-     *
-     * @param key name of the key
-     * @return the amount of the counter value for this key
-     */
-    CompletableFuture<Long> getCounterAsync(String key);
-
-    /**
-     * Update the state value for the key.
-     *
-     * @param key   name of the key
-     * @param value state value of the key
-     */
-    void putState(String key, ByteBuffer value);
-
-    /**
-     * Update the state value for the key, but don't wait for the operation to be completed
-     *
-     * @param key   name of the key
-     * @param value state value of the key
-     */
-    CompletableFuture<Void> putStateAsync(String key, ByteBuffer value);
-
-    /**
-     * Delete the state value for the key.
-     *
-     * @param key   name of the key
-     */
-    void deleteState(String key);
-
-    /**
-     * Delete the state value for the key, but don't wait for the operation to be completed
-     *
-     * @param key   name of the key
-     */
-    CompletableFuture<Void> deleteStateAsync(String key);
-
-    /**
-     * Retrieve the state value for the key.
-     *
-     * @param key name of the key
-     * @return the state value for the key.
-     */
-    ByteBuffer getState(String key);
-
-    /**
-     * Retrieve the state value for the key, but don't wait for the operation to be completed
-     *
-     * @param key name of the key
-     * @return the state value for the key.
-     */
-    CompletableFuture<ByteBuffer> getStateAsync(String key);
 
     /**
      * Get a map of all user-defined key/value configs for the function.
@@ -257,27 +114,11 @@ public interface Context {
     Object getUserConfigValueOrDefault(String key, Object defaultValue);
 
     /**
-     * Get the secret associated with this key.
-     *
-     * @param secretName The name of the secret
-     * @return The secret if anything was found or null
-     */
-    String getSecret(String secretName);
-
-    /**
      * Get the pulsar admin client.
      *
      * @return The instance of pulsar admin client
      */
     PulsarAdmin getPulsarAdmin();
-
-    /**
-     * Record a user defined metric.
-     *
-     * @param metricName The name of the metric
-     * @param value      The value of the metric
-     */
-    void recordMetric(String metricName, double value);
 
     /**
      * Publish an object using serDe or schema class for serializing to the topic.

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SinkContext.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.functions.api.BaseContext;
 
 /**
  * Interface for a sink connector providing information about environment where it is running.
@@ -31,14 +32,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public interface SinkContext extends ConnectorContext {
-
-    /**
-     * Get a list of all input topics
-     * @return a list of all input topics
-     */
-    Collection<String> getInputTopics();
-
+public interface SinkContext extends BaseContext {
     /**
      * The name of the sink that we are executing
      * @return The Sink name
@@ -46,7 +40,15 @@ public interface SinkContext extends ConnectorContext {
     String getSinkName();
 
     /**
+     * Get a list of all input topics.
+     *
+     * @return a list of all input topics
+     */
+    Collection<String> getInputTopics();
+
+    /**
      * Get subscription type used by the source providing data for the sink
+     *
      * @return subscription type
      */
     default SubscriptionType getSubscriptionType() {
@@ -55,6 +57,7 @@ public interface SinkContext extends ConnectorContext {
 
     /**
      * Reset the subscription associated with this topic and partition to a specific message id.
+     *
      * @param topic - topic name
      * @param partition - partition id (0 for non-partitioned topics)
      * @param messageId to reset to
@@ -65,7 +68,9 @@ public interface SinkContext extends ConnectorContext {
     }
 
     /**
-     * Stop requesting new messages for given topic and partition until {@link #resume(String topic)} is called.
+     * Stop requesting new messages for given topic and partition until {@link #resume(String topic, int partition)}
+     * is called.
+     *
      * @param topic - topic name
      * @param partition - partition id (0 for non-partitioned topics)
      */

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SourceContext.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/SourceContext.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
+import org.apache.pulsar.functions.api.BaseContext;
 
 /**
  * Interface for a source connector providing information about environment where it is running.
@@ -31,7 +32,13 @@ import org.apache.pulsar.common.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public interface SourceContext extends ConnectorContext {
+public interface SourceContext extends BaseContext {
+    /**
+     * The name of the source that we are executing.
+     *
+     * @return The Source name
+     */
+    String getSourceName();
 
     /**
      * Get the output topic of the source.
@@ -39,13 +46,6 @@ public interface SourceContext extends ConnectorContext {
      * @return output topic name
      */
     String getOutputTopic();
-
-    /**
-     * The name of the source that we are executing.
-     *
-     * @return The Source name
-     */
-    String getSourceName();
 
     /**
      * New output message using schema for serializing to the topic


### PR DESCRIPTION
Cherry-pick #10631. 

## Why cherry-pick #10631?
We have to cherry-pick #11293, but 11293 depends on #10631. So we have to cherry-pick #10631 first.

## Motivation
Currently the context relationship for function, source and sink is not well defined. This prevents some common features to be added once for all and creates some confusion, code duplication in the current repo. As demonstrated in the following graph, this PR changes the hierarchy from left to right. By introducing a common base context, it help solving some issues we are seeing. The base context provides common access to pulsar cluster, state, metrics, and meta-data to make sure all components can reuse it.

context hierarchy

## Modifications
Remove ConnectorContext interface.
Introduce a BaseContext interface.
Update existing Context, SourceContext, SinkContext interface to extend the new common interface.
