### PR TITLE
(Fixes #12182) Replaced urlencoded OAuth2 creds with Basic header

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -23,11 +23,11 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import java.util.Base64;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
@@ -112,29 +112,27 @@ public class TokenClient implements ClientCredentialsExchanger {
             Response res = httpClient.preparePost(tokenUrl.toString())
                     .setHeader("Accept", "application/json")
                     .setHeader("Content-Type", "application/x-www-form-urlencoded")
-                    .setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))
+                    .setHeader("Authorization",
+                            "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))
                     .setBody(body)
                     .execute()
                     .get();
 
             switch (res.getStatusCode()) {
-            case 200:
-                return ObjectMapperFactory.getThreadLocal().reader().readValue(res.getResponseBodyAsBytes(),
-                        TokenResult.class);
+                case 200:
+                    return ObjectMapperFactory.getThreadLocal().reader().readValue(res.getResponseBodyAsBytes(),
+                            TokenResult.class);
 
-            case 400: // Bad request
-            case 401: // Unauthorized
-                throw new TokenExchangeException(
-                        ObjectMapperFactory.getThreadLocal().reader().readValue(res.getResponseBodyAsBytes(),
-                                TokenError.class));
+                case 400: // Bad request
+                case 401: // Unauthorized
+                    throw new TokenExchangeException(
+                            ObjectMapperFactory.getThreadLocal().reader().readValue(res.getResponseBodyAsBytes(),
+                                    TokenError.class));
 
-            default:
-                throw new IOException(
-                        "Failed to perform HTTP request. res: " + res.getStatusCode() + " " + res.getStatusText());
+                default:
+                    throw new IOException(
+                            "Failed to perform HTTP request. res: " + res.getStatusCode() + " " + res.getStatusText());
             }
-
-
-
         } catch (InterruptedException | ExecutionException e1) {
             throw new IOException(e1);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
@@ -112,7 +112,7 @@ public class TokenClient implements ClientCredentialsExchanger {
             Response res = httpClient.preparePost(tokenUrl.toString())
                     .setHeader("Accept", "application/json")
                     .setHeader("Content-Type", "application/x-www-form-urlencoded")
-                    .setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))
+                    .setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))
                     .setBody(body)
                     .execute()
                     .get();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharset;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import java.util.Base64;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
@@ -96,10 +98,9 @@ public class TokenClient implements ClientCredentialsExchanger {
      */
     public TokenResult exchangeClientCredentials(ClientCredentialsExchangeRequest req)
             throws TokenExchangeException, IOException {
+        String credPayload = req.getClientId() + ":" + req.getClientSecret();
         Map<String, String> bodyMap = new TreeMap<>();
         bodyMap.put("grant_type", "client_credentials");
-        bodyMap.put("client_id", req.getClientId());
-        bodyMap.put("client_secret", req.getClientSecret());
         bodyMap.put("audience", req.getAudience());
         if (!StringUtils.isBlank(req.getScope())) {
             bodyMap.put("scope", req.getScope());
@@ -111,6 +112,7 @@ public class TokenClient implements ClientCredentialsExchanger {
             Response res = httpClient.preparePost(tokenUrl.toString())
                     .setHeader("Accept", "application/json")
                     .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                    .setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))
                     .setBody(body)
                     .execute()
                     .get();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -31,6 +31,8 @@ import java.net.URL;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
+import java.nio.charset.StandardCharset;
+import java.util.Base64;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,9 +56,8 @@ public class TokenClientTest {
                 .clientSecret("test-client-secret")
                 .scope("test-scope")
                 .build();
+        String credPayload = request.getClientId() + ":" + request.getClientSecret();
         bodyMap.put("grant_type", "client_credentials");
-        bodyMap.put("client_id", request.getClientId());
-        bodyMap.put("client_secret", request.getClientSecret());
         bodyMap.put("audience", request.getAudience());
         bodyMap.put("scope", request.getScope());
         String body = tokenClient.buildClientCredentialsBody(bodyMap);
@@ -66,6 +67,7 @@ public class TokenClientTest {
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);
@@ -91,9 +93,8 @@ public class TokenClientTest {
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
                 .build();
+        String credPayload = request.getClientId() + ":" + request.getClientSecret();
         bodyMap.put("grant_type", "client_credentials");
-        bodyMap.put("client_id", request.getClientId());
-        bodyMap.put("client_secret", request.getClientSecret());
         bodyMap.put("audience", request.getAudience());
         String body = tokenClient.buildClientCredentialsBody(bodyMap);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
@@ -102,6 +103,7 @@ public class TokenClientTest {
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -31,7 +31,7 @@ import java.net.URL;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
-import java.nio.charset.StandardCharset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static org.mockito.Mockito.mock;
@@ -67,7 +67,7 @@ public class TokenClientTest {
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);
@@ -103,7 +103,7 @@ public class TokenClientTest {
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharset.UTF_8)))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -28,11 +28,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -66,8 +67,10 @@ public class TokenClientTest {
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(
+                boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder()
+                .encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);
@@ -102,8 +105,10 @@ public class TokenClientTest {
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
         when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
-        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type", "application/x-www-form-urlencoded")).thenReturn(
+                boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Authorization", "Basic " + Base64.getEncoder()
+                .encodeToString(credPayload.getBytes(StandardCharsets.UTF_8)))).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
         when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
         when(listenableFuture.get()).thenReturn(response);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #12182

### Motivation
Token request should use Basic auth instead of urlencoded credentials

### Modifications

Replaced the URLEncoded OAuth2 creds with the `Authorization Basic ...` variant in accordance with [RFC 6749 section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1)  recommendation.

Note that this could affect users of OAuth2 where their token provider accepts URLEncoded credentials but not `Authorization Basic ...` header - which would be against the recommendation of [RFC 6749 section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1).

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Updated TokenClientTest to reflect the cred request change


### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [X] no-need-doc:   **Simply correcting the request type when requesting a token from OAuth2 provider**
  

