### PR TITLE
[C++] Delay ClientCredentialFlow::initialize to the first authenticate call

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthOauth2.cc
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.cc
@@ -281,10 +281,8 @@ static std::string buildClientCredentialsBody(CURL* curl, const ParamMap& params
     return oss.str();
 }
 
-static std::once_flag initializeOnce;
-
 Oauth2TokenResultPtr ClientCredentialFlow::authenticate() {
-    std::call_once(initializeOnce, &ClientCredentialFlow::initialize, this);
+    std::call_once(initializeOnce_, &ClientCredentialFlow::initialize, this);
     Oauth2TokenResultPtr resultPtr = Oauth2TokenResultPtr(new Oauth2TokenResult());
     if (tokenEndPoint_.empty()) {
         return resultPtr;

--- a/pulsar-client-cpp/lib/auth/AuthOauth2.h
+++ b/pulsar-client-cpp/lib/auth/AuthOauth2.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <pulsar/Authentication.h>
+#include <mutex>
 #include <string>
 
 namespace pulsar {
@@ -63,6 +64,7 @@ class ClientCredentialFlow : public Oauth2Flow {
     const KeyFile keyFile_;
     const std::string audience_;
     const std::string scope_;
+    std::once_flag initializeOnce_;
 };
 
 class Oauth2CachedToken : public CachedToken {


### PR DESCRIPTION
Fixes #12325

### Motivation

C++ client uses one logger per thread, but if the logger of a thread has been initialized, even if the logger factory was changed, this logger would still keep not changed.

When a `AuthOauth2` object is created, it calls `ClientCredentialFlow::initialize`, which calls `LOG_DEBUG` to try logging debug level logs. At this moment, the logger of the current thread is created and won't change after the custom logger factory is set in `ClientImpl`'s constructor. Then the custom logger won't work for that thread.

### Modifications

To avoid creating the logger in advance to `ClientImpl`'s constructor, this PR delays `ClientCredentialFlow::initialize` to the first time `ClientCredentialFlow::authenticate` is called. Use `std::call_once` to ensure `initialize` is only called once. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.