### PR TITLE
Ensure the ownership cache lock expiring triggers an unload

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -104,6 +104,8 @@ public class OwnershipCache {
                         locallyAcquiredLocks.put(namespaceBundle, rl);
                         rl.getLockExpiredFuture()
                                 .thenRun(() -> {
+                                    log.info("Resource lock for {} has expired", rl.getPath());
+                                    namespaceService.unloadNamespaceBundle(namespaceBundle);
                                     ownedBundlesCache.synchronous().invalidate(namespaceBundle);
                                     namespaceService.onNamespaceBundleUnload(namespaceBundle);
                                 });


### PR DESCRIPTION
### Motivation

When the lock over a bundles expires (and it fails to get automatically revalidated), meaning that some other broker has already acquired the ownership, we need to unload the bundle. 

Note: this is a bit to test deterministically because it's inherently depending on a race condition. 