### PR TITLE
Fixed: "Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Login failed for user 'sa'.." in MS SQL integration test

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMsSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMsSqlContainer.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.tests.integration.containers;
 
 
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -63,7 +64,10 @@ public class DebeziumMsSqlContainer extends ChaosContainer<DebeziumMsSqlContaine
                 createContainerCmd.withHostName(NAME);
                 createContainerCmd.withName(getContainerName());
             })
-            .waitingFor(new HostPortWaitStrategy());
+            // wait strategy to address problem with MS SQL responding to the connection
+            // before service starts up completely
+            // https://github.com/microsoft/mssql-docker/issues/625#issuecomment-882025521
+            .waitingFor(Wait.forLogMessage(".*The tempdb database has .*", 2));
     }
 
 }


### PR DESCRIPTION
### Motivation

`Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Login failed for user 'sa'..` in one of the runs of the MS SQL integration tests. Other runs succeeded, possibly due to the cached docker container image.

### Modifications

Looks like MSFT updated name of the env var that sets sa password, looks like the most possible explanation at the time (still testing locally).
Set specific tag for the image, added new env var.

### Verifying this change

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

NO

### Documentation

Check the box below and label this PR (if you have committer privilege).
  
- [X] no-need-doc 
  
