### PR TITLE
[Standalone] Remove redundant judgment for PulsarStandalone#start

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -248,11 +248,6 @@ public class PulsarStandalone implements AutoCloseable {
     private boolean help = false;
 
     public void start() throws Exception {
-
-        if (config == null) {
-            System.exit(1);
-        }
-
         log.debug("--- setup PulsarStandaloneStarter ---");
 
         if (!this.isOnlyBroker()) {


### PR DESCRIPTION
### Motivation

*Remove redundant judgment for PulsarStandalone#start to simplify the code.*

### Modifications

*Because the ```config``` is already initialized before the call, and it cannot be null. So I removed the redundant judgment for PulsarStandalone#start.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required   
- [x] no-need-doc
- [ ] doc 

