### PR TITLE
Fix broken Javadoc links

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
@@ -45,8 +45,8 @@ public enum ConsumerCryptoFailureAction {
      * <p>If message is also compressed, decompression will fail. If message contain batch messages, client will not be
      * able to retrieve individual messages in the batch.
      *
-     * <p>Delivered encrypted message contains {@link EncryptionContext} which contains encryption and compression
-     * information in it using which application can decrypt consumed message payload.
+     * <p>Delivered encrypted message contains {@link org.apache.pulsar.common.api.EncryptionContext} which contains
+     * encryption and compression information in it using which application can decrypt consumed message payload.
      */
     CONSUME;
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -57,7 +57,7 @@ public interface PulsarClient extends Closeable {
 
     /**
      * Create a producer builder that can be used to configure
-     * and construct a producer with default {@link Schema.BYTES}.
+     * and construct a producer with default {@link Schema#BYTES}.
      *
      * <p>Example:
      *
@@ -97,7 +97,7 @@ public interface PulsarClient extends Closeable {
     <T> ProducerBuilder<T> newProducer(Schema<T> schema);
 
     /**
-     * Create a consumer builder with no schema ({@link Schema.BYTES}) for subscribing to
+     * Create a consumer builder with no schema ({@link Schema#BYTES}) for subscribing to
      * one or more topics.
      *
      * <pre>{@code
@@ -147,7 +147,7 @@ public interface PulsarClient extends Closeable {
     <T> ConsumerBuilder<T> newConsumer(Schema<T> schema);
 
     /**
-     * Create a topic reader builder with no schema ({@link Schema.BYTES}) to read from the specified topic.
+     * Create a topic reader builder with no schema ({@link Schema#BYTES}) to read from the specified topic.
      *
      * <p>The Reader provides a low-level abstraction that allows for manual positioning in the topic, without using a
      * subscription. A reader needs to be specified a {@link ReaderBuilder#startMessageId(MessageId)}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/tls/PublicSuffixMatcher.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/tls/PublicSuffixMatcher.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * An up-to-date list of suffixes can be obtained from
  * <a href="http://publicsuffix.org/">publicsuffix.org</a>
  *
- * @see org.apache.pulsar.client.impl.tls.PublicSuffixList
+ * @see org.apache.pulsar.common.tls.PublicSuffixList
  *
  * @since 4.4
  */

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -321,7 +321,7 @@ public abstract class BookKeeperClusterTestCase {
      *
      * @param addr
      *            Socket Address
-     * @param latch
+     * @param l
      *            Latch to wait on
      * @throws InterruptedException
      * @throws IOException


### PR DESCRIPTION
### Motivation

Correct the Javadocs to improve readability of pulsar code base, especially in an IDE.

### Modifications

* Use correct formatting in Javadoc links by. Replace `.` with `#`.
* Fully qualify reference to `EncryptionContext`.
* `PublicSuffixList` was moved by this PR, https://github.com/apache/pulsar/pull/10541, but this reference was missed. Fix its reference.

### Verifying this change

These are trivial changes to docs.

### Does this pull request potentially affect one of the following parts:

This does not change any public behavior.

### Documentation
No need to update docs, as this is only a fix to Javadocs.
