### PR TITLE
[Issue 12271][Modernizer] Add Maven Modernizer plugin in pulsar-proxy module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
+    <modernizer-maven-plugin.version>2.3.0</modernizer-maven-plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -179,6 +179,27 @@
           <artifactId>log4j-core</artifactId>
       </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <version>${modernizer-maven-plugin.version}</version>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <profiles>
     <profile>
       <!-- enables builds with -Dmaven.test.skip=true -->

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/extensions/ProxyExtensions.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/extensions/ProxyExtensions.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.proxy.extensions;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
+import java.util.HashMap;
+import java.util.HashSet;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.proxy.server.ProxyConfiguration;
 import org.apache.pulsar.proxy.server.ProxyService;
@@ -108,8 +108,8 @@ public class ProxyExtensions implements AutoCloseable {
     }
 
     public Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> newChannelInitializers() {
-        Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> channelInitializers = Maps.newHashMap();
-        Set<InetSocketAddress> addresses = Sets.newHashSet();
+        Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> channelInitializers = new HashMap<>();
+        Set<InetSocketAddress> addresses = new HashSet<>();
 
         for (Map.Entry<String, ProxyExtensionWithClassLoader> extension : extensions.entrySet()) {
             Map<InetSocketAddress, ChannelInitializer<SocketChannel>> initializers =

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ParserProxyHandler.java
@@ -20,6 +20,7 @@
 package org.apache.pulsar.proxy.server;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,8 +33,6 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.proxy.stats.TopicStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -96,7 +95,7 @@ public class ParserProxyHandler extends ChannelInboundHandlerAdapter {
 
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         TopicName topicName ;
-        List<RawMessage> messages = Lists.newArrayList();
+        List<RawMessage> messages = new ArrayList<>();
         ByteBuf buffer = (ByteBuf)(msg);
 
         try {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import com.google.common.collect.Sets;
-
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -203,7 +203,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
             + " `super-user`, meaning they will be able to do all admin operations and publish"
             + " & consume from all topics"
     )
-    private Set<String> superUserRoles = Sets.newTreeSet();
+    private Set<String> superUserRoles = new TreeSet<>();
 
     @FieldContext(
         category = CATEGORY_AUTHENTICATION,
@@ -214,7 +214,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
         category = CATEGORY_AUTHENTICATION,
         doc = "Authentication provider name list (a comma-separated list of class names"
     )
-    private Set<String> authenticationProviders = Sets.newTreeSet();
+    private Set<String> authenticationProviders = new TreeSet<>();
     @FieldContext(
         category = CATEGORY_AUTHORIZATION,
         doc = "Whether authorization is enforced by the Pulsar proxy"
@@ -346,14 +346,14 @@ public class ProxyConfiguration implements PulsarConfiguration {
             + " (a comma-separated list of protocol names).\n\n"
             + "Examples:- [TLSv1.3, TLSv1.2]"
     )
-    private Set<String> tlsProtocols = Sets.newTreeSet();
+    private Set<String> tlsProtocols = new TreeSet<>();
     @FieldContext(
         category = CATEGORY_TLS,
         doc = "Specify the tls cipher the proxy will use to negotiate during TLS Handshake"
             + " (a comma-separated list of ciphers).\n\n"
             + "Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]"
     )
-    private Set<String> tlsCiphers = Sets.newTreeSet();
+    private Set<String> tlsCiphers = new TreeSet<>();
     @FieldContext(
         category = CATEGORY_TLS,
         doc = "Whether client certificates are required for TLS.\n\n"
@@ -449,7 +449,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
                   + "Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256].\n"
                   + " used by the Pulsar proxy to authenticate with Pulsar brokers"
     )
-    private Set<String> brokerClientTlsCiphers = Sets.newTreeSet();
+    private Set<String> brokerClientTlsCiphers = new TreeSet<>();
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "Specify the tls protocols the broker will use to negotiate during TLS handshake"
@@ -457,7 +457,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
                   + "Examples:- [TLSv1.3, TLSv1.2] \n"
                   + " used by the Pulsar proxy to authenticate with Pulsar brokers"
     )
-    private Set<String> brokerClientTlsProtocols = Sets.newTreeSet();
+    private Set<String> brokerClientTlsProtocols = new TreeSet<>();
 
     /***** --- HTTP --- ****/
 
@@ -465,7 +465,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
         category = CATEGORY_HTTP,
         doc = "Http directs to redirect to non-pulsar services"
     )
-    private Set<HttpReverseProxyConfig> httpReverseProxyConfigs = Sets.newHashSet();
+    private Set<HttpReverseProxyConfig> httpReverseProxyConfigs = new HashSet<>();
 
     @FieldContext(
         minValue = 1,
@@ -523,13 +523,13 @@ public class ProxyConfiguration implements PulsarConfiguration {
             category = CATEGORY_PLUGIN,
             doc = "List of proxy additional servlet to load, which is a list of proxy additional servlet names"
     )
-    private Set<String> proxyAdditionalServlets = Sets.newTreeSet();
+    private Set<String> proxyAdditionalServlets = new TreeSet<>();
 
     @FieldContext(
             category = CATEGORY_PLUGIN,
             doc = "List of proxy additional servlet to load, which is a list of proxy additional servlet names"
     )
-    private Set<String> additionalServlets = Sets.newTreeSet();
+    private Set<String> additionalServlets = new TreeSet<>();
 
     @FieldContext(
             category =  CATEGORY_HTTP,
@@ -579,7 +579,7 @@ public class ProxyConfiguration implements PulsarConfiguration {
             category = CATEGORY_PLUGIN,
             doc = "List of messaging protocols to load, which is a list of extension names"
     )
-    private Set<String> proxyExtensions = Sets.newTreeSet();
+    private Set<String> proxyExtensions = new TreeSet<>();
 
     /***** --- WebSocket --- ****/
     @FieldContext(

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.AdaptiveRecvByteBufAllocator;
@@ -41,6 +40,7 @@ import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
@@ -131,11 +131,11 @@ public class ProxyService implements Closeable {
 
     public ProxyService(ProxyConfiguration proxyConfig,
                         AuthenticationService authenticationService) throws Exception {
-        checkNotNull(proxyConfig);
+        requireNonNull(proxyConfig);
         this.proxyConfig = proxyConfig;
         this.timer = new HashedWheelTimer(new DefaultThreadFactory("pulsar-timer", Thread.currentThread().isDaemon()), 1, TimeUnit.MILLISECONDS);
         this.clientCnxs = Sets.newConcurrentHashSet();
-        this.topicStats = Maps.newConcurrentMap();
+        this.topicStats = new ConcurrentHashMap<>();
 
         this.lookupRequestSemaphore = new AtomicReference<Semaphore>(
                 new Semaphore(proxyConfig.getMaxConcurrentLookupRequests(), false));

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import com.google.common.collect.Lists;
-
 import io.prometheus.client.jetty.JettyStatisticsCollector;
 import java.io.IOException;
 import java.net.URI;
@@ -69,8 +67,8 @@ public class WebServer {
     private final Server server;
     private final WebExecutorThreadPool webServiceExecutor;
     private final AuthenticationService authenticationService;
-    private final List<String> servletPaths = Lists.newArrayList();
-    private final List<Handler> handlers = Lists.newArrayList();
+    private final List<String> servletPaths = new ArrayList<>();
+    private final List<Handler> handlers = new ArrayList<>();
     private final ProxyConfiguration config;
     protected int externalServicePort;
     private URI serviceURI = null;
@@ -84,7 +82,7 @@ public class WebServer {
         this.authenticationService = authenticationService;
         this.config = config;
 
-        List<ServerConnector> connectors = Lists.newArrayList();
+        List<ServerConnector> connectors = new ArrayList<>();
 
         HttpConfiguration http_config = new HttpConfiguration();
         http_config.setOutputBufferSize(config.getHttpOutputBufferSize());

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/ProxyStats.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/ProxyStats.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.proxy.stats;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,8 +34,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.pulsar.proxy.server.ProxyService;
-
-import com.google.common.collect.Lists;
 
 import io.netty.channel.Channel;
 import io.swagger.annotations.Api;
@@ -59,7 +58,7 @@ public class ProxyStats {
     @ApiOperation(value = "Proxy stats api to get info for live connections", response = List.class, responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 503, message = "Proxy service is not initialized") })
     public List<ConnectionStats> metrics() {
-        List<ConnectionStats> stats = Lists.newArrayList();
+        List<ConnectionStats> stats = new ArrayList<>();
         proxyService().getClientCnxs().forEach(cnx -> {
             if (cnx.getDirectProxyHandler() == null) {
                 return;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
@@ -189,7 +189,7 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithAuth.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 
 import com.google.common.collect.Sets;
@@ -195,7 +195,7 @@ public class ProxyKeyStoreTlsTestWithAuth extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
         }
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithoutAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsTestWithoutAuth.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 
 import java.util.HashMap;
@@ -180,7 +180,7 @@ public class ProxyKeyStoreTlsTestWithoutAuth extends MockedPulsarServiceBaseTest
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
         }
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.proxy.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 
@@ -128,7 +128,7 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
         }
 
@@ -162,7 +162,7 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
         }
     }
 
@@ -231,7 +231,7 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(10, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
         }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -120,7 +120,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < totalMessages; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
         }
 
@@ -169,7 +169,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < totalMessages; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
             msg = consumer2.receive(1, TimeUnit.SECONDS);
         }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.proxy.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import io.netty.channel.EventLoopGroup;
@@ -149,7 +149,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
         }
 
@@ -183,7 +183,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
         }
     }
 
@@ -192,8 +192,8 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
      **/
     @Test
     public void testAutoCreateTopic() throws Exception{
-        int defaultPartition=2;
-        int defaultNumPartitions=pulsar.getConfiguration().getDefaultNumPartitions();
+        int defaultPartition = 2;
+        int defaultNumPartitions = pulsar.getConfiguration().getDefaultNumPartitions();
         pulsar.getConfiguration().setAllowAutoTopicCreationType("partitioned");
         pulsar.getConfiguration().setDefaultNumPartitions(defaultPartition);
         try {
@@ -204,7 +204,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
             CompletableFuture<List<String>> partitionNamesFuture = client.getPartitionsForTopic(topic);
             List<String> partitionNames = partitionNamesFuture.get(30000, TimeUnit.MILLISECONDS);
             Assert.assertEquals(partitionNames.size(), defaultPartition);
-        }finally {
+        } finally {
             pulsar.getConfiguration().setAllowAutoTopicCreationType("non-partitioned");
             pulsar.getConfiguration().setDefaultNumPartitions(defaultNumPartitions);
         }
@@ -271,12 +271,13 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
             Assert.fail("Should not have failed since can acquire LookupRequestSemaphore");
         }
         byte[] schemaVersion = new byte[8];
-        byte b = new Long(0l).byteValue();
-        for (int i = 0; i<8; i++){
+        byte b = Long.valueOf(0L).byteValue();
+        for (int i = 0; i < 8; i++){
             schemaVersion[i] = b;
         }
         SchemaInfo schemaInfo = ((PulsarClientImpl) client).getLookup()
-                .getSchema(TopicName.get("persistent://sample/test/local/get-schema"), schemaVersion).get().orElse(null);
+                .getSchema(TopicName.get("persistent://sample/test/local/get-schema"), schemaVersion)
+                .get().orElse(null);
         Assert.assertEquals(new String(schemaInfo.getSchema()), new String(schema.getSchemaInfo().getSchema()));
     }
 
@@ -304,7 +305,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(10, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
             consumer.acknowledge(msg);
         }
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.doReturn;
 
 import java.util.Optional;
@@ -117,7 +117,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 10; i++) {
             Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
-            checkNotNull(msg);
+            requireNonNull(msg);
         }
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
@@ -210,7 +210,7 @@ public class ProxyWithAuthorizationNegTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import lombok.Cleanup;
@@ -88,47 +89,47 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
     @DataProvider(name = "protocolsCiphersProvider")
     public Object[][] protocolsCiphersProviderCodecProvider() {
         // Test using defaults
-        Set<String> ciphers_1 = Sets.newTreeSet();
-        Set<String> protocols_1 = Sets.newTreeSet();
+        Set<String> ciphers_1 = new TreeSet<>();
+        Set<String> protocols_1 = new TreeSet<>();
 
         // Test explicitly specifying protocols defaults
-        Set<String> ciphers_2 = Sets.newTreeSet();
-        Set<String> protocols_2 = Sets.newTreeSet();
+        Set<String> ciphers_2 = new TreeSet<>();
+        Set<String> protocols_2 = new TreeSet<>();
         protocols_2.add("TLSv1.3");
         protocols_2.add("TLSv1.2");
 
         // Test for invalid ciphers
-        Set<String> ciphers_3 = Sets.newTreeSet();
-        Set<String> protocols_3 = Sets.newTreeSet();
+        Set<String> ciphers_3 = new TreeSet<>();
+        Set<String> protocols_3 = new TreeSet<>();
         ciphers_3.add("INVALID_PROTOCOL");
 
         // Incorrect Config since TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 was introduced in TLSv1.2
-        Set<String> ciphers_4 = Sets.newTreeSet();
-        Set<String> protocols_4 = Sets.newTreeSet();
+        Set<String> ciphers_4 = new TreeSet<>();
+        Set<String> protocols_4 = new TreeSet<>();
         ciphers_4.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
         protocols_4.add("TLSv1.1");
 
         // Incorrect Config since TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 was introduced in TLSv1.2
-        Set<String> ciphers_5 = Sets.newTreeSet();
-        Set<String> protocols_5 = Sets.newTreeSet();
+        Set<String> ciphers_5 = new TreeSet<>();
+        Set<String> protocols_5 = new TreeSet<>();
         ciphers_5.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
         protocols_5.add("TLSv1");
 
         // Correct Config
-        Set<String> ciphers_6 = Sets.newTreeSet();
-        Set<String> protocols_6 = Sets.newTreeSet();
+        Set<String> ciphers_6 = new TreeSet<>();
+        Set<String> protocols_6 = new TreeSet<>();
         ciphers_6.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
         protocols_6.add("TLSv1.2");
 
         // In correct config - JDK 8 doesn't support TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-        Set<String> ciphers_7 = Sets.newTreeSet();
-        Set<String> protocols_7 = Sets.newTreeSet();
+        Set<String> ciphers_7 = new TreeSet<>();
+        Set<String> protocols_7 = new TreeSet<>();
         protocols_7.add("TLSv1.2");
         ciphers_7.add("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
 
         // Correct config - Atlease one of the Cipher Suite is supported
-        Set<String> ciphers_8 = Sets.newTreeSet();
-        Set<String> protocols_8 = Sets.newTreeSet();
+        Set<String> ciphers_8 = new TreeSet<>();
+        Set<String> protocols_8 = new TreeSet<>();
         protocols_8.add("TLSv1.2");
         ciphers_8.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
         ciphers_8.add("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
@@ -265,7 +266,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -185,7 +185,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -227,7 +227,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
 
         admin.tenants().createTenant("my-property",
-                new TenantInfoImpl(Sets.newHashSet(), Sets.newHashSet(clusterName)));
+                new TenantInfoImpl(new HashSet<>(), Sets.newHashSet(clusterName)));
         admin.namespaces().createNamespace(namespaceName);
         admin.topics().createPartitionedTopic(topicName, 2);
         admin.topics().grantPermission(topicName, CLIENT_ROLE,
@@ -240,7 +240,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         Producer<byte[]> producer = proxyClient.newProducer(Schema.BYTES)
                 .topic(topicName).create();
         final int MSG_NUM = 10;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         for (int i = 0; i < MSG_NUM; i++) {
             String message = "my-message-" + i;
             messageSet.add(message);
@@ -248,7 +248,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg;
-        Set<String> receivedMessageSet = Sets.newHashSet();
+        Set<String> receivedMessageSet = new HashSet<>();
         for (int i = 0; i < MSG_NUM; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
@@ -347,7 +347,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -180,7 +180,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         int count = 0;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);


### PR DESCRIPTION
Master Issue: #12271 

### Motivation
Apply Maven Modernizer plugin to enforce we move away from legacy APIs.

### Modifications
Add Maven Modernizer plugin in `pulsar-proxy` module and fix the violation.

### Verifying this change
This change is already covered by existing tests.


### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Need to update docs? 
- [x] no-need-doc 
 
  


