### PR TITLE
fix: Various NPEs on terminated managed ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -795,14 +795,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Write into current ledger lh={} entries={}", name,
-                        currentLedger == null ? null : currentLedger.getId(),
-                        currentLedgerEntries);
+                        getCurrentLedgerIdOrNull(), currentLedgerEntries);
             }
 
             if (currentLedgerIsFull()) {
                 if (log.isDebugEnabled()) {
-                    log.debug("[{}] Closing current ledger lh={}", name,
-                            currentLedger == null ? null : currentLedger.getId());
+                    log.debug("[{}] Closing current ledger lh={}", name, getCurrentLedgerIdOrNull());
                 }
                 // This entry will be the last added to current ledger
                 addOperation.setCloseWhenDone(true);
@@ -1593,8 +1591,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 op.initiate();
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Stop writing into ledger {} queue={}", name,
-                            currentLedger == null ? null : currentLedger.getId(),
-                            pendingAddEntries.size());
+                            getCurrentLedgerIdOrNull(), pendingAddEntries.size());
                 }
                 break;
             } else {
@@ -2488,7 +2485,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                             "[{}] Checking ledger {} -- time-old: {} sec -- "
                                     + "expired: {} -- over-quota: {} -- current-ledger: {}",
                             name, ls.getLedgerId(), (clock.millis() - ls.getTimestamp()) / 1000.0, expired,
-                            overRetentionQuota, currentLedger == null ? null : currentLedger.getId());
+                            overRetentionQuota, getCurrentLedgerIdOrNull());
                 }
 
                 if (expired || overRetentionQuota) {
@@ -4109,4 +4106,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
+    // for logging, avoid in other cases to prevent boxing of i.e. other side in case of comaprison
+    private Long getCurrentLedgerIdOrNull() {
+        return currentLedger == null ? null : currentLedger.getId();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -22,27 +22,29 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.util.MessageIdUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+@Slf4j
 @Test(groups = "broker")
 public class ConsumedLedgersTrimTest extends BrokerTestBase {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ConsumedLedgersTrimTest.class);
-
+    
     @Override
     protected void setup() throws Exception {
         //No-op
@@ -127,7 +129,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         managedLedgerConfig.setMaxEntriesPerLedger(1000);
         managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
         MessageId initialMessageId = persistentTopic.getLastMessageId().get();
-        LOG.info("lastmessageid " + initialMessageId);
+        log.info("lastmessageid " + initialMessageId);
 
         int msgNum = 7;
         for (int i = 0; i < msgNum; i++) {
@@ -137,7 +139,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
         Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 1);
         MessageId messageIdBeforeRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        LOG.info("messageIdBeforeRestart " + messageIdBeforeRestart);
+        log.info("messageIdBeforeRestart " + messageIdBeforeRestart);
         assertNotEquals(messageIdBeforeRestart, initialMessageId);
 
         // restart the broker we have to start a new ledger
@@ -146,7 +148,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         // force load topic
         pulsar.getAdminClient().topics().getStats(topicName);
         MessageId messageIdAfterRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        LOG.info("lastmessageid " + messageIdAfterRestart);
+        log.info("lastmessageid " + messageIdAfterRestart);
         assertEquals(messageIdAfterRestart, messageIdBeforeRestart);
 
         persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
@@ -169,8 +171,89 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         // lastMessageId should be available even in this case, but is must
         // refer to -1
         MessageId messageIdAfterTrim = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        LOG.info("lastmessageid " + messageIdAfterTrim);
+        log.info("admin lastmessageid {}", messageIdAfterTrim);
         assertEquals(messageIdAfterTrim, MessageId.earliest);
 
+        messageIdAfterTrim = persistentTopic.getLastMessageId().get();
+        log.info("topic lastmessageid {}", messageIdAfterTrim);
+        assertEquals(messageIdAfterTrim, MessageId.earliest);
+    }
+
+    @Test
+    public void testTerminateAndRestart() throws Exception {
+        conf.setRetentionCheckIntervalInSeconds(10000);
+        conf.setBrokerDeleteInactiveTopicsEnabled(false);
+        super.baseSetup();
+        final String topicName = "persistent://prop/ns-abc/testTerminateAndRestart";
+
+        // write some messages
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .producerName("producer-name")
+                .create();
+
+        // set retention parameters, the ledgers are to be deleted as soon as possible
+        // but the topic is not to be automatically deleted
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        ManagedLedgerConfig managedLedgerConfig = persistentTopic.getManagedLedger().getConfig();
+        managedLedgerConfig.setRetentionSizeInMB(-1);
+        managedLedgerConfig.setRetentionTime(100000, TimeUnit.SECONDS);
+        managedLedgerConfig.setMaxEntriesPerLedger(2);
+        managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
+        MessageId initialMessageId = persistentTopic.getLastMessageId().get();
+        log.info("lastmessageid " + initialMessageId);
+
+        int msgNum = 5;
+        for (int i = 0; i < msgNum; i++) {
+            producer.send(new byte[10]);
+        }
+
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 3);
+        MessageId messageIdBeforeRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
+        log.info("messageIdBeforeRestart " + messageIdBeforeRestart);
+        assertNotEquals(messageIdBeforeRestart, initialMessageId);
+        assertNotEquals(MessageIdUtils.getOffset(messageIdBeforeRestart), -1);
+
+        Set<Long> ledgerIdsBeforeRestart = managedLedger.getLedgersInfo().keySet();
+        log.info("current ledgers {}", ledgerIdsBeforeRestart);
+
+        managedLedger.terminate();
+
+        restartBroker();
+        // force load topic
+        pulsar.getAdminClient().topics().getStats(topicName);
+
+        persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        managedLedgerConfig = persistentTopic.getManagedLedger().getConfig();
+        managedLedgerConfig.setRetentionSizeInMB(-1);
+        managedLedgerConfig.setRetentionTime(1, TimeUnit.SECONDS);
+        managedLedgerConfig.setMaxEntriesPerLedger(2);
+        managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
+
+        managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 3);
+
+        MessageIdImpl mId = (MessageIdImpl)persistentTopic.getLastMessageId().get();
+        log.info("topic lastmessageid {}", mId);
+        assertEquals(mId.getEntryId(), 0);
+        // also forces managed ledger's initialization
+        MessageIdImpl messageIdAfterRestart = (MessageIdImpl)pulsar.getAdminClient().topics().getLastMessageId(topicName);
+
+        log.info("admin lastmessageid {}", messageIdAfterRestart);
+        assertEquals(messageIdAfterRestart.getEntryId(), 0);
+
+        restartBroker();
+        pulsar.getAdminClient().topics().getStats(topicName);
+        persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+
+        CompletableFuture f = new CompletableFuture();
+        // force it to throw exception on this thread and not on the executor
+        // to fail the test instead of silently logging it
+        MethodUtils.invokeMethod(managedLedger, true, "internalTrimLedgers", true, f);
+        f.join();
+        // expect not to throw
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -129,7 +129,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         managedLedgerConfig.setMaxEntriesPerLedger(1000);
         managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
         MessageId initialMessageId = persistentTopic.getLastMessageId().get();
-        log.info("lastmessageid " + initialMessageId);
+        log.info("lastmessageid {}", initialMessageId);
 
         int msgNum = 7;
         for (int i = 0; i < msgNum; i++) {
@@ -139,7 +139,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
         Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 1);
         MessageId messageIdBeforeRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        log.info("messageIdBeforeRestart " + messageIdBeforeRestart);
+        log.info("messageIdBeforeRestart {}", messageIdBeforeRestart);
         assertNotEquals(messageIdBeforeRestart, initialMessageId);
 
         // restart the broker we have to start a new ledger
@@ -148,7 +148,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         // force load topic
         pulsar.getAdminClient().topics().getStats(topicName);
         MessageId messageIdAfterRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        log.info("lastmessageid " + messageIdAfterRestart);
+        log.info("lastmessageid {}", messageIdAfterRestart);
         assertEquals(messageIdAfterRestart, messageIdBeforeRestart);
 
         persistentTopic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
@@ -202,7 +202,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         managedLedgerConfig.setMaxEntriesPerLedger(2);
         managedLedgerConfig.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
         MessageId initialMessageId = persistentTopic.getLastMessageId().get();
-        log.info("lastmessageid " + initialMessageId);
+        log.info("lastmessageid {}", initialMessageId);
 
         int msgNum = 5;
         for (int i = 0; i < msgNum; i++) {
@@ -212,7 +212,7 @@ public class ConsumedLedgersTrimTest extends BrokerTestBase {
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
         Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 3);
         MessageId messageIdBeforeRestart = pulsar.getAdminClient().topics().getLastMessageId(topicName);
-        log.info("messageIdBeforeRestart " + messageIdBeforeRestart);
+        log.info("messageIdBeforeRestart {}", messageIdBeforeRestart);
         assertNotEquals(messageIdBeforeRestart, initialMessageId);
         assertNotEquals(MessageIdUtils.getOffset(messageIdBeforeRestart), -1);
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*



### Motivation

I encountered this while experimenting with repros for issue: #12070 

The problem here is that various methods on terminated managed ledger throw NPEs after broker restart. 
The rootcause is that `currentLedger` field is not expected to be set in case of terminated ledger hence stays null; the null check on that field is inconsistent.

### Modifications

Add  null check everywhere the `currentLedger` is accessed, added unit test.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added unit tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

No

### Documentation

Need to update docs? 

- [X] no-need-doc 
  

