### PR TITLE
Fix improper usage in refactoring ns-policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -211,7 +211,7 @@ public abstract class AbstractTopic implements Topic {
             Policies policies;
             try {
                 // Use getDataIfPresent from zk cache to make the call non-blocking and prevent deadlocks
-                policies = brokerService.pulsar().getPulsarResources().getNamespaceResources().getPolicies(
+                policies = brokerService.pulsar().getPulsarResources().getNamespaceResources().getPoliciesIfCached(
                                 TopicName.get(topic).getNamespaceObject())
                         .orElseGet(() -> new Policies());
 


### PR DESCRIPTION
A simple fix for imporper usage during code refactoring. The cause of the issue can refer to the following PRs: #5371 #12078

No doc is required.