### PR TITLE
Flaky-test:PulsarServiceTest.testAppliedAdvertised

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertSame;
+
+import java.net.ServerSocket;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -57,10 +59,10 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
         super.doInitConf();
         if (useListenerName) {
             conf.setAdvertisedAddress(null);
-            conf.setBrokerServicePortTls(Optional.of(6651));
-            conf.setBrokerServicePort(Optional.of(6660));
-            conf.setWebServicePort(Optional.of(8081));
-            conf.setWebServicePortTls(Optional.of(8082));
+            conf.setBrokerServicePortTls(Optional.of(PortUtil.nextFreePort()));
+            conf.setBrokerServicePort(Optional.of(PortUtil.nextFreePort()));
+            conf.setWebServicePort(Optional.of(PortUtil.nextFreePort()));
+            conf.setWebServicePortTls(Optional.of(PortUtil.nextFreePort()));
         }
     }
 
@@ -124,4 +126,30 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
         assertEquals(pulsar.webAddressTls(conf), "https://localhost:" + pulsar.getWebService().getListenPortHTTPS().get());
     }
 
+}
+
+class PortUtil {
+    private static int nextPort = getBasePort();
+
+    public static synchronized int nextFreePort() {
+        int exceptionCount = 0;
+        while (true) {
+            int port = nextPort++;
+            try (ServerSocket ss = new ServerSocket(port)) {
+                ss.close();
+                //Give it some time to truly close the connection
+                Thread.sleep(100);
+                return port;
+            } catch (Exception e) {
+                exceptionCount++;
+                if (exceptionCount > 5) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private static int getBasePort() {
+        return Integer.valueOf(System.getProperty("test.basePort", "15000"));
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -28,6 +28,7 @@ import java.net.ServerSocket;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.PortManager;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
@@ -59,10 +60,10 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
         super.doInitConf();
         if (useListenerName) {
             conf.setAdvertisedAddress(null);
-            conf.setBrokerServicePortTls(Optional.of(PortUtil.nextFreePort()));
-            conf.setBrokerServicePort(Optional.of(PortUtil.nextFreePort()));
-            conf.setWebServicePort(Optional.of(PortUtil.nextFreePort()));
-            conf.setWebServicePortTls(Optional.of(PortUtil.nextFreePort()));
+            conf.setBrokerServicePortTls(Optional.of(PortManager.nextFreePort()));
+            conf.setBrokerServicePort(Optional.of(PortManager.nextFreePort()));
+            conf.setWebServicePort(Optional.of(PortManager.nextFreePort()));
+            conf.setWebServicePortTls(Optional.of(PortManager.nextFreePort()));
         }
     }
 
@@ -126,30 +127,4 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
         assertEquals(pulsar.webAddressTls(conf), "https://localhost:" + pulsar.getWebService().getListenPortHTTPS().get());
     }
 
-}
-
-class PortUtil {
-    private static int nextPort = getBasePort();
-
-    public static synchronized int nextFreePort() {
-        int exceptionCount = 0;
-        while (true) {
-            int port = nextPort++;
-            try (ServerSocket ss = new ServerSocket(port)) {
-                ss.close();
-                //Give it some time to truly close the connection
-                Thread.sleep(100);
-                return port;
-            } catch (Exception e) {
-                exceptionCount++;
-                if (exceptionCount > 5) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-    }
-
-    private static int getBasePort() {
-        return Integer.valueOf(System.getProperty("test.basePort", "15000"));
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -58,10 +58,6 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
         super.doInitConf();
         if (useListenerName) {
             conf.setAdvertisedAddress(null);
-            conf.setBrokerServicePortTls(Optional.of(PortManager.nextFreePort()));
-            conf.setBrokerServicePort(Optional.of(PortManager.nextFreePort()));
-            conf.setWebServicePort(Optional.of(PortManager.nextFreePort()));
-            conf.setWebServicePortTls(Optional.of(PortManager.nextFreePort()));
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertSame;
-
-import java.net.ServerSocket;
 import java.util.Optional;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
# Motivation
When running a unit test, the problem of port 6660 being occupied is prone to occur, and this problem will cause the unit test to fail.

Error log：
[ERROR] testAppliedAdvertised(org.apache.pulsar.broker.PulsarServiceTest)  Time elapsed: 0.051 s  <<< FAILURE!
org.apache.pulsar.broker.PulsarServerException: java.io.IOException: Failed to bind Pulsar broker on /0.0.0.0:6660
    at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:787)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBrokerWithoutAuthorization(MockedPulsarServiceBaseTest.java:292)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBroker(MockedPulsarServiceBaseTest.java:284)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBroker(MockedPulsarServiceBaseTest.java:265)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.init(MockedPulsarServiceBaseTest.java:183)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.internalSetup(MockedPulsarServiceBaseTest.java:117)
    at org.apache.pulsar.broker.PulsarServiceTest.setup(PulsarServiceTest.java:44)
    at org.apache.pulsar.broker.PulsarServiceTest.testAppliedAdvertised(PulsarServiceTest.java:111)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
    at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
    at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
    at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: Failed to bind Pulsar broker on /0.0.0.0:6660
    at org.apache.pulsar.broker.service.BrokerService.start(BrokerService.java:431)
    at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:672)
    at org.apache.pulsar.broker.PulsarService$MockitoMock$1473645329.start$accessor$lvqb3AGG(Unknown Source)
    at org.apache.pulsar.broker.PulsarService$MockitoMock$1473645329$auxiliary$SZeXe3id.call(Unknown Source)
    at org.mockito.internal.invocation.RealMethod$FromCallable$1.call(RealMethod.java:40)
    at org.mockito.internal.invocation.RealMethod$FromBehavior.invoke(RealMethod.java:62)
    at org.mockito.internal.invocation.InterceptedInvocation.callRealMethod(InterceptedInvocation.java:141)
    at org.mockito.internal.stubbing.answers.CallsRealMethods.answer(CallsRealMethods.java:44)
    at org.mockito.Answers.answer(Answers.java:98)
    at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:106)
    at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
    at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:33)
    at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:82)
    at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:56)
    at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$DispatcherDefaultingToRealMethod.interceptSuperCallable(MockMethodInterceptor.java:141)
    at org.apache.pulsar.broker.PulsarService$MockitoMock$1473645329.start(Unknown Source)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBrokerWithoutAuthorization(MockedPulsarServiceBaseTest.java:292)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBroker(MockedPulsarServiceBaseTest.java:284)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.startBroker(MockedPulsarServiceBaseTest.java:265)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.init(MockedPulsarServiceBaseTest.java:183)
    at org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.internalSetup(MockedPulsarServiceBaseTest.java:117)
    at org.apache.pulsar.broker.PulsarServiceTest.setup(PulsarServiceTest.java:44)
    at org.apache.pulsar.broker.PulsarServiceTest.testAppliedAdvertised(PulsarServiceTest.java:111)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    ... 8 more
Caused by: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use

# Modifications
We should not write the 6660 port number in the code, we should dynamically obtain the free port number, which can make the unit test stronger.