### PR TITLE
[Modernizer]Add Maven Modernizer plugin in pulsar-common module and fix violation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@ flexible messaging model and an intuitive client API.</description>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-modernizer-plugin.version>2.3.0</maven-modernizer-plugin.version>
-    <maven-shade-plugin>2.3.0</maven-shade-plugin>
+    <maven-shade-plugin>3.2.4</maven-shade-plugin>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,8 @@ flexible messaging model and an intuitive client API.</description>
     <surefire.version>3.0.0-M3</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-    <maven-modernizer-plugin.version>3.1.2</maven-modernizer-plugin.version>
-    <maven-shade-plugin>3.2.4</maven-shade-plugin>
+    <maven-modernizer-plugin.version>2.3.0</maven-modernizer-plugin.version>
+    <maven-shade-plugin>2.3.0</maven-shade-plugin>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     <nifi-nar-maven-plugin.version>1.2.0</nifi-nar-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,7 @@ flexible messaging model and an intuitive client API.</description>
     <surefire.version>3.0.0-M3</surefire.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+    <maven-modernizer-plugin.version>3.1.2</maven-modernizer-plugin.version>
     <maven-shade-plugin>3.2.4</maven-shade-plugin>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
@@ -1660,6 +1661,11 @@ flexible messaging model and an intuitive client API.</description>
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.gaul</groupId>
+          <artifactId>modernizer-maven-plugin</artifactId>
+          <version>${maven-modernizer-plugin.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -196,6 +196,24 @@
 
   <build>
   <plugins>
+    <plugin>
+      <groupId>org.gaul</groupId>
+      <artifactId>modernizer-maven-plugin</artifactId>
+      <version>2.3.0</version>
+      <configuration>
+        <failOnViolations>true</failOnViolations>
+        <javaVersion>8</javaVersion>
+      </configuration>
+      <executions>
+        <execution>
+          <id>modernizer</id>
+          <goals>
+            <goal>modernizer</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+
 	<plugin>
 		<groupId>com.github.splunk.lightproto</groupId>
 		<artifactId>lightproto-maven-plugin</artifactId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -199,7 +199,6 @@
     <plugin>
       <groupId>org.gaul</groupId>
       <artifactId>modernizer-maven-plugin</artifactId>
-      <version>2.3.0</version>
       <configuration>
         <failOnViolations>true</failOnViolations>
         <javaVersion>8</javaVersion>

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfo.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.client.impl.schema;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -134,7 +134,7 @@ public final class KeyValueSchemaInfo {
                                                       SchemaInfo keySchemaInfo,
                                                       SchemaInfo valueSchemaInfo,
                                                       KeyValueEncodingType keyValueEncodingType) {
-        checkNotNull(keyValueEncodingType, "Null encoding type is provided");
+        requireNonNull(keyValueEncodingType, "Null encoding type is provided");
 
         if (keySchemaInfo == null || valueSchemaInfo == null) {
             // schema is not ready

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pulsar.common.naming;
 
-import com.google.common.base.Objects;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -167,7 +168,7 @@ public class NamespaceName implements ServiceUnitId {
     public boolean equals(Object obj) {
         if (obj instanceof NamespaceName) {
             NamespaceName other = (NamespaceName) obj;
-            return Objects.equal(namespace, other.namespace);
+            return Objects.equals(namespace, other.namespace);
         }
 
         return false;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pulsar.common.naming;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
@@ -361,7 +361,7 @@ public class TopicName implements ServiceUnitId {
     public boolean equals(Object obj) {
         if (obj instanceof TopicName) {
             TopicName other = (TopicName) obj;
-            return Objects.equal(completeTopicName, other.completeTopicName);
+            return Objects.equals(completeTopicName, other.completeTopicName);
         }
 
         return false;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/net/ServiceURI.java
@@ -20,7 +20,8 @@ package org.apache.pulsar.common.net;
 
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -62,11 +63,11 @@ public class ServiceURI {
      *
      * @param uriStr service uri string
      * @return a service uri instance
-     * @throws NullPointerException if {@code uriStr} is null
+     * @throws NullPointerExceptionFieldParser if {@code uriStr} is null
      * @throws IllegalArgumentException if the given string violates RFC&nbsp;2396
      */
     public static ServiceURI create(String uriStr) {
-        checkNotNull(uriStr, "service uri string is null");
+        requireNonNull(uriStr, "service uri string is null");
 
         if (uriStr.contains("[") && uriStr.contains("]")) {
             // deal with ipv6 address
@@ -116,7 +117,7 @@ public class ServiceURI {
      * @throws IllegalArgumentException if the given string violates RFC&nbsp;2396
      */
     public static ServiceURI create(URI uri) {
-        checkNotNull(uri, "service uri instance is null");
+        requireNonNull(uri, "service uri instance is null");
 
         String serviceName;
         final String[] serviceInfos;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfig.java
@@ -19,12 +19,12 @@
 package org.apache.pulsar.common.policies.data;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Objects;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 public class EnsemblePlacementPolicyConfig {
     public static final String ENSEMBLE_PLACEMENT_POLICY_CONFIG = "EnsemblePlacementPolicyConfig";
@@ -53,16 +53,16 @@ public class EnsemblePlacementPolicyConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(policyClass != null ? policyClass.getName() : "", properties);
+        return Objects.hash(policyClass != null ? policyClass.getName() : "", properties);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof EnsemblePlacementPolicyConfig) {
             EnsemblePlacementPolicyConfig other = (EnsemblePlacementPolicyConfig) obj;
-            return Objects.equal(this.policyClass == null ? null : this.policyClass.getName(),
+            return Objects.equals(this.policyClass == null ? null : this.policyClass.getName(),
                 other.policyClass == null ? null : other.policyClass.getName())
-                && Objects.equal(this.properties, other.properties);
+                && Objects.equals(this.properties, other.properties);
         }
         return false;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistentOfflineTopicStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistentOfflineTopicStats.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,8 +55,8 @@ public class PersistentOfflineTopicStats {
     public PersistentOfflineTopicStats(String topicName, String brokerName) {
         this.brokerName = brokerName;
         this.topicName = topicName;
-        this.dataLedgerDetails = Lists.newArrayList();
-        this.cursorDetails = Maps.newHashMap();
+        this.dataLedgerDetails = new ArrayList<>();
+        this.cursorDetails = new HashMap<>();
         this.statGeneratedAt = new Date(System.currentTimeMillis());
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import com.google.common.collect.Maps;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -46,7 +45,7 @@ import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 public class TopicPolicies {
 
     @Builder.Default
-    private Map<String, BacklogQuotaImpl> backLogQuotaMap = Maps.newHashMap();
+    private Map<String, BacklogQuotaImpl> backLogQuotaMap = new HashMap<>();
     @Builder.Default
     private List<SubType> subscriptionTypesEnabled = new ArrayList<>();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/impl/NamespaceIsolationPolicyImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/impl/NamespaceIsolationPolicyImpl.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.common.policies.impl;
 
-import com.google.common.base.Objects;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -29,7 +29,6 @@ import org.apache.pulsar.common.policies.AutoFailoverPolicy;
 import org.apache.pulsar.common.policies.NamespaceIsolationPolicy;
 import org.apache.pulsar.common.policies.data.BrokerStatus;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
-import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 
 /**
  * Implementation of the namespace isolation policy.
@@ -122,7 +121,7 @@ public class NamespaceIsolationPolicyImpl implements NamespaceIsolationPolicy {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(namespaces, primary, secondary,
+        return Objects.hash(namespaces, primary, secondary,
             autoFailoverPolicy);
     }
 
@@ -130,9 +129,9 @@ public class NamespaceIsolationPolicyImpl implements NamespaceIsolationPolicy {
     public boolean equals(Object obj) {
         if (obj instanceof NamespaceIsolationPolicyImpl) {
             NamespaceIsolationPolicyImpl other = (NamespaceIsolationPolicyImpl) obj;
-            return Objects.equal(this.namespaces, other.namespaces) && Objects.equal(this.primary, other.primary)
-                    && Objects.equal(this.secondary, other.secondary)
-                    && Objects.equal(this.autoFailoverPolicy, other.autoFailoverPolicy);
+            return Objects.equals(this.namespaces, other.namespaces) && Objects.equals(this.primary, other.primary)
+                    && Objects.equals(this.secondary, other.secondary)
+                    && Objects.equals(this.autoFailoverPolicy, other.autoFailoverPolicy);
         }
 
         return false;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmDefaultGCMetricsLogger.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pulsar.common.stats;
 
-import com.google.common.collect.Maps;
-
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +43,7 @@ public class JvmDefaultGCMetricsLogger implements JvmGCMetricsLogger {
     private static Method getTotalSafepointTimeHandle;
     private static Method getSafepointCountHandle;
 
-    private Map<String, GCMetrics> gcMetricsMap = Maps.newHashMap();
+    private Map<String, GCMetrics> gcMetricsMap = new HashMap<>();
 
     static {
         try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -19,19 +19,20 @@
 package org.apache.pulsar.common.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.util.EnumResolver;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -83,7 +84,7 @@ public final class FieldParser {
     @SuppressWarnings("unchecked")
     public static <T> T convert(Object from, Class<T> to) {
 
-        checkNotNull(to);
+        requireNonNull(to);
         if (from == null) {
             return null;
         }
@@ -163,7 +164,7 @@ public final class FieldParser {
      * @return
      */
     public static Object value(String strValue, Field field) {
-        checkNotNull(field);
+        requireNonNull(field);
         // if field is not primitive type
         Type fieldType = field.getGenericType();
         if (fieldType instanceof ParameterizedType) {
@@ -205,14 +206,14 @@ public final class FieldParser {
      */
     public static <T> void setEmptyValue(String strValue, Field field, T obj)
             throws IllegalArgumentException, IllegalAccessException {
-        checkNotNull(field);
+        requireNonNull(field);
         // if field is not primitive type
         Type fieldType = field.getGenericType();
         if (fieldType instanceof ParameterizedType) {
             if (field.getType().equals(List.class)) {
-                field.set(obj, Lists.newArrayList());
+                field.set(obj, new ArrayList<>());
             } else if (field.getType().equals(Set.class)) {
-                field.set(obj, Sets.newHashSet());
+                field.set(obj, new HashSet<>());
             } else if (field.getType().equals(Optional.class)) {
                 field.set(obj, Optional.empty());
             } else {
@@ -349,7 +350,7 @@ public final class FieldParser {
     }
 
     private static String trim(String val) {
-        checkNotNull(val);
+        requireNonNull(val);
         return val.trim();
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -19,7 +19,8 @@
 package org.apache.pulsar.common.util.collections;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
@@ -118,19 +119,19 @@ public class ConcurrentLongHashMap<V> {
     }
 
     public V put(long key, V value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).put(key, value, (int) h, false, null);
     }
 
     public V putIfAbsent(long key, V value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).put(key, value, (int) h, true, null);
     }
 
     public V computeIfAbsent(long key, LongFunction<V> provider) {
-        checkNotNull(provider);
+        requireNonNull(provider);
         long h = hash(key);
         return getSection(h).put(key, null, (int) h, true, provider);
     }
@@ -141,7 +142,7 @@ public class ConcurrentLongHashMap<V> {
     }
 
     public boolean remove(long key, Object value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).remove(key, value, (int) h) != null;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -19,7 +19,8 @@
 package org.apache.pulsar.common.util.collections;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -99,7 +100,7 @@ public class ConcurrentOpenHashMap<K, V> {
     }
 
     public V get(K key) {
-        checkNotNull(key);
+        requireNonNull(key);
         long h = hash(key);
         return getSection(h).get(key, (int) h);
     }
@@ -109,35 +110,35 @@ public class ConcurrentOpenHashMap<K, V> {
     }
 
     public V put(K key, V value) {
-        checkNotNull(key);
-        checkNotNull(value);
+        requireNonNull(key);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).put(key, value, (int) h, false, null);
     }
 
     public V putIfAbsent(K key, V value) {
-        checkNotNull(key);
-        checkNotNull(value);
+        requireNonNull(key);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).put(key, value, (int) h, true, null);
     }
 
     public V computeIfAbsent(K key, Function<K, V> provider) {
-        checkNotNull(key);
-        checkNotNull(provider);
+        requireNonNull(key);
+        requireNonNull(provider);
         long h = hash(key);
         return getSection(h).put(key, null, (int) h, true, provider);
     }
 
     public V remove(K key) {
-        checkNotNull(key);
+        requireNonNull(key);
         long h = hash(key);
         return getSection(h).remove(key, null, (int) h);
     }
 
     public boolean remove(K key, Object value) {
-        checkNotNull(key);
-        checkNotNull(value);
+        requireNonNull(key);
+        requireNonNull(value);
         long h = hash(key);
         return getSection(h).remove(key, value, (int) h) != null;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -19,8 +19,9 @@
 package org.apache.pulsar.common.util.collections;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import com.google.common.collect.Lists;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,19 +101,19 @@ public class ConcurrentOpenHashSet<V> {
     }
 
     public boolean contains(V value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(value);
         return getSection(h).contains(value, (int) h);
     }
 
     public boolean add(V value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(value);
         return getSection(h).add(value, (int) h);
     }
 
     public boolean remove(V value) {
-        checkNotNull(value);
+        requireNonNull(value);
         long h = hash(value);
         return getSection(h).remove(value, (int) h);
     }
@@ -136,7 +137,7 @@ public class ConcurrentOpenHashSet<V> {
     }
 
     public int removeIf(Predicate<V> filter) {
-        checkNotNull(filter);
+        requireNonNull(filter);
 
         int removedCount = 0;
         for (int i = 0; i < sections.length; i++) {
@@ -150,7 +151,7 @@ public class ConcurrentOpenHashSet<V> {
      * @return a new list of all values (makes a copy)
      */
     public List<V> values() {
-        List<V> values = Lists.newArrayList();
+        List<V> values = new ArrayList<>();
         forEach(value -> values.add(value));
         return values;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pulsar.common.util.collections;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
@@ -309,7 +310,7 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
     }
 
     public boolean contains(LongPair position) {
-        checkNotNull(position, "argument can't be null");
+        requireNonNull(position, "argument can't be null");
         return contains(position.getKey(), position.getValue());
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.policies.data.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.Maps;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -261,7 +260,7 @@ public class LoadReport implements LoadManagerReport {
         }
 
         NamespaceBundleStatsComparator nsc = new NamespaceBundleStatsComparator(bundleStats, resType);
-        TreeMap<String, NamespaceBundleStats> sortedBundleStats = Maps.newTreeMap(nsc);
+        TreeMap<String, NamespaceBundleStats> sortedBundleStats = new TreeMap<>(nsc);
         sortedBundleStats.putAll(bundleStats);
         return sortedBundleStats;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.policies.data.loadbalancer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Contains all the data that is maintained locally on each broker.
@@ -109,7 +109,7 @@ public class LocalBrokerData implements LoadManagerReport {
         this.webServiceUrlTls = webServiceUrlTls;
         this.pulsarServiceUrl = pulsarServiceUrl;
         this.pulsarServiceUrlTls = pulsarServiceUrlTls;
-        lastStats = Maps.newConcurrentMap();
+        lastStats = new ConcurrentHashMap<>();
         lastUpdate = System.currentTimeMillis();
         cpu = new ResourceUsage();
         memory = new ResourceUsage();
@@ -120,7 +120,7 @@ public class LocalBrokerData implements LoadManagerReport {
         lastBundleGains = new HashSet<>();
         lastBundleLosses = new HashSet<>();
         protocols = new HashMap<>();
-        this.advertisedListeners = Collections.unmodifiableMap(Maps.newHashMap(advertisedListeners));
+        this.advertisedListeners = Collections.unmodifiableMap(new HashMap<>(advertisedListeners));
     }
 
     /**

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
@@ -21,13 +21,12 @@ package org.apache.pulsar.common.compression;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
-import com.google.common.base.Charsets;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.CompressionType;
@@ -185,7 +184,7 @@ public class CompressorCodecTest {
         compressed.writeBytes(ByteBufUtil.decodeHexDump(compressedText));
 
         ByteBuf uncompressed = codec.decode(compressed, text.length());
-        assertEquals(uncompressed.toString(Charsets.UTF_8), text);
+        assertEquals(uncompressed.toString(StandardCharsets.UTF_8), text);
 
         compressed.release();
         uncompressed.release();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfigTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfigTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,7 +32,7 @@ public class EnsemblePlacementPolicyConfigTest {
         throws EnsemblePlacementPolicyConfig.ParseEnsemblePlacementPolicyConfigException {
 
         EnsemblePlacementPolicyConfig originalConfig =
-            new EnsemblePlacementPolicyConfig(MockedEnsemblePlacementPolicy.class, Collections.EMPTY_MAP);
+            new EnsemblePlacementPolicyConfig(MockedEnsemblePlacementPolicy.class, Collections.emptyMap());
         byte[] encodedConfig = originalConfig.encode();
 
         EnsemblePlacementPolicyConfig decodedConfig =

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/LocalPolicesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/LocalPolicesTest.java
@@ -25,8 +25,8 @@ import static org.testng.Assert.assertNotEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -76,16 +76,16 @@ public class LocalPolicesTest {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(bundles, bookieAffinityGroup);
+            return Objects.hash(bundles, bookieAffinityGroup);
         }
 
         @Override
         public boolean equals(Object obj) {
             if (obj instanceof LocalPolicies) {
                 LocalPolicies other = (LocalPolicies) obj;
-                return Objects.equal(bundles, other.bundles)
-                        && Objects.equal(bookieAffinityGroup, other.bookieAffinityGroup)
-                        && Objects.equal(namespaceAntiAffinityGroup, other.namespaceAntiAffinityGroup);
+                return Objects.equals(bundles, other.bundles)
+                        && Objects.equals(bookieAffinityGroup, other.bookieAffinityGroup)
+                        && Objects.equals(namespaceAntiAffinityGroup, other.namespaceAntiAffinityGroup);
             }
             return false;
         }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
@@ -76,7 +76,7 @@ public class OffloadPoliciesTest {
         Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(),
                 offloadThresholdInBytes);
         Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis(),
-                new Long(offloadDeletionLagInMillis));
+                Long.valueOf(offloadDeletionLagInMillis));
     }
 
     @Test
@@ -260,14 +260,14 @@ public class OffloadPoliciesTest {
         policies.offload_threshold = 0;
         offloadPolicies = OffloadPoliciesImpl.oldPoliciesCompatible(offloadPolicies, policies);
         Assert.assertNotNull(offloadPolicies);
-        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis(), new Long(1000));
-        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), new Long(0));
+        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis(), Long.valueOf(1000));
+        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), Long.valueOf(0));
 
         policies.offload_deletion_lag_ms = 2000L;
         policies.offload_threshold = 100;
         offloadPolicies = OffloadPoliciesImpl.oldPoliciesCompatible(offloadPolicies, policies);
-        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis(), new Long(1000));
-        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), new Long(0));
+        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis(), Long.valueOf(1000));
+        Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), Long.valueOf(0));
     }
 
     @Test
@@ -301,7 +301,7 @@ public class OffloadPoliciesTest {
         Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), brokerOffloadThreshold);
         Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadMaxThreads(), brokerOffloadMaxThreads);
         Assert.assertEquals(offloadPolicies.getManagedLedgerOffloadPrefetchRounds(),
-                new Integer(OffloadPoliciesImpl.DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS));
+                Integer.valueOf(OffloadPoliciesImpl.DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS));
         Assert.assertNull(offloadPolicies.getS3ManagedLedgerOffloadRegion());
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OldPolicies.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OldPolicies.java
@@ -18,16 +18,11 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.pulsar.common.policies.data.AuthPolicies;
-import org.apache.pulsar.common.policies.data.BacklogQuota;
-import org.apache.pulsar.common.policies.data.PersistencePolicies;
-
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.util.Objects;
 
 public class OldPolicies {
     public final AuthPolicies auth_policies;
@@ -38,21 +33,21 @@ public class OldPolicies {
 
     public OldPolicies() {
         auth_policies = AuthPolicies.builder().build();
-        replication_clusters = Lists.newArrayList();
-        backlog_quota_map = Maps.newHashMap();
+        replication_clusters = new ArrayList<>();
+        backlog_quota_map = new HashMap<>();
         persistence = null;
-        latency_stats_sample_rate = Maps.newHashMap();
+        latency_stats_sample_rate = new HashMap<>();
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof OldPolicies) {
             OldPolicies other = (OldPolicies) obj;
-            return Objects.equal(auth_policies, other.auth_policies)
-                    && Objects.equal(replication_clusters, other.replication_clusters)
-                    && Objects.equal(backlog_quota_map, other.backlog_quota_map)
-                    && Objects.equal(persistence, other.persistence)
-                    && Objects.equal(latency_stats_sample_rate, other.latency_stats_sample_rate);
+            return Objects.equals(auth_policies, other.auth_policies)
+                    && Objects.equals(replication_clusters, other.replication_clusters)
+                    && Objects.equals(backlog_quota_map, other.backlog_quota_map)
+                    && Objects.equals(persistence, other.persistence)
+                    && Objects.equals(latency_stats_sample_rate, other.latency_stats_sample_rate);
         }
 
         return false;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
@@ -22,10 +22,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.annotations.Test;
@@ -34,7 +36,6 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 public class PoliciesDataTest {
@@ -51,7 +52,7 @@ public class PoliciesDataTest {
         assertNotEquals(new Object(), policies);
 
         policies.auth_policies.getNamespaceAuthentication().clear();
-        Map<String, Set<AuthAction>> permissions = Maps.newTreeMap();
+        Map<String, Set<AuthAction>> permissions = new TreeMap<>();
         permissions.put("my-role", EnumSet.of(AuthAction.consume));
         policies.auth_policies.getTopicAuthentication().put("persistent://my-dest", permissions);
 
@@ -94,7 +95,7 @@ public class PoliciesDataTest {
         ObjectMapper jsonMapper = ObjectMapperFactory.create();
         String newJsonPolicy = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{}},\"replication_clusters\":[],\"bundles\":{\"boundaries\":[\"0x00000000\",\"0xffffffff\"]},\"backlog_quota_map\":{},\"persistence\":null,\"latency_stats_sample_rate\":{}}";
 
-        List<String> bundleSet = Lists.newArrayList();
+        List<String> bundleSet = new ArrayList<>();
         bundleSet.add("0x00000000");
         bundleSet.add("0xffffffff");
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FieldParserTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FieldParserTest.java
@@ -20,17 +20,16 @@ package org.apache.pulsar.common.util;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Maps;
 
 public class FieldParserTest {
 
     @Test
     public void testMap() {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = new HashMap<>();
         properties.put("name", "config");
         properties.put("stringStringMap", "key1=value1,key2=value2");
         properties.put("stringIntMap", "key1=1,key2=2");

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.util.collections;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -29,7 +30,6 @@ import org.apache.pulsar.common.util.collections.LongPairRangeSet.LongPairConsum
 import org.testng.annotations.Test;
 
 import com.google.common.collect.BoundType;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.TreeRangeSet;
 
@@ -129,7 +129,7 @@ public class ConcurrentOpenLongPairRangeSetTest {
         // add 10K values for key 0
         int totalInsert = 10_000;
         // add single values
-        List<Range<LongPair>> removedRanges = Lists.newArrayList();
+        List<Range<LongPair>> removedRanges = new ArrayList<>();
         for (int i = 0; i < totalInsert; i++) {
             if (i % 3 == 0 || i % 7 == 0 || i % 11 == 0) {
                 continue;
@@ -415,7 +415,7 @@ public class ConcurrentOpenLongPairRangeSetTest {
     }
 
     private List<Range<LongPair>> getConnectedRange(Set<Range<LongPair>> gRanges) {
-        List<Range<LongPair>> gRangeConnected = Lists.newArrayList();
+        List<Range<LongPair>> gRangeConnected = new ArrayList<>();
         Range<LongPair> lastRange = null;
         for (Range<LongPair> range : gRanges) {
             if (lastRange == null) {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowablePriorityLongPairQueueTest.java
@@ -267,7 +267,7 @@ public class GrowablePriorityLongPairQueueTest {
         assertEquals(values, Lists.newArrayList(new LongPair(0, 0), new LongPair(1, 1), new LongPair(3, 3),
                 new LongPair(6, 6), new LongPair(7, 7)));
 
-        List<LongPair> removeList = Lists.newArrayList();
+        List<LongPair> removeList = new ArrayList<>();
         queue.forEach((first, second) -> {
             System.out.println(first + "," + second);
             if (first < 5) {


### PR DESCRIPTION
Master Issue: #12271

### Motivation
Apply Maven Modernizer plugin to enforce we move away from legacy APIs.

### Modifications
Add Maven Modernizer plugin in pulsar-common module and fix violation.

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] no-need-doc 
  
