### PR TITLE
[pulsar-admin] Add --update-mode to optimize namespace rate policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1177,10 +1177,10 @@ public abstract class NamespacesBase extends AdminResource {
         return algorithm;
     }
 
-    protected void internalSetPublishRate(boolean resetMode, PublishRate publishRate) {
+    protected void internalSetPublishRate(boolean updateMode, PublishRate publishRate) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
         log.info("[{}] Set namespace publish-rate {}/{}", clientAppId(), namespaceName, publishRate);
-        if (!resetMode) {
+        if (updateMode) {
             Policies policies = getNamespacePolicies(namespaceName);
             PublishRate originalPublishRate =
                     policies.publishMaxMessageRate.get(pulsar().getConfiguration().getClusterName());
@@ -1241,12 +1241,12 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     @SuppressWarnings("deprecation")
-    protected void internalSetTopicDispatchRate(boolean resetMode, DispatchRateImpl dispatchRate) {
+    protected void internalSetTopicDispatchRate(boolean updateMode, DispatchRateImpl dispatchRate) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
         log.info("[{}] Set namespace dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
 
         try {
-            if (!resetMode) {
+            if (updateMode) {
                 Policies policies = getNamespacePolicies(namespaceName);
                 DispatchRateImpl originalDispatchRate =
                         policies.topicDispatchRate.get(pulsar().getConfiguration().getClusterName());
@@ -1280,9 +1280,6 @@ public abstract class NamespacesBase extends AdminResource {
             newDispatchRate.setDispatchThrottlingRateInByte(newDispatchRate.getDispatchThrottlingRateInByte() == -1
                 ? originalDispatchRate.getDispatchThrottlingRateInByte()
                 : newDispatchRate.getDispatchThrottlingRateInByte());
-            newDispatchRate.setRatePeriodInSecond(newDispatchRate.getRatePeriodInSecond() == 1
-                ? originalDispatchRate.getRatePeriodInSecond()
-                : newDispatchRate.getRatePeriodInSecond());
             return newDispatchRate;
         }
 
@@ -1314,12 +1311,12 @@ public abstract class NamespacesBase extends AdminResource {
         return policies.topicDispatchRate.get(pulsar().getConfiguration().getClusterName());
     }
 
-    protected void internalSetSubscriptionDispatchRate(boolean resetMode, DispatchRateImpl dispatchRate) {
+    protected void internalSetSubscriptionDispatchRate(boolean updateMode, DispatchRateImpl dispatchRate) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
         log.info("[{}] Set namespace subscription dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
 
         try {
-            if (!resetMode) {
+            if (updateMode) {
                 Policies policies = getNamespacePolicies(namespaceName);
                 DispatchRateImpl originalDispatchRate =
                         policies.subscriptionDispatchRate.get(pulsar().getConfiguration().getClusterName());
@@ -1363,11 +1360,11 @@ public abstract class NamespacesBase extends AdminResource {
         return policies.subscriptionDispatchRate.get(pulsar().getConfiguration().getClusterName());
     }
 
-    protected void internalSetSubscribeRate(boolean resetMode, SubscribeRate subscribeRate) {
+    protected void internalSetSubscribeRate(boolean updateMode, SubscribeRate subscribeRate) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
         log.info("[{}] Set namespace subscribe-rate {}/{}", clientAppId(), namespaceName, subscribeRate);
         try {
-            if (!resetMode) {
+            if (updateMode) {
                 Policies policies = getNamespacePolicies(namespaceName);
                 SubscribeRate originalSubscribeRate =
                         policies.clusterSubscribeRate.get(pulsar().getConfiguration().getClusterName());
@@ -1398,9 +1395,6 @@ public abstract class NamespacesBase extends AdminResource {
                     newSubscribeRate.subscribeThrottlingRatePerConsumer == -1
                             ? originalSubscribeRate.subscribeThrottlingRatePerConsumer
                             : newSubscribeRate.subscribeThrottlingRatePerConsumer;
-            newSubscribeRate.ratePeriodInSecond = newSubscribeRate.ratePeriodInSecond == 30
-                    ? originalSubscribeRate.ratePeriodInSecond
-                    : newSubscribeRate.ratePeriodInSecond;
             return newSubscribeRate;
         }
 
@@ -1445,11 +1439,11 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected void internalSetReplicatorDispatchRate(boolean resetMode, DispatchRateImpl dispatchRate) {
+    protected void internalSetReplicatorDispatchRate(boolean updateMode, DispatchRateImpl dispatchRate) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE);
         log.info("[{}] Set namespace replicator dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
         try {
-            if (!resetMode) {
+            if (updateMode) {
                 Policies policies = getNamespacePolicies(namespaceName);
                 DispatchRateImpl originalDispatchRate =
                         policies.replicatorDispatchRate.get(pulsar().getConfiguration().getClusterName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -667,10 +667,14 @@ public class Namespaces extends NamespacesBase {
     @Path("/{property}/{cluster}/{namespace}/publishRate")
     @ApiOperation(hidden = true, value = "Set publish-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public void setPublishRate(@PathParam("property") String property, @PathParam("cluster") String cluster,
-            @PathParam("namespace") String namespace, PublishRate publishRate) {
+    public void setPublishRate(
+            @PathParam("property") String property,
+            @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            PublishRate publishRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetPublishRate(publishRate);
+        internalSetPublishRate(resetMode, publishRate);
     }
 
     @GET
@@ -690,10 +694,14 @@ public class Namespaces extends NamespacesBase {
     @Path("/{property}/{cluster}/{namespace}/dispatchRate")
     @ApiOperation(hidden = true, value = "Set dispatch-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public void setDispatchRate(@PathParam("property") String property, @PathParam("cluster") String cluster,
-            @PathParam("namespace") String namespace, DispatchRateImpl dispatchRate) {
+    public void setDispatchRate(
+            @PathParam("property") String property,
+            @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            DispatchRateImpl dispatchRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetTopicDispatchRate(dispatchRate);
+        internalSetTopicDispatchRate(resetMode, dispatchRate);
     }
 
     @GET
@@ -716,9 +724,10 @@ public class Namespaces extends NamespacesBase {
     public void setSubscriptionDispatchRate(@PathParam("property") String property,
                                             @PathParam("cluster") String cluster,
                                             @PathParam("namespace") String namespace,
+                                            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
                                             DispatchRateImpl dispatchRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetSubscriptionDispatchRate(dispatchRate);
+        internalSetSubscriptionDispatchRate(resetMode, dispatchRate);
     }
 
     @GET
@@ -742,10 +751,11 @@ public class Namespaces extends NamespacesBase {
     public void setReplicatorDispatchRate(
             @PathParam("tenant") String tenant,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Replicator dispatch rate for all topics of the specified namespace")
                     DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, cluster, namespace);
-        internalSetReplicatorDispatchRate(dispatchRate);
+        internalSetReplicatorDispatchRate(resetMode, dispatchRate);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -671,10 +671,10 @@ public class Namespaces extends NamespacesBase {
             @PathParam("property") String property,
             @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             PublishRate publishRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetPublishRate(resetMode, publishRate);
+        internalSetPublishRate(updateMode, publishRate);
     }
 
     @GET
@@ -698,10 +698,10 @@ public class Namespaces extends NamespacesBase {
             @PathParam("property") String property,
             @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             DispatchRateImpl dispatchRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetTopicDispatchRate(resetMode, dispatchRate);
+        internalSetTopicDispatchRate(updateMode, dispatchRate);
     }
 
     @GET
@@ -724,10 +724,10 @@ public class Namespaces extends NamespacesBase {
     public void setSubscriptionDispatchRate(@PathParam("property") String property,
                                             @PathParam("cluster") String cluster,
                                             @PathParam("namespace") String namespace,
-                                            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+                                            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
                                             DispatchRateImpl dispatchRate) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetSubscriptionDispatchRate(resetMode, dispatchRate);
+        internalSetSubscriptionDispatchRate(updateMode, dispatchRate);
     }
 
     @GET
@@ -751,11 +751,11 @@ public class Namespaces extends NamespacesBase {
     public void setReplicatorDispatchRate(
             @PathParam("tenant") String tenant,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Replicator dispatch rate for all topics of the specified namespace")
                     DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, cluster, namespace);
-        internalSetReplicatorDispatchRate(resetMode, dispatchRate);
+        internalSetReplicatorDispatchRate(updateMode, dispatchRate);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -589,10 +589,10 @@ public class Namespaces extends NamespacesBase {
     public void setPublishRate(
             @PathParam("property") String property,
             @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Publish rate for all topics of the specified namespace") PublishRate publishRate) {
         validateNamespaceName(property, namespace);
-        internalSetPublishRate(resetMode, publishRate);
+        internalSetPublishRate(updateMode, publishRate);
     }
 
     @DELETE
@@ -625,11 +625,11 @@ public class Namespaces extends NamespacesBase {
     public void setDispatchRate(
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Dispatch rate for all topics of the specified namespace")
                     DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetTopicDispatchRate(resetMode, dispatchRate);
+        internalSetTopicDispatchRate(updateMode, dispatchRate);
     }
 
     @DELETE
@@ -659,11 +659,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void setSubscriptionDispatchRate(@PathParam("tenant") String tenant,
                                             @PathParam("namespace") String namespace,
-                                            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+                                            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
                                             @ApiParam(value =
             "Subscription dispatch rate for all topics of the specified namespace") DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetSubscriptionDispatchRate(resetMode, dispatchRate);
+        internalSetSubscriptionDispatchRate(updateMode, dispatchRate);
     }
 
     @GET
@@ -703,10 +703,10 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Set subscribe-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public void setSubscribeRate(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
-            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+            @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
             @ApiParam(value = "Subscribe rate for all topics of the specified namespace") SubscribeRate subscribeRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetSubscribeRate(resetMode, subscribeRate);
+        internalSetSubscribeRate(updateMode, subscribeRate);
     }
 
     @GET
@@ -737,11 +737,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void setReplicatorDispatchRate(@PathParam("tenant") String tenant,
                                           @PathParam("namespace") String namespace,
-                                          @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+                                          @QueryParam("updateMode") @DefaultValue("false") boolean updateMode,
                                           @ApiParam(value =
             "Replicator dispatch rate for all topics of the specified namespace") DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetReplicatorDispatchRate(resetMode, dispatchRate);
+        internalSetReplicatorDispatchRate(updateMode, dispatchRate);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -586,10 +586,13 @@ public class Namespaces extends NamespacesBase {
     @Path("/{property}/{namespace}/publishRate")
     @ApiOperation(hidden = true, value = "Set publish-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public void setPublishRate(@PathParam("property") String property, @PathParam("namespace") String namespace,
+    public void setPublishRate(
+            @PathParam("property") String property,
+            @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Publish rate for all topics of the specified namespace") PublishRate publishRate) {
         validateNamespaceName(property, namespace);
-        internalSetPublishRate(publishRate);
+        internalSetPublishRate(resetMode, publishRate);
     }
 
     @DELETE
@@ -619,11 +622,14 @@ public class Namespaces extends NamespacesBase {
     @Path("/{tenant}/{namespace}/dispatchRate")
     @ApiOperation(value = "Set dispatch-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
-    public void setDispatchRate(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
+    public void setDispatchRate(
+            @PathParam("tenant") String tenant,
+            @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Dispatch rate for all topics of the specified namespace")
                     DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetTopicDispatchRate(dispatchRate);
+        internalSetTopicDispatchRate(resetMode, dispatchRate);
     }
 
     @DELETE
@@ -652,11 +658,12 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Set Subscription dispatch-rate throttling for all topics of the namespace")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void setSubscriptionDispatchRate(@PathParam("tenant") String tenant,
-                                            @PathParam("namespace") String namespace, @ApiParam(value =
-            "Subscription dispatch rate for all topics of the specified namespace")
-                                                        DispatchRateImpl dispatchRate) {
+                                            @PathParam("namespace") String namespace,
+                                            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+                                            @ApiParam(value =
+            "Subscription dispatch rate for all topics of the specified namespace") DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetSubscriptionDispatchRate(dispatchRate);
+        internalSetSubscriptionDispatchRate(resetMode, dispatchRate);
     }
 
     @GET
@@ -696,9 +703,10 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Set subscribe-rate throttling for all topics of the namespace")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public void setSubscribeRate(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
+            @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
             @ApiParam(value = "Subscribe rate for all topics of the specified namespace") SubscribeRate subscribeRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetSubscribeRate(subscribeRate);
+        internalSetSubscribeRate(resetMode, subscribeRate);
     }
 
     @GET
@@ -728,11 +736,12 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Set replicator dispatch-rate throttling for all topics of the namespace")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void setReplicatorDispatchRate(@PathParam("tenant") String tenant,
-                                          @PathParam("namespace") String namespace, @ApiParam(value =
-            "Replicator dispatch rate for all topics of the specified namespace")
-                                                      DispatchRateImpl dispatchRate) {
+                                          @PathParam("namespace") String namespace,
+                                          @QueryParam("resetMode") @DefaultValue("true") boolean resetMode,
+                                          @ApiParam(value =
+            "Replicator dispatch rate for all topics of the specified namespace") DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetReplicatorDispatchRate(dispatchRate);
+        internalSetReplicatorDispatchRate(resetMode, dispatchRate);
     }
 
     @GET

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -683,7 +683,6 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate namespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(10)
-                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setSubscriptionDispatchRate(myNamespace, namespaceDispatchRate);
@@ -694,7 +693,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
                 .build();
-        admin.namespaces().setSubscriptionDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        admin.namespaces().setSubscriptionDispatchRate(myNamespace, true, namespaceDispatchRate2);
         Awaitility.await().untilAsserted(() ->
                 assertNotNull(admin.namespaces().getSubscriptionDispatchRate(myNamespace)));
         assertEquals(admin.topics().getSubscriptionDispatchRate(topic, true), expectedNamespaceDispatchRate);
@@ -899,7 +898,6 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate namespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(10)
-                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setDispatchRate(myNamespace, namespaceDispatchRate);
@@ -910,7 +908,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
                 .build();
-        admin.namespaces().setDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        admin.namespaces().setDispatchRate(myNamespace, true, namespaceDispatchRate2);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getDispatchRate(myNamespace)));
         assertEquals(admin.topics().getDispatchRate(topic, true), expectedNamespaceDispatchRate);
 
@@ -1736,15 +1734,16 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
 
         SubscribeRate expectedSubscribeRate = new SubscribeRate(1, 60);
-        SubscribeRate subscribeRate = new SubscribeRate(-1, 60);
+        SubscribeRate subscribeRate = new SubscribeRate(1, 30);
         log.info("Subscribe Rate: {} will be set to the namespace: {}", subscribeRate, myNamespace);
         admin.namespaces().setSubscribeRate(myNamespace, subscribeRate);
+
         Awaitility.await().untilAsserted(() ->
                 Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), subscribeRate));
 
-        SubscribeRate subscribeRate1 = new SubscribeRate(1, 30);
+        SubscribeRate subscribeRate1 = new SubscribeRate(-1, 60);
         log.info("Subscribe Rate: {} will be set to the namespace: {}", subscribeRate1, myNamespace);
-        admin.namespaces().setSubscribeRate(myNamespace, false, subscribeRate1);
+        admin.namespaces().setSubscribeRate(myNamespace, true, subscribeRate1);
 
         Awaitility.await().untilAsserted(() ->
                 Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), expectedSubscribeRate));
@@ -1984,7 +1983,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PublishRate publishMsgRate = new PublishRate(10, -1);
         admin.namespaces().setPublishRate(myNamespace, publishMsgRate);
         PublishRate newPublishMsgRate = new PublishRate(-1, 100L);
-        admin.namespaces().setPublishRate(myNamespace, false, newPublishMsgRate);
+        admin.namespaces().setPublishRate(myNamespace, true, newPublishMsgRate);
 
         Awaitility.await()
                 .until(() -> {
@@ -2470,7 +2469,6 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         DispatchRate namespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(10)
-                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setReplicatorDispatchRate(myNamespace, namespaceDispatchRate);
@@ -2481,7 +2479,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
                 .build();
-        admin.namespaces().setReplicatorDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        admin.namespaces().setReplicatorDispatchRate(myNamespace, true, namespaceDispatchRate2);
         Awaitility.await().untilAsserted(() ->
                 assertNotNull(admin.namespaces().getReplicatorDispatchRate(myNamespace)));
         assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), expectedNamespaceDispatchRate);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -675,15 +675,29 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .ratePeriodInSecond(1)
                 .build();
         assertEquals(admin.topicPolicies().getSubscriptionDispatchRate(topic, true), brokerDispatchRate);
-        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+        DispatchRate expectedNamespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
+                .build();
+        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(10)
+                .dispatchThrottlingRateInByte(10)
+                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setSubscriptionDispatchRate(myNamespace, namespaceDispatchRate);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getSubscriptionDispatchRate(myNamespace)));
         assertEquals(admin.topicPolicies().getSubscriptionDispatchRate(topic, true), namespaceDispatchRate);
+
+        DispatchRate namespaceDispatchRate2 = DispatchRate.builder()
+                .dispatchThrottlingRateInByte(11)
+                .ratePeriodInSecond(12)
+                .build();
+        admin.namespaces().setSubscriptionDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        Awaitility.await().untilAsserted(() ->
+                assertNotNull(admin.namespaces().getSubscriptionDispatchRate(myNamespace)));
+        assertEquals(admin.topics().getSubscriptionDispatchRate(topic, true), expectedNamespaceDispatchRate);
 
         DispatchRate topicDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(20)
@@ -877,15 +891,28 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .ratePeriodInSecond(1)
                 .build();
         assertEquals(admin.topicPolicies().getDispatchRate(topic, true), brokerDispatchRate);
-        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+        DispatchRate expectedNamespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
+                .build();
+        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(10)
+                .dispatchThrottlingRateInByte(10)
+                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setDispatchRate(myNamespace, namespaceDispatchRate);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getDispatchRate(myNamespace)));
         assertEquals(admin.topicPolicies().getDispatchRate(topic, true), namespaceDispatchRate);
+
+        DispatchRate namespaceDispatchRate2 = DispatchRate.builder()
+                .dispatchThrottlingRateInByte(11)
+                .ratePeriodInSecond(12)
+                .build();
+        admin.namespaces().setDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getDispatchRate(myNamespace)));
+        assertEquals(admin.topics().getDispatchRate(topic, true), expectedNamespaceDispatchRate);
 
         DispatchRate topicDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(20)
@@ -1708,12 +1735,19 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     public void testGetSetSubscribeRate() throws Exception {
         admin.topics().createPartitionedTopic(persistenceTopic, 2);
 
+        SubscribeRate expectedSubscribeRate = new SubscribeRate(1, 60);
+        SubscribeRate subscribeRate = new SubscribeRate(-1, 60);
+        log.info("Subscribe Rate: {} will be set to the namespace: {}", subscribeRate, myNamespace);
+        admin.namespaces().setSubscribeRate(myNamespace, subscribeRate);
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), subscribeRate));
+
         SubscribeRate subscribeRate1 = new SubscribeRate(1, 30);
         log.info("Subscribe Rate: {} will be set to the namespace: {}", subscribeRate1, myNamespace);
-        admin.namespaces().setSubscribeRate(myNamespace, subscribeRate1);
+        admin.namespaces().setSubscribeRate(myNamespace, false, subscribeRate1);
 
-        Awaitility.await()
-                .untilAsserted(() -> Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), subscribeRate1));
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertEquals(admin.namespaces().getSubscribeRate(myNamespace), expectedSubscribeRate));
 
         SubscribeRate subscribeRate2 =  new SubscribeRate(2, 30);
         log.info("Subscribe Rate: {} will set to the topic: {}", subscribeRate2, persistenceTopic);
@@ -1947,13 +1981,16 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(publishMaxByteRate.get(publishRateLimiter), 50L);
 
         //2 set namespace-level policy
-        PublishRate publishMsgRate = new PublishRate(10, 100L);
+        PublishRate publishMsgRate = new PublishRate(10, -1);
         admin.namespaces().setPublishRate(myNamespace, publishMsgRate);
+        PublishRate newPublishMsgRate = new PublishRate(-1, 100L);
+        admin.namespaces().setPublishRate(myNamespace, false, newPublishMsgRate);
 
         Awaitility.await()
                 .until(() -> {
                     PublishRateLimiterImpl limiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
-                    return (int)publishMaxMessageRate.get(limiter) == 10;
+                    return (int) publishMaxMessageRate.get(limiter) == 10
+                            && (long) publishMaxByteRate.get(limiter) == 100L;
                 });
 
         publishRateLimiter = (PublishRateLimiterImpl) topic.getTopicPublishRateLimiter();
@@ -2425,15 +2462,29 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .ratePeriodInSecond(1)
                 .build();
         assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), brokerDispatchRate);
-        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+        DispatchRate expectedNamespaceDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
+                .build();
+        DispatchRate namespaceDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(10)
+                .dispatchThrottlingRateInByte(10)
+                .ratePeriodInSecond(10)
                 .build();
 
         admin.namespaces().setReplicatorDispatchRate(myNamespace, namespaceDispatchRate);
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.namespaces().getReplicatorDispatchRate(myNamespace)));
         assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), namespaceDispatchRate);
+
+        DispatchRate namespaceDispatchRate2 = DispatchRate.builder()
+                .dispatchThrottlingRateInByte(11)
+                .ratePeriodInSecond(12)
+                .build();
+        admin.namespaces().setReplicatorDispatchRate(myNamespace, false, namespaceDispatchRate2);
+        Awaitility.await().untilAsserted(() ->
+                assertNotNull(admin.namespaces().getReplicatorDispatchRate(myNamespace)));
+        assertEquals(admin.topics().getReplicatorDispatchRate(topic, true), expectedNamespaceDispatchRate);
 
         DispatchRate topicDispatchRate = DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(20)

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -2086,7 +2086,21 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setPublishRate(String namespace, PublishRate publishMsgRate) throws PulsarAdminException;
+
+    /**
+     * Set message-publish-rate (topics under this namespace can publish this many messages per second).
+     *
+     * @param namespace
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param publishMsgRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setPublishRate(String namespace, boolean resetMode, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
      * Remove message-publish-rate (topics under this namespace can publish this many messages per second).
@@ -2104,7 +2118,19 @@ public interface Namespaces {
      * @param publishMsgRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate);
+
+    /**
+     * Set message-publish-rate (topics under this namespace can publish this many messages per second) asynchronously.
+     *
+     * @param namespace
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param publishMsgRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setPublishRateAsync(String namespace, boolean resetMode, PublishRate publishMsgRate);
 
     /**
      * Remove message-publish-rate asynchronously.
@@ -2153,7 +2179,21 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set message-dispatch-rate (topics under this namespace can dispatch this many messages per second).
+     *
+     * @param namespace
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setDispatchRate(String namespace, boolean resetMode, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
      * Set message-dispatch-rate asynchronously.
@@ -2164,7 +2204,21 @@ public interface Namespaces {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setDispatchRateAsync(String namespace, DispatchRate dispatchRate);
+
+    /**
+     * Set message-dispatch-rate asynchronously.
+     * <p/>
+     * topics under this namespace can dispatch this many messages per second
+     *
+     * @param namespace
+     * @param resetMode
+     *            clear the previous rate and reset (default true). if it is false, merge the two rat
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setDispatchRateAsync(String namespace, boolean resetMode, DispatchRate dispatchRate);
 
     /**
      * Get message-dispatch-rate (topics under this namespace can dispatch this many messages per second).
@@ -2197,7 +2251,18 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setSubscribeRate(String namespace, SubscribeRate subscribeRate) throws PulsarAdminException;
+
+    /**
+     * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate).
+     *
+     * @param namespace
+     * @param resetMode     clear the previous rate and reset (default true). if false, merge two rate
+     * @param subscribeRate consumer subscribe limit by this subscribeRate
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setSubscribeRate(String namespace, boolean resetMode, SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
      * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate) asynchronously.
@@ -2206,7 +2271,17 @@ public interface Namespaces {
      * @param subscribeRate
      *            consumer subscribe limit by this subscribeRate
      */
+    @Deprecated
     CompletableFuture<Void> setSubscribeRateAsync(String namespace, SubscribeRate subscribeRate);
+
+    /**
+     * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate) asynchronously.
+     *
+     * @param namespace
+     * @param resetMode     clear the previous rate and reset (default true). if false, merge two rate
+     * @param subscribeRate consumer subscribe limit by this subscribeRate
+     */
+    CompletableFuture<Void> setSubscribeRateAsync(String namespace, boolean resetMode, SubscribeRate subscribeRate);
 
     /**
      * Remove namespace-subscribe-rate (topics under this namespace will limit by subscribeRate).
@@ -2268,7 +2343,22 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setSubscriptionDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set subscription-message-dispatch-rate.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second
+     *
+     * @param namespace
+     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate number of messages per second
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setSubscriptionDispatchRate(String namespace,
+                                     boolean resetMode,
+                                     DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
      * Set subscription-message-dispatch-rate asynchronously.
@@ -2279,7 +2369,21 @@ public interface Namespaces {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace, DispatchRate dispatchRate);
+
+    /**
+     * Set subscription-message-dispatch-rate asynchronously.
+     * <p/>
+     * Subscriptions under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate number of messages per second
+     */
+    CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace,
+                                                             boolean resetMode,
+                                                             DispatchRate dispatchRate);
 
     /**
      * Get subscription-message-dispatch-rate.
@@ -2316,7 +2420,22 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     void setReplicatorDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
+     * Set replicator-message-dispatch-rate.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate number of messages per second
+     * @throws PulsarAdminException Unexpected error
+     */
+    void setReplicatorDispatchRate(String namespace,
+                                   boolean resetMode,
+                                   DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
      * Set replicator-message-dispatch-rate asynchronously.
@@ -2327,7 +2446,21 @@ public interface Namespaces {
      * @param dispatchRate
      *            number of messages per second
      */
+    @Deprecated
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, DispatchRate dispatchRate);
+
+    /**
+     * Set replicator-message-dispatch-rate asynchronously.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param dispatchRate number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace,
+                                                           boolean resetMode,
+                                                           DispatchRate dispatchRate);
 
     /**
      * Remove replicator-message-dispatch-rate.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -2093,14 +2093,14 @@ public interface Namespaces {
      * Set message-publish-rate (topics under this namespace can publish this many messages per second).
      *
      * @param namespace
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
      * @param publishMsgRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setPublishRate(String namespace, boolean resetMode, PublishRate publishMsgRate) throws PulsarAdminException;
+    void setPublishRate(String namespace, boolean updateMode, PublishRate publishMsgRate) throws PulsarAdminException;
 
     /**
      * Remove message-publish-rate (topics under this namespace can publish this many messages per second).
@@ -2125,12 +2125,12 @@ public interface Namespaces {
      * Set message-publish-rate (topics under this namespace can publish this many messages per second) asynchronously.
      *
      * @param namespace
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update publish rate. If it is true then merging the previous and current rate
      * @param publishMsgRate
      *            number of messages per second
      */
-    CompletableFuture<Void> setPublishRateAsync(String namespace, boolean resetMode, PublishRate publishMsgRate);
+    CompletableFuture<Void> setPublishRateAsync(String namespace, boolean updateMode, PublishRate publishMsgRate);
 
     /**
      * Remove message-publish-rate asynchronously.
@@ -2186,14 +2186,14 @@ public interface Namespaces {
      * Set message-dispatch-rate (topics under this namespace can dispatch this many messages per second).
      *
      * @param namespace
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rate
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setDispatchRate(String namespace, boolean resetMode, DispatchRate dispatchRate) throws PulsarAdminException;
+    void setDispatchRate(String namespace, boolean updateMode, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
      * Set message-dispatch-rate asynchronously.
@@ -2213,12 +2213,12 @@ public interface Namespaces {
      * topics under this namespace can dispatch this many messages per second
      *
      * @param namespace
-     * @param resetMode
-     *            clear the previous rate and reset (default true). if it is false, merge the two rat
+     * @param updateMode
+     *            update dispatch rate. If it is true then merging the previous and current rate
      * @param dispatchRate
      *            number of messages per second
      */
-    CompletableFuture<Void> setDispatchRateAsync(String namespace, boolean resetMode, DispatchRate dispatchRate);
+    CompletableFuture<Void> setDispatchRateAsync(String namespace, boolean updateMode, DispatchRate dispatchRate);
 
     /**
      * Get message-dispatch-rate (topics under this namespace can dispatch this many messages per second).
@@ -2258,11 +2258,16 @@ public interface Namespaces {
      * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate).
      *
      * @param namespace
-     * @param resetMode     clear the previous rate and reset (default true). if false, merge two rate
-     * @param subscribeRate consumer subscribe limit by this subscribeRate
-     * @throws PulsarAdminException Unexpected error
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
+     * @throws PulsarAdminException
+     *             Unexpected error
      */
-    void setSubscribeRate(String namespace, boolean resetMode, SubscribeRate subscribeRate) throws PulsarAdminException;
+    void setSubscribeRate(String namespace,
+                          boolean updateMode,
+                          SubscribeRate subscribeRate) throws PulsarAdminException;
 
     /**
      * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate) asynchronously.
@@ -2278,10 +2283,12 @@ public interface Namespaces {
      * Set namespace-subscribe-rate (topics under this namespace will limit by subscribeRate) asynchronously.
      *
      * @param namespace
-     * @param resetMode     clear the previous rate and reset (default true). if false, merge two rate
-     * @param subscribeRate consumer subscribe limit by this subscribeRate
+     * @param updateMode
+     *            update subscribe rate. If it is true then merging the previous and current rate
+     * @param subscribeRate
+     *            consumer subscribe limit by this subscribeRate
      */
-    CompletableFuture<Void> setSubscribeRateAsync(String namespace, boolean resetMode, SubscribeRate subscribeRate);
+    CompletableFuture<Void> setSubscribeRateAsync(String namespace, boolean updateMode, SubscribeRate subscribeRate);
 
     /**
      * Remove namespace-subscribe-rate (topics under this namespace will limit by subscribeRate).
@@ -2352,12 +2359,15 @@ public interface Namespaces {
      * Subscriptions under this namespace can dispatch this many messages per second
      *
      * @param namespace
-     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
-     * @param dispatchRate number of messages per second
-     * @throws PulsarAdminException Unexpected error
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
      */
     void setSubscriptionDispatchRate(String namespace,
-                                     boolean resetMode,
+                                     boolean updateMode,
                                      DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2378,11 +2388,13 @@ public interface Namespaces {
      * Subscriptions under this namespace can dispatch this many messages per second.
      *
      * @param namespace
-     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
-     * @param dispatchRate number of messages per second
+     * @param updateMode
+     *            update subscription dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
      */
     CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace,
-                                                             boolean resetMode,
+                                                             boolean updateMode,
                                                              DispatchRate dispatchRate);
 
     /**
@@ -2429,12 +2441,15 @@ public interface Namespaces {
      * Replicators under this namespace can dispatch this many messages per second.
      *
      * @param namespace
-     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
-     * @param dispatchRate number of messages per second
-     * @throws PulsarAdminException Unexpected error
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
      */
     void setReplicatorDispatchRate(String namespace,
-                                   boolean resetMode,
+                                   boolean updateMode,
                                    DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
@@ -2455,11 +2470,13 @@ public interface Namespaces {
      * Replicators under this namespace can dispatch this many messages per second.
      *
      * @param namespace
-     * @param resetMode    clear the previous rate and reset (default true). if it is false, merge the two rate
-     * @param dispatchRate number of messages per second
+     * @param updateMode
+     *            update replicator dispatch rate. If it is true then merging the previous and current rate
+     * @param dispatchRate
+     *            number of messages per second
      */
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace,
-                                                           boolean resetMode,
+                                                           boolean updateMode,
                                                            DispatchRate dispatchRate);
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1123,7 +1123,14 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setPublishRate(String namespace, PublishRate publishMsgRate) throws PulsarAdminException {
-        sync(() -> setPublishRateAsync(namespace, publishMsgRate));
+        setPublishRate(namespace, true, publishMsgRate);
+    }
+
+    @Override
+    public void setPublishRate(String namespace,
+                               boolean resetMode,
+                               PublishRate publishMsgRate) throws PulsarAdminException {
+        sync(() -> setPublishRateAsync(namespace, resetMode, publishMsgRate));
     }
 
     @Override
@@ -1132,10 +1139,16 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishMsgRate) {
+    public CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishRate) {
+        return setPublishRateAsync(namespace, true, publishRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setPublishRateAsync(String namespace, boolean resetMode, PublishRate publishRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "publishRate");
-        return asyncPostRequest(path, Entity.entity(publishMsgRate, MediaType.APPLICATION_JSON));
+        path = path.queryParam("resetMode", resetMode);
+        return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
     }
 
     @Override
@@ -1184,13 +1197,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setDispatchRateAsync(namespace, dispatchRate));
+        setDispatchRate(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public void setDispatchRate(String namespace,
+                                boolean resetMode,
+                                DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setDispatchRateAsync(namespace, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
+        return setDispatchRateAsync(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setDispatchRateAsync(String namespace,
+                                                        boolean resetMode,
+                                                        DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "dispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1221,13 +1249,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setSubscribeRate(String namespace, SubscribeRate subscribeRate) throws PulsarAdminException {
-        sync(() -> setSubscribeRateAsync(namespace, subscribeRate));
+        setSubscribeRate(namespace, true, subscribeRate);
+    }
+
+    @Override
+    public void setSubscribeRate(String namespace,
+                                 boolean resetMode,
+                                 SubscribeRate subscribeRate) throws PulsarAdminException {
+        sync(() -> setSubscribeRateAsync(namespace, resetMode, subscribeRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String namespace, SubscribeRate subscribeRate) {
+        return setSubscribeRateAsync(namespace, true, subscribeRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscribeRateAsync(String namespace,
+                                                         boolean resetMode,
+                                                         SubscribeRate subscribeRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscribeRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1283,13 +1326,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setSubscriptionDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setSubscriptionDispatchRateAsync(namespace, dispatchRate));
+        setSubscriptionDispatchRate(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public void setSubscriptionDispatchRate(String namespace,
+                                            boolean resetMode,
+                                            DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setSubscriptionDispatchRateAsync(namespace, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
+        return setSubscriptionDispatchRateAsync(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace,
+                                                                    boolean resetMode,
+                                                                    DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionDispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1320,13 +1378,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setReplicatorDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setReplicatorDispatchRateAsync(namespace, dispatchRate));
+        setReplicatorDispatchRate(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String namespace,
+                                          boolean resetMode,
+                                          DispatchRate dispatchRate) throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(namespace, resetMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
+        return setReplicatorDispatchRateAsync(namespace, true, dispatchRate);
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace,
+                                                                  boolean resetMode,
+                                                                  DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "replicatorDispatchRate");
+        path = path.queryParam("resetMode", resetMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1123,14 +1123,14 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setPublishRate(String namespace, PublishRate publishMsgRate) throws PulsarAdminException {
-        setPublishRate(namespace, true, publishMsgRate);
+        setPublishRate(namespace, false, publishMsgRate);
     }
 
     @Override
     public void setPublishRate(String namespace,
-                               boolean resetMode,
+                               boolean updateMode,
                                PublishRate publishMsgRate) throws PulsarAdminException {
-        sync(() -> setPublishRateAsync(namespace, resetMode, publishMsgRate));
+        sync(() -> setPublishRateAsync(namespace, updateMode, publishMsgRate));
     }
 
     @Override
@@ -1140,14 +1140,14 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public CompletableFuture<Void> setPublishRateAsync(String namespace, PublishRate publishRate) {
-        return setPublishRateAsync(namespace, true, publishRate);
+        return setPublishRateAsync(namespace, false, publishRate);
     }
 
     @Override
-    public CompletableFuture<Void> setPublishRateAsync(String namespace, boolean resetMode, PublishRate publishRate) {
+    public CompletableFuture<Void> setPublishRateAsync(String namespace, boolean updateMode, PublishRate publishRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "publishRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(publishRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1197,28 +1197,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        setDispatchRate(namespace, true, dispatchRate);
+        setDispatchRate(namespace, false, dispatchRate);
     }
 
     @Override
     public void setDispatchRate(String namespace,
-                                boolean resetMode,
+                                boolean updateMode,
                                 DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setDispatchRateAsync(namespace, resetMode, dispatchRate));
+        sync(() -> setDispatchRateAsync(namespace, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
-        return setDispatchRateAsync(namespace, true, dispatchRate);
+        return setDispatchRateAsync(namespace, false, dispatchRate);
     }
 
     @Override
     public CompletableFuture<Void> setDispatchRateAsync(String namespace,
-                                                        boolean resetMode,
+                                                        boolean updateMode,
                                                         DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "dispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1249,28 +1249,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setSubscribeRate(String namespace, SubscribeRate subscribeRate) throws PulsarAdminException {
-        setSubscribeRate(namespace, true, subscribeRate);
+        setSubscribeRate(namespace, false, subscribeRate);
     }
 
     @Override
     public void setSubscribeRate(String namespace,
-                                 boolean resetMode,
+                                 boolean updateMode,
                                  SubscribeRate subscribeRate) throws PulsarAdminException {
-        sync(() -> setSubscribeRateAsync(namespace, resetMode, subscribeRate));
+        sync(() -> setSubscribeRateAsync(namespace, updateMode, subscribeRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String namespace, SubscribeRate subscribeRate) {
-        return setSubscribeRateAsync(namespace, true, subscribeRate);
+        return setSubscribeRateAsync(namespace, false, subscribeRate);
     }
 
     @Override
     public CompletableFuture<Void> setSubscribeRateAsync(String namespace,
-                                                         boolean resetMode,
+                                                         boolean updateMode,
                                                          SubscribeRate subscribeRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscribeRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(subscribeRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1326,28 +1326,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setSubscriptionDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        setSubscriptionDispatchRate(namespace, true, dispatchRate);
+        setSubscriptionDispatchRate(namespace, false, dispatchRate);
     }
 
     @Override
     public void setSubscriptionDispatchRate(String namespace,
-                                            boolean resetMode,
+                                            boolean updateMode,
                                             DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setSubscriptionDispatchRateAsync(namespace, resetMode, dispatchRate));
+        sync(() -> setSubscriptionDispatchRateAsync(namespace, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
-        return setSubscriptionDispatchRateAsync(namespace, true, dispatchRate);
+        return setSubscriptionDispatchRateAsync(namespace, false, dispatchRate);
     }
 
     @Override
     public CompletableFuture<Void> setSubscriptionDispatchRateAsync(String namespace,
-                                                                    boolean resetMode,
+                                                                    boolean updateMode,
                                                                     DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "subscriptionDispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1378,28 +1378,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setReplicatorDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException {
-        setReplicatorDispatchRate(namespace, true, dispatchRate);
+        setReplicatorDispatchRate(namespace, false, dispatchRate);
     }
 
     @Override
     public void setReplicatorDispatchRate(String namespace,
-                                          boolean resetMode,
+                                          boolean updateMode,
                                           DispatchRate dispatchRate) throws PulsarAdminException {
-        sync(() -> setReplicatorDispatchRateAsync(namespace, resetMode, dispatchRate));
+        sync(() -> setReplicatorDispatchRateAsync(namespace, updateMode, dispatchRate));
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
-        return setReplicatorDispatchRateAsync(namespace, true, dispatchRate);
+        return setReplicatorDispatchRateAsync(namespace, false, dispatchRate);
     }
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace,
-                                                                  boolean resetMode,
+                                                                  boolean updateMode,
                                                                   DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "replicatorDispatchRate");
-        path = path.queryParam("resetMode", resetMode);
+        path = path.queryParam("updateMode", updateMode);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -398,7 +398,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).deleteBookieAffinityGroup("myprop/clust/ns1");
 
         namespaces.run(split("set-replicator-dispatch-rate myprop/clust/ns1 -md 10 -bd 11 -dt 12"));
-        verify(mockNamespaces).setReplicatorDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
+        verify(mockNamespaces).setReplicatorDispatchRate("myprop/clust/ns1", false, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
@@ -678,7 +678,7 @@ public class PulsarAdminToolTest {
         namespaces = new CmdNamespaces(() -> admin);
 
         namespaces.run(split("set-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
+        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", false, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
@@ -691,7 +691,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removeDispatchRate("myprop/clust/ns1");
 
         namespaces.run(split("set-publish-rate myprop/clust/ns1 -m 10 -b 20"));
-        verify(mockNamespaces).setPublishRate("myprop/clust/ns1", true, new PublishRate(10, 20));
+        verify(mockNamespaces).setPublishRate("myprop/clust/ns1", false, new PublishRate(10, 20));
 
         namespaces.run(split("get-publish-rate myprop/clust/ns1"));
         verify(mockNamespaces).getPublishRate("myprop/clust/ns1");
@@ -700,7 +700,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removePublishRate("myprop/clust/ns1");
 
         namespaces.run(split("set-subscribe-rate myprop/clust/ns1 -sr 2 -st 60"));
-        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", true, new SubscribeRate(2, 60));
+        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", false, new SubscribeRate(2, 60));
 
         namespaces.run(split("get-subscribe-rate myprop/clust/ns1"));
         verify(mockNamespaces).getSubscribeRate("myprop/clust/ns1");
@@ -709,7 +709,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removeSubscribeRate("myprop/clust/ns1");
 
         namespaces.run(split("set-subscription-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
+        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", false, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -398,7 +398,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).deleteBookieAffinityGroup("myprop/clust/ns1");
 
         namespaces.run(split("set-replicator-dispatch-rate myprop/clust/ns1 -md 10 -bd 11 -dt 12"));
-        verify(mockNamespaces).setReplicatorDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        verify(mockNamespaces).setReplicatorDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(10)
                 .dispatchThrottlingRateInByte(11)
                 .ratePeriodInSecond(12)
@@ -678,7 +678,7 @@ public class PulsarAdminToolTest {
         namespaces = new CmdNamespaces(() -> admin);
 
         namespaces.run(split("set-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        verify(mockNamespaces).setDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)
@@ -691,7 +691,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removeDispatchRate("myprop/clust/ns1");
 
         namespaces.run(split("set-publish-rate myprop/clust/ns1 -m 10 -b 20"));
-        verify(mockNamespaces).setPublishRate("myprop/clust/ns1", new PublishRate(10, 20));
+        verify(mockNamespaces).setPublishRate("myprop/clust/ns1", true, new PublishRate(10, 20));
 
         namespaces.run(split("get-publish-rate myprop/clust/ns1"));
         verify(mockNamespaces).getPublishRate("myprop/clust/ns1");
@@ -700,7 +700,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removePublishRate("myprop/clust/ns1");
 
         namespaces.run(split("set-subscribe-rate myprop/clust/ns1 -sr 2 -st 60"));
-        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", new SubscribeRate(2, 60));
+        verify(mockNamespaces).setSubscribeRate("myprop/clust/ns1", true, new SubscribeRate(2, 60));
 
         namespaces.run(split("get-subscribe-rate myprop/clust/ns1"));
         verify(mockNamespaces).getSubscribeRate("myprop/clust/ns1");
@@ -709,7 +709,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).removeSubscribeRate("myprop/clust/ns1");
 
         namespaces.run(split("set-subscription-dispatch-rate myprop/clust/ns1 -md -1 -bd -1 -dt 2"));
-        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", DispatchRate.builder()
+        verify(mockNamespaces).setSubscriptionDispatchRate("myprop/clust/ns1", true, DispatchRate.builder()
                 .dispatchThrottlingRateInMsg(-1)
                 .dispatchThrottlingRateInByte(-1)
                 .ratePeriodInSecond(2)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -905,10 +905,14 @@ public class CmdNamespaces extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
+        @Parameter(names = { "--reset-mode", "-r" },
+            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setDispatchRate(namespace,
+            getAdmin().namespaces().setDispatchRate(namespace, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -956,10 +960,14 @@ public class CmdNamespaces extends CmdBase {
                 "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
+        @Parameter(names = { "--reset-mode", "-r" },
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setSubscribeRate(namespace,
+            getAdmin().namespaces().setSubscribeRate(namespace, resetMode,
                     new SubscribeRate(subscribeRate, subscribeRatePeriodSec));
         }
     }
@@ -1010,10 +1018,14 @@ public class CmdNamespaces extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
+        @Parameter(names = { "--reset-mode", "-r" },
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setSubscriptionDispatchRate(namespace,
+            getAdmin().namespaces().setSubscriptionDispatchRate(namespace, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -1061,10 +1073,14 @@ public class CmdNamespaces extends CmdBase {
             "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
+        @Parameter(names = { "--reset-mode", "-r" },
+            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
+        private boolean resetMode = true;
+
          @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setPublishRate(namespace,
+            getAdmin().namespaces().setPublishRate(namespace, resetMode,
                 new PublishRate(msgPublishRate, bytePublishRate));
         }
     }
@@ -1110,10 +1126,14 @@ public class CmdNamespaces extends CmdBase {
             "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
+        @Parameter(names = { "--reset-mode", "-r" },
+                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
+        private boolean resetMode = true;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setReplicatorDispatchRate(namespace,
+            getAdmin().namespaces().setReplicatorDispatchRate(namespace, resetMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -905,14 +905,15 @@ public class CmdNamespaces extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
-        @Parameter(names = { "--reset-mode", "-r" },
-            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update dispatch rate. If it is true then merging the previous and current rate "
+                + "(only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setDispatchRate(namespace, resetMode,
+            getAdmin().namespaces().setDispatchRate(namespace, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -960,14 +961,15 @@ public class CmdNamespaces extends CmdBase {
                 "-st" }, description = "subscribe-rate-period in second type (default 30 second will be overwrite if not passed)", required = false)
         private int subscribeRatePeriodSec = 30;
 
-        @Parameter(names = { "--reset-mode", "-r" },
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update subscribe rate. If it is true then merging the previous and current rate "
+                + "(only for --subscribe-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setSubscribeRate(namespace, resetMode,
+            getAdmin().namespaces().setSubscribeRate(namespace, updateMode,
                     new SubscribeRate(subscribeRate, subscribeRatePeriodSec));
         }
     }
@@ -1018,14 +1020,15 @@ public class CmdNamespaces extends CmdBase {
                 "-rp" }, description = "dispatch rate relative to publish-rate (if publish-relative flag is enabled then broker will apply throttling value to (publish-rate + dispatch rate))", required = false)
         private boolean relativeToPublishRate = false;
 
-        @Parameter(names = { "--reset-mode", "-r" },
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update subscription dispatch rate. If it is true then merging the previous and "
+                + "current rate (only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setSubscriptionDispatchRate(namespace, resetMode,
+            getAdmin().namespaces().setSubscriptionDispatchRate(namespace, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -1073,14 +1076,14 @@ public class CmdNamespaces extends CmdBase {
             "-b" }, description = "byte-publish-rate (default -1 will be overwrite if not passed)", required = false)
         private long bytePublishRate = -1;
 
-        @Parameter(names = { "--reset-mode", "-r" },
-            description = "clear the previous rate and reset (default true). if false, merge the two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update publish rate. If it is true then merging the previous and current rate")
+        private boolean updateMode;
 
          @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setPublishRate(namespace, resetMode,
+            getAdmin().namespaces().setPublishRate(namespace, updateMode,
                 new PublishRate(msgPublishRate, bytePublishRate));
         }
     }
@@ -1126,14 +1129,15 @@ public class CmdNamespaces extends CmdBase {
             "-dt" }, description = "dispatch-rate-period in second type (default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
-        @Parameter(names = { "--reset-mode", "-r" },
-                description = "clear the previous rate and reset (default true). if false, merge two rate", arity = 1)
-        private boolean resetMode = true;
+        @Parameter(names = {"--update-mode",
+                "-um"}, description = "update replicator dispatch rate. If it is true then merging the previous and "
+                + "current rate (only for --msg-dispatch-rate and --byte-dispatch-rate)")
+        private boolean updateMode;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setReplicatorDispatchRate(namespace, resetMode,
+            getAdmin().namespaces().setReplicatorDispatchRate(namespace, updateMode,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)


### PR DESCRIPTION
### Motivation
This PR is similar to [12242](https://github.com/apache/pulsar/pull/12242) and mainly adds `--update-mode` option for rate-related commands, including:
- [set-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-dispatch-rate-em-)
- [set-subscription-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-subscription-dispatch-rate-em-)
- [set-replicator-dispatch-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-replicator-dispatch-rate-em-)
- [set-publish-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-publish-rate-em-)
- [set-subscribe-rate](https://pulsar.apache.org/tools/pulsar-admin/2.9.0-SNAPSHOT/#-em-set-subscribe-rate-em-)

### Documentation  
Automatically generate doc through code
- [x] `doc`
