### PR TITLE
[Java Client] Remove unnecessary stats incremement

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1677,7 +1677,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         format("The producer %s can not send message to the topic %s within given timeout",
                             producerName, topic), firstMsg.sequenceId);
                     failPendingMessages(cnx(), te);
-                    stats.incrementSendFailed(pendingMessages.size());
                     // Since the pending queue is cleared now, set timer to expire after configured value.
                     timeToWaitMs = conf.getSendTimeoutMs();
                 } else {


### PR DESCRIPTION
### Motivation

The Java client currently increments a stat with the size of pending messages queue. This would make sense, except for the fact that the queue is cleared right before getting the size. Further, the stat in question is incremented within the `failPendingMessages` method, which is called right before the removed line.

### Modifications

* Remove the line `stats.incrementSendFailed();`, since it is unnecessary.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

This change does not affect any public behavior.

### Documentation

No docs need updating.

