### PR TITLE
[pulsar-broker] Additional mTLS Logging and Metrics

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -574,6 +574,45 @@ tlsCiphers=
 # authentication.
 tlsRequireTrustedClientCertOnConnect=false
 
+# Print the entire trust chain for the client's certificate in
+# the application logs when authenticating
+# Default value is false (off)
+tlsLogEntireCertificateChain=false
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus counter if the client's
+# certificate is within this many milliseconds of expiration.
+# Default value is 0 (off)
+tlsPrintWarnOnClientCertNearingExpirationMillis=0
+
+# If set to a positive non-zero value, the broker will print an error in
+# the application logs and increment a Prometheus counter if the client's
+# certificate is within this many milliseconds of expiration.
+# Default value is 0 (off)
+tlsPrintErrorOnClientCertNearingExpirationMillis=0
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus metric if the client's
+# certificate has a validity duration exceeding the supplied number of milliseconds.
+# Default value is 0 (off)
+tlsPrintWarnOnClientCertValidityDurationExceedsMillis=0
+
+# If set to a true the broker will print a warning in the logs and increment
+# a Prometheus metric if a self-signed client certificate is encountered.
+# Default value is false (off)
+tlsPrintWarnOnSelfSignedCertificate=false
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus metric if the client's
+# certificate has a RSA key with bit size < number of supplied bits
+# Default value is 0 (off)
+tlsPrintWarnOnRsaKeySizeLessThanBits=0
+
+# If true broker will print a warning and increment a Prometheus metric if
+# a client certificate with a wildcard CN is encountered
+# Default value is false (off)
+tlsPrintWarnOnWildcardCertificate=false
+
 ### --- KeyStore TLS config variables --- ###
 # Enable TLS with KeyStore type configuration in broker.
 tlsEnabledWithKeyStore=false

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -482,6 +482,45 @@ tlsCiphers=
 # authentication.
 tlsRequireTrustedClientCertOnConnect=false
 
+# Print the entire trust chain for the client's certificate in
+# the application logs when authenticating
+# Default value is false (off)
+tlsLogEntireCertificateChain=false
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus counter if the client's
+# certificate is within this many milliseconds of expiration.
+# Default value is 0 (off)
+tlsPrintWarnOnClientCertNearingExpirationMillis=0
+
+# If set to a positive non-zero value, the broker will print an error in
+# the application logs and increment a Prometheus counter if the client's
+# certificate is within this many milliseconds of expiration.
+# Default value is 0 (off)
+tlsPrintErrorOnClientCertNearingExpirationMillis=0
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus metric if the client's
+# certificate has a validity duration exceeding the supplied number of milliseconds.
+# Default value is 0 (off)
+tlsPrintWarnOnClientCertValidityDurationExceedsMillis=0
+
+# If set to a true the broker will print a warning in the logs and increment
+# a Prometheus metric if a self-signed client certificate is encountered.
+# Default value is false (off)
+tlsPrintWarnOnSelfSignedCertificate=false
+
+# If set to a positive non-zero value, the broker will print a warning in
+# the application logs and increment a Prometheus metric if the client's
+# certificate has a RSA key with bit size < number of supplied bits
+# Default value is 0 (off)
+tlsPrintWarnOnRsaKeySizeLessThanBits=0
+
+# If true broker will print a warning and increment a Prometheus metric if
+# a client certificate with a wildcard CN is encountered
+# Default value is false (off)
+tlsPrintWarnOnWildcardCertificate=false
+
 ### --- KeyStore TLS config variables --- ###
 # Enable TLS with KeyStore type configuration in broker.
 tlsEnabledWithKeyStore=false

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1074,6 +1074,52 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Specify whether Client certificates are required for TLS Reject.\n"
             + "the Connection if the Client Certificate is not trusted")
     private boolean tlsRequireTrustedClientCertOnConnect = false;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "Print the entire trust chain for the client's certificate in\n"
+                + "the application logs when authenticating\n"
+                + "Default value is 0 (off)")
+    private boolean tlsLogEntireCertificateChain = false;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If set to a positive non-zero value, the broker will print a warning in\n"
+                + "the application logs and increment a Prometheus counter if the client's\n"
+                + "certificate is within this many milliseconds of expiration.\n"
+                + "Default value is 0 (off)")
+    private long tlsPrintWarnOnClientCertNearingExpirationMillis = 0;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If set to a positive non-zero value, the broker will print an error in\n"
+                + "the application logs and increment a Prometheus counter if the client's\n"
+                + "certificate is within this many milliseconds of expiration.\n"
+                + "Default value is 0 (off)")
+    private long tlsPrintErrorOnClientCertNearingExpirationMillis = 0;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If set to a positive non-zero value, the broker will print a warning in\n"
+                + "the application logs and increment a Prometheus metric if the client's\n"
+                + "certificate has a validity duration exceeding the supplied number of milliseconds.\n"
+                + "Default value is 0 (off)")
+    private long tlsPrintWarnOnClientCertValidityDurationExceedsMillis = 0;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If set to a true the broker will print a warning in the logs and increment\n"
+                + "a Prometheus metric if a self-signed client certificate is encountered.\n"
+                + "Default value is 0 (off)")
+    private boolean tlsPrintWarnOnSelfSignedCertificate = false;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If set to a positive non-zero value, the broker will print a warning in\n"
+                + "the application logs and increment a Prometheus metric if the client's\n"
+                + "certificate has a RSA key with bit size < number of supplied bits\n"
+                + "Default value is 0 (off)")
+    private int tlsPrintWarnOnRsaKeySizeLessThanBits = 0;
+    @FieldContext(
+            category = CATEGORY_TLS,
+            doc = "If true broker will print a warning and increment a Prometheus metric if\n"
+                + "a client certificate with a wildcard CN is encountered\n"
+                + "Default value is false (off)")
+    private boolean tlsPrintWarnOnWildcardCertificate = false;
 
     /***** --- Authentication --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTls.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTls.java
@@ -167,7 +167,13 @@ public class AuthenticationProviderTls implements AuthenticationProvider {
                 // The format is defined in RFC 2253.
                 // Example:
                 // CN=Steve Kille,O=Isode Limited,C=GB
-                clientCertificateChain = (X509Certificate[]) authData.getTlsCertificates();
+                Certificate[] uncastCerts = authData.getTlsCertificates();
+                clientCertificateChain = new X509Certificate[uncastCerts.length];
+
+                for(int i = 0; i < uncastCerts.length; i++) {
+                    clientCertificateChain[i] = (X509Certificate) uncastCerts[i];
+                }
+
                 if (null == clientCertificateChain) {
                     throw new AuthenticationException("Failed to get TLS certificates from client");
                 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/metrics/AuthenticationMetrics.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/metrics/AuthenticationMetrics.java
@@ -37,9 +37,10 @@ public class AuthenticationMetrics {
             .help("Pulsar client authenticating with a TLS cert that is self-signed")
             .register();
 
-    private static final Counter clientCertSmallRsaKeySizeMetrics = Counter.build()
-            .name("pulsar_authentication_tls_cert_small_rsa_key_count")
-            .help("Pulsar client authenticating with a TLS cert that has a small rsa key")
+    private static final Counter clientCertInvalidKeySizeMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_invalid_key_size_count")
+            .labelNames("algorithm")
+            .help("Pulsar client authenticating with a TLS cert that has a key size violation")
             .register();
 
     private static final Counter clientCertReachedWarnThresholdMetrics = Counter.build()
@@ -92,7 +93,7 @@ public class AuthenticationMetrics {
      * Log small RSA key size certificate encountered event to the authentication metrics.
      */
     public static void encounteredSmallRsaKeySize() {
-        clientCertSmallRsaKeySizeMetrics.inc();
+        clientCertInvalidKeySizeMetrics.labels("rsa").inc();
     }
 
     /**
@@ -128,7 +129,7 @@ public class AuthenticationMetrics {
      */
     public static void resetTlsMetrics() {
         clientCertSelfSignedMetrics.clear();
-        clientCertSmallRsaKeySizeMetrics.clear();
+        clientCertInvalidKeySizeMetrics.clear();
         clientCertReachedWarnThresholdMetrics.clear();
         clientCertReachedErrorThresholdMetrics.clear();
         clientCertValidityDurationExceedsThresholdMetrics.clear();
@@ -140,7 +141,7 @@ public class AuthenticationMetrics {
     }
 
     public static double getSmallRsaKeySizeCount() {
-        return clientCertSmallRsaKeySizeMetrics.get();
+        return clientCertInvalidKeySizeMetrics.labels("rsa").get();
     }
 
     public static double getCertificateUnderWarnThresholdCount() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/metrics/AuthenticationMetrics.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/metrics/AuthenticationMetrics.java
@@ -32,6 +32,36 @@ public class AuthenticationMetrics {
             .labelNames("provider_name", "auth_method", "reason")
             .register();
 
+    private static final Counter clientCertSelfSignedMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_self_signed_count")
+            .help("Pulsar client authenticating with a TLS cert that is self-signed")
+            .register();
+
+    private static final Counter clientCertSmallRsaKeySizeMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_small_rsa_key_count")
+            .help("Pulsar client authenticating with a TLS cert that has a small rsa key")
+            .register();
+
+    private static final Counter clientCertReachedWarnThresholdMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_expiration_soon_count")
+            .help("Pulsar client authenticating with a TLS cert nearing expiration")
+            .register();
+
+    private static final Counter clientCertReachedErrorThresholdMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_expiration_imminent_count")
+            .help("Pulsar client authenticating with a TLS cert whose expiration is imminent")
+            .register();
+
+    private static final Counter clientCertValidityDurationExceedsThresholdMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_validity_too_long_count")
+            .help("Pulsar client authenticating with a TLS cert whose validity duration exceeds the system's configured (soft) maximum value")
+            .register();
+
+    private static final Counter clientCertWildcardMetrics = Counter.build()
+            .name("pulsar_authentication_tls_cert_wildcard_count")
+            .help("Pulsar client authenticating with a TLS cert that has wildcard CN")
+            .register();
+
     /**
      * Log authenticate success event to the authentication metrics
      * @param providerName The short class name of the provider
@@ -50,4 +80,83 @@ public class AuthenticationMetrics {
     public static void authenticateFailure(String providerName, String authMethod, String reason) {
         authFailuresMetrics.labels(providerName, authMethod, reason).inc();
     }
+
+    /**
+     * Log self-signed certificate encountered event to the authentication metrics.
+     */
+    public static void encounteredSelfSignedCertificate() {
+        clientCertSelfSignedMetrics.inc();
+    }
+
+    /**
+     * Log small RSA key size certificate encountered event to the authentication metrics.
+     */
+    public static void encounteredSmallRsaKeySize() {
+        clientCertSmallRsaKeySizeMetrics.inc();
+    }
+
+    /**
+     * Log certificate with warning expiration encountered event to the authentication metrics.
+     */
+    public static void encounteredCertificateUnderWarnThreshold() {
+        clientCertReachedWarnThresholdMetrics.inc();
+    }
+
+    /**
+     * Log certificate with error expiration encountered event to the authentication metrics.
+     */
+    public static void encounteredCertificateUnderErrorThreshold() {
+        clientCertReachedErrorThresholdMetrics.inc();
+    }
+
+    /**
+     * Log long validity certificate encountered event to the authentication metrics.
+     */
+    public static void encounteredLongValidityCertificate() {
+        clientCertValidityDurationExceedsThresholdMetrics.inc();
+    }
+
+    /**
+     * Log wildcard certificate encountered event to the authentication metrics.
+     */
+    public static void encounteredWildcardCertificate() {
+        clientCertWildcardMetrics.inc();
+    }
+
+    /**
+     * Reset the TLS metrics (for testing purposes)
+     */
+    public static void resetTlsMetrics() {
+        clientCertSelfSignedMetrics.clear();
+        clientCertSmallRsaKeySizeMetrics.clear();
+        clientCertReachedWarnThresholdMetrics.clear();
+        clientCertReachedErrorThresholdMetrics.clear();
+        clientCertValidityDurationExceedsThresholdMetrics.clear();
+        clientCertWildcardMetrics.clear();
+    }
+
+    public static double getClientCertSelfSignedCount() {
+        return clientCertSelfSignedMetrics.get();
+    }
+
+    public static double getSmallRsaKeySizeCount() {
+        return clientCertSmallRsaKeySizeMetrics.get();
+    }
+
+    public static double getCertificateUnderWarnThresholdCount() {
+        return clientCertReachedWarnThresholdMetrics.get();
+    }
+
+    public static double getCertificateUnderErrorThresholdCount() {
+        return clientCertReachedErrorThresholdMetrics.get();
+    }
+
+    public static double getLongValidityCertificateCount() {
+        return clientCertValidityDurationExceedsThresholdMetrics.get();
+    }
+
+    public static double getWildcardCertificateCount(){
+        return clientCertWildcardMetrics.get();
+    }
+
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTlsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTlsTest.java
@@ -80,15 +80,14 @@ public class AuthenticationProviderTlsTest {
     }
 
     @Test
-    public void testPrintCertificateChain() throws CertificateException, NoSuchAlgorithmException,
-            CertIOException, OperatorCreationException {
+    public void testPrintCertificateChain() {
         assertEquals("O=Stark Industries,OU=CEO,CN=Tony Stark -> O=Wayne Enterprises\\, Inc.,OU=Chairman,CN=*.BruceWayne.com -> O=Planet Express\\, Inc.,OU=Delivery Dept.,CN=Phillip J Fry",
                 AuthenticationProviderTls.concatenateFullCertChain(chain));
     }
 
     @Test
     public void testCheckIfWildcardCertificate() {
-        AuthenticationProviderTls.checkIfWildcardCertificate(chain[1], INTERMEDIATE_CN);
+        AuthenticationProviderTls.checkIfWildcardCertificate(INTERMEDIATE_CN);
         assertEquals(1, AuthenticationProviderTls.clientCertWildcardMetrics.get(), 0);
     }
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTlsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTlsTest.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.authentication;
+
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeClass;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Unit test for {@link AuthenticationProviderTls}.
+ */
+public class AuthenticationProviderTlsTest {
+
+    private static final String ROOT_CN = "Tony Stark";
+    private static final String ROOT_OU = "CEO";
+    private static final String ROOT_O = "Stark Industries";
+
+    private static final String INTERMEDIATE_CN = "*.BruceWayne.com";
+    private static final String INTERMEDIATE_OU = "Chairman";
+    private static final String INTERMEDIATE_O = "Wayne Enterprises, Inc.";
+
+    private static final String CLIENT_CN= "Phillip J Fry";
+    private static final String CLIENT_OU= "Delivery Dept.";
+    private static final String CLIENT_O= "Planet Express, Inc.";
+
+
+    private X509Certificate[] chain;
+
+    @BeforeClass
+    public void setUpCertificateChain() throws CertificateException, NoSuchAlgorithmException,
+            OperatorCreationException, CertIOException {
+        chain = generateCertificateChain(new String[][] {
+                new String[] {ROOT_CN, ROOT_OU, ROOT_O},
+                new String[] {INTERMEDIATE_CN, INTERMEDIATE_OU, INTERMEDIATE_O},
+                new String[] {CLIENT_CN, CLIENT_OU, CLIENT_O}},
+                30000, 30000);
+
+    }
+
+    @BeforeMethod
+    public void resetStatistics() {
+        AuthenticationProviderTls.resetMetrics();
+    }
+
+    @Test
+    public void testPrintCertificateChain() throws CertificateException, NoSuchAlgorithmException,
+            CertIOException, OperatorCreationException {
+        assertEquals("O=Stark Industries,OU=CEO,CN=Tony Stark -> O=Wayne Enterprises\\, Inc.,OU=Chairman,CN=*.BruceWayne.com -> O=Planet Express\\, Inc.,OU=Delivery Dept.,CN=Phillip J Fry",
+                AuthenticationProviderTls.concatenateFullCertChain(chain));
+    }
+
+    @Test
+    public void testCheckIfWildcardCertificate() {
+        AuthenticationProviderTls.checkIfWildcardCertificate(chain[1], INTERMEDIATE_CN);
+        assertEquals(1, AuthenticationProviderTls.clientCertWildcardMetrics.get(), 0);
+    }
+
+    @Test
+    public void testCheckIfSelfSignedCertificate() {
+        AuthenticationProviderTls.checkIfSelfSignedCertificate(chain[chain.length-1], ROOT_CN);
+        assertEquals(1, AuthenticationProviderTls.clientCertSelfSignedMetrics.get(), 0);
+    }
+
+    @Test
+    public void testCheckIfNearingExpiration() {
+        AuthenticationProviderTls.checkIfNearingExpiration(chain[0], CLIENT_CN,
+                1, 35000L);
+        assertEquals(1, AuthenticationProviderTls.clientCertReachedWarnThresholdMetrics.get(), 0);
+        AuthenticationProviderTls.checkIfNearingExpiration(chain[0], CLIENT_CN,
+                35000L, 1L);
+        assertEquals(1, AuthenticationProviderTls.clientCertReachedErrorThresholdMetrics.get(), 0);
+    }
+
+    @Test
+    public void testCheckMaxValidityPeriod() {
+        AuthenticationProviderTls.checkMaxValidityPeriod(chain[0], CLIENT_CN, 59999);
+        assertEquals(1, AuthenticationProviderTls.clientCertValidityDurationExceedsThresholdMetrics.get(), 0);
+    }
+
+    @Test
+    public void testCheckIfUsingSmallRsaKeySize() {
+        AuthenticationProviderTls.checkIfUsingSmallRsaKeySize(chain[0], 4096, CLIENT_CN);
+        assertEquals(1, AuthenticationProviderTls.clientCertSmallRsaKeySizeMetrics.get(), 0);
+    }
+
+    private X509Certificate[] generateCertificateChain(final String[][] chainCommonNames,
+             final long millisBefore, final long millisAfter) throws NoSuchAlgorithmException,
+            CertIOException, CertificateException, OperatorCreationException {
+
+        X509Certificate[] certChain = new X509Certificate[chainCommonNames.length];
+
+        X500Name[] certNames = new X500Name[chainCommonNames.length];
+        BigInteger[] serialNumbers = new BigInteger[chainCommonNames.length];
+
+        for(int i = 0; i< certChain.length; i++) {
+            X500NameBuilder x500NameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
+            x500NameBuilder.addRDN(BCStyle.CN, chainCommonNames[i][0]);
+            x500NameBuilder.addRDN(BCStyle.OU, chainCommonNames[i][1]);
+            x500NameBuilder.addRDN(BCStyle.O, chainCommonNames[i][2]);
+            certNames[i] = x500NameBuilder.build();
+
+            serialNumbers[i] = new BigInteger(UUID.randomUUID().toString().replace("-", ""), 16);
+        }
+
+        for(int i = 0; i< certChain.length; i++) {
+
+            Instant now = Instant.now();
+
+            Instant notBefore = now.minusMillis(millisBefore);
+            Instant notAfter = now.plusMillis(millisAfter);
+
+
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+            keyGen.initialize(2048);
+            KeyPair key = keyGen.generateKeyPair();
+            PrivateKey priv = key.getPrivate();
+            PublicKey pub = key.getPublic();
+
+            final byte[] encoded = pub.getEncoded();
+            SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(
+                    ASN1Sequence.getInstance(encoded));
+
+            final X509v3CertificateBuilder generator = new X509v3CertificateBuilder(
+                    (i == 0) ? certNames[i] /* CA */: certNames[i-1] /* Not a CA */,
+                    serialNumbers[i],
+                    Date.from(notBefore),
+                    Date.from(notAfter),
+                    certNames[i],
+                    subjectPublicKeyInfo);
+
+            //generator.addExtension(Extension.certificateIssuer, true, new IssuerSerial());
+
+
+            if(i != 0) {
+                // Not a CA
+                generator.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.dataEncipherment));
+                generator.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+            } else {
+                // CA
+                generator.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
+            }
+
+            X509CertificateHolder holder = generator.build(
+                    new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(priv));
+
+            certChain[i] = new JcaX509CertificateConverter().getCertificate(holder);
+
+        }
+
+        Collections.reverse(Arrays.asList(certChain));
+        return certChain;
+    }
+}

--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -79,6 +79,17 @@ brokerClientAuthenticationParameters={"tlsCertFile":"/path/my-ca/admin.cert.pem,
 brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 ```
 
+### Log when soon-to-be non-compliant certificates are encountered
+
+Brokers can be configured (via properties in ```broker.conf```) to emit WARN/ERROR messages and increment Prometheus metrics when client certificates meeting the following criteria are encountered:
+* About to expire: ```tlsPrintWarnOnClientCertNearingExpirationMillis``` and ```tlsPrintErrorOnClientCertNearingExpirationMillis```
+* Long validity durations ```tlsPrintWarnOnClientCertValidityDurationExceedsMillis```
+* Self-Signed: ```tlsPrintWarnOnSelfSignedCertificate```
+* Small RSA public key size ```tlsPrintWarnOnRsaKeySizeLessThanBits```
+* Wildcard in the CN ```tlsPrintWarnOnWildcardCertificate```
+
+>None of the above settings are hard limits that will prevent the broker from performing a TLS handshake. These configuration options are intended to be used in conjunction with a Prometheus monitoring and/or log collection. These settings can be useful for identifying certificates currently in use that are allowable but are in danger of becoming unusable in the near future due to upcoming policy changes or expiration.
+
 ## Enable TLS authentication on proxies
 
 To configure proxies to authenticate clients, add the following parameters to `proxy.conf`, alongside [the configuration to enable tls transport](security-tls-transport.md#proxy-configuration):

--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -81,14 +81,16 @@ brokerClientTrustCertsFilePath=/path/my-ca/certs/ca.cert.pem
 
 ### Log when soon-to-be non-compliant certificates are encountered
 
-Brokers can be configured (via properties in ```broker.conf```) to emit WARN/ERROR messages and increment Prometheus metrics when client certificates meeting the following criteria are encountered:
+You can configure Pulsar brokers (via properties in ```broker.conf```) to emit WARN/ERROR messages and increment Prometheus metrics when the certificates used by a Pulsar client are in the following situations: 
 * About to expire: ```tlsPrintWarnOnClientCertNearingExpirationMillis``` and ```tlsPrintErrorOnClientCertNearingExpirationMillis```
 * Long validity durations ```tlsPrintWarnOnClientCertValidityDurationExceedsMillis```
 * Self-Signed: ```tlsPrintWarnOnSelfSignedCertificate```
 * Small RSA public key size ```tlsPrintWarnOnRsaKeySizeLessThanBits```
 * Wildcard in the CN ```tlsPrintWarnOnWildcardCertificate```
 
->None of the above settings are hard limits that will prevent the broker from performing a TLS handshake. These configuration options are intended to be used in conjunction with a Prometheus monitoring and/or log collection. These settings can be useful for identifying certificates currently in use that are allowable but are in danger of becoming unusable in the near future due to upcoming policy changes or expiration.
+> **Note**
+>
+> None of the above settings are hard limits that prevent the broker from performing a TLS handshake. These configuration options are intended to be used together with a Prometheus monitoring and/or log collection. These settings can be useful for identifying existing certificates that are allowable but are in danger of becoming unusable in the near future due to upcoming policy changes or expiration.
 
 ## Enable TLS authentication on proxies
 


### PR DESCRIPTION
### Motivation

This PR includes additional logic to the ```AuthenticationProviderTls``` class that will check the supplied client cert for the following conditions:

- Close to expiration
- Issued for long durations
- Self-signed
- Small RSA key size
- Wildcard in the CN

When these conditions are met and the broker is configured to do so, the broker will emit application logs and increment Prometheus metrics.

In addition there is a new boolean property :```tlsLogEntireCertificateChain``` in ```broker.conf``` that will control whether the broker logs the entire certificate chain.

These settings can be useful for identifying certificates currently in use that are allowable but are in danger of becoming unusable in the near future due to upcoming policy changes or expiration.

### Modifications

Changes made to the ```initialize(...)``` and ```authenticate(...)``` methods in the ```AuthenticationProviderTls``` class

### Verifying this change

This change added tests and can be verified as follows:

  - *Added six (6) unit tests to new class AuthenticationProviderTlsTest to test the the checking logic

### Does this pull request potentially affect one of the following parts:

N/A

### Documentation

This PR contains doc changes


