### PR TITLE
When the producer or client is normally closed, data will be lost

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -843,6 +843,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     @Override
     public CompletableFuture<Void> closeAsync() {
+        try {
+            flush();
+        } catch (PulsarClientException e) {
+            FutureUtil.failedFuture(e);
+        }
+
         final State currentState = getAndUpdateState(state -> {
             if (state == State.Closed) {
                 return state;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -910,7 +910,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
                 return null;
             });
-
         }).exceptionally(exception -> {
             flushAndCloseFuture.completeExceptionally(exception);
             return null;


### PR DESCRIPTION
### Motivation
In the following example, the data will be lost(The data cannot be consumed):
` try {
            PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://127.0.0.1:6650").build();

            Producer<byte[]> producer = client.newProducer().topic("test1").create();

            producer.sendAsync("hello".getBytes());
            client.close();
        } catch (PulsarClientException e) {
            e.printStackTrace();
        }

        Thread.sleep(1000);`

The reason is because the producer did not send the data in the client buffer when it was closed;

The correct approach is to first flush data when closing。