### PR TITLE
Future completed twice in the method of  impl.MLPendingAckStore#closeAsync

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
@@ -124,7 +124,9 @@ public class MLPendingAckStore implements PendingAckStore {
 
                     @Override
                     public void closeComplete(Object ctx) {
-                        log.error("[{}][{}] MLPendingAckStore closed successfully！", managedLedger.getName(), ctx);
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}][{}] MLPendingAckStore closed successfully！", managedLedger.getName(), ctx);
+                        }
                         completableFuture.complete(null);
                     }
 


### PR DESCRIPTION
CompletableFuture is completed twice in this code：
https://github.com/apache/pulsar/blob/04604724dd89a4c8ff40b922e80c7045fedf112d/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java#L120-L135