### PR TITLE
[Proxy] set default httpProxyTimeout to 5 minutes

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -496,7 +496,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
             doc = "Http proxy timeout.\n\n"
                     + "The timeout value for HTTP proxy is in millisecond."
     )
-    private int httpProxyTimeout = 30 * 1000;
+    private int httpProxyTimeout = 5 * 60 * 1000;
 
     @FieldContext(
            minValue = 1,


### PR DESCRIPTION

Motivation
- Follow up  of 8b55636cc3df8c4cb1d2dd3896bc2bab79c267cc
- @merlimat suggested to set the default timeout to 5 minutes.

Modifications
- set httpProxyTimeout to 5 minutes
