### PR TITLE
[C++] Use weak ref to ClientConnection for timeout task

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -543,8 +543,7 @@ void ClientConnection::handleResolve(const boost::system::error_code& err,
 
         if (ptr->state_ != Ready) {
             LOG_ERROR(ptr->cnxString_ << "Connection was not established in "
-                                      << ptr->connectTimeoutTask_->getPeriodMs()
-                                      << " ms, close the socket");
+                                      << ptr->connectTimeoutTask_->getPeriodMs() << " ms, close the socket");
             PeriodicTask::ErrorCode err;
             ptr->socket_->close(err);
             if (err) {


### PR DESCRIPTION
### Motivation

Fixes #12408. Using a weak reference in the timeout task for `ClientConnection` to break a circular reference dependency between the connection instance and the task.

