### PR TITLE
Missing '@Override' annotation on 'getProducerName()'

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1923,6 +1923,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return stats;
     }
 
+    @Override
     public String getProducerName() {
         return producerName;
     }


### PR DESCRIPTION
In this method: org.apache.pulsar.client.impl.ProducerImpl#getProducerName, the  Override tag is missing