### PR TITLE
Release: allow Integration Tests Jar to be deployed to Maven central

### DIFF
--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -238,5 +238,26 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+              <skip>${maven.deploy.skip}</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
- integration tests framework is needed by Pulsar Adapters project
- during the release procedure, while running 'mvn deploy -DskipTests -Papache-release -DintegrationTests --settings src/settings.xml' allow to deploy integration tests jars

This is the reference to our release procedure
https://github.com/apache/pulsar/wiki/Release-process#5-stage-artifacts-in-maven
