### PR TITLE
Update PIP GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pip.md
+++ b/.github/ISSUE_TEMPLATE/pip.md
@@ -6,6 +6,29 @@ labels: PIP
 assignees: ''
 
 ---
+<!---
+Instructions for creating a PIP using this issue template:
+
+ 1. The author(s) of the proposal will create a GitHub issue ticket using this template.
+    (Optionally, it can be helpful to send a note discussing the proposal to
+    dev@pulsar.apache.org mailing list before submitting this GitHub issue. This discussion can
+    help developers gauge interest in the proposed changes before formalizing the proposal.)
+ 2. The author(s) will send a note to the dev@pulsar.apache.org mailing list
+    to start the discussion, using subject prefix `[PIP] xxx`. To determine the appropriate PIP
+    number `xxx`, inspect the mailing list (https://lists.apache.org/list.html?dev@pulsar.apache.org)
+    for the most recent PIP. Add 1 to that PIP's number to get your PIP's number.
+ 3. Based on the discussion and feedback, some changes might be applied by
+    the author(s) to the text of the proposal.
+ 4. Once some consensus is reached, there will be a vote to formally approve
+    the proposal. The vote will be held on the dev@pulsar.apache.org mailing list. Everyone
+    is welcome to vote on the proposal, though it will considered to be binding
+    only the vote of PMC members. It will be required to have a lazy majority of
+    at least 3 binding +1s votes. The vote should stay open for at least 48 hours.
+ 5. When the vote is closed, if the outcome is positive, the state of the
+    proposal is updated and the Pull Requests associated with this proposal can
+    start to get merged into the master branch.
+
+-->
 
 ## Motivation
 


### PR DESCRIPTION
### Motivation

As discussed on the [dev mailing list](https://lists.apache.org/thread.html/ra0155c8d385fe74038a49ffc00899f1f67bb8cf39f24e24664ec3092%40%3Cdev.pulsar.apache.org%3E), the new PIP process appears to need more definition regarding choosing the number for a PIP. This PR seeks to add clarity to the process by updating the GitHub PIP template.

### Modifications

* Add steps to the GitHub PIP template. Note that much of the content in this PIP is copied from @merlimat's initial [email](https://lists.apache.org/thread.html/r16833b7fd091e571cca52d51ebeb96b859cd3ee21fa929e854844683%40%3Cdev.pulsar.apache.org%3E) to the ML where the updated PIP process was proposed

### Verifying this change

This is a minor update to a process. No verification is required beyond community acceptance.

### Does this pull request potentially affect one of the following parts:

Yes, it affects the PIP process by seeking to add a little more definition around acquiring a lock on a PIP number.

### Documentation

It is an update to documentation.


