### PR TITLE
[pulsar-admin] Add --update-mode to optimize topic rate policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3134,11 +3134,16 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(DispatchRateImpl dispatchRate) {
+    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(boolean resetMode,
+                                                                        DispatchRateImpl dispatchRate) {
         return getTopicPoliciesAsyncWithRetry(topicName)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setReplicatorDispatchRate(dispatchRate);
+                DispatchRateImpl maxDispatchRate = dispatchRate;
+                if (!resetMode) {
+                    maxDispatchRate = mergeDispatchRate(topicPolicies.getReplicatorDispatchRate(), dispatchRate);
+                }
+                topicPolicies.setReplicatorDispatchRate(maxDispatchRate);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });
     }
@@ -4126,17 +4131,45 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetDispatchRate(DispatchRateImpl dispatchRate, boolean isGlobal) {
+    protected CompletableFuture<Void> internalSetDispatchRate(boolean resetMode,
+                                                              DispatchRateImpl dispatchRate,
+                                                              boolean isGlobal) {
         if (dispatchRate == null) {
             return CompletableFuture.completedFuture(null);
         }
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setDispatchRate(dispatchRate);
+                DispatchRateImpl maxDispatchRate = dispatchRate;
+                if (!resetMode) {
+                    maxDispatchRate = mergeDispatchRate(topicPolicies.getDispatchRate(), dispatchRate);
+                }
+                topicPolicies.setDispatchRate(maxDispatchRate);
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });
+    }
+
+    private DispatchRateImpl mergeDispatchRate(DispatchRateImpl originalDispatchRate,
+                                               DispatchRateImpl newDispatchRate) {
+        if (originalDispatchRate == null ^ newDispatchRate == null) { // one is null and the other is not null
+            return originalDispatchRate == null
+                    ? newDispatchRate
+                    : originalDispatchRate;
+        } else if (originalDispatchRate != null) {
+            newDispatchRate.setDispatchThrottlingRateInMsg(newDispatchRate.getDispatchThrottlingRateInMsg() == -1
+                    ? originalDispatchRate.getDispatchThrottlingRateInMsg()
+                    : newDispatchRate.getDispatchThrottlingRateInMsg());
+            newDispatchRate.setDispatchThrottlingRateInByte(newDispatchRate.getDispatchThrottlingRateInByte() == -1
+                    ? originalDispatchRate.getDispatchThrottlingRateInByte()
+                    : newDispatchRate.getDispatchThrottlingRateInByte());
+            newDispatchRate.setRatePeriodInSecond(newDispatchRate.getRatePeriodInSecond() == 1
+                    ? originalDispatchRate.getRatePeriodInSecond()
+                    : newDispatchRate.getRatePeriodInSecond());
+            return newDispatchRate;
+        }
+
+        return null;
     }
 
     protected CompletableFuture<Void> internalRemoveDispatchRate(boolean isGlobal) {
@@ -4165,15 +4198,20 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetSubscriptionDispatchRate
-            (DispatchRateImpl dispatchRate, boolean isGlobal) {
+    protected CompletableFuture<Void> internalSetSubscriptionDispatchRate(boolean resetMode,
+                                                                          DispatchRateImpl dispatchRate,
+                                                                          boolean isGlobal) {
         if (dispatchRate == null) {
             return CompletableFuture.completedFuture(null);
         }
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setSubscriptionDispatchRate(dispatchRate);
+                DispatchRateImpl maxdispatchRate = dispatchRate;
+                if (!resetMode) {
+                    maxdispatchRate = mergeDispatchRate(topicPolicies.getSubscriptionDispatchRate(), dispatchRate);
+                }
+                topicPolicies.setSubscriptionDispatchRate(maxdispatchRate);
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });
@@ -4268,17 +4306,42 @@ public class PersistentTopicsBase extends AdminResource {
             .thenApply(op -> op.map(TopicPolicies::getPublishRate));
     }
 
-    protected CompletableFuture<Void> internalSetPublishRate(PublishRate publishRate, boolean isGlobal) {
+    protected CompletableFuture<Void> internalSetPublishRate(boolean resetMode,
+                                                             PublishRate publishRate,
+                                                             boolean isGlobal) {
         if (publishRate == null) {
             return CompletableFuture.completedFuture(null);
         }
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setPublishRate(publishRate);
+                PublishRate maxPublishRate = publishRate;
+                if (!resetMode) {
+                    maxPublishRate = mergePublishRate(topicPolicies.getPublishRate(), publishRate);
+                }
+                topicPolicies.setPublishRate(maxPublishRate);
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });
+    }
+
+    private PublishRate mergePublishRate(PublishRate originalPublishRate,
+                                         PublishRate newPublishRate) {
+        if (originalPublishRate == null ^ newPublishRate == null) { // one is null and the other is not null
+            return originalPublishRate == null
+                    ? newPublishRate
+                    : originalPublishRate;
+        } else if (originalPublishRate != null) {
+            newPublishRate.publishThrottlingRateInMsg = newPublishRate.publishThrottlingRateInMsg == -1
+                    ? originalPublishRate.publishThrottlingRateInMsg
+                    : newPublishRate.publishThrottlingRateInMsg;
+            newPublishRate.publishThrottlingRateInByte = newPublishRate.publishThrottlingRateInByte == -1
+                    ? originalPublishRate.publishThrottlingRateInByte
+                    : newPublishRate.publishThrottlingRateInByte;
+            return newPublishRate;
+        }
+
+        return null;
     }
 
     protected CompletableFuture<Optional<List<SubType>>> internalGetSubscriptionTypesEnabled(boolean isGlobal) {
@@ -4336,17 +4399,43 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetSubscribeRate(SubscribeRate subscribeRate, boolean isGlobal) {
+    protected CompletableFuture<Void> internalSetSubscribeRate(boolean resetMode,
+                                                               SubscribeRate subscribeRate,
+                                                               boolean isGlobal) {
         if (subscribeRate == null) {
             return CompletableFuture.completedFuture(null);
         }
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setSubscribeRate(subscribeRate);
+                SubscribeRate maxSubscribeRate = subscribeRate;
+                if (!resetMode) {
+                    maxSubscribeRate = mergeSubscribeRate(topicPolicies.getSubscribeRate(), subscribeRate);
+                }
+                topicPolicies.setSubscribeRate(maxSubscribeRate);
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });
+    }
+
+    private SubscribeRate mergeSubscribeRate(SubscribeRate originalSubscribeRate,
+                                             SubscribeRate newSubscribeRate) {
+        if (originalSubscribeRate == null ^ newSubscribeRate == null) { // one is null and the other is not null
+            return originalSubscribeRate == null
+                    ? newSubscribeRate
+                    : originalSubscribeRate;
+        } else if (originalSubscribeRate != null) {
+            newSubscribeRate.subscribeThrottlingRatePerConsumer =
+                    newSubscribeRate.subscribeThrottlingRatePerConsumer == -1
+                            ? originalSubscribeRate.subscribeThrottlingRatePerConsumer
+                            : newSubscribeRate.subscribeThrottlingRatePerConsumer;
+            newSubscribeRate.ratePeriodInSecond = newSubscribeRate.ratePeriodInSecond == 30
+                    ? originalSubscribeRate.ratePeriodInSecond
+                    : newSubscribeRate.ratePeriodInSecond;
+            return newSubscribeRate;
+        }
+
+        return null;
     }
 
     protected CompletableFuture<Void> internalRemoveSubscribeRate(boolean isGlobal) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3134,13 +3134,13 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(boolean resetMode,
+    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(boolean updateMode,
                                                                         DispatchRateImpl dispatchRate) {
         return getTopicPoliciesAsyncWithRetry(topicName)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 DispatchRateImpl maxDispatchRate = dispatchRate;
-                if (!resetMode) {
+                if (updateMode) {
                     maxDispatchRate = mergeDispatchRate(topicPolicies.getReplicatorDispatchRate(), dispatchRate);
                 }
                 topicPolicies.setReplicatorDispatchRate(maxDispatchRate);
@@ -4131,7 +4131,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetDispatchRate(boolean resetMode,
+    protected CompletableFuture<Void> internalSetDispatchRate(boolean updateMode,
                                                               DispatchRateImpl dispatchRate,
                                                               boolean isGlobal) {
         if (dispatchRate == null) {
@@ -4141,7 +4141,7 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 DispatchRateImpl maxDispatchRate = dispatchRate;
-                if (!resetMode) {
+                if (updateMode) {
                     maxDispatchRate = mergeDispatchRate(topicPolicies.getDispatchRate(), dispatchRate);
                 }
                 topicPolicies.setDispatchRate(maxDispatchRate);
@@ -4163,9 +4163,6 @@ public class PersistentTopicsBase extends AdminResource {
             newDispatchRate.setDispatchThrottlingRateInByte(newDispatchRate.getDispatchThrottlingRateInByte() == -1
                     ? originalDispatchRate.getDispatchThrottlingRateInByte()
                     : newDispatchRate.getDispatchThrottlingRateInByte());
-            newDispatchRate.setRatePeriodInSecond(newDispatchRate.getRatePeriodInSecond() == 1
-                    ? originalDispatchRate.getRatePeriodInSecond()
-                    : newDispatchRate.getRatePeriodInSecond());
             return newDispatchRate;
         }
 
@@ -4198,7 +4195,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetSubscriptionDispatchRate(boolean resetMode,
+    protected CompletableFuture<Void> internalSetSubscriptionDispatchRate(boolean updateMode,
                                                                           DispatchRateImpl dispatchRate,
                                                                           boolean isGlobal) {
         if (dispatchRate == null) {
@@ -4208,7 +4205,7 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 DispatchRateImpl maxdispatchRate = dispatchRate;
-                if (!resetMode) {
+                if (updateMode) {
                     maxdispatchRate = mergeDispatchRate(topicPolicies.getSubscriptionDispatchRate(), dispatchRate);
                 }
                 topicPolicies.setSubscriptionDispatchRate(maxdispatchRate);
@@ -4306,7 +4303,7 @@ public class PersistentTopicsBase extends AdminResource {
             .thenApply(op -> op.map(TopicPolicies::getPublishRate));
     }
 
-    protected CompletableFuture<Void> internalSetPublishRate(boolean resetMode,
+    protected CompletableFuture<Void> internalSetPublishRate(boolean updateMode,
                                                              PublishRate publishRate,
                                                              boolean isGlobal) {
         if (publishRate == null) {
@@ -4316,7 +4313,7 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 PublishRate maxPublishRate = publishRate;
-                if (!resetMode) {
+                if (updateMode) {
                     maxPublishRate = mergePublishRate(topicPolicies.getPublishRate(), publishRate);
                 }
                 topicPolicies.setPublishRate(maxPublishRate);
@@ -4399,7 +4396,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetSubscribeRate(boolean resetMode,
+    protected CompletableFuture<Void> internalSetSubscribeRate(boolean updateMode,
                                                                SubscribeRate subscribeRate,
                                                                boolean isGlobal) {
         if (subscribeRate == null) {
@@ -4409,7 +4406,7 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
                 SubscribeRate maxSubscribeRate = subscribeRate;
-                if (!resetMode) {
+                if (updateMode) {
                     maxSubscribeRate = mergeSubscribeRate(topicPolicies.getSubscribeRate(), subscribeRate);
                 }
                 topicPolicies.setSubscribeRate(maxSubscribeRate);
@@ -4429,9 +4426,6 @@ public class PersistentTopicsBase extends AdminResource {
                     newSubscribeRate.subscribeThrottlingRatePerConsumer == -1
                             ? originalSubscribeRate.subscribeThrottlingRatePerConsumer
                             : newSubscribeRate.subscribeThrottlingRatePerConsumer;
-            newSubscribeRate.ratePeriodInSecond = newSubscribeRate.ratePeriodInSecond == 30
-                    ? originalSubscribeRate.ratePeriodInSecond
-                    : newSubscribeRate.ratePeriodInSecond;
             return newSubscribeRate;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2262,12 +2262,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Replicator dispatch rate of the topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(dispatchRate))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(resetMode, dispatchRate))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated replicatorDispatchRate: namespace={}, topic={}"
                                 + ", replicatorDispatchRate={}",
@@ -2296,7 +2297,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(null))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(true, null))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove replicatorDispatchRate limit: namespace={}, topic={}",
                         clientAppId(), namespaceName, topicName.getLocalName());
@@ -2821,13 +2822,14 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @ApiParam(value = "Dispatch rate for the specified topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetDispatchRate(dispatchRate, isGlobal))
+            .thenCompose(__ -> internalSetDispatchRate(resetMode, dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic dispatch rate:"
@@ -2917,6 +2919,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
@@ -2924,7 +2927,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                     DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetSubscriptionDispatchRate(dispatchRate, isGlobal))
+            .thenCompose(__ -> internalSetSubscriptionDispatchRate(resetMode, dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic subscription dispatch rate:"
@@ -3203,12 +3206,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @ApiParam(value = "Dispatch rate for the specified topic") PublishRate publishRate) {
+            @ApiParam(value = "Publish rate for the specified topic") PublishRate publishRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetPublishRate(publishRate, isGlobal))
+            .thenCompose(__ -> internalSetPublishRate(resetMode, publishRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic publish rate:"
@@ -3397,12 +3401,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Subscribe rate for the specified topic") SubscribeRate subscribeRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetSubscribeRate(subscribeRate, isGlobal))
+            .thenCompose(__ -> internalSetSubscribeRate(resetMode, subscribeRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic subscribe rate:"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2262,13 +2262,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Replicator dispatch rate of the topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(resetMode, dispatchRate))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(updateMode, dispatchRate))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated replicatorDispatchRate: namespace={}, topic={}"
                                 + ", replicatorDispatchRate={}",
@@ -2297,7 +2297,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(true, null))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(false, null))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove replicatorDispatchRate limit: namespace={}, topic={}",
                         clientAppId(), namespaceName, topicName.getLocalName());
@@ -2822,14 +2822,14 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @ApiParam(value = "Dispatch rate for the specified topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetDispatchRate(resetMode, dispatchRate, isGlobal))
+            .thenCompose(__ -> internalSetDispatchRate(updateMode, dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic dispatch rate:"
@@ -2919,7 +2919,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
@@ -2927,7 +2927,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                     DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetSubscriptionDispatchRate(resetMode, dispatchRate, isGlobal))
+            .thenCompose(__ -> internalSetSubscriptionDispatchRate(updateMode, dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic subscription dispatch rate:"
@@ -3206,13 +3206,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Publish rate for the specified topic") PublishRate publishRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetPublishRate(resetMode, publishRate, isGlobal))
+            .thenCompose(__ -> internalSetPublishRate(updateMode, publishRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic publish rate:"
@@ -3401,13 +3401,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("namespace") String namespace,
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Is authentication required to perform this operation")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @ApiParam(value = "Subscribe rate for the specified topic") SubscribeRate subscribeRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
-            .thenCompose(__ -> internalSetSubscribeRate(resetMode, subscribeRate, isGlobal))
+            .thenCompose(__ -> internalSetSubscribeRate(updateMode, subscribeRate, isGlobal))
             .thenRun(() -> {
                 try {
                     log.info("[{}] Successfully set topic subscribe rate:"

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
@@ -745,6 +745,19 @@ public interface TopicPolicies {
     void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set message-dispatch-rate (topic can dispatch this many messages per second).
+     *
+     * @param topic
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setDispatchRate(String topic, boolean updateMode, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set message-dispatch-rate asynchronously.
      * <p/>
      * topic can dispatch this many messages per second
@@ -754,6 +767,19 @@ public interface TopicPolicies {
      *            number of messages per second
      */
     CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set message-dispatch-rate asynchronously.
+     * <p/>
+     * topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate);
 
     /**
      * Get message-dispatch-rate (topic can dispatch this many messages per second).
@@ -835,6 +861,23 @@ public interface TopicPolicies {
     void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set subscription-message-dispatch-rate for the topic.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second
+     *
+     * @param topic
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscriptionDispatchRate(String topic,
+                                     boolean updateMode,
+                                     DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set subscription-message-dispatch-rate for the topic asynchronously.
      * <p/>
      * Subscriptions under this namespace can dispatch this many messages per second.
@@ -844,6 +887,21 @@ public interface TopicPolicies {
      *            number of messages per second
      */
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set subscription-message-dispatch-rate for the topic asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
+                                                             boolean updateMode,
+                                                             DispatchRate dispatchRate);
 
     /**
      * Get applied subscription-message-dispatch-rate.
@@ -923,6 +981,23 @@ public interface TopicPolicies {
     void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set replicatorDispatchRate for the topic.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setReplicatorDispatchRate(String topic,
+                                   boolean updateMode,
+                                   DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set replicatorDispatchRate for the topic asynchronously.
      * <p/>
      * Replicator dispatch rate under this topic can dispatch this many messages per second.
@@ -932,6 +1007,19 @@ public interface TopicPolicies {
      *            number of messages per second
      */
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set replicatorDispatchRate for the topic asynchronously.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate);
 
     /**
      * Get replicatorDispatchRate for the topic.
@@ -1113,6 +1201,19 @@ public interface TopicPolicies {
     void setPublishRate(String topic, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
+     * Set message-publish-rate (topics can publish this many messages per second).
+     *
+     * @param topic
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
+     * @param publishMsgRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setPublishRate(String topic, boolean updateMode, PublishRate publishMsgRate) throws PulsarAdminException;
+
+    /**
      * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
      *
      * @param topic
@@ -1120,6 +1221,17 @@ public interface TopicPolicies {
      *            number of messages per second
      */
     CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishMsgRate);
+
+    /**
+     * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
+     *
+     * @param topic
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
+     * @param publishMsgRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setPublishRateAsync(String topic, boolean updateMode, PublishRate publishMsgRate);
 
     /**
      * Get message-publish-rate (topics can publish this many messages per second).
@@ -1603,6 +1715,19 @@ public interface TopicPolicies {
     void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
+     * Set topic-subscribe-rate (topic will limit by subscribeRate).
+     *
+     * @param topic
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscribeRate(String topic, boolean updateMode, SubscribeRate subscribeRate) throws PulsarAdminException;
+
+    /**
      * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
      *
      * @param topic
@@ -1610,6 +1735,17 @@ public interface TopicPolicies {
      *            consumer subscribe limit by this subscribeRate
      */
     CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate);
+
+    /**
+     * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
+     *
+     * @param topic
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     */
+    CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean updateMode, SubscribeRate subscribeRate);
 
     /**
      * Get topic-subscribe-rate (topics allow subscribe times per consumer in a period).

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2547,6 +2547,19 @@ public interface Topics {
     void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set message-dispatch-rate (topic can dispatch this many messages per second).
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setDispatchRate(String topic, boolean resetMode, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set message-dispatch-rate asynchronously.
      * <p/>
      * topic can dispatch this many messages per second
@@ -2557,6 +2570,19 @@ public interface Topics {
      */
     @Deprecated
     CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set message-dispatch-rate asynchronously.
+     * <p/>
+     * topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate);
 
     /**
      * Get message-dispatch-rate (topic can dispatch this many messages per second).
@@ -2645,6 +2671,23 @@ public interface Topics {
     void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set subscription-message-dispatch-rate for the topic.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscriptionDispatchRate(String topic,
+                                     boolean resetMode,
+                                     DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set subscription-message-dispatch-rate for the topic asynchronously.
      * <p/>
      * Subscriptions under this namespace can dispatch this many messages per second.
@@ -2655,6 +2698,21 @@ public interface Topics {
      */
     @Deprecated
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set subscription-message-dispatch-rate for the topic asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
+                                                             boolean resetMode,
+                                                             DispatchRate dispatchRate);
 
     /**
      * Get applied subscription-message-dispatch-rate.
@@ -2741,6 +2799,23 @@ public interface Topics {
     void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set replicatorDispatchRate for the topic.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setReplicatorDispatchRate(String topic,
+                                   boolean resetMode,
+                                   DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set replicatorDispatchRate for the topic asynchronously.
      * <p/>
      * Replicator dispatch rate under this topic can dispatch this many messages per second.
@@ -2751,6 +2826,20 @@ public interface Topics {
      */
     @Deprecated
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+
+    /**
+     * Set replicatorDispatchRate for the topic asynchronously.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate);
 
     /**
      * Get replicatorDispatchRate for the topic.
@@ -2947,6 +3036,19 @@ public interface Topics {
     void setPublishRate(String topic, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
+     * Set message-publish-rate (topics can publish this many messages per second).
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param publishMsgRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setPublishRate(String topic, boolean resetMode, PublishRate publishMsgRate) throws PulsarAdminException;
+
+    /**
      * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
      *
      * @param topic
@@ -2955,6 +3057,17 @@ public interface Topics {
      */
     @Deprecated
     CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishMsgRate);
+
+    /**
+     * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param publishMsgRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setPublishRateAsync(String topic, boolean resetMode, PublishRate publishMsgRate);
 
     /**
      * Get message-publish-rate (topics can publish this many messages per second).
@@ -3490,6 +3603,19 @@ public interface Topics {
     void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
+     * Set topic-subscribe-rate (topic will limit by subscribeRate).
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setSubscribeRate(String topic, boolean resetMode, SubscribeRate subscribeRate) throws PulsarAdminException;
+
+    /**
      * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
      *
      * @param topic
@@ -3498,6 +3624,17 @@ public interface Topics {
      */
     @Deprecated
     CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate);
+
+    /**
+     * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
+     *
+     * @param topic
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     */
+    CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean resetMode, SubscribeRate subscribeRate);
 
     /**
      * Get topic-subscribe-rate (topics allow subscribe times per consumer in a period).

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2550,14 +2550,14 @@ public interface Topics {
      * Set message-dispatch-rate (topic can dispatch this many messages per second).
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setDispatchRate(String topic, boolean resetMode, DispatchRate dispatchRate) throws PulsarAdminException;
+    void setDispatchRate(String topic, boolean updateMode, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
      * Set message-dispatch-rate asynchronously.
@@ -2577,12 +2577,12 @@ public interface Topics {
      * topic can dispatch this many messages per second
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      */
-    CompletableFuture<Void> setDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate);
+    CompletableFuture<Void> setDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate);
 
     /**
      * Get message-dispatch-rate (topic can dispatch this many messages per second).
@@ -2676,15 +2676,15 @@ public interface Topics {
      * Subscriptions under this namespace can dispatch this many messages per second
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
     void setSubscriptionDispatchRate(String topic,
-                                     boolean resetMode,
+                                     boolean updateMode,
                                      DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2705,13 +2705,13 @@ public interface Topics {
      * Subscriptions under this namespace can dispatch this many messages per second.
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      */
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
-                                                             boolean resetMode,
+                                                             boolean updateMode,
                                                              DispatchRate dispatchRate);
 
     /**
@@ -2804,15 +2804,15 @@ public interface Topics {
      * Replicator dispatch rate under this topic can dispatch this many messages per second
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
     void setReplicatorDispatchRate(String topic,
-                                   boolean resetMode,
+                                   boolean updateMode,
                                    DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2834,12 +2834,12 @@ public interface Topics {
      * Replicator dispatch rate under this topic can dispatch this many messages per second.
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      */
-    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate);
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate);
 
     /**
      * Get replicatorDispatchRate for the topic.
@@ -3039,14 +3039,14 @@ public interface Topics {
      * Set message-publish-rate (topics can publish this many messages per second).
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
      * @param publishMsgRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setPublishRate(String topic, boolean resetMode, PublishRate publishMsgRate) throws PulsarAdminException;
+    void setPublishRate(String topic, boolean updateMode, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
      * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
@@ -3062,12 +3062,12 @@ public interface Topics {
      * Set message-publish-rate (topics can publish this many messages per second) asynchronously.
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
      * @param publishMsgRate
      *            number of messages per second
      */
-    CompletableFuture<Void> setPublishRateAsync(String topic, boolean resetMode, PublishRate publishMsgRate);
+    CompletableFuture<Void> setPublishRateAsync(String topic, boolean updateMode, PublishRate publishMsgRate);
 
     /**
      * Get message-publish-rate (topics can publish this many messages per second).
@@ -3606,14 +3606,14 @@ public interface Topics {
      * Set topic-subscribe-rate (topic will limit by subscribeRate).
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
      * @param subscribeRate
      *            consumer subscribe limit by this subscribeRate
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setSubscribeRate(String topic, boolean resetMode, SubscribeRate subscribeRate) throws PulsarAdminException;
+    void setSubscribeRate(String topic, boolean updateMode, SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
      * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
@@ -3629,12 +3629,12 @@ public interface Topics {
      * Set topic-subscribe-rate (topics will limit by subscribeRate) asynchronously.
      *
      * @param topic
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
      * @param subscribeRate
      *            consumer subscribe limit by this subscribeRate
      */
-    CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean resetMode, SubscribeRate subscribeRate);
+    CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean updateMode, SubscribeRate subscribeRate);
 
     /**
      * Get topic-subscribe-rate (topics allow subscribe times per consumer in a period).

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -685,13 +685,26 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setDispatchRateAsync(topic, dispatchRate));
+        setDispatchRate(topic, false, dispatchRate);
+    }
+
+    @Override
+    public void setDispatchRate(String topic,
+                                boolean updateMode,
+                                DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        return setDispatchRateAsync(topic, false, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "dispatchRate");
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -745,13 +758,28 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setSubscriptionDispatchRateAsync(topic, dispatchRate));
+        setSubscriptionDispatchRate(topic, false, dispatchRate);
+    }
+
+    @Override
+    public void setSubscriptionDispatchRate(String topic,
+                                            boolean updateMode,
+                                            DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setSubscriptionDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        return setSubscriptionDispatchRateAsync(topic, false, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
+                                                                    boolean updateMode,
+                                                                    DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -854,13 +882,24 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void setPublishRate(String topic, PublishRate publishRate) throws PulsarAdminException {
-        sync(() -> setPublishRateAsync(topic, publishRate));
+        setPublishRate(topic, false, publishRate);
+    }
+
+    @Override
+    public void setPublishRate(String topic, boolean updateMode, PublishRate publishRate) throws PulsarAdminException {
+        sync(() -> setPublishRateAsync(topic, updateMode, publishRate));
     }
 
     @Override
     public CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishRate) {
+        return setPublishRateAsync(topic, false, publishRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setPublishRateAsync(String topic, boolean updateMode, PublishRate publishRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "publishRate");
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1294,13 +1333,28 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException {
-        sync(() -> setSubscribeRateAsync(topic, subscribeRate));
+        setSubscribeRate(topic, false, subscribeRate);
+    }
+
+    @Override
+    public void setSubscribeRate(String topic,
+                                 boolean updateMode,
+                                 SubscribeRate subscribeRate) throws PulsarAdminException {
+        sync(() -> setSubscribeRateAsync(topic, updateMode, subscribeRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate) {
+        return setSubscribeRateAsync(topic, false, subscribeRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscribeRateAsync(String topic,
+                                                         boolean updateMode,
+                                                         SubscribeRate subscribeRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscribeRate");
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1354,13 +1408,28 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setReplicatorDispatchRateAsync(topic, dispatchRate));
+        setReplicatorDispatchRate(topic, false, dispatchRate);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String topic,
+                                          boolean updateMode,
+                                          DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        return setReplicatorDispatchRateAsync(topic, false, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic,
+                                                                  boolean updateMode,
+                                                                  DispatchRate dispatchRate) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2186,13 +2186,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setDispatchRateAsync(topic, dispatchRate));
+        setDispatchRate(topic, true, dispatchRate);
+    }
+
+    @Override
+    public void setDispatchRate(String topic,
+                                boolean resetMode,
+                                DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setDispatchRateAsync(topic, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "dispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> setDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "dispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2246,13 +2261,30 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setSubscriptionDispatchRateAsync(topic, dispatchRate));
+        setSubscriptionDispatchRate(topic, true, dispatchRate);
+    }
+
+    @Override
+    public void setSubscriptionDispatchRate(String topic,
+                                            boolean resetMode,
+                                            DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setSubscriptionDispatchRateAsync(topic, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
+                                                                    boolean resetMode,
+                                                                    DispatchRate dispatchRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2355,13 +2387,26 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setPublishRate(String topic, PublishRate publishRate) throws PulsarAdminException {
-        sync(() -> setPublishRateAsync(topic, publishRate));
+        setPublishRate(topic, true, publishRate);
+    }
+
+    @Override
+    public void setPublishRate(String topic, boolean resetMode, PublishRate publishRate) throws PulsarAdminException {
+        sync(() -> setPublishRateAsync(topic, resetMode, publishRate));
     }
 
     @Override
     public CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "publishRate");
+        return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> setPublishRateAsync(String topic, boolean resetMode, PublishRate publishRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "publishRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2785,13 +2830,30 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setReplicatorDispatchRateAsync(topic, dispatchRate));
+        setReplicatorDispatchRate(topic, true, dispatchRate);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String topic,
+                                          boolean resetMode,
+                                          DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(topic, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic,
+                                                                  boolean resetMode,
+                                                                  DispatchRate dispatchRate) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2845,13 +2907,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException {
-        sync(() -> setSubscribeRateAsync(topic, subscribeRate));
+        setSubscribeRate(topic, true, subscribeRate);
+    }
+
+    @Override
+    public void setSubscribeRate(String topic,
+                                 boolean resetMode,
+                                 SubscribeRate subscribeRate) throws PulsarAdminException {
+        sync(() -> setSubscribeRateAsync(topic, resetMode, subscribeRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscribeRate");
+        return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean resetMode, SubscribeRate subscribeRate) {
+        TopicName topicName = validateTopic(topic);
+        WebTarget path = topicPath(topicName, "subscribeRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2186,28 +2186,26 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        setDispatchRate(topic, true, dispatchRate);
+        setDispatchRate(topic, false, dispatchRate);
     }
 
     @Override
     public void setDispatchRate(String topic,
-                                boolean resetMode,
+                                boolean updateMode,
                                 DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setDispatchRateAsync(topic, resetMode, dispatchRate));
+        sync(() -> setDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String topic, DispatchRate dispatchRate) {
-        TopicName topicName = validateTopic(topic);
-        WebTarget path = topicPath(topicName, "dispatchRate");
-        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+        return setDispatchRateAsync(topic, false, dispatchRate);
     }
 
     @Override
-    public CompletableFuture<Void> setDispatchRateAsync(String topic, boolean resetMode, DispatchRate dispatchRate) {
+    public CompletableFuture<Void> setDispatchRateAsync(String topic, boolean updateMode, DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "dispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2261,30 +2259,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        setSubscriptionDispatchRate(topic, true, dispatchRate);
+        setSubscriptionDispatchRate(topic, false, dispatchRate);
     }
 
     @Override
     public void setSubscriptionDispatchRate(String topic,
-                                            boolean resetMode,
+                                            boolean updateMode,
                                             DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setSubscriptionDispatchRateAsync(topic, resetMode, dispatchRate));
+        sync(() -> setSubscriptionDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic, DispatchRate dispatchRate) {
-        TopicName topicName = validateTopic(topic);
-        WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
-        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+        return setSubscriptionDispatchRateAsync(topic, false, dispatchRate);
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String topic,
-                                                                    boolean resetMode,
+                                                                    boolean updateMode,
                                                                     DispatchRate dispatchRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscriptionDispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2387,26 +2383,24 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setPublishRate(String topic, PublishRate publishRate) throws PulsarAdminException {
-        setPublishRate(topic, true, publishRate);
+        setPublishRate(topic, false, publishRate);
     }
 
     @Override
-    public void setPublishRate(String topic, boolean resetMode, PublishRate publishRate) throws PulsarAdminException {
-        sync(() -> setPublishRateAsync(topic, resetMode, publishRate));
+    public void setPublishRate(String topic, boolean updateMode, PublishRate publishRate) throws PulsarAdminException {
+        sync(() -> setPublishRateAsync(topic, updateMode, publishRate));
     }
 
     @Override
     public CompletableFuture<Void> setPublishRateAsync(String topic, PublishRate publishRate) {
-        TopicName topicName = validateTopic(topic);
-        WebTarget path = topicPath(topicName, "publishRate");
-        return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
+        return setPublishRateAsync(topic, false, publishRate);
     }
 
     @Override
-    public CompletableFuture<Void> setPublishRateAsync(String topic, boolean resetMode, PublishRate publishRate) {
+    public CompletableFuture<Void> setPublishRateAsync(String topic, boolean updateMode, PublishRate publishRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "publishRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2830,30 +2824,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        setReplicatorDispatchRate(topic, true, dispatchRate);
+        setReplicatorDispatchRate(topic, false, dispatchRate);
     }
 
     @Override
     public void setReplicatorDispatchRate(String topic,
-                                          boolean resetMode,
+                                          boolean updateMode,
                                           DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setReplicatorDispatchRateAsync(topic, resetMode, dispatchRate));
+        sync(() -> setReplicatorDispatchRateAsync(topic, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate) {
-        TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn, "replicatorDispatchRate");
-        return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+        return setReplicatorDispatchRateAsync(topic, false, dispatchRate);
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic,
-                                                                  boolean resetMode,
+                                                                  boolean updateMode,
                                                                   DispatchRate dispatchRate) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "replicatorDispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -2907,28 +2899,28 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException {
-        setSubscribeRate(topic, true, subscribeRate);
+        setSubscribeRate(topic, false, subscribeRate);
     }
 
     @Override
     public void setSubscribeRate(String topic,
-                                 boolean resetMode,
+                                 boolean updateMode,
                                  SubscribeRate subscribeRate) throws PulsarAdminException {
-        sync(() -> setSubscribeRateAsync(topic, resetMode, subscribeRate));
+        sync(() -> setSubscribeRateAsync(topic, updateMode, subscribeRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String topic, SubscribeRate subscribeRate) {
-        TopicName topicName = validateTopic(topic);
-        WebTarget path = topicPath(topicName, "subscribeRate");
-        return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
+        return setSubscribeRateAsync(topic, false, subscribeRate);
     }
 
     @Override
-    public CompletableFuture<Void> setSubscribeRateAsync(String topic, boolean resetMode, SubscribeRate subscribeRate) {
+    public CompletableFuture<Void> setSubscribeRateAsync(String topic,
+                                                         boolean updateMode,
+                                                         SubscribeRate subscribeRate) {
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "subscribeRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1282,7 +1282,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getSubscribeRate("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("set-subscribe-rate persistent://myprop/clust/ns1/ds1 -sr 2 -st 60"));
-        verify(mockTopics).setSubscribeRate("persistent://myprop/clust/ns1/ds1", true, new SubscribeRate(2, 60));
+        verify(mockTopics).setSubscribeRate("persistent://myprop/clust/ns1/ds1", false, new SubscribeRate(2, 60));
 
         cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
@@ -1342,7 +1342,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).setDeduplicationStatus("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopics).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", true,
+        verify(mockTopics).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", false,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
@@ -1370,7 +1370,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).removeSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md 10 -bd 11 -dt 12"));
-        verify(mockTopics).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", true,
+        verify(mockTopics).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", false,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(10)
                         .dispatchThrottlingRateInByte(11)
@@ -1430,7 +1430,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-publish-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPublishRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-publish-rate persistent://myprop/clust/ns1/ds1 -m 100 -b 10240"));
-        verify(mockTopics).setPublishRate("persistent://myprop/clust/ns1/ds1", true, new PublishRate(100, 10240L));
+        verify(mockTopics).setPublishRate("persistent://myprop/clust/ns1/ds1", false, new PublishRate(100, 10240L));
         cmdTopics.run(split("remove-publish-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removePublishRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
@@ -1471,7 +1471,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("remove-dispatch-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeDispatchRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopics).setDispatchRate("persistent://myprop/clust/ns1/ds1", true, DispatchRate.builder()
+        verify(mockTopics).setDispatchRate("persistent://myprop/clust/ns1/ds1", false, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1282,7 +1282,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).getSubscribeRate("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("set-subscribe-rate persistent://myprop/clust/ns1/ds1 -sr 2 -st 60"));
-        verify(mockTopics).setSubscribeRate("persistent://myprop/clust/ns1/ds1", new SubscribeRate(2, 60));
+        verify(mockTopics).setSubscribeRate("persistent://myprop/clust/ns1/ds1", true, new SubscribeRate(2, 60));
 
         cmdTopics.run(split("remove-subscribe-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeSubscribeRate("persistent://myprop/clust/ns1/ds1");
@@ -1342,7 +1342,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).setDeduplicationStatus("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopics).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1", true,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
@@ -1370,7 +1370,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).removeSubscriptionTypesEnabled("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md 10 -bd 11 -dt 12"));
-        verify(mockTopics).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+        verify(mockTopics).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", true,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(10)
                         .dispatchThrottlingRateInByte(11)
@@ -1430,7 +1430,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-publish-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPublishRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-publish-rate persistent://myprop/clust/ns1/ds1 -m 100 -b 10240"));
-        verify(mockTopics).setPublishRate("persistent://myprop/clust/ns1/ds1", new PublishRate(100, 10240L));
+        verify(mockTopics).setPublishRate("persistent://myprop/clust/ns1/ds1", true, new PublishRate(100, 10240L));
         cmdTopics.run(split("remove-publish-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removePublishRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-max-unacked-messages-on-subscription persistent://myprop/clust/ns1/ds1 -m 99"));
@@ -1471,7 +1471,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("remove-dispatch-rate persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).removeDispatchRate("persistent://myprop/clust/ns1/ds1");
         cmdTopics.run(split("set-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
-        verify(mockTopics).setDispatchRate("persistent://myprop/clust/ns1/ds1", DispatchRate.builder()
+        verify(mockTopics).setDispatchRate("persistent://myprop/clust/ns1/ds1", true, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1943,10 +1943,14 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
+        @Parameter(names = {"--reset-mode", "-r"},
+            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setDispatchRate(persistentTopic,
+            getTopics().setDispatchRate(persistentTopic, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2174,10 +2178,14 @@ public class CmdTopics extends CmdBase {
             "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
+        @Parameter(names = {"--reset-mode", "-r"},
+            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setPublishRate(persistentTopic,
+            getTopics().setPublishRate(persistentTopic, resetMode,
                 new PublishRate(msgPublishRate, bytePublishRate));
         }
     }
@@ -2230,10 +2238,14 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
+        @Parameter(names = {"--reset-mode", "-r"},
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setSubscriptionDispatchRate(persistentTopic,
+            getTopics().setSubscriptionDispatchRate(persistentTopic, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2291,10 +2303,14 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
+        @Parameter(names = {"--reset-mode", "-r"},
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setReplicatorDispatchRate(persistentTopic,
+            getTopics().setReplicatorDispatchRate(persistentTopic, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2617,10 +2633,14 @@ public class CmdTopics extends CmdBase {
                 "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
+        @Parameter(names = {"--reset-mode", "-r"},
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setSubscribeRate(persistentTopic,
+            getTopics().setSubscribeRate(persistentTopic, resetMode,
                     new SubscribeRate(subscribeRate, subscribeRatePeriodSec));
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1943,14 +1943,15 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
-        @Parameter(names = {"--reset-mode", "-r"},
-            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update dispatch rate. If it is true then merging the previous and current rate "
+                + "(only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setDispatchRate(persistentTopic, resetMode,
+            getTopics().setDispatchRate(persistentTopic, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2178,14 +2179,14 @@ public class CmdTopics extends CmdBase {
             "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
-        @Parameter(names = {"--reset-mode", "-r"},
-            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update publish rate. If it is true then merging the previous and current rate")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setPublishRate(persistentTopic, resetMode,
+            getTopics().setPublishRate(persistentTopic, updateMode,
                 new PublishRate(msgPublishRate, bytePublishRate));
         }
     }
@@ -2238,14 +2239,15 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
-        @Parameter(names = {"--reset-mode", "-r"},
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update subscription dispatch rate. If it is true then merging the previous and "
+                + "current rate (only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setSubscriptionDispatchRate(persistentTopic, resetMode,
+            getTopics().setSubscriptionDispatchRate(persistentTopic, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2303,14 +2305,15 @@ public class CmdTopics extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
-        @Parameter(names = {"--reset-mode", "-r"},
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update replicator dispatch rate. If it is true then merging the previous and "
+                + "current rate (only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setReplicatorDispatchRate(persistentTopic, resetMode,
+            getTopics().setReplicatorDispatchRate(persistentTopic, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -2633,14 +2636,15 @@ public class CmdTopics extends CmdBase {
                 "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
-        @Parameter(names = {"--reset-mode", "-r"},
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update subscribe rate. If it is true then merging the previous and "
+                + "current rate (only for --subscribe-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopics().setSubscribeRate(persistentTopic, resetMode,
+            getTopics().setSubscribeRate(persistentTopic, updateMode,
                     new SubscribeRate(subscribeRate, subscribeRatePeriodSec));
         }
     }


### PR DESCRIPTION
### Motivation
Currently we can use cli `./pulsar-admin topics set-publish-rate` / `./pulsar-admin topics set-dispatch-rate` to set message publish/dispatch rate for a topic, but its effect is to clear the previous rate and then reset which causes the previously rate to disappear (unless I specifically add the previous rate when I set it again), for example:
**1st**
> ./pulsar-admin topics set-publish-rate `-b 10485760` persistent://public/default/topic-rate-test
./pulsar-admin topics get-publish-rate persistent://public/default/topic-rate-test
{
   "publishThrottlingRateInMsg" : -1,
   "publishThrottlingRateInByte" : 10485760
 }

**2nd**
> ./pulsar-admin topics set-publish-rate `-m 1000` persistent://public/default/topic-rate-test
./pulsar-admin topics get-publish-rate persistent://public/default/topic-rate-test
{
  "publishThrottlingRateInMsg" : 1000,
  "publishThrottlingRateInByte" : -1
}

The purpose of this PR is to combine the previous and current rate by adding an option `--update-mode`(default false, which will be consistent with the above effect), in this case, we will execute **2nd** as the result below.
**2nd**
> ./pulsar-admin topics set-publish-rate `-m 1000` `--update-mode` persistent://public/default/topic-rate-test
./pulsar-admin topics get-publish-rate persistent://public/default/topic-rate-test
{
  "publishThrottlingRateInMsg" : 1000,
  "publishThrottlingRateInByte" : 10485760
}


This PR mainly adds `--update-mode` option for rate-related commands, including:
- [set-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-dispatch-rate-em--70)
- [set-subscription-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-subscription-dispatch-rate-em--73)
- [set-replicator-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-replicator-dispatch-rate-em--76)
- [set-publish-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-publish-rate-em--87)
- [set-subscribe-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-subscribe-rate-em--98)

### Documentation  
Automatically generate doc through code
- [x] `doc`
