### PR TITLE
[Broker] Change the default number of namespace bundles to 32

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -248,7 +248,7 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=4
+defaultNumberOfNamespaceBundles=32
 
 # The maximum number of namespaces that each tenant can create
 # This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -164,7 +164,7 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=4
+defaultNumberOfNamespaceBundles=32
 
 # Max number of topics allowed to be created in the namespace. When the topics reach the max topics of the namespace,
 # the broker should reject the new topic request(include topic auto-created by the producer or consumer)

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -188,7 +188,7 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=4
+defaultNumberOfNamespaceBundles=32
 
 # The maximum number of namespaces that each tenant can create
 # This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded

--- a/faq.md
+++ b/faq.md
@@ -46,7 +46,7 @@ On the broker side, the namespace is broken down into multiple bundles, and each
 
 A bundle is represented by a hash-range. The 32-bit hash space is initially divided equally into the requested bundles. Topics are matched to a bundle by hashing on the topic name.
 
-Default number of bundles is configured in `broker.conf`: `defaultNumberOfNamespaceBundles=4`
+Default number of bundles is configured in `broker.conf`: `defaultNumberOfNamespaceBundles=32`
 
 When the traffic increases on a given bundle, it will be split in 2 and reassigned to a different broker.
 

--- a/site2/docs/administration-load-balance.md
+++ b/site2/docs/administration-load-balance.md
@@ -47,7 +47,7 @@ When you create a new namespace, the new namespace sets to use the default numbe
 ```properties
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=4
+defaultNumberOfNamespaceBundles=32
 ```
 
 You can either change the system default, or override it when you create a new namespace:

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -481,7 +481,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | brokerDeduplicationMaxNumberOfProducers | Maximum number of producer information that it's going to be persisted for deduplication purposes | 10000 |
 | brokerDeduplicationEntriesInterval | Number of entries after which a deduplication information snapshot is taken. A greater interval leads to less snapshots being taken though it would increase the topic recovery time, when the entries published after the snapshot need to be replayed. | 1000 |
 | brokerDeduplicationProducerInactivityTimeoutMinutes | The time of inactivity (in minutes) after which the broker discards deduplication information related to a disconnected producer. | 360 |
-| defaultNumberOfNamespaceBundles | When a namespace is created without specifying the number of bundles, this value is used as the default setting.| 4 |
+| defaultNumberOfNamespaceBundles | When a namespace is created without specifying the number of bundles, this value is used as the default setting.| 32 |
 |clientLibraryVersionCheckEnabled|  Enable checks for minimum allowed client library version. |false|
 |clientLibraryVersionCheckAllowUnversioned| Allow client libraries with no version information  |true|
 |statusFilePath|  The path for the file used to determine the rotation status for the broker when responding to service discovery health checks |/usr/local/apache/htdocs|


### PR DESCRIPTION
### Motivation

Currently, the default number of namespace bundles is 4. This leads to cases where a lot of topics can reside in just 1 or 2 brokers in 3 broker cluster. 

Side note:
A good rule of thumb rule for defining the number of shards is to have at least 10x more shards than there are nodes ([this 10x rule of thumb comes from Akka Cluster documentation](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation)). In Pulsar a "namespace bundle" behaves like a shard. In addition to this, there are some recommendations to use a power of 2 for the number of shards (reference to this recommendation not found).
From these rules, you could get that a 3 broker node cluster should use 32 bundles, a 4-6 node cluster 64 bundles and 7-12 node cluster should use 128 bundles. 
This might not be the best advice, but I haven't seen better rule of thumb rules for choosing the number of namespace bundles. 


### Modifications

Change the defaultNumberOfNamespaceBundles to 32.