### PR TITLE
[Doc]--Update contents for Pulsar adaptor for Apache Spark

### DIFF
--- a/site2/docs/adaptors-spark.md
+++ b/site2/docs/adaptors-spark.md
@@ -4,13 +4,10 @@ title: Pulsar adaptor for Apache Spark
 sidebar_label: Apache Spark
 ---
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 

--- a/site2/website-next/docs/adaptors-spark.md
+++ b/site2/website-next/docs/adaptors-spark.md
@@ -8,13 +8,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 

--- a/site2/website-next/versioned_docs/version-2.7.3/adaptors-spark.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/adaptors-spark.md
@@ -9,9 +9,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website-next/versioned_docs/version-2.8.0/adaptors-spark.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/adaptors-spark.md
@@ -8,14 +8,10 @@ original_id: adaptors-spark
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
-
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.2.0/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.2.0/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.3.2/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.3.2/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.6.0/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.6.0/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.6.1/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.6.1/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.6.2/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.6.2/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.6.3/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.6.3/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.6.4/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.6.4/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.7.0/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.7.0/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.7.1/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.7.1/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.7.2/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.7.2/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.7.3/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.7.3/adaptors-spark.md
@@ -5,9 +5,9 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ## Prerequisites
 

--- a/site2/website/versioned_docs/version-2.8.0/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.8.0/adaptors-spark.md
@@ -5,13 +5,10 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 

--- a/site2/website/versioned_docs/version-2.8.1/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.8.1/adaptors-spark.md
@@ -5,13 +5,10 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 

--- a/site2/website/versioned_docs/version-2.8.2/adaptors-spark.md
+++ b/site2/website/versioned_docs/version-2.8.2/adaptors-spark.md
@@ -5,13 +5,10 @@ sidebar_label: Apache Spark
 original_id: adaptors-spark
 ---
 
-## Spark structured streaming connector
-Pulsar Spark Connector is an integration of Apache Pulsar and Apache Spark (data processing engine), which allows Spark reading data from Pulsar and writing data to Pulsar using Spark structured streaming and Spark SQL and provides exactly-once source semantics and at-least-once sink semantics. 
+## Spark Streaming receiver
+The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive raw data from Pulsar.
 
-## Spark streaming connector
-The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache [Spark Streaming](https://spark.apache.org/streaming/) to receive data from Pulsar.
-
-An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming Pulsar receiver and can process it in a variety of ways.
+An application can receive data in [Resilient Distributed Dataset](https://spark.apache.org/docs/latest/programming-guide.html#resilient-distributed-datasets-rdds) (RDD) format via the Spark Streaming receiver and can process it in a variety of ways.
 
 ### Prerequisites
 


### PR DESCRIPTION



### Motivation


Contents in the **[Pulsar adaptor for Apache Spark](https://pulsar.apache.org/docs/en/adaptors-spark/)** document are not correct. Update the docs based on eng's input.

### Modifications

1. Update "Spark streaming connector" to "spark streaming receiver"

   - Affected releases: 2.8.0 and later releases

2. Remove Spark structured streaming connector section

   - Affected releases: 2.8.0 and later releases

3. Update"The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache Spark Streaming to **receive data from Pulsar.**" to "The Spark Streaming receiver for Pulsar is a custom receiver that enables Apache Spark Streaming to **receive raw data from Pulsar**."
   - Affected releases: all releases

4. Fix some typos
   - Affected releases: all releases



