### PR TITLE
Fixed counter base path getting deleted

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/CoordinationServiceImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/CoordinationServiceImpl.java
@@ -82,6 +82,19 @@ public class CoordinationServiceImpl implements CoordinationService {
 
     @Override
     public CompletableFuture<Long> getNextCounterValue(String path) {
+        return store.exists(path)
+                .thenCompose(exists -> {
+                    if (exists) {
+                        // The base path already exists
+                        return incrementCounter(path);
+                    } else {
+                        return store.put(path, new byte[0], Optional.empty())
+                                .thenCompose(__ -> incrementCounter(path));
+                    }
+                });
+    }
+
+    private CompletableFuture<Long> incrementCounter(String path) {
         String counterBasePath = path + "/-";
         return store
                 .put(counterBasePath, new byte[0], Optional.of(-1L),


### PR DESCRIPTION
### Motivation

In #11925, we switched to use ZK container type for intermediate nodes so that they will be automatically deleted when empty. This kind of broke the counter logic because it's relying on the z-node version of the base path: if the base path goes away and it gets recreated, the next counter value is going to be reset to 0.

### Modifications

Pre-create the base path as a non-ephemeral, non-container key that will not be deleted.
