### PR TITLE
Change dependencySet scope of assembly from compile to runtime

### DIFF
--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -121,7 +121,7 @@
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>
-      <scope>compile</scope>
+      <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
       <!-- Include 'groupId' in the dependencies Jar names to better identify
            the provenance of the jar -->


### PR DESCRIPTION
Coauthored with Henry Saputra (hsaputra@apache.org)

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>
-->

### Motivation

Currently, the dependencySet scope of assembly is set to `compile` for Pulsar deployment, this causes the Pulsar's distribution assembly to not include the transitive dependences that tagged with `runtime` scope. 
Having the dependencySet as `runtime` instead of scope will actually include both scopes (since `runtime` scope includes the `compile` scope implicitly). This needs to be done before next release artifacts by Apache Bookkeeper generated by Gradle.

### Modifications

*Change dependencySet scope of assembly from `compile` to `runtime` in distribution/server/src/assemble/bin.xml*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

<!--
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*
-->
This change is already covered by existing tests, such as *integration tests*.
<!--
*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*
-->

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (don't know)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - **Anything that affects deployment: (yes)**

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


