### PR TITLE
[Python Schema] Support setting namespace for python schema

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -57,6 +57,8 @@ class RecordMeta(type):
 
 class Record(with_metaclass(RecordMeta, object)):
 
+    _namespace = None
+
     def __init__(self, default=None, required_default=False, required=False, *args, **kwargs):
         self._required_default = required_default
         self._default = default
@@ -101,15 +103,23 @@ class Record(with_metaclass(RecordMeta, object)):
 
     @classmethod
     def schema_info(cls, defined_names):
-        if cls.__name__ in defined_names:
-            return cls.__name__
+        namespace_prefix = ''
+        if cls._namespace is not None:
+            namespace_prefix = cls._namespace + '.'
+        namespace_name = namespace_prefix + cls.__name__
 
-        defined_names.add(cls.__name__)
+        if namespace_name in defined_names:
+            return namespace_name
+
+        defined_names.add(namespace_name)
         schema = {
             'name': str(cls.__name__),
+            'namespace': cls._namespace,
             'type': 'record',
             'fields': []
         }
+        if schema['namespace'] is None:
+            del schema['namespace']
         for name in sorted(cls._fields.keys()):
             field = cls._fields[name]
             field_type = field.schema_info(defined_names) \

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -113,14 +113,13 @@ class Record(with_metaclass(RecordMeta, object)):
             return namespace_name
 
         defined_names.add(namespace_name)
-        schema = {
-            'name': str(cls.__name__),
-            'namespace': cls._avro_namespace,
-            'type': 'record',
-            'fields': []
-        }
-        if schema['namespace'] is None:
-            del schema['namespace']
+
+        schema = {'name': str(cls.__name__)}
+        if cls._avro_namespace is not None:
+            schema['namespace'] = cls._avro_namespace
+        schema['type'] = 'record'
+        schema['fields'] = []
+
         for name in sorted(cls._fields.keys()):
             field = cls._fields[name]
             field_type = field.schema_info(defined_names) \

--- a/pulsar-client-cpp/python/pulsar/schema/definition.py
+++ b/pulsar-client-cpp/python/pulsar/schema/definition.py
@@ -57,7 +57,8 @@ class RecordMeta(type):
 
 class Record(with_metaclass(RecordMeta, object)):
 
-    _namespace = None
+    # This field is used to set namespace for Avro Record schema.
+    _avro_namespace = None
 
     def __init__(self, default=None, required_default=False, required=False, *args, **kwargs):
         self._required_default = required_default
@@ -104,8 +105,8 @@ class Record(with_metaclass(RecordMeta, object)):
     @classmethod
     def schema_info(cls, defined_names):
         namespace_prefix = ''
-        if cls._namespace is not None:
-            namespace_prefix = cls._namespace + '.'
+        if cls._avro_namespace is not None:
+            namespace_prefix = cls._avro_namespace + '.'
         namespace_name = namespace_prefix + cls.__name__
 
         if namespace_name in defined_names:
@@ -114,7 +115,7 @@ class Record(with_metaclass(RecordMeta, object)):
         defined_names.add(namespace_name)
         schema = {
             'name': str(cls.__name__),
-            'namespace': cls._namespace,
+            'namespace': cls._avro_namespace,
             'type': 'record',
             'fields': []
         }

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -1114,8 +1114,5 @@ class SchemaTest(TestCase):
             y = Integer()
         print('schema: ', NamespaceDemo.schema())
 
-# if __name__ == '__main__':
-#     main()
-
-test = SchemaTest()
-test.test()
+if __name__ == '__main__':
+    main()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -891,7 +891,7 @@ class SchemaTest(TestCase):
             na3 = Integer()
 
         class NestedObj4(Record):
-            _namespace = 'xxx4'
+            _avro_namespace = 'xxx4'
             na4 = String()
             nb4 = Integer()
 
@@ -901,7 +901,7 @@ class SchemaTest(TestCase):
             blue = 3
 
         class ComplexRecord(Record):
-            _namespace = 'xxx.xxx'
+            _avro_namespace = 'xxx.xxx'
             a = Integer()
             b = Integer()
             color = Color
@@ -1107,5 +1107,15 @@ class SchemaTest(TestCase):
 
         client.close()
 
-if __name__ == '__main__':
-    main()
+    def test(self):
+        class NamespaceDemo(Record):
+            _namespace = 'xxx.xxx.xxx'
+            x = String()
+            y = Integer()
+        print('schema: ', NamespaceDemo.schema())
+
+# if __name__ == '__main__':
+#     main()
+
+test = SchemaTest()
+test.test()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -895,11 +895,6 @@ class SchemaTest(TestCase):
             na4 = String()
             nb4 = Integer()
 
-        class NestedObj5(Record):
-            _namespace = 'xxx5'
-            na5 = String()
-            nb5 = Integer()
-
         class Color(Enum):
             red = 1
             green = 2
@@ -917,8 +912,6 @@ class SchemaTest(TestCase):
             mapNested2 = Map(NestedObj3())
             arrayNested = Array(NestedObj4())
             arrayNested2 = Array(NestedObj4())
-            nested5 = NestedObj5()
-            nested5_2 = NestedObj5()
 
         print('complex schema: ', ComplexRecord.schema())
         self.assertEqual(ComplexRecord.schema(), {
@@ -952,12 +945,7 @@ class SchemaTest(TestCase):
                         {'name': 'nb1', 'type': ['null', 'double']}
                     ]}]}
                 ]}]},
-                {"name": "nested2", "type": ['null', 'NestedObj2']},
-                {'name': 'nested5', 'type': ['null', {'name': 'NestedObj5', 'namespace': 'xxx5', 'type': 'record', 'fields': [
-                    {'name': 'na5', 'type': ['null', 'string']},
-                    {'name': 'nb5', 'type': ['null', 'int']}
-                ]}]},
-                {'name': 'nested5_2', 'type': ['null', 'xxx5.NestedObj5']}
+                {"name": "nested2", "type": ['null', 'NestedObj2']}
             ]
         })
 
@@ -984,7 +972,7 @@ class SchemaTest(TestCase):
             ], arrayNested2=[
                 NestedObj4(na4='value na4 3', nb4=300),
                 NestedObj4(na4='value na4 4', nb4=400)
-            ], nested5=NestedObj5(na5='na5 value', nb5=10), nested5_2=NestedObj5(na5='na5_2 value', nb5=20))
+            ])
             data_encode = data_schema.encode(r)
 
             data_decode = data_schema.decode(data_encode)
@@ -1016,10 +1004,6 @@ class SchemaTest(TestCase):
             self.assertEqual(data_decode.arrayNested2[0].nb4, 300)
             self.assertEqual(data_decode.arrayNested2[1].na4, 'value na4 4')
             self.assertEqual(data_decode.arrayNested2[1].nb4, 400)
-            self.assertEqual(data_decode.nested5.na5, 'na5 value')
-            self.assertEqual(data_decode.nested5.nb5, 10)
-            self.assertEqual(data_decode.nested5_2.na5, 'na5_2 value')
-            self.assertEqual(data_decode.nested5_2.nb5, 20)
             print('Encode and decode complex schema finish. schema_type: ', schema_type)
 
         encode_and_decode('avro')

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -891,8 +891,14 @@ class SchemaTest(TestCase):
             na3 = Integer()
 
         class NestedObj4(Record):
+            _namespace = 'xxx4'
             na4 = String()
             nb4 = Integer()
+
+        class NestedObj5(Record):
+            _namespace = 'xxx5'
+            na5 = String()
+            nb5 = Integer()
 
         class Color(Enum):
             red = 1
@@ -900,6 +906,7 @@ class SchemaTest(TestCase):
             blue = 3
 
         class ComplexRecord(Record):
+            _namespace = 'xxx.xxx'
             a = Integer()
             b = Integer()
             color = Color
@@ -910,20 +917,23 @@ class SchemaTest(TestCase):
             mapNested2 = Map(NestedObj3())
             arrayNested = Array(NestedObj4())
             arrayNested2 = Array(NestedObj4())
+            nested5 = NestedObj5()
+            nested5_2 = NestedObj5()
 
         print('complex schema: ', ComplexRecord.schema())
         self.assertEqual(ComplexRecord.schema(), {
             "name": "ComplexRecord",
+            "namespace": "xxx.xxx",
             "type": "record",
             "fields": [
                 {"name": "a", "type": ["null", "int"]},
                 {'name': 'arrayNested', 'type': ['null', {'type': 'array', 'items':
-                    {'name': 'NestedObj4', 'type': 'record', 'fields': [
+                    {'name': 'NestedObj4', 'namespace': 'xxx4', 'type': 'record', 'fields': [
                         {'name': 'na4', 'type': ['null', 'string']},
                         {'name': 'nb4', 'type': ['null', 'int']}
                     ]}}
                 ]},
-                {'name': 'arrayNested2', 'type': ['null', {'type': 'array', 'items': 'NestedObj4'}]},
+                {'name': 'arrayNested2', 'type': ['null', {'type': 'array', 'items': 'xxx4.NestedObj4'}]},
                 {"name": "b", "type": ["null", "int"]},
                 {'name': 'color', 'type': ['null', {'type': 'enum', 'name': 'Color', 'symbols': [
                     'red', 'green', 'blue']}]},
@@ -942,7 +952,12 @@ class SchemaTest(TestCase):
                         {'name': 'nb1', 'type': ['null', 'double']}
                     ]}]}
                 ]}]},
-                {"name": "nested2", "type": ['null', 'NestedObj2']}
+                {"name": "nested2", "type": ['null', 'NestedObj2']},
+                {'name': 'nested5', 'type': ['null', {'name': 'NestedObj5', 'namespace': 'xxx5', 'type': 'record', 'fields': [
+                    {'name': 'na5', 'type': ['null', 'string']},
+                    {'name': 'nb5', 'type': ['null', 'int']}
+                ]}]},
+                {'name': 'nested5_2', 'type': ['null', 'xxx5.NestedObj5']}
             ]
         })
 
@@ -969,7 +984,7 @@ class SchemaTest(TestCase):
             ], arrayNested2=[
                 NestedObj4(na4='value na4 3', nb4=300),
                 NestedObj4(na4='value na4 4', nb4=400)
-            ])
+            ], nested5=NestedObj5(na5='na5 value', nb5=10), nested5_2=NestedObj5(na5='na5_2 value', nb5=20))
             data_encode = data_schema.encode(r)
 
             data_decode = data_schema.decode(data_encode)
@@ -1001,6 +1016,10 @@ class SchemaTest(TestCase):
             self.assertEqual(data_decode.arrayNested2[0].nb4, 300)
             self.assertEqual(data_decode.arrayNested2[1].na4, 'value na4 4')
             self.assertEqual(data_decode.arrayNested2[1].nb4, 400)
+            self.assertEqual(data_decode.nested5.na5, 'na5 value')
+            self.assertEqual(data_decode.nested5.nb5, 10)
+            self.assertEqual(data_decode.nested5_2.na5, 'na5_2 value')
+            self.assertEqual(data_decode.nested5_2.nb5, 20)
             print('Encode and decode complex schema finish. schema_type: ', schema_type)
 
         encode_and_decode('avro')

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -307,6 +307,26 @@ class Example(Record):
     sub = MySubRecord()
 ```
 
+##### Set namespace for Avro schema
+
+Set the namespace for Avro Record schema using the special field `_avro_namespace`.
+```python
+class NamespaceDemo(Record):
+   _avro_namespace = 'xxx.xxx.xxx'
+   x = String()
+   y = Integer()
+```
+
+The schema definition is like this.
+```
+{
+  'name': 'NamespaceDemo', 'namespace': 'xxx.xxx.xxx', 'type': 'record', 'fields': [
+    {'name': 'x', 'type': ['null', 'string']}, 
+    {'name': 'y', 'type': ['null', 'int']}
+  ]
+}
+```
+
 ## End-to-end encryption
 
 [End-to-end encryption](https://pulsar.apache.org/docs/en/next/cookbooks-encryption/#docsNav) allows applications to encrypt messages at producers and decrypt messages at consumers.


### PR DESCRIPTION
### Motivation

Currently, the python schema didn't support setting namespace in the schema definition.

This PR is used to support setting namespace in the python schema definition.

I have two ways to set the namespace for Record, one is to add a new class method for Record to set the namespace, one is to add a new field `_avro_namespace` for class Record. I select the second way.

for example, add a special field `_avro_namespace` for the custom Record to add the namespace.
```
class User(Record):
    _avro_namespace = 'xxx.xxx.xxx'
    name = String()
    age = Integer()
```

The schema definition is like this.
```
{
  'name': 'User', 'namespace': 'xxx.xxx.xxx', 'type': 'record', 'fields': [
    {'name': 'age', 'type': ['null', 'int']}, 
    {'name': 'name', 'type': ['null', 'string']}
  ]
}
```

### Modifications

Modify the method `schema_info ` of the class `Record` to add the namespace field when generating the schema definition.

### Verifying this change

Add test to verify the schema definition.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


