### PR TITLE
[pulsar-broker] handle NPE when check active consumer in stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -558,10 +558,10 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
 
     @Override
     public boolean checkAndUnblockIfStuck() {
-        if (cursor.checkAndUpdateReadPositionChanged()) {
+        Consumer consumer = ACTIVE_CONSUMER_UPDATER.get(this);
+        if (consumer == null || cursor.checkAndUpdateReadPositionChanged()) {
             return false;
         }
-        Consumer consumer = ACTIVE_CONSUMER_UPDATER.get(this);
         int totalAvailablePermits = consumer.getAvailablePermits();
         // consider dispatch is stuck if : dispatcher has backlog, available-permits and there is no pending read
         if (totalAvailablePermits > 0 && !havePendingRead && cursor.getNumberOfEntriesInBacklog(false) > 0) {


### PR DESCRIPTION
### Motivation
Handle NPE when broker-stats access active-consumer for subscription without any connected topic.