### PR TITLE
Avoid trying to refresh MetadataCaches when we're disconnected from ZK

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -220,18 +220,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
     private synchronized void handleMetadataStoreNotification(SessionEvent e) {
         log.info("Received MetadataStore session event: {}", e);
-
-        switch (e) {
-            case ConnectionLost:
-            case SessionLost:
-                metadataServiceAvailable = false;
-                break;
-
-            case Reconnected:
-            case SessionReestablished:
-                metadataServiceAvailable = true;
-                break;
-        }
+        metadataServiceAvailable = e.isConnected();
     }
 
     private synchronized void flushCursors() {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/SessionEvent.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/SessionEvent.java
@@ -42,5 +42,21 @@ public enum SessionEvent {
     /**
      * The session was established
      */
-    SessionReestablished,
+    SessionReestablished;
+
+    /**
+     * Check whether the state represents a connected or not-connected state.
+     */
+    public boolean isConnected() {
+        switch (this) {
+            case Reconnected:
+            case SessionReestablished:
+                return true;
+
+            case ConnectionLost:
+            case SessionLost:
+            default:
+                return false;
+        }
+    }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -25,10 +25,7 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -36,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -49,7 +45,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException
 import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
-import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.impl.AbstractMetadataStore;
 
 @Slf4j
 public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notification> {
@@ -83,9 +79,17 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     }
 
                     @Override
-                    public CompletableFuture<Optional<CacheGetResult<T>>> asyncReload(String key,
-                            Optional<CacheGetResult<T>> oldValue, Executor executor) {
-                        return readValueFromStore(key);
+                    public CompletableFuture<Optional<CacheGetResult<T>>> asyncReload(
+                            String key,
+                            Optional<CacheGetResult<T>> oldValue,
+                            Executor executor) {
+                        if (store instanceof AbstractMetadataStore && ((AbstractMetadataStore) store).isConnected()) {
+                            return readValueFromStore(key);
+                        } else {
+                            // Do not try to refresh the cache item if we know that we're not connected to the
+                            // metadata store
+                            return CompletableFuture.completedFuture(oldValue);
+                        }
                     }
                 });
     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -67,6 +67,8 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     private final AsyncLoadingCache<String, Boolean> existsCache;
     private final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
 
+    // We don't strictly need to use 'volatile' here because we don't need the precise consistent semantic. Instead,
+    // we want to avoid the overhead of 'volatile'.
     @Getter
     private boolean isConnected = true;
 
@@ -261,17 +263,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     }
 
     protected void receivedSessionEvent(SessionEvent event) {
-        switch (event) {
-            case Reconnected:
-            case SessionReestablished:
-                isConnected = true;
-                break;
-
-            case ConnectionLost:
-            case SessionLost:
-                isConnected = false;
-                break;
-        }
+        isConnected = event.isConnected();
 
         sessionListeners.forEach(l -> {
             try {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -40,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.common.util.FutureUtil;
@@ -65,6 +67,9 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     private final AsyncLoadingCache<String, Boolean> existsCache;
     private final CopyOnWriteArrayList<MetadataCacheImpl<?>> metadataCaches = new CopyOnWriteArrayList<>();
 
+    @Getter
+    private boolean isConnected = true;
+
     protected abstract CompletableFuture<List<String>> getChildrenFromStore(String path);
 
     protected abstract CompletableFuture<Boolean> existsFromStore(String path);
@@ -85,7 +90,12 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
                     @Override
                     public CompletableFuture<List<String>> asyncReload(String key, List<String> oldValue,
                             Executor executor) {
-                        return getChildrenFromStore(key);
+                        if (isConnected) {
+                            return getChildrenFromStore(key);
+                        } else {
+                            // Do not refresh if we're not connected
+                            return CompletableFuture.completedFuture(oldValue);
+                        }
                     }
                 });
 
@@ -100,7 +110,12 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
                     @Override
                     public CompletableFuture<Boolean> asyncReload(String key, Boolean oldValue,
                             Executor executor) {
-                        return existsFromStore(key);
+                        if (isConnected) {
+                            return existsFromStore(key);
+                        } else {
+                            // Do not refresh if we're not connected
+                            return CompletableFuture.completedFuture(oldValue);
+                        }
                     }
                 });
     }
@@ -246,6 +261,18 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     }
 
     protected void receivedSessionEvent(SessionEvent event) {
+        switch (event) {
+            case Reconnected:
+            case SessionReestablished:
+                isConnected = true;
+                break;
+
+            case ConnectionLost:
+            case SessionLost:
+                isConnected = false;
+                break;
+        }
+
         sessionListeners.forEach(l -> {
             try {
                 l.accept(event);


### PR DESCRIPTION
### Motivation

We're using a 5min TTL for entries stored in the metadata cache. After that time a refresh is triggered in background. 
This is done to prevent an entry that could have gone out of sync to remain stale forever. 

As an enhancement, if we know that we are not connected to metadata service, we should not attempt the refresh because it would certainly fail. Instead, we wait until we're reconnected back.