### PR TITLE
Adding Multi-tiered storage key to broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1261,6 +1261,9 @@ gcsManagedLedgerOffloadReadBufferSizeInBytes=1048576
 # For more details, see the "Service Accounts" section of https://support.google.com/googleapi/answer/6158849
 gcsManagedLedgerOffloadServiceAccountKeyFile=
 
+# For Azure BlobStore ledger offload, Blob Container (Bucket) to place offloaded ledger into
+managedLedgerOffloadBucket=
+
 #For File System Storage, file system profile path
 fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -1114,6 +1114,9 @@ gcsManagedLedgerOffloadReadBufferSizeInBytes=1048576
 # For more details, see the "Service Accounts" section of https://support.google.com/googleapi/answer/6158849
 gcsManagedLedgerOffloadServiceAccountKeyFile=
 
+# For Azure BlobStore ledger offload, Blob Container (Bucket) to place offloaded ledger into
+managedLedgerOffloadBucket=
+
 #For File System Storage, file system profile path
 fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

The helm deployment of pulsar with azure Multi Tiered Offloading enabled would fail, as [`broker.conf`](https://github.com/apache/pulsar/blob/master/conf/broker.conf) is missing the required key `managedLedgerOffloadBucket`. This is evident when deploying pulsar via the [pulsar-helm-chart](https://github.com/datastax/pulsar-helm-chart) with the command below. 

```
helm install \                                                                                             
     --values $HELM_CHART_DIR/ci-archive/azure-no-test.yaml \
     --values bucket-values.yaml \
     --set enableAntiAffinity=0 \
     --set storageOffload.storageAccount=$AZURE_STORAGE_ACCOUNT \
     --set storageOffload.storageAccountKey=$AZURE_STORAGE_ACCESS_KEY \
     --dependency-update --debug --version=1.2.1 \
     pulsar $HELM_CHART_DIR
```

Where `HELM_CHART_DIR` contains the path to the latest version of the [helm chart](https://github.com/datastax/pulsar-helm-chart). This issue can be reproduced by undoing the workaround I applied to the helm chart and described below.

The workaround consists of [the line](https://github.com/datastax/pulsar-helm-chart/blob/master/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml#L217) (also below) from [`broker-configmap.yaml` ](https://github.com/datastax/pulsar-helm-chart/blob/master/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml). Then, launching the `helm install` above will only inject the env variable `managedLedgerOffloadBucket` without adding it to `/pulsar/conf/broker.conf`.

```
# workaround to inject it in the broker.conf (problem: gets injected also in client.conf)
PULSAR_PREFIX_managedLedgerOffloadBucket: "{{ .Values.storageOffload.bucket }}"
```

As a result, running the following commands on the broker pod 
```
/pulsar/bin/pulsar-admin topics create public/default/offload
/pulsar/bin/pulsar-admin topics create-subscription public/default/offload -m earliest -s sub
/pulsar/bin/pulsar-perf produce -n 1 public/default/offload -m 10000 -s 20
/pulsar/bin/pulsar-admin topics offload -s 1M public/default/offload
/pulsar/bin/pulsar-admin topics offload-status public/default/offload
```

will lead to the error:

```
Error in offload
null

Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: java.lang.NullPointerException: Null containerName
```

The disadvantage of the workaround (and hence the need for this fix) is that `managedLedgerOffloadBucket` would then be injected also on the `client.conf` by [apply-config-from-env.py](https://github.com/apache/pulsar/blob/master/docker/pulsar/scripts/apply-config-from-env.py).

### Modifications

Addition of the `managedLedgerOffloadBucket` to [`broker.conf`](https://github.com/apache/pulsar/blob/master/conf/broker.conf).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Anything that affects deployment:  `managedLedgerOffloadBucket` value would be successfully injected in `conf/broker.conf`

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] no-need-doc 
  
  It's a key addition to a config file. Moreover the inserted key is not set to a default value.
  
- [ ] doc 
  
  (If this PR contains doc changes)


