### PR TITLE
[pulsar-admin] Add remove-clusters command for namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -781,9 +781,7 @@ public abstract class NamespacesBase extends AdminResource {
         validatePoliciesReadOnlyAccess();
         checkNotNull(clusterIds, "ClusterIds should not be null");
 
-        Set<String> replicationClusterSet = clusterIds.isEmpty()
-                ? Sets.newHashSet(namespaceName.isV2() ? config().getClusterName() : namespaceName.getCluster())
-                : Sets.newHashSet(clusterIds);
+        Set<String> replicationClusterSet = Sets.newHashSet(clusterIds);
         if (!namespaceName.isGlobal()) {
             throw new RestException(Status.PRECONDITION_FAILED, "Cannot set replication on a non-global namespace");
         }
@@ -802,6 +800,20 @@ public abstract class NamespacesBase extends AdminResource {
             validateClusterForTenant(namespaceName.getTenant(), clusterId);
         }
         updatePolicies(namespaceName, policies ->{
+            policies.replication_clusters = replicationClusterSet;
+            return policies;
+        });
+    }
+
+    protected void internalRemoveNamespaceReplicationClusters() {
+        validateNamespacePolicyOperation(namespaceName, PolicyName.REPLICATION, PolicyOperation.WRITE);
+        validatePoliciesReadOnlyAccess();
+
+        Set<String> replicationClusterSet = namespaceName.isV2()
+                ? Sets.newHashSet(config().getClusterName())
+                : Sets.newHashSet();
+
+        updatePolicies(namespaceName, policies -> {
             policies.replication_clusters = replicationClusterSet;
             return policies;
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -781,7 +781,9 @@ public abstract class NamespacesBase extends AdminResource {
         validatePoliciesReadOnlyAccess();
         checkNotNull(clusterIds, "ClusterIds should not be null");
 
-        Set<String> replicationClusterSet = Sets.newHashSet(clusterIds);
+        Set<String> replicationClusterSet = clusterIds.isEmpty()
+                ? Sets.newHashSet(namespaceName.isV2() ? config().getClusterName() : namespaceName.getCluster())
+                : Sets.newHashSet(clusterIds);
         if (!namespaceName.isGlobal()) {
             throw new RestException(Status.PRECONDITION_FAILED, "Cannot set replication on a non-global namespace");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -344,7 +344,7 @@ public class Namespaces extends NamespacesBase {
 
     @DELETE
     @Path("/{property}/{cluster}/{namespace}/replication")
-    @ApiOperation(value = "Set the replication clusters for namespace")
+    @ApiOperation(value = "Remove the replication clusters for namespace")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
             @ApiResponse(code = 412, message = "Namespace is not global")})
@@ -352,7 +352,7 @@ public class Namespaces extends NamespacesBase {
                                                    @PathParam("cluster") String cluster,
                                                    @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
-        internalSetNamespaceReplicationClusters(Lists.newArrayList());
+        internalRemoveNamespaceReplicationClusters();
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -342,6 +342,19 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceReplicationClusters(clusterIds);
     }
 
+    @DELETE
+    @Path("/{property}/{cluster}/{namespace}/replication")
+    @ApiOperation(value = "Set the replication clusters for namespace")
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 412, message = "Namespace is not global")})
+    public void removeNamespaceReplicationClusters(@PathParam("property") String property,
+                                                   @PathParam("cluster") String cluster,
+                                                   @PathParam("namespace") String namespace) {
+        validateNamespaceName(property, cluster, namespace);
+        internalSetNamespaceReplicationClusters(Lists.newArrayList());
+    }
+
     @GET
     @Path("/{property}/{cluster}/{namespace}/messageTTL")
     @ApiOperation(hidden = true, value = "Get the message TTL for the namespace")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -19,8 +19,6 @@
 package org.apache.pulsar.broker.admin.v2;
 
 import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
-
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -291,14 +289,14 @@ public class Namespaces extends NamespacesBase {
 
     @DELETE
     @Path("/{tenant}/{namespace}/replication")
-    @ApiOperation(value = "Set the replication clusters for namespace")
+    @ApiOperation(value = "Remove the replication clusters for namespace")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
             @ApiResponse(code = 412, message = "Namespace is not global")})
     public void removeNamespaceReplicationClusters(@PathParam("tenant") String tenant,
                                                     @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
-        internalSetNamespaceReplicationClusters(Lists.newArrayList());
+        internalRemoveNamespaceReplicationClusters();
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.admin.v2;
 
 import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
+
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -285,6 +287,18 @@ public class Namespaces extends NamespacesBase {
             @ApiParam(value = "List of replication clusters", required = true) List<String> clusterIds) {
         validateNamespaceName(tenant, namespace);
         internalSetNamespaceReplicationClusters(clusterIds);
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/replication")
+    @ApiOperation(value = "Set the replication clusters for namespace")
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 412, message = "Namespace is not global")})
+    public void removeNamespaceReplicationClusters(@PathParam("tenant") String tenant,
+                                                    @PathParam("namespace") String namespace) {
+        validateNamespaceName(tenant, namespace);
+        internalSetNamespaceReplicationClusters(Lists.newArrayList());
     }
 
     @GET

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -210,6 +211,19 @@ public class ReplicatorTest extends ReplicatorTestBase {
         Assert.assertNotNull(replicationClients3.get("r2"));
 
         // Case 3: TODO: Once automatic cleanup is implemented, add tests case to verify auto removal of clusters
+    }
+
+    @Test
+    public void testNamespaceWithReplicationClusters() throws PulsarAdminException {
+        // set replication cluster for namespace
+        admin1.namespaces().setNamespaceReplicationClusters("pulsar/ns", Sets.newHashSet("r1", "r2"));
+        Assert.assertEquals(
+                admin1.namespaces().getNamespaceReplicationClusters("pulsar/ns"), Sets.newHashSet("r1","r2"));
+
+        // remove replication cluster for namespace
+        admin1.namespaces().removeNamespaceReplicationClusters("pulsar/ns");
+        Assert.assertEquals(
+                admin1.namespaces().getNamespaceReplicationClusters("pulsar/ns"), Sets.newHashSet());
     }
 
     @Test(timeOut = 10000)

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -774,6 +774,22 @@ public interface Namespaces {
     CompletableFuture<List<String>> getNamespaceReplicationClustersAsync(String namespace);
 
     /**
+     * Remove the replication clusters for a namespace.
+     *
+     * @param namespace
+     * @throws PulsarAdminException
+     */
+    void removeNamespaceReplicationClusters(String namespace) throws PulsarAdminException;
+
+    /**
+     * Remove the replication clusters for a namespace asynchronously.
+     *
+     * @param namespace
+     * @return
+     */
+    CompletableFuture<Void> removeNamespaceReplicationClustersAsync(String namespace);
+
+    /**
      * Set the replication clusters for a namespace.
      * <p/>
      * Request example:

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -461,6 +461,28 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
+    public void removeNamespaceReplicationClusters(String namespace) throws PulsarAdminException {
+        try {
+            removeNamespaceReplicationClustersAsync(namespace)
+                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e);
+        } catch (TimeoutException e) {
+            throw new PulsarAdminException.TimeoutException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> removeNamespaceReplicationClustersAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "replication");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
     public Integer getNamespaceMessageTTL(String namespace) throws PulsarAdminException {
         return sync(() -> getNamespaceMessageTTLAsync(namespace));
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -462,17 +462,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void removeNamespaceReplicationClusters(String namespace) throws PulsarAdminException {
-        try {
-            removeNamespaceReplicationClustersAsync(namespace)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeNamespaceReplicationClustersAsync(namespace));
     }
 
     @Override

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -369,6 +369,9 @@ public class PulsarAdminToolTest {
         namespaces.run(split("get-clusters myprop/clust/ns1"));
         verify(mockNamespaces).getNamespaceReplicationClusters("myprop/clust/ns1");
 
+        namespaces.run(split("remove-clusters myprop/clust/ns1"));
+        verify(mockNamespaces).removeNamespaceReplicationClusters("myprop/clust/ns1");
+
         namespaces.run(split("set-subscription-types-enabled myprop/clust/ns1 -t Shared,Failover"));
         verify(mockNamespaces).setSubscriptionTypesEnabled("myprop/clust/ns1",
                 Sets.newHashSet(SubscriptionType.Shared, SubscriptionType.Failover));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -326,6 +326,18 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Remove replication clusters for a namespace")
+    private class RemoveReplicationClusters extends CliCommand {
+        @Parameter(description = "tenant/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            getAdmin().namespaces().removeNamespaceReplicationClusters(namespace);
+        }
+    }
+
     @Parameters(commandDescription = "Set subscription types enabled for a namespace")
     private class SetSubscriptionTypesEnabled extends CliCommand {
         @Parameter(description = "tenant/namespace", required = true)
@@ -2473,6 +2485,7 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("set-clusters", new SetReplicationClusters());
         jcommander.addCommand("get-clusters", new GetReplicationClusters());
+        jcommander.addCommand("remove-clusters", new RemoveReplicationClusters());
 
         jcommander.addCommand("set-subscription-types-enabled", new SetSubscriptionTypesEnabled());
         jcommander.addCommand("get-subscription-types-enabled", new GetSubscriptionTypesEnabled());


### PR DESCRIPTION
From [dev-email](https://lists.apache.org/thread/z531k47nlzy3gvbdkthh2n2wblwgxzfs)
Fixes #12822 

### Motivation
CLI `bin/pulsar-admin` supports `set-clusters` and `get-clusters` command, but lacks corresponding `remove-clusters` commands,  the purpose of this PR is to add this command.

### Documentation
Automatically generate doc through code
- [x] `doc` 

