### PR TITLE
[unit test] use correct line separator instead of \n

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/CmdGenerateDocsTest.java
@@ -57,7 +57,7 @@ public class CmdGenerateDocsTest {
                     + "    -h, --help\n"
                     + "      Display help information\n"
                     + "      Default: false\n"
-                    + "\n";
+                    + System.lineSeparator();
             assertEquals(rightMsg, message);
         } finally {
             System.setOut(oldStream);
@@ -98,7 +98,7 @@ public class CmdGenerateDocsTest {
                     + "|---|---|---|\n"
                     + "| `-n, --name` | Name|null|\n"
                     + "| `-h, --help` | Show this help message|false|\n"
-                    + "\n";
+                    + System.lineSeparator();
             assertEquals(rightMsg, message);
         } finally {
             System.setOut(oldStream);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -44,8 +44,8 @@ public class FutureUtilTest {
         timeoutException.printStackTrace(new PrintWriter(stringWriter, true));
         assertEquals(stringWriter.toString(),
                 "org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: "
-                + "hello world\n"
-                + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)\n");
+                + "hello world" + System.lineSeparator()
+                + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)" + System.lineSeparator());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
The unit test use \n, it can only paas in linux and OSX, can't run on windows.

### Modifications

use System line separator instead of \n

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [ ] no-need-doc 
  
a little enhance, doesn't need doc
  


