### PR TITLE
[Issue 12314][Go Functions] Remove extra call to gi.stats.incrTotalProcessedSuccessfully()

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -177,7 +177,6 @@ CLOSE:
 
 			gi.stats.processTimeEnd()
 			gi.processResult(msgInput, output)
-			gi.stats.incrTotalProcessedSuccessfully()
 		case <-idleTimer.C:
 			close(channel)
 			break CLOSE

--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -352,32 +352,42 @@ func (gi *goInstance) processResult(msgInput pulsar.Message, output []byte) {
 	atMostOnce := gi.context.instanceConf.funcDetails.ProcessingGuarantees == pb.ProcessingGuarantees_ATMOST_ONCE
 	autoAck := gi.context.instanceConf.funcDetails.AutoAck
 
+	// If the function had an output and the user has specified an output topic, the output needs to be sent to the
+	// assigned output topic.
 	if output != nil && gi.context.instanceConf.funcDetails.Sink.Topic != "" {
 		asyncMsg := pulsar.ProducerMessage{
 			Payload: output,
 		}
-		// Attempt to send the message and handle the response
-		gi.producer.SendAsync(context.Background(), &asyncMsg, func(messageID pulsar.MessageID,
-			message *pulsar.ProducerMessage, err error) {
-			if err != nil {
-				if autoAck && atLeastOnce {
-					gi.nackInputMessage(msgInput)
+		// Dispatch an async send for the message with callback in case of error.
+		gi.producer.SendAsync(context.Background(), &asyncMsg,
+			func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
+				// Callback after message async send:
+				// If there was an error, the SDK is entrusted with responding, and we have at-least-once delivery
+				// semantics, ensure we nack so someone else can get it, in case we are the only handler. Then mark
+				// exception and fail out.
+				if err != nil {
+					if autoAck && atLeastOnce {
+						gi.nackInputMessage(msgInput)
+					}
+					gi.stats.incrTotalSysExceptions(err)
+					log.Fatal(err)
 				}
-				gi.stats.incrTotalSysExceptions(err)
-				log.Fatal(err)
-			} else {
+				// Otherwise the message succeeded. If the SDK is entrusted with responding and we are not using
+				// at-most-once delivery semantics, ack the message.
 				if autoAck && !atMostOnce {
 					gi.ackInputMessage(msgInput)
 				}
 				gi.stats.incrTotalProcessedSuccessfully()
-			}
-		})
-	} else if autoAck && atLeastOnce {
-		gi.ackInputMessage(msgInput)
-		// Report that we processed successfully even though it's not going to an output topic?
-		// We probably shouldn't...
-		// gi.stats.incrTotalProcessedSuccessfully()
+			},
+		)
+		return
 	}
+
+	// No output from the function or no output topic. Ack if we need to and mark the success before rturning.
+	if autoAck && atLeastOnce {
+		gi.ackInputMessage(msgInput)
+	}
+	gi.stats.incrTotalProcessedSuccessfully()
 }
 
 // ackInputMessage doesn't produce any result, or the user doesn't want the result.


### PR DESCRIPTION
- This call will be made by gi.processResult if
    - there is a result
    - there were no system exceptions
- Fixes #12314

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

**NOTES**
- due to the way the pulsar-function-go SDK is structured, adding regression tests to the Go code itself would be impossible without spinning up a complete environment; the call has been removed from the core loop of `startFunction()`, which depends on a complete environment with successfully-initialized client, producer, consumer, log producer and metrics server, as well as instance communication.
- This means that the best way to test this would be in the Java example tests or E2E testing, but I have been unable to locate any Java tests that exercise the metrics, so if there is a place I could add this easily, I would be most grateful for guidance (and even more so for a patch or PR :D )
- for these reasons, the change must be verified in situ for now

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no
  - 
### Documentation

Check the box below and label this PR (if you have committer privilege).
  
- [x] no-need-doc 
  
  As far as I can tell, this change restores the ProcessedSuccessfully metric to what it should be:

- <= ReceivedTotal
- Only incremented on an error-free function handler that produces a result.