### PR TITLE
[Python] Do not sort schema fields by default

### DIFF
--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -348,6 +348,30 @@ class SchemaTest(TestCase):
         self.assertEqual(r2.__class__.__name__, 'Example')
         self.assertEqual(r2, r)
 
+    def test_non_sorted_fields(self):
+        class T1(Record):
+            a = Integer()
+            b = Integer()
+
+        class T2(Record):
+            b = Integer()
+            a = Integer()
+
+        self.assertNotEqual(T1.schema()['fields'], T2.schema()['fields'])
+
+    def test_sorted_fields(self):
+        class T1(Record):
+            _sorted_fields = True
+            a = Integer()
+            b = Integer()
+
+        class T2(Record):
+            _sorted_fields = True
+            b = Integer()
+            a = Integer()
+
+        self.assertEqual(T1.schema()['fields'], T2.schema()['fields'])
+
     def test_schema_version(self):
         class Example(Record):
             a = Integer()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -38,6 +38,7 @@ class SchemaTest(TestCase):
             blue = 3
 
         class Example(Record):
+            _sorted_fields = True
             a = String()
             b = Integer()
             c = Array(String())
@@ -78,11 +79,13 @@ class SchemaTest(TestCase):
 
     def test_complex(self):
         class MySubRecord(Record):
+            _sorted_fields = True
             x = Integer()
             y = Long()
             z = String()
 
         class Example(Record):
+            _sorted_fields = True
             a = String()
             sub = MySubRecord     # Test with class
             sub2 = MySubRecord()  # Test with instance
@@ -352,10 +355,14 @@ class SchemaTest(TestCase):
         class T1(Record):
             a = Integer()
             b = Integer()
+            c = Double()
+            d = String()
 
         class T2(Record):
             b = Integer()
             a = Integer()
+            d = String()
+            c = Double()
 
         self.assertNotEqual(T1.schema()['fields'], T2.schema()['fields'])
 
@@ -715,6 +722,7 @@ class SchemaTest(TestCase):
 
     def test_avro_required_default(self):
         class MySubRecord(Record):
+            _sorted_fields = True
             x = Integer()
             y = Long()
             z = String()
@@ -731,7 +739,9 @@ class SchemaTest(TestCase):
             i = Map(String())
             j = MySubRecord()
 
+
         class ExampleRequiredDefault(Record):
+            _sorted_fields = True
             a = Integer(required_default=True)
             b = Boolean(required=True, required_default=True)
             c = Long(required_default=True)
@@ -903,10 +913,12 @@ class SchemaTest(TestCase):
 
     def test_serialize_schema_complex(self):
         class NestedObj1(Record):
+            _sorted_fields = True
             na1 = String()
             nb1 = Double()
 
         class NestedObj2(Record):
+            _sorted_fields = True
             na2 = Integer()
             nb2 = Boolean()
             nc2 = NestedObj1()
@@ -916,6 +928,7 @@ class SchemaTest(TestCase):
 
         class NestedObj4(Record):
             _avro_namespace = 'xxx4'
+            _sorted_fields = True
             na4 = String()
             nb4 = Integer()
 

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -926,6 +926,7 @@ class SchemaTest(TestCase):
 
         class ComplexRecord(Record):
             _avro_namespace = 'xxx.xxx'
+            _sorted_fields = True
             a = Integer()
             b = Integer()
             color = Color


### PR DESCRIPTION
### Motivation

In Avro schema, the order of fields is used in the validation process, so if we are sorting the fields, that will generate an unexpected schema for a python producer/consumer and it will make it not interoperable with Java and other clients.