### PR TITLE
[pulsar-admin] New option takes precedence over deprecated option

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -325,22 +325,52 @@ public class CmdFunctions extends CmdBase {
         protected String userCodeFile;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_className)) className = DEPRECATED_className;
-            if (!StringUtils.isBlank(DEPRECATED_topicsPattern)) topicsPattern = DEPRECATED_topicsPattern;
-            if (!StringUtils.isBlank(DEPRECATED_logTopic)) logTopic = DEPRECATED_logTopic;
-            if (!StringUtils.isBlank(DEPRECATED_outputSerdeClassName)) outputSerdeClassName = DEPRECATED_outputSerdeClassName;
-            if (!StringUtils.isBlank(DEPRECATED_customSerdeInputString)) customSerdeInputString = DEPRECATED_customSerdeInputString;
+            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
+                className = DEPRECATED_className;
+            }
+            if (isBlank(topicsPattern) && !isBlank(DEPRECATED_topicsPattern)) {
+                topicsPattern = DEPRECATED_topicsPattern;
+            }
+            if (isBlank(logTopic) && !isBlank(DEPRECATED_logTopic)) {
+                logTopic = DEPRECATED_logTopic;
+            }
+            if (isBlank(outputSerdeClassName) && !isBlank(DEPRECATED_outputSerdeClassName)) {
+                outputSerdeClassName = DEPRECATED_outputSerdeClassName;
+            }
+            if (isBlank(customSerdeInputString) && !isBlank(DEPRECATED_customSerdeInputString)) {
+                customSerdeInputString = DEPRECATED_customSerdeInputString;
+            }
 
-            if (!StringUtils.isBlank(DEPRECATED_fnConfigFile)) fnConfigFile = DEPRECATED_fnConfigFile;
-            if (DEPRECATED_processingGuarantees != null) processingGuarantees = DEPRECATED_processingGuarantees;
-            if (!StringUtils.isBlank(DEPRECATED_userConfigString)) userConfigString = DEPRECATED_userConfigString;
-            if (DEPRECATED_retainOrdering != null) retainOrdering = DEPRECATED_retainOrdering;
-            if (DEPRECATED_windowLengthCount != null) windowLengthCount = DEPRECATED_windowLengthCount;
-            if (DEPRECATED_windowLengthDurationMs != null) windowLengthDurationMs = DEPRECATED_windowLengthDurationMs;
-            if (DEPRECATED_slidingIntervalCount != null) slidingIntervalCount = DEPRECATED_slidingIntervalCount;
-            if (DEPRECATED_slidingIntervalDurationMs != null) slidingIntervalDurationMs = DEPRECATED_slidingIntervalDurationMs;
-            if (DEPRECATED_autoAck != null) autoAck = DEPRECATED_autoAck;
-            if (DEPRECATED_timeoutMs != null) timeoutMs = DEPRECATED_timeoutMs;
+            if (isBlank(fnConfigFile) && !isBlank(DEPRECATED_fnConfigFile)) {
+                fnConfigFile = DEPRECATED_fnConfigFile;
+            }
+            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
+                processingGuarantees = DEPRECATED_processingGuarantees;
+            }
+            if (isBlank(userConfigString) && !isBlank(DEPRECATED_userConfigString)) {
+                userConfigString = DEPRECATED_userConfigString;
+            }
+            if (retainOrdering == null && DEPRECATED_retainOrdering != null) {
+                retainOrdering = DEPRECATED_retainOrdering;
+            }
+            if (windowLengthCount == null && DEPRECATED_windowLengthCount != null) {
+                windowLengthCount = DEPRECATED_windowLengthCount;
+            }
+            if (windowLengthDurationMs == null && DEPRECATED_windowLengthDurationMs != null) {
+                windowLengthDurationMs = DEPRECATED_windowLengthDurationMs;
+            }
+            if (slidingIntervalCount == null && DEPRECATED_slidingIntervalCount != null) {
+                slidingIntervalCount = DEPRECATED_slidingIntervalCount;
+            }
+            if (slidingIntervalDurationMs == null && DEPRECATED_slidingIntervalDurationMs != null) {
+                slidingIntervalDurationMs = DEPRECATED_slidingIntervalDurationMs;
+            }
+            if (autoAck == null && DEPRECATED_autoAck != null) {
+                autoAck = DEPRECATED_autoAck;
+            }
+            if (timeoutMs == null && DEPRECATED_timeoutMs != null) {
+                timeoutMs = DEPRECATED_timeoutMs;
+            }
         }
 
         @Override
@@ -657,15 +687,33 @@ public class CmdFunctions extends CmdBase {
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_stateStorageServiceUrl)) stateStorageServiceUrl = DEPRECATED_stateStorageServiceUrl;
-            if (!StringUtils.isBlank(DEPRECATED_brokerServiceUrl)) brokerServiceUrl = DEPRECATED_brokerServiceUrl;
-            if (!StringUtils.isBlank(DEPRECATED_clientAuthPlugin)) clientAuthPlugin = DEPRECATED_clientAuthPlugin;
-            if (!StringUtils.isBlank(DEPRECATED_clientAuthParams)) clientAuthParams = DEPRECATED_clientAuthParams;
-            if (DEPRECATED_useTls != null) useTls = DEPRECATED_useTls;
-            if (DEPRECATED_tlsAllowInsecureConnection != null) tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
-            if (DEPRECATED_tlsHostNameVerificationEnabled != null) tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
-            if (!StringUtils.isBlank(DEPRECATED_tlsTrustCertFilePath)) tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
-            if (DEPRECATED_instanceIdOffset != null) instanceIdOffset = DEPRECATED_instanceIdOffset;
+            if (isBlank(stateStorageServiceUrl) && !isBlank(DEPRECATED_stateStorageServiceUrl)) {
+                stateStorageServiceUrl = DEPRECATED_stateStorageServiceUrl;
+            }
+            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
+                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            }
+            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
+                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            }
+            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
+                clientAuthParams = DEPRECATED_clientAuthParams;
+            }
+            if (useTls == false && DEPRECATED_useTls != null) {
+                useTls = DEPRECATED_useTls;
+            }
+            if (tlsAllowInsecureConnection == false && DEPRECATED_tlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            }
+            if (tlsHostNameVerificationEnabled == false && DEPRECATED_tlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            }
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            }
+            if (instanceIdOffset == null && DEPRECATED_instanceIdOffset != null) {
+                instanceIdOffset = DEPRECATED_instanceIdOffset;
+            }
         }
 
         @Override
@@ -935,8 +983,12 @@ public class CmdFunctions extends CmdBase {
         protected String topic;
 
         public void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_triggerValue)) triggerValue = DEPRECATED_triggerValue;
-            if (!StringUtils.isBlank(DEPRECATED_triggerFile)) triggerFile = DEPRECATED_triggerFile;
+            if (isBlank(triggerValue) && !isBlank(DEPRECATED_triggerValue)) {
+                triggerValue = DEPRECATED_triggerValue;
+            }
+            if (isBlank(triggerFile) && !isBlank(DEPRECATED_triggerFile)) {
+                triggerFile = DEPRECATED_triggerFile;
+            }
         }
 
         @Override
@@ -971,7 +1023,9 @@ public class CmdFunctions extends CmdBase {
         protected String path;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_sourceFile)) sourceFile = DEPRECATED_sourceFile;
+            if (isBlank(sourceFile) && !isBlank(DEPRECATED_sourceFile)) {
+                sourceFile = DEPRECATED_sourceFile;
+            }
         }
 
         @Override
@@ -1006,7 +1060,9 @@ public class CmdFunctions extends CmdBase {
         protected String path;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_destinationFile)) destinationFile = DEPRECATED_destinationFile;
+            if (isBlank(destinationFile) && !isBlank(DEPRECATED_destinationFile)) {
+                destinationFile = DEPRECATED_destinationFile;
+            }
         }
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -182,13 +182,27 @@ public class CmdSinks extends CmdBase {
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_brokerServiceUrl)) brokerServiceUrl = DEPRECATED_brokerServiceUrl;
-            if (!StringUtils.isBlank(DEPRECATED_clientAuthPlugin)) clientAuthPlugin = DEPRECATED_clientAuthPlugin;
-            if (!StringUtils.isBlank(DEPRECATED_clientAuthParams)) clientAuthParams = DEPRECATED_clientAuthParams;
-            if (DEPRECATED_useTls != null) useTls = DEPRECATED_useTls;
-            if (DEPRECATED_tlsAllowInsecureConnection != null) tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
-            if (DEPRECATED_tlsHostNameVerificationEnabled != null) tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
-            if (!StringUtils.isBlank(DEPRECATED_tlsTrustCertFilePath)) tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
+                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            }
+            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
+                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            }
+            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
+                clientAuthParams = DEPRECATED_clientAuthParams;
+            }
+            if (useTls == false && DEPRECATED_useTls != null) {
+                useTls = DEPRECATED_useTls;
+            }
+            if (tlsAllowInsecureConnection == false && DEPRECATED_tlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            }
+            if (tlsHostNameVerificationEnabled == false && DEPRECATED_tlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            }
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            }
         }
 
         @Override
@@ -349,14 +363,30 @@ public class CmdSinks extends CmdBase {
         protected SinkConfig sinkConfig;
 
         private void mergeArgs() {
-            if (!StringUtils.isBlank(DEPRECATED_subsName)) subsName = DEPRECATED_subsName;
-            if (!StringUtils.isBlank(DEPRECATED_topicsPattern)) topicsPattern = DEPRECATED_topicsPattern;
-            if (!StringUtils.isBlank(DEPRECATED_customSerdeInputString)) customSerdeInputString = DEPRECATED_customSerdeInputString;
-            if (DEPRECATED_processingGuarantees != null) processingGuarantees = DEPRECATED_processingGuarantees;
-            if (DEPRECATED_retainOrdering != null) retainOrdering = DEPRECATED_retainOrdering;
-            if (!StringUtils.isBlank(DEPRECATED_className)) className = DEPRECATED_className;
-            if (!StringUtils.isBlank(DEPRECATED_sinkConfigFile)) sinkConfigFile = DEPRECATED_sinkConfigFile;
-            if (!StringUtils.isBlank(DEPRECATED_sinkConfigString)) sinkConfigString = DEPRECATED_sinkConfigString;
+            if (isBlank(subsName) && !isBlank(DEPRECATED_subsName)) {
+                subsName = DEPRECATED_subsName;
+            }
+            if (isBlank(topicsPattern) && !isBlank(DEPRECATED_topicsPattern)) {
+                topicsPattern = DEPRECATED_topicsPattern;
+            }
+            if (isBlank(customSerdeInputString) && !isBlank(DEPRECATED_customSerdeInputString)) {
+                customSerdeInputString = DEPRECATED_customSerdeInputString;
+            }
+            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
+                processingGuarantees = DEPRECATED_processingGuarantees;
+            }
+            if (retainOrdering == null && DEPRECATED_retainOrdering != null) {
+                retainOrdering = DEPRECATED_retainOrdering;
+            }
+            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
+                className = DEPRECATED_className;
+            }
+            if (isBlank(sinkConfigFile) && !isBlank(DEPRECATED_sinkConfigFile)) {
+                sinkConfigFile = DEPRECATED_sinkConfigFile;
+            }
+            if (isBlank(sinkConfigString) && !isBlank(DEPRECATED_sinkConfigString)) {
+                sinkConfigString = DEPRECATED_sinkConfigString;
+            }
         }
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -181,13 +181,27 @@ public class CmdSources extends CmdBase {
         protected String metricsPortStart;
 
         private void mergeArgs() {
-            if (!isBlank(DEPRECATED_brokerServiceUrl)) brokerServiceUrl = DEPRECATED_brokerServiceUrl;
-            if (!isBlank(DEPRECATED_clientAuthPlugin)) clientAuthPlugin = DEPRECATED_clientAuthPlugin;
-            if (!isBlank(DEPRECATED_clientAuthParams)) clientAuthParams = DEPRECATED_clientAuthParams;
-            if (DEPRECATED_useTls != null) useTls = DEPRECATED_useTls;
-            if (DEPRECATED_tlsAllowInsecureConnection != null) tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
-            if (DEPRECATED_tlsHostNameVerificationEnabled != null) tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
-            if (!isBlank(DEPRECATED_tlsTrustCertFilePath)) tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            if (isBlank(brokerServiceUrl) && !isBlank(DEPRECATED_brokerServiceUrl)) {
+                brokerServiceUrl = DEPRECATED_brokerServiceUrl;
+            }
+            if (isBlank(clientAuthPlugin) && !isBlank(DEPRECATED_clientAuthPlugin)) {
+                clientAuthPlugin = DEPRECATED_clientAuthPlugin;
+            }
+            if (isBlank(clientAuthParams) && !isBlank(DEPRECATED_clientAuthParams)) {
+                clientAuthParams = DEPRECATED_clientAuthParams;
+            }
+            if (useTls == false && DEPRECATED_useTls != null) {
+                useTls = DEPRECATED_useTls;
+            }
+            if (tlsAllowInsecureConnection == false && DEPRECATED_tlsAllowInsecureConnection != null) {
+                tlsAllowInsecureConnection = DEPRECATED_tlsAllowInsecureConnection;
+            }
+            if (tlsHostNameVerificationEnabled == false && DEPRECATED_tlsHostNameVerificationEnabled != null) {
+                tlsHostNameVerificationEnabled = DEPRECATED_tlsHostNameVerificationEnabled;
+            }
+            if (isBlank(tlsTrustCertFilePath) && !isBlank(DEPRECATED_tlsTrustCertFilePath)) {
+                tlsTrustCertFilePath = DEPRECATED_tlsTrustCertFilePath;
+            }
         }
 
         @Override
@@ -329,12 +343,24 @@ public class CmdSources extends CmdBase {
         protected SourceConfig sourceConfig;
 
         private void mergeArgs() {
-            if (DEPRECATED_processingGuarantees != null) processingGuarantees = DEPRECATED_processingGuarantees;
-            if (!isBlank(DEPRECATED_destinationTopicName)) destinationTopicName = DEPRECATED_destinationTopicName;
-            if (!isBlank(DEPRECATED_deserializationClassName)) deserializationClassName = DEPRECATED_deserializationClassName;
-            if (!isBlank(DEPRECATED_className)) className = DEPRECATED_className;
-            if (!isBlank(DEPRECATED_sourceConfigFile)) sourceConfigFile = DEPRECATED_sourceConfigFile;
-            if (!isBlank(DEPRECATED_sourceConfigString)) sourceConfigString = DEPRECATED_sourceConfigString;
+            if (processingGuarantees == null && DEPRECATED_processingGuarantees != null) {
+                processingGuarantees = DEPRECATED_processingGuarantees;
+            }
+            if (isBlank(destinationTopicName) && !isBlank(DEPRECATED_destinationTopicName)) {
+                destinationTopicName = DEPRECATED_destinationTopicName;
+            }
+            if (isBlank(deserializationClassName) && !isBlank(DEPRECATED_deserializationClassName)) {
+                deserializationClassName = DEPRECATED_deserializationClassName;
+            }
+            if (isBlank(className) && !isBlank(DEPRECATED_className)) {
+                className = DEPRECATED_className;
+            }
+            if (isBlank(sourceConfigFile) && !isBlank(DEPRECATED_sourceConfigFile)) {
+                sourceConfigFile = DEPRECATED_sourceConfigFile;
+            }
+            if (isBlank(sourceConfigString) && !isBlank(DEPRECATED_sourceConfigString)) {
+                sourceConfigString = DEPRECATED_sourceConfigString;
+            }
         }
 
         @Override


### PR DESCRIPTION
### Motivation
Currently, we use new option to replace some deprecated option in `client-tools`. for example:
https://github.com/apache/pulsar/blob/9d309145f342bc416b8b4663125e1216903a3e83/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java#L141-L144

In order to maintain compatibility, the deprecated option still take effect through merging, as below:
https://github.com/apache/pulsar/blob/9d309145f342bc416b8b4663125e1216903a3e83/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java#L183-L191
But I found that its priority is higher than the new option, which causes the new option to be invalid when we set both at the same time.

### Modifications
Adjust the priority of the new and deprecated option, the deprecated option only takes effect when the new option is not set.

### Documentation
Need to update docs? 
- doc-required
