### PR TITLE
[pulsar-admin] Fix NPE when executing set-auto-topic-creation without num-partitions

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -573,8 +573,10 @@ public class CmdNamespaces extends CmdBase {
                             "Possible values: (partitioned, non-partitioned)");
                 }
 
-                if (TopicType.PARTITIONED.toString().equals(type) && !(defaultNumPartitions > 0)) {
-                    throw new ParameterException("Must specify num-partitions > 0 for partitioned topic type.");
+                if (TopicType.PARTITIONED.toString().equals(type)
+                        && (defaultNumPartitions == null || !(defaultNumPartitions > 0))) {
+                    throw new ParameterException("Must specify num-partitions or num-partitions > 0 " +
+                            "for partitioned topic type.");
                 }
             }
             getAdmin().namespaces().setAutoTopicCreation(namespace,


### PR DESCRIPTION
### Motivation
When I execute the `set-auto-topic-creation` command on namesapce to specify `-e` and specify `-t` as _**partitioned**_ but not specify `-n`, an NPE will occur. as below:
`./pulsar-admin namespaces set-auto-topic-creation -e -t partitioned test/app1`
![image](https://user-images.githubusercontent.com/13013780/136653495-ae7d3370-cebd-435f-9227-665d24ede2c6.png)

> original code:
L576
https://github.com/apache/pulsar/blob/8b50af517255c314c773c6fe0c2530e09fafa312/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java#L543-L587

### Documentation
- no-need-doc
