### PR TITLE
Variable compressedStr assignment error

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -414,7 +414,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             int compressedSize = compressedPayload.readableBytes();
             if (compressedSize > ClientCnx.getMaxMessageSize() && !this.conf.isChunkingEnabled()) {
                 compressedPayload.release();
-                String compressedStr = (!isBatchMessagingEnabled() && conf.getCompressionType() != CompressionType.NONE)
+                String compressedStr = (conf.getCompressionType() != CompressionType.NONE)
                                            ? "Compressed"
                                            : "";
                 PulsarClientException.InvalidMessageException invalidMessageException = new PulsarClientException.InvalidMessageException(


### PR DESCRIPTION
### Motivation
Consider the following conditions are true:
isBatchMessagingEnabled()=true
msgMetadata.hasDeliverAtTime()=true
conf.getCompressionType() != CompressionType.NONE

At this time compressedSize represents the compressed data size, but according to the original logic, an empty string will be assigned to the compressedStr variable, and the user will be told through InvalidMessageException that the message is uncompressed and the size is compressedSize, which is obviously a Wrong prompt

https://github.com/apache/pulsar/blob/38539b351869b829c99a2b96354ce852f137015d/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L409-L426