### PR TITLE
fix lastCumulativeAck.messageId npe when PersistentAcknowledgmentsGroupingTracker.flushSync

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -477,13 +477,16 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     private void flushAsync(ClientCnx cnx) {
         boolean shouldFlush = false;
         if (cumulativeAckFlushRequired) {
-            newMessageAckCommandAndWrite(cnx, consumer.consumerId, lastCumulativeAck.messageId.ledgerId,
-                    lastCumulativeAck.messageId.getEntryId(), lastCumulativeAck.bitSetRecyclable,
-                    AckType.Cumulative, null, Collections.emptyMap(), false,
-                    this.currentCumulativeAckFuture, null);
-            this.consumer.unAckedChunkedMessageIdSequenceMap.remove(lastCumulativeAck.messageId);
-            shouldFlush = true;
-            cumulativeAckFlushRequired = false;
+            final MessageIdImpl messageIdOfLastAck = lastCumulativeAck.messageId;
+            if (messageIdOfLastAck != null) {
+                newMessageAckCommandAndWrite(cnx, consumer.consumerId, messageIdOfLastAck.ledgerId,
+                        messageIdOfLastAck.getEntryId(), lastCumulativeAck.bitSetRecyclable,
+                        AckType.Cumulative, null, Collections.emptyMap(), false,
+                        this.currentCumulativeAckFuture, null);
+                this.consumer.unAckedChunkedMessageIdSequenceMap.remove(messageIdOfLastAck);
+                shouldFlush = true;
+                cumulativeAckFlushRequired = false;
+            }
         }
 
         // Flush all individual acks


### PR DESCRIPTION
 Reader ACK would be  stuck:
![image](https://user-images.githubusercontent.com/9278488/137125423-0ba68950-63db-4b33-a9e9-6acc482c94f7.png)
This was caused by: 
`flushAsync` is executed by `scheduledTask`,  Any thrown exception or error reaching the executor causes the executor to halt。

The exception is as below:

![image](https://user-images.githubusercontent.com/9278488/137125216-9564a9dc-a3a1-44df-94a7-c46e3ddf4832.png)
