### PR TITLE
[#12279 ] missed check exit code of stop before calling start

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -220,6 +220,7 @@ case $startStop in
     stop $1
     if [ "$exitCode" != 1 ]
     then
+       sleep 3
        start
     else
        echo "WARNNING :  $command failed restart, for $command is not stopped completely."

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -134,11 +134,9 @@ rotate_out_log ()
     fi
 }
 
-mkdir -p "$PULSAR_LOG_DIR"
-
-case $startStop in
-  (start)
-    if [ -f $pid ]; then
+start ()
+{
+  if [ -f $pid ]; then
       if kill -0 `cat $pid` > /dev/null 2>&1; then
         echo $command running as process `cat $pid`.  Stop it first.
         exit 1
@@ -156,112 +154,75 @@ case $startStop in
     if ! ps -p $! > /dev/null ; then
       exit 1
     fi
+}
+
+stop ()
+{
+  if [ -f $pid ]; then
+      TARGET_PID=$(cat $pid)
+      if kill -0 $TARGET_PID > /dev/null 2>&1; then
+        echo "stopping $command"
+        kill $TARGET_PID
+
+        count=0
+        location=$PULSAR_LOG_DIR
+        while ps -p $TARGET_PID > /dev/null;
+         do
+          echo "Shutdown is in progress... Please wait..."
+          sleep 1
+          count=`expr $count + 1`
+
+          if [ "$count" = "$PULSAR_STOP_TIMEOUT" ]; then
+                break
+          fi
+         done
+
+        if [ "$count" != "$PULSAR_STOP_TIMEOUT" ]; then
+            echo "Shutdown completed."
+        fi
+
+        if kill -0 $TARGET_PID > /dev/null 2>&1; then
+              fileName=$location/$command.out
+              $JAVA_HOME/bin/jstack $TARGET_PID > $fileName
+              echo "Thread dumps are taken for analysis at $fileName"
+              if [ "$1" == "-force" ]
+              then
+                 echo "forcefully stopping $command"
+                 kill -9 $TARGET_PID >/dev/null 2>&1
+                 echo Successfully stopped the process
+              else
+                 echo "WARNNING :  $command is not stopped completely."
+                 exit 1
+              fi
+        fi
+      else
+        echo "no $command to stop"
+      fi
+      rm $pid
+    else
+      echo no "$command to stop"
+    fi
+}
+
+mkdir -p "$PULSAR_LOG_DIR"
+
+case $startStop in
+  (start)
+    start
     ;;
 
   (stop)
-    if [ -f $pid ]; then
-      TARGET_PID=$(cat $pid)
-      if kill -0 $TARGET_PID > /dev/null 2>&1; then
-        echo "stopping $command"
-        kill $TARGET_PID
-
-        count=0
-        location=$PULSAR_LOG_DIR
-        while ps -p $TARGET_PID > /dev/null;
-         do
-          echo "Shutdown is in progress... Please wait..."
-          sleep 1
-          count=`expr $count + 1`
-
-          if [ "$count" = "$PULSAR_STOP_TIMEOUT" ]; then
-                break
-          fi
-         done
-
-        if [ "$count" != "$PULSAR_STOP_TIMEOUT" ]; then
-            echo "Shutdown completed."
-        fi
-
-        if kill -0 $TARGET_PID > /dev/null 2>&1; then
-              fileName=$location/$command.out
-              $JAVA_HOME/bin/jstack $TARGET_PID > $fileName
-              echo "Thread dumps are taken for analysis at $fileName"
-              if [ "$1" == "-force" ]
-              then
-                 echo "forcefully stopping $command"
-                 kill -9 $TARGET_PID >/dev/null 2>&1
-                 echo Successfully stopped the process
-              else
-                 echo "WARNNING :  $command is not stopped completely."
-                 exit 1
-              fi
-        fi
-      else
-        echo "no $command to stop"
-      fi
-      rm $pid
-    else
-      echo no "$command to stop"
-    fi
+    stop $1
     ;;
 
   (restart)
-   if [ -f $pid ]; then
-      TARGET_PID=$(cat $pid)
-      if kill -0 $TARGET_PID > /dev/null 2>&1; then
-        echo "stopping $command"
-        kill $TARGET_PID
-
-        count=0
-        location=$PULSAR_LOG_DIR
-        while ps -p $TARGET_PID > /dev/null;
-         do
-          echo "Shutdown is in progress... Please wait..."
-          sleep 1
-          count=`expr $count + 1`
-
-          if [ "$count" = "$PULSAR_STOP_TIMEOUT" ]; then
-                break
-          fi
-         done
-
-        if [ "$count" != "$PULSAR_STOP_TIMEOUT" ]; then
-            echo "Shutdown completed."
-        fi
-
-        if kill -0 $TARGET_PID > /dev/null 2>&1; then
-              fileName=$location/$command.out
-              $JAVA_HOME/bin/jstack $TARGET_PID > $fileName
-              echo "Thread dumps are taken for analysis at $fileName"
-              if [ "$1" == "-force" ]
-              then
-                 echo "forcefully stopping $command"
-                 kill -9 $TARGET_PID >/dev/null 2>&1
-                 echo Successfully stopped the process
-              else
-                 echo "WARNNING :  $command is not stopped completely."
-                 exit 1
-              fi
-        fi
-      else
-        echo "no $command to stop"
-      fi
-      rm $pid
+    exitCode=$?
+    stop $1
+    if [ "$exitCode" != 1 ]
+    then
+       start
     else
-      echo no "$command to stop"
-    fi
-    sleep 3
-
-    rotate_out_log $out
-    echo restarting $command, logging to $logfile
-    echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
-    pulsar=$PULSAR_HOME/bin/pulsar
-    nohup $pulsar $command "$@" > "$out" 2>&1 < /dev/null &
-    echo $! > $pid
-    sleep 1; head $out
-    sleep 2;
-    if ! ps -p $! > /dev/null ; then
-      exit 1
+       echo "WARNNING :  $command failed restart, for $command is not stopped completely."
     fi
     ;;
 

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -147,7 +147,7 @@ start ()
     echo starting $command, logging to $logfile
     echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
     pulsar=$PULSAR_HOME/bin/pulsar
-    nohup $pulsar $command "$@" > "$out" 2>&1 < /dev/null &
+    nohup $pulsar $command "$1" > "$out" 2>&1 < /dev/null &
     echo $! > $pid
     sleep 1; head $out
     sleep 2;
@@ -208,7 +208,7 @@ mkdir -p "$PULSAR_LOG_DIR"
 
 case $startStop in
   (start)
-    start
+    start "$*"
     ;;
 
   (stop)
@@ -216,12 +216,19 @@ case $startStop in
     ;;
 
   (restart)
-    exitCode=$?
-    stop $1
-    if [ "$exitCode" != 1 ]
+    forceStopFlag=$(echo "$*"|grep "\-force")
+    if [[ "$forceStopFlag" != "" ]]
+    then
+      stop "-force"
+    else
+      stop
+    fi
+    if [ "$?" == 0 ]
     then
        sleep 3
-       start
+       paramaters="$*"
+       startParamaters=${paramaters//-force/}
+       start "$startParamaters"
     else
        echo "WARNNING :  $command failed restart, for $command is not stopped completely."
     fi


### PR DESCRIPTION
#12279  missed check exit code of stop before calling start method, avoiding stop failed and continue to call start.

also #12279 has another problem, When restarting with `-force`, `-force` flag will also be passed to `start` by `$@`.
throws` Caused by: org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -force`