### PR TITLE
Documentation: Clarify units on load balancing metrics

### DIFF
--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -307,11 +307,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent.  |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). | 
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website-next/docs/reference-metrics.md
+++ b/site2/website-next/docs/reference-metrics.md
@@ -307,11 +307,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage  |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website-next/versioned_docs/version-2.7.3/reference-metrics.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/reference-metrics.md
@@ -275,11 +275,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage  |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website-next/versioned_docs/version-2.8.0/reference-metrics.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/reference-metrics.md
@@ -289,11 +289,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage  |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-metrics.md
@@ -257,11 +257,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-metrics.md
@@ -257,11 +257,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-metrics.md
@@ -257,11 +257,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.3/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-metrics.md
@@ -257,11 +257,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.6.4/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.6.4/reference-metrics.md
@@ -257,11 +257,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.7.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-metrics.md
@@ -253,11 +253,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.7.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-metrics.md
@@ -255,11 +255,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.7.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.2/reference-metrics.md
@@ -255,11 +255,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.7.3/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.7.3/reference-metrics.md
@@ -275,11 +275,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.8.0/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.0/reference-metrics.md
@@ -289,11 +289,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.8.1/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.1/reference-metrics.md
@@ -292,11 +292,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent. |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). | 
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:

--- a/site2/website/versioned_docs/version-2.8.2/reference-metrics.md
+++ b/site2/website/versioned_docs/version-2.8.2/reference-metrics.md
@@ -301,11 +301,11 @@ All the loadbalancing metrics are labelled with the following labels:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| pulsar_lb_bandwidth_in_usage | Gauge | The broker bandwith in usage. Units are percent. |
-| pulsar_lb_bandwidth_out_usage | Gauge | The broker bandwith out usage. Units are percent. |
-| pulsar_lb_cpu_usage | Gauge | The broker cpu usage. Units are percent. |
-| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage. Units are percent. |
-| pulsar_lb_memory_usage | Gauge | The broker process memory usage. Units are percent.  |
+| pulsar_lb_bandwidth_in_usage | Gauge | The broker inbound bandwith usage (in percent). |
+| pulsar_lb_bandwidth_out_usage | Gauge | The broker outbound bandwith usage (in percent). |
+| pulsar_lb_cpu_usage | Gauge | The broker cpu usage (in percent). |
+| pulsar_lb_directMemory_usage | Gauge | The broker process direct memory usage (in percent). |
+| pulsar_lb_memory_usage | Gauge | The broker process memory usage (in percent). |
 
 #### BundleUnloading metrics
 All the bundleUnloading metrics are labelled with the following labels:


### PR DESCRIPTION
Clarify which units to use when graphing these metrics

### Motivation
Not clear whether bytes in / out was in units of bytes, or memory also in bytes etc.

### Modifications
Added information on the units

### Verifying this change
Small documentatin change

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies: no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol:  no
  - The rest endpoints:  no
  - The admin cli options: no
  - Anything that affects deployment: no 

### Documentation

Need to update docs? 
  
- [ X] doc 
  



