### PR TITLE
fix logger number not correct in tests

### DIFF
--- a/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerTest.java
+++ b/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerTest.java
@@ -43,7 +43,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int MESSAGE_SIZE = 16 * 1024 + 1;
-        log.info("-- message size --", MESSAGE_SIZE);
+        log.info("-- message size {} --", MESSAGE_SIZE);
 
         internalSetUpForClient(true, pulsar.getBrokerServiceUrlTls());
         internalSetUpForNamespace();
@@ -77,7 +77,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int MESSAGE_SIZE = 16 * 1024 + 1;
-        log.info("-- message size --", MESSAGE_SIZE);
+        log.info("-- message size {} --", MESSAGE_SIZE);
         internalSetUpForNamespace();
 
         // Test 1 - Using TLS on binary protocol without sending certs - expect failure
@@ -88,7 +88,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
             Assert.fail("Server should have failed the TLS handshake since client didn't .");
         } catch (Exception ex) {
             // OK
-            log.info("first test success: without certs set, meet exception {}", ex);
+            log.info("first test success: without certs set, meet exception ", ex);
         }
 
         // Test 2 - Using TLS on binary protocol - sending certs
@@ -107,7 +107,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int MESSAGE_SIZE = 16 * 1024 + 1;
-        log.info("-- message size --", MESSAGE_SIZE);
+        log.info("-- message size {} --", MESSAGE_SIZE);
         internalSetUpForNamespace();
 
         // Test 1 - Using TLS on https without sending certs - expect failure
@@ -118,7 +118,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
             Assert.fail("Server should have failed the TLS handshake since client didn't .");
         } catch (Exception ex) {
             // OK
-            log.info("first test success: without certs set, meet exception {}", ex);
+            log.info("first test success: without certs set, meet exception ", ex);
         }
 
         // Test 2 - Using TLS on https - sending certs

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -924,7 +924,7 @@ public abstract class PulsarWebResource {
                 throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
             }
         } catch (Exception e) {
-            log.warn("Unable to fetch read-only policy config {}", e);
+            log.warn("Unable to fetch read-only policy config ", e);
             throw new RestException(e);
         }
     }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -257,7 +257,7 @@ public class ElasticSearchClientTests {
             long start = System.currentTimeMillis();
             for (int i = 6; i <= 15; i++) {
                 client.bulkIndex(mockRecord, Pair.of(Integer.toString(i), "{\"a\":" + i + "}"));
-                log.info("{} index [}", System.currentTimeMillis(), i);
+                log.info("{} index {}", System.currentTimeMillis(), i);
             }
             long elapsed = System.currentTimeMillis() - start;
             log.info("elapsed = {}", elapsed);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -662,7 +662,7 @@ public class PulsarCluster {
                 });
                 log.info("Function {} logs {}", name, logs);
             } catch (com.github.dockerjava.api.exception.NotFoundException notFound) {
-                log.info("Cannot download {} logs from {}", name, container.getContainerName(), notFound.toString());
+                log.info("Cannot download {} logs from {} not found exception {}", name, container.getContainerName(), notFound.toString());
             } catch (Throwable err) {
                 log.info("Cannot download {} logs from {}", name, container.getContainerName(), err);
             }


### PR DESCRIPTION
### Motivation

Log placehodlers not correct. Cause some log info is missing or `{}` alone

### Modifications

Fix the placeholder, add `{}` or delete `{}`

### Documentation
  
- [ ] no-need-doc 
 this is an internal optimize, don't need doc.


