### PR TITLE
[Issue 12055] Doc use wrong databases name

### DIFF
--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -480,7 +480,7 @@ In this section, you need to configure a JDBC sink connector.
     configs:
       userName: "postgres"
       password: "password"
-      jdbcUrl: "jdbc:postgresql://localhost:5432/pulsar_postgres_jdbc_sink"
+      jdbcUrl: "jdbc:postgresql://localhost:5432/postgres"
       tableName: "pulsar_postgres_jdbc_sink"
     ```
 


### PR DESCRIPTION
Fixes #12055

### Motivation
The doc has wrong database name, people can't success push message to database.

### Modifications

Fix the wrong database name

### Documentation

Need to update docs? 
This is a doc change.


