### PR TITLE
PIP-45: Allow more info in MetadataSerde

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Stat;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,12 +90,13 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         this.config = pulsar.getConfiguration();
         this.locatorEntryCache = store.getMetadataCache(new MetadataSerde<SchemaStorageFormat.SchemaLocator>() {
             @Override
-            public byte[] serialize(SchemaStorageFormat.SchemaLocator value) {
+            public byte[] serialize(String path, SchemaStorageFormat.SchemaLocator value) {
                 return value.toByteArray();
             }
 
             @Override
-            public SchemaStorageFormat.SchemaLocator deserialize(byte[] content) throws IOException {
+            public SchemaStorageFormat.SchemaLocator deserialize(String path, byte[] content, Stat stat)
+                    throws IOException {
                 return SchemaStorageFormat.SchemaLocator.parseFrom(content);
             }
         });

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataSerde.java
@@ -20,9 +20,30 @@ package org.apache.pulsar.metadata.api;
 
 import java.io.IOException;
 
+/**
+ * Interface that define a serializer/deserializer implementation.
+ *
+ * @param <T>
+ */
 public interface MetadataSerde<T> {
 
-    byte[] serialize(T value) throws IOException;
+    /**
+     * Serialize the object into a byte array.
+     *
+     * @param path the path of the object on the metadata store
+     * @param value the object instance
+     * @return a byte array of the serialized version
+     * @throws IOException if the serialization fails
+     */
+    byte[] serialize(String path, T value) throws IOException;
 
-    T deserialize(byte[] content) throws IOException;
+    /**
+     * Serialize the object from a byte array.
+     * @param path the path of the object on the metadata store
+     * @param content the content as stored on metadata store
+     * @param stat the {@link Stat} metadata for the object
+     * @return the deserialized object
+     * @throws IOException if the deserialization fails
+     */
+    T deserialize(String path, byte[] content, Stat stat) throws IOException;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/CoordinationService.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.metadata.api.coordination;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 
 /**
  * Interface for the coordination service. Provides abstraction for distributed locks and leader election.
@@ -41,6 +42,7 @@ public interface CoordinationService extends AutoCloseable {
             Consumer<LeaderElectionState> stateChangesListener);
 
     <T> LockManager<T> getLockManager(Class<T> clazz);
+    <T> LockManager<T> getLockManager(MetadataSerde<T> serde);
 
     /**
      * Increment a counter identified by the specified path and return the current value.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeSimpleType.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeSimpleType.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import java.io.IOException;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.Stat;
 
 public class JSONMetadataSerdeSimpleType<T> implements MetadataSerde<T> {
 
@@ -32,12 +33,12 @@ public class JSONMetadataSerdeSimpleType<T> implements MetadataSerde<T> {
     }
 
     @Override
-    public byte[] serialize(T value) throws IOException {
+    public byte[] serialize(String path, T value) throws IOException {
         return ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value);
     }
 
     @Override
-    public T deserialize(byte[] content) throws IOException {
+    public T deserialize(String path, byte[] content, Stat stat) throws IOException {
         return ObjectMapperFactory.getThreadLocal().readValue(content, typeRef);
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.Stat;
 
 public class JSONMetadataSerdeTypeRef<T> implements MetadataSerde<T> {
 
@@ -34,12 +35,12 @@ public class JSONMetadataSerdeTypeRef<T> implements MetadataSerde<T> {
     }
 
     @Override
-    public byte[] serialize(T value) throws IOException {
+    public byte[] serialize(String paht, T value) throws IOException {
         return ObjectMapperFactory.getThreadLocal().writeValueAsBytes(value);
     }
 
     @Override
-    public T deserialize(byte[] content) throws IOException {
+    public T deserialize(String path, byte[] content, Stat stat) throws IOException {
         return ObjectMapperFactory.getThreadLocal().readValue(content, typeRef);
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/CoordinationServiceImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/CoordinationServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.coordination.LeaderElection;
@@ -44,7 +45,7 @@ public class CoordinationServiceImpl implements CoordinationService {
 
     private final MetadataStoreExtended store;
 
-    private final Map<Class<?>, LockManager<?>> lockManagers = new ConcurrentHashMap<>();
+    private final Map<Object, LockManager<?>> lockManagers = new ConcurrentHashMap<>();
     private final Map<String, LeaderElection<?>> leaderElections = new ConcurrentHashMap<>();
 
     private final ScheduledExecutorService executor;
@@ -78,6 +79,12 @@ public class CoordinationServiceImpl implements CoordinationService {
     public <T> LockManager<T> getLockManager(Class<T> clazz) {
         return (LockManager<T>) lockManagers.computeIfAbsent(clazz,
                 k -> new LockManagerImpl<T>(store, clazz, executor));
+    }
+
+    @Override
+    public <T> LockManager<T> getLockManager(MetadataSerde<T> serde) {
+        return (LockManager<T>) lockManagers.computeIfAbsent(serde,
+                k -> new LockManagerImpl<T>(store, serde, executor));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
@@ -117,7 +117,7 @@ class LeaderElectionImpl<T> implements LeaderElection<T> {
     private synchronized CompletableFuture<LeaderElectionState> handleExistingLeaderValue(GetResult res) {
         T existingValue;
         try {
-            existingValue = serde.deserialize(res.getValue());
+            existingValue = serde.deserialize(path, res.getValue(), res.getStat());
         } catch (Throwable t) {
             return FutureUtils.exception(t);
         }
@@ -160,7 +160,7 @@ class LeaderElectionImpl<T> implements LeaderElection<T> {
     private synchronized CompletableFuture<LeaderElectionState> tryToBecomeLeader() {
         byte[] payload;
         try {
-            payload = serde.serialize(proposedValue.get());
+            payload = serde.serialize(path, proposedValue.get());
         } catch (Throwable t) {
             return FutureUtils.exception(t);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -73,7 +73,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     public synchronized CompletableFuture<Void> updateValue(T newValue) {
         byte[] payload;
         try {
-            payload = serde.serialize(newValue);
+            payload = serde.serialize(path, newValue);
         } catch (Throwable t) {
             return FutureUtils.exception(t);
         }
@@ -160,7 +160,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     private CompletableFuture<Void> acquireWithNoRevalidation() {
         byte[] payload;
         try {
-            payload = serde.serialize(value);
+            payload = serde.serialize(path, value);
         } catch (Throwable t) {
             return FutureUtils.exception(t);
         }
@@ -242,7 +242,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
 
                     T existingValue;
                     try {
-                        existingValue = serde.deserialize(optGetResult.get().getValue());
+                        existingValue = serde.deserialize(path, res.getValue(), res.getStat());
                     } catch (Throwable t) {
                         return FutureUtils.exception(t);
                     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -44,7 +44,7 @@ public class BacklogQuotaCompatibilityTest {
 
         JSONMetadataSerdeSimpleType jsonMetadataSerdeSimpleType = new JSONMetadataSerdeSimpleType(
                 TypeFactory.defaultInstance().constructSimpleType(Policies.class, null));
-        Policies policies = (Policies) jsonMetadataSerdeSimpleType.deserialize(oldPolicyStr.getBytes());
+        Policies policies = (Policies) jsonMetadataSerdeSimpleType.deserialize(null, oldPolicyStr.getBytes(), null);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
                 1001);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),


### PR DESCRIPTION
### Motivation

In some cases, at the moment of doing serialization/deserialization, we need to use more information than just the `byte[]` payload. For example this happens in the context of BK abstract interfaces for metadata access. 

Adding here the support for passing the path and stats of the metadata value to the serializer, which it can then either use or ignore.