### PR TITLE
[pulsar-perf] Support version command

### DIFF
--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -98,6 +98,7 @@ where command is one of:
 
     gen-doc                 Generate documentation automatically.
 
+    version                 Get the current version of pulsar
     help                    This help message
 
 or command is the full name of a class with a defined main() method.
@@ -174,6 +175,8 @@ elif [ "$COMMAND" == "managed-ledger" ]; then
     exec $JAVA $OPTS org.apache.pulsar.testclient.ManagedLedgerWriter "$@"
 elif [ "$COMMAND" == "gen-doc" ]; then
     exec $JAVA $OPTS org.apache.pulsar.testclient.CmdGenerateDocumentation "$@"
+elif [ "$COMMAND" == "version" ]; then
+    exec $JAVA $OPTS org.apache.pulsar.PulsarVersionStarter "$@"
 else
     pulsar_help;
 fi

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -404,6 +404,7 @@ Commands
 * `monitor-brokers`
 * `simulation-client`
 * `simulation-controller`
+* `version`
 * `help`
 
 Environment variables
@@ -661,6 +662,14 @@ Usage
 ```bash
 $ pulsar-perf help
 ```
+
+### `version`
+Get the current version of pulsar
+
+Usage
+```bash
+$ pulsar-perf version
+
 
 
 ## `bookkeeper`


### PR DESCRIPTION
### Motivation
Support `version` command to get the current version of pulsar in `pulsar-perf`

### Modifications
- Modify script `pulsar-perf`. Call `org.apache.pulsar.PulsarVersionStarter` when the command is `version`
- Modify document `reference-cli-tools.md`. Show usage of `version` command

### Documentation
- need to update docs
