### PR TITLE
BookkeeperClientFactory should pass in the ZK instance

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -81,6 +81,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         try {
             return BookKeeper.forConfig(bkConf)
                     .allocator(PulsarByteBufAllocator.DEFAULT)
+                    .setZookeeper(zkClient)
                     .eventLoopGroup(eventLoopGroup)
                     .statsLogger(statsLogger)
                     .build();


### PR DESCRIPTION
### Motivation

The ZK client is not currently passed directly to the BK client, resulting in 2 additional ZK connections, one for each BK client (managed ledger and schema storage).