### PR TITLE
feat(cli): add restart command to pulsar-daemon

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -20,7 +20,7 @@
 
 usage() {
     cat <<EOF
-Usage: pulsar-daemon (start|stop) <command> <args...>
+Usage: pulsar-daemon (start|stop|restart) <command> <args...>
 where command is one of:
     broker              Run a broker server
     bookie              Run a bookie server
@@ -202,6 +202,66 @@ case $startStop in
       rm $pid
     else
       echo no "$command to stop"
+    fi
+    ;;
+
+  (restart)
+   if [ -f $pid ]; then
+      TARGET_PID=$(cat $pid)
+      if kill -0 $TARGET_PID > /dev/null 2>&1; then
+        echo "stopping $command"
+        kill $TARGET_PID
+
+        count=0
+        location=$PULSAR_LOG_DIR
+        while ps -p $TARGET_PID > /dev/null;
+         do
+          echo "Shutdown is in progress... Please wait..."
+          sleep 1
+          count=`expr $count + 1`
+
+          if [ "$count" = "$PULSAR_STOP_TIMEOUT" ]; then
+                break
+          fi
+         done
+
+        if [ "$count" != "$PULSAR_STOP_TIMEOUT" ]; then
+            echo "Shutdown completed."
+        fi
+
+        if kill -0 $TARGET_PID > /dev/null 2>&1; then
+              fileName=$location/$command.out
+              $JAVA_HOME/bin/jstack $TARGET_PID > $fileName
+              echo "Thread dumps are taken for analysis at $fileName"
+              if [ "$1" == "-force" ]
+              then
+                 echo "forcefully stopping $command"
+                 kill -9 $TARGET_PID >/dev/null 2>&1
+                 echo Successfully stopped the process
+              else
+                 echo "WARNNING :  $command is not stopped completely."
+                 exit 1
+              fi
+        fi
+      else
+        echo "no $command to stop"
+      fi
+      rm $pid
+    else
+      echo no "$command to stop"
+    fi
+    sleep 3
+
+    rotate_out_log $out
+    echo restarting $command, logging to $logfile
+    echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
+    pulsar=$PULSAR_HOME/bin/pulsar
+    nohup $pulsar $command "$@" > "$out" 2>&1 < /dev/null &
+    echo $! > $pid
+    sleep 1; head $out
+    sleep 2;
+    if ! ps -p $! > /dev/null ; then
+      exit 1
     fi
     ;;
 


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

It's inconvenient to restart the broker/bk/zk process when users change the config, they have use `pulsar-daemon` stop the process first then start it again.

### Modifications

I added a command as `restart` in `pulsar-daemon`.  

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


