### PR TITLE
[Java Client] Use failPendingMessages to ensure proper cleanup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerCloseTest.java
@@ -85,9 +85,9 @@ public class ProducerCloseTest extends ProducerConsumerBase {
                 .batchingMaxBytes(Integer.MAX_VALUE)
                 .enableBatching(true)
                 .create();
-        final TypedMessageBuilder<byte[]> messageBuilder = producer.newMessage();
-        final TypedMessageBuilder<byte[]> value = messageBuilder.value("test-msg".getBytes(StandardCharsets.UTF_8));
-        final CompletableFuture<MessageId> completableFuture = value.sendAsync();
+        CompletableFuture<MessageId> completableFuture = producer.newMessage()
+            .value("test-msg".getBytes(StandardCharsets.UTF_8))
+            .sendAsync();
         // By setting the state to Failed, the close method will exit early because the previous state was not Ready.
         producer.setState(HandlerState.State.Failed);
         producer.closeAsync();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerCloseTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 @Test(groups = "broker-impl")
@@ -71,6 +72,31 @@ public class ProducerCloseTest extends ProducerConsumerBase {
         producer.getClientCnx().handleSuccess(commandSuccess);
         Thread.sleep(3000);
         Assert.assertEquals(completableFuture.isDone(), true);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testProducerCloseFailsPendingBatchWhenPreviousStateNotReadyCallback() throws Exception {
+        initClient();
+        @Cleanup
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
+                .topic("testProducerClose")
+                .maxPendingMessages(10)
+                .batchingMaxPublishDelay(10, TimeUnit.SECONDS)
+                .batchingMaxBytes(Integer.MAX_VALUE)
+                .enableBatching(true)
+                .create();
+        final TypedMessageBuilder<byte[]> messageBuilder = producer.newMessage();
+        final TypedMessageBuilder<byte[]> value = messageBuilder.value("test-msg".getBytes(StandardCharsets.UTF_8));
+        final CompletableFuture<MessageId> completableFuture = value.sendAsync();
+        // By setting the state to Failed, the close method will exit early because the previous state was not Ready.
+        producer.setState(HandlerState.State.Failed);
+        producer.closeAsync();
+        Assert.assertTrue(completableFuture.isCompletedExceptionally());
+        try {
+            completableFuture.get();
+        } catch (ExecutionException e) {
+            Assert.assertTrue(e.getCause() instanceof PulsarClientException.AlreadyClosedException);
+        }
     }
 
     private void initClient() throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -875,11 +875,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         ClientCnx cnx = cnx();
         if (cnx == null || currentState != State.Ready) {
             log.info("[{}] [{}] Closed Producer (not connected)", topic, producerName);
-            synchronized (this) {
-                setState(State.Closed);
-                client.cleanupProducer(this);
-                clearPendingMessagesWhenClose();
-            }
+            client.cleanupProducer(this);
+            clearPendingMessagesWhenClose();
 
             return CompletableFuture.completedFuture(null);
         }
@@ -893,11 +890,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (exception == null || !cnx.ctx().channel().isActive()) {
                 // Either we've received the success response for the close producer command from the broker, or the
                 // connection did break in the meantime. In any case, the producer is gone.
-                synchronized (ProducerImpl.this) {
-                    log.info("[{}] [{}] Closed Producer", topic, producerName);
-                    setState(State.Closed);
-                    clearPendingMessagesWhenClose();
-                }
+                log.info("[{}] [{}] Closed Producer", topic, producerName);
+                clearPendingMessagesWhenClose();
 
                 closeFuture.complete(null);
                 client.cleanupProducer(this);
@@ -912,16 +906,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     private void clearPendingMessagesWhenClose() {
-        PulsarClientException ex = new PulsarClientException.AlreadyClosedException(
-                format("The producer %s of the topic %s was already closed when closing the producers",
-                        producerName, topic));
-        pendingMessages.forEach(msg -> {
-            client.getMemoryLimitController().releaseMemory(msg.uncompressedSize);
-            msg.sendComplete(ex);
-            msg.cmd.release();
-            msg.recycle();
-        });
-        pendingMessages.clear();
+        setState(State.Closed);
+        synchronized (this) {
+            PulsarClientException ex = new PulsarClientException.AlreadyClosedException(
+                    format("The producer %s of the topic %s was already closed when closing the producers",
+                            producerName, topic));
+            // Use null for cnx to ensure that the pending messages are failed immediately
+            failPendingMessages(null, ex);
+        }
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -876,7 +876,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         if (cnx == null || currentState != State.Ready) {
             log.info("[{}] [{}] Closed Producer (not connected)", topic, producerName);
             client.cleanupProducer(this);
-            clearPendingMessagesWhenClose();
+            closeAndClearPendingMessages();
 
             return CompletableFuture.completedFuture(null);
         }
@@ -891,7 +891,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 // Either we've received the success response for the close producer command from the broker, or the
                 // connection did break in the meantime. In any case, the producer is gone.
                 log.info("[{}] [{}] Closed Producer", topic, producerName);
-                clearPendingMessagesWhenClose();
+                closeAndClearPendingMessages();
 
                 closeFuture.complete(null);
                 client.cleanupProducer(this);
@@ -905,7 +905,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return closeFuture;
     }
 
-    private void clearPendingMessagesWhenClose() {
+    private void closeAndClearPendingMessages() {
         setState(State.Closed);
         synchronized (this) {
             PulsarClientException ex = new PulsarClientException.AlreadyClosedException(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -901,16 +901,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return closeFuture;
     }
 
-    private void closeAndClearPendingMessages() {
-        synchronized (this) {
-            setState(State.Closed);
-            client.cleanupProducer(this);
-            PulsarClientException ex = new PulsarClientException.AlreadyClosedException(
-                    format("The producer %s of the topic %s was already closed when closing the producers",
-                            producerName, topic));
-            // Use null for cnx to ensure that the pending messages are failed immediately
-            failPendingMessages(null, ex);
-        }
+    private synchronized void closeAndClearPendingMessages() {
+        setState(State.Closed);
+        client.cleanupProducer(this);
+        PulsarClientException ex = new PulsarClientException.AlreadyClosedException(
+                format("The producer %s of the topic %s was already closed when closing the producers",
+                        producerName, topic));
+        // Use null for cnx to ensure that the pending messages are failed immediately
+        failPendingMessages(null, ex);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -902,9 +902,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     private void closeAndClearPendingMessages() {
-        client.cleanupProducer(this);
         synchronized (this) {
             setState(State.Closed);
+            client.cleanupProducer(this);
             PulsarClientException ex = new PulsarClientException.AlreadyClosedException(
                     format("The producer %s of the topic %s was already closed when closing the producers",
                             producerName, topic));


### PR DESCRIPTION
### Motivation

When calling `ProducerImpl#closeAsync`, the current cleanup relies on `clearPendingMessagesWhenClose`. This method does not fail any remaining messages in the `batchMessageContainer`. After inspecting the `failPendingMessages` method, it looks like it would be better to call this within the `clearPendingMessagesWhenClose` method. It also has more robust handling of failing the messages contained in the `pendingMessages` queue.

### Modifications

* Update the implementation of `clearPendingMessagesWhenClose` to rely on `failPendingMessages`.
* ~Move already thread safe method calls, like `setState` outside of the `synchronized` block~

### Verifying this change

I added a test that will pass regardless of the outcome of the current mailing list thread discussing whether "close implies flush". There is also already a test that ensures that any outstanding pending messages are failed. Together, these tests ensure correct behavior.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation

There is no need to update the docs for this change.