### PR TITLE
[testing] Make python3 the default python in java-test-image

### DIFF
--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -43,15 +43,12 @@ RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/s
 
 # /pulsar/bin/watch-znode.py requires python3-kazoo
 # /pulsar/bin/pulsar-managed-ledger-admin requires python3-protobuf
-RUN apt-get install -y python3-kazoo python3-protobuf
-# use python3 for watch-znode.py and pulsar-managed-ledger-admin
-RUN sed -i '1 s/.*/#!\/usr\/bin\/python3/' /pulsar/bin/watch-znode.py /pulsar/bin/pulsar-managed-ledger-admin
-
-# required by gen-yml-from-env.py
-RUN apt-get install -y python-yaml
+# gen-yml-from-env.py requires python3-yaml
+# make python3 the default
+RUN apt-get install -y python3-kazoo python3-protobuf python3-yaml \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN apt-get install -y supervisor procps curl less netcat dnsutils iputils-ping
-
 
 RUN mkdir -p /var/log/pulsar \
     && mkdir -p /var/run/supervisor/ \


### PR DESCRIPTION
### Motivation

The java-test-image docker image is broken. It has been broken since the base image was changed to ubuntu:20.04 .
python3 should be default for the image to work .
java-test-image isn't currently used in Pulsar CI. It could be used to run integration tests that don't require Pulsar SQL / Presto or other parts that are outside of the core-modules profile.

### Modifications

- make python3 the default
- install python3-yaml instead of python-yaml package