### PR TITLE
[pulsar-broker] Provide option to split bundle based on load

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -86,6 +86,7 @@ import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.Policies.BundleType;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.PublishRate;
@@ -1113,9 +1114,7 @@ public abstract class NamespacesBase extends AdminResource {
         checkNotNull(bundleName, "BundleRange should not be null");
         log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
 
-        String bundleRange = bundleName.equals(Policies.LARGEST_BUNDLE)
-                ? findLargestBundleWithTopics(namespaceName).getBundleRange()
-                : bundleName;
+        String bundleRange = getBundleRange(bundleName);
 
         Policies policies = getNamespacePolicies(namespaceName);
 
@@ -1167,8 +1166,22 @@ public abstract class NamespacesBase extends AdminResource {
         });
     }
 
+    private String getBundleRange(String bundleName) {
+        if (BundleType.LARGEST.toString().equals(bundleName)) {
+            return findLargestBundleWithTopics(namespaceName).getBundleRange();
+        } else if (BundleType.HOT.toString().equals(bundleName)) {
+            return findHotBundle(namespaceName).getBundleRange();
+        } else {
+            return bundleName;
+        }
+    }
+
     private NamespaceBundle findLargestBundleWithTopics(NamespaceName namespaceName) {
-        return pulsar().getNamespaceService().getNamespaceBundleFactory().getBundlesWithHighestTopics(namespaceName);
+        return pulsar().getNamespaceService().getNamespaceBundleFactory().getBundleWithHighestTopics(namespaceName);
+    }
+
+    private NamespaceBundle findHotBundle(NamespaceName namespaceName) {
+        return pulsar().getNamespaceService().getNamespaceBundleFactory().getBundleWithHighestThroughput(namespaceName);
     }
 
     private NamespaceBundleSplitAlgorithm getNamespaceBundleSplitAlgorithmByName(String algorithmName) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.pulsar.broker.BundleData;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.ServiceUnitId;
@@ -125,4 +126,12 @@ public interface ModularLoadManager {
      * @return List of LoadBalancing Metrics
      */
     List<Metrics> getLoadBalancingMetrics();
+
+    /**
+     * Fetch bundle's load report data.
+     *
+     * @param bundle
+     * @return bundle data
+     */
+    BundleData getBundleDataOrDefault(String bundle);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -357,7 +357,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
     // Attempt to local the data for the given bundle in metadata store
     // If it cannot be found, return the default bundle data.
-    private BundleData getBundleDataOrDefault(final String bundle) {
+    @Override
+    public BundleData getBundleDataOrDefault(final String bundle) {
         BundleData bundleData = null;
         try {
             Optional<BundleData> optBundleData = bundlesCache.get(getBundleDataPath(bundle)).join();
@@ -398,7 +399,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     // Get the metadata store path for the given bundle full name.
-    private static String getBundleDataPath(final String bundle) {
+    public static String getBundleDataPath(final String bundle) {
         return BUNDLE_DATA_PATH + "/" + bundle;
     }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -66,7 +66,6 @@ public class Policies {
     public boolean deleted = false;
     public static final String FIRST_BOUNDARY = "0x00000000";
     public static final String LAST_BOUNDARY = "0xffffffff";
-    public static final String LARGEST_BUNDLE = "LARGEST";
 
     @SuppressWarnings("checkstyle:MemberName")
     public boolean encryption_required = false;
@@ -125,6 +124,10 @@ public class Policies {
 
     @SuppressWarnings("checkstyle:MemberName")
     public String resource_group_name = null;
+
+    public enum BundleType {
+        LARGEST, HOT;
+    }
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
### Motivation
This will be on top of #12361  . Sometimes, we need to split a bundle to scale namespace across multiple brokers. So, we need a way to find out hot bundle under a  namespace that is serving the highest load and we would like to split it.

### Modification
- add admin/CLI to find and split bundle that's serving highest load across all bundles in a given namespace.
- it doesn't impact any existing API/CLI.