### PR TITLE
review details self

### DIFF
--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManagedLedgerOffloaderBase {
+public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManagedLedgerOffloaderTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(BlobStoreManagedLedgerOffloaderStreamingTest.class);
     private TieredStorageConfiguration mockedConfig;

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -51,7 +51,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
-public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerOffloaderBase {
+public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerOffloaderTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(BlobStoreManagedLedgerOffloaderTest.class);
     private TieredStorageConfiguration mockedConfig;

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTestBase.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTestBase.java
@@ -42,7 +42,7 @@ import org.jclouds.blobstore.BlobStore;
 import org.jclouds.domain.Credentials;
 import org.testng.Assert;
 
-public abstract class BlobStoreManagedLedgerOffloaderBase {
+public abstract class BlobStoreManagedLedgerOffloaderTestBase {
 
     public static final String BUCKET = "pulsar-unittest";
     protected static final int DEFAULT_BLOCK_SIZE = 5*1024*1024;
@@ -54,7 +54,7 @@ public abstract class BlobStoreManagedLedgerOffloaderBase {
     protected TieredStorageConfiguration config;
     protected BlobStore blobStore = null;
 
-    protected BlobStoreManagedLedgerOffloaderBase() throws Exception {
+    protected BlobStoreManagedLedgerOffloaderTestBase() throws Exception {
         scheduler = OrderedScheduler.newSchedulerBuilder().numThreads(5).name("offloader").build();
         bk = new PulsarMockBookKeeper(scheduler);
         provider = getBlobStoreProvider();


### PR DESCRIPTION
### Motivation
BlobStoreManagedLedgerOffloaderBase.class is the base class used to test BlobStoreManagedLedgerOffloader, but this name is easy to mistakenly think that this is not a test-related class.
### Modifications 

Change the class name from BlobStoreManagedLedgerOffloaderBase to BlobStoreManagedLedgerOffloaderTestBase.

### Verifying this change
- Name change, No need to add tests. 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Need to update docs? 

- [x] no-need-doc 
  Here is just changing the naming of a class
  


