### PR TITLE
[Python] Allow required=False default=None setting on fields

### DIFF
--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -348,6 +348,30 @@ class SchemaTest(TestCase):
         self.assertEqual(r2.__class__.__name__, 'Example')
         self.assertEqual(r2, r)
 
+    def test_non_sorted_fields(self):
+        class T1(Record):
+            a = Integer()
+            b = Integer()
+
+        class T2(Record):
+            b = Integer()
+            a = Integer()
+
+        self.assertNotEqual(T1.schema()['fields'], T2.schema()['fields'])
+
+    def test_sorted_fields(self):
+        class T1(Record):
+            _sorted_fields = True
+            a = Integer()
+            b = Integer()
+
+        class T2(Record):
+            _sorted_fields = True
+            b = Integer()
+            a = Integer()
+
+        self.assertEqual(T1.schema()['fields'], T2.schema()['fields'])
+
     def test_schema_version(self):
         class Example(Record):
             a = Integer()

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -732,16 +732,16 @@ class SchemaTest(TestCase):
             j = MySubRecord()
 
         class ExampleRequiredDefault(Record):
-            a = Integer(required_default=True)
-            b = Boolean(required=True, required_default=True)
-            c = Long(required_default=True)
-            d = Float(required_default=True)
-            e = Double(required_default=True)
-            f = String(required_default=True)
-            g = Bytes(required_default=True)
-            h = Array(String(), required_default=True)
-            i = Map(String(), required_default=True)
-            j = MySubRecord(required_default=True)
+            a = Integer(required=False, default=None)
+            b = Boolean(required=False, default=None)
+            c = Long(required=False, default=None)
+            d = Float(required=False, default=None)
+            e = Double(required=False, default=None)
+            f = String(required=False, default=None)
+            g = Bytes(required=False, default=None)
+            h = Array(String(), required=False, default=None)
+            i = Map(String(), required=False, default=None)
+            j = MySubRecord(required=False, default=None)
         self.assertEqual(ExampleRequiredDefault.schema(), {
                 "name": "ExampleRequiredDefault",
                 "type": "record",
@@ -756,8 +756,11 @@ class SchemaTest(TestCase):
                     },
                     {
                         "name": "b",
-                        "type": "boolean",
-                        "default": False
+                        "type": [
+                            "null",
+                            "boolean"
+                        ],
+                        "default": None
                     },
                     {
                         "name": "c",

--- a/pulsar-client-cpp/python/schema_test.py
+++ b/pulsar-client-cpp/python/schema_test.py
@@ -713,7 +713,7 @@ class SchemaTest(TestCase):
 
         client.close()
 
-    def test_avro_required_default(self):
+    def test_avro_required_default_None(self):
         class MySubRecord(Record):
             x = Integer()
             y = Long()
@@ -742,6 +742,168 @@ class SchemaTest(TestCase):
             h = Array(String(), required=False, default=None)
             i = Map(String(), required=False, default=None)
             j = MySubRecord(required=False, default=None)
+        self.assertEqual(ExampleRequiredDefault.schema(), {
+                "name": "ExampleRequiredDefault",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "a",
+                        "type": [
+                            "null",
+                            "int"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "b",
+                        "type": [
+                            "null",
+                            "boolean"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "c",
+                        "type": [
+                            "null",
+                            "long"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "d",
+                        "type": [
+                            "null",
+                            "float"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "e",
+                        "type": [
+                            "null",
+                            "double"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "f",
+                        "type": [
+                            "null",
+                            "string"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "g",
+                        "type": [
+                            "null",
+                            "bytes"
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "h",
+                        "type": [
+                            "null",
+                            {
+                                "type": "array",
+                                "items": "string"
+                            }
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "i",
+                        "type": [
+                            "null",
+                            {
+                                "type": "map",
+                                "values": "string"
+                            }
+                        ],
+                        "default": None
+                    },
+                    {
+                        "name": "j",
+                        "type": [
+                            "null",
+                            {
+                                "name": "MySubRecord",
+                                "type": "record",
+                                "fields": [
+                                    {
+                                        "name": "x",
+                                        "type": [
+                                            "null",
+                                            "int"
+                                        ]
+                                    },
+                                    {
+                                        "name": "y",
+                                        "type": [
+                                            "null",
+                                            "long"
+                                        ],
+                                    },
+                                    {
+                                        "name": "z",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "default": None
+                    }
+                ]
+            })
+
+        client = pulsar.Client(self.serviceUrl)
+        producer = client.create_producer(
+            'my-avro-python-default-topic',
+            schema=AvroSchema(Example))
+
+        producer_default = client.create_producer(
+            'my-avro-python-default-topic',
+            schema=AvroSchema(ExampleRequiredDefault))
+
+        producer.close()
+        producer_default.close()
+
+        client.close()
+
+    def test_avro_required_default(self):
+        class MySubRecord(Record):
+            x = Integer()
+            y = Long()
+            z = String()
+
+        class Example(Record):
+            a = Integer()
+            b = Boolean(required=True)
+            c = Long()
+            d = Float()
+            e = Double()
+            f = String()
+            g = Bytes()
+            h = Array(String())
+            i = Map(String())
+            j = MySubRecord()
+
+        class ExampleRequiredDefault(Record):
+            a = Integer(required_default=True)
+            b = Boolean(required_default=True)
+            c = Long(required_default=True)
+            d = Float(required_default=True)
+            e = Double(required_default=True)
+            f = String(required_default=True)
+            g = Bytes(required_default=True)
+            h = Array(String(), required_default=True)
+            i = Map(String(), required_default=True)
+            j = MySubRecord(required_default=True)
         self.assertEqual(ExampleRequiredDefault.schema(), {
                 "name": "ExampleRequiredDefault",
                 "type": "record",


### PR DESCRIPTION
### Motivation

Recently, a new keyword `required_default` was added to address the case where a `default=None` needs to be set on the schema. The problem with this argument is that it's really counterintuitive on its behavior.

The problem was that we were not able to distinguish between `default=None` as in "there's no default" and `default=None` as in "there is a default which value is None". 

The `required_default=True` was introduced for that but it's very confusing. 

Instead, we should be able to just be able to use the original `required` and `default` keywords.

### Modification

Use a special object value to distinguish between a default not set and default=None scenarios.