### PR TITLE
useV2WireProtocol for bookkeeper autorecovery

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -252,6 +252,9 @@ autoRecoveryDaemonEnabled=true
 # How long to wait, in seconds, before starting auto recovery of a lost bookie
 lostBookieRecoveryDelay=0
 
+# Use older Bookkeeper wire protocol (Before Version 3) for AutoRecovery. Default is false
+useV2WireProtocol=true
+
 #############################################################################
 ## Placement settings
 #############################################################################


### PR DESCRIPTION
### Motivation
Currently we only set `bookkeeperUseV2WireProtocol=true` on Pulsar brokers to enforce brokers to use v2 protocol to avoid GC issues introduced by protobuf.

However, we don’t set this setting on autorecovery, and the default value is false, Hence AutoRecovery will use v3 protocol.

We'd better set `useV2WireProtocol=true` in autorecovery in the helm charts

### Modifications
Set `useV2WireProtocol=true` in autorecovery.