### PR TITLE
use correct property when determine if jsr310 enabled

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaDefinitionBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/SchemaDefinitionBuilderImpl.java
@@ -120,7 +120,7 @@ public class SchemaDefinitionBuilderImpl<T> implements SchemaDefinitionBuilder<T
         if (properties.containsKey(ALWAYS_ALLOW_NULL)) {
             alwaysAllowNull = Boolean.parseBoolean(properties.get(ALWAYS_ALLOW_NULL));
         }
-        if (properties.containsKey(ALWAYS_ALLOW_NULL)) {
+        if (properties.containsKey(JSR310_CONVERSION_ENABLED)) {
             jsr310ConversionEnabled = Boolean.parseBoolean(properties.get(JSR310_CONVERSION_ENABLED));
         }
         return this;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/SchemaDefinitionBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/SchemaDefinitionBuilderTest.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pulsar.client.api;
 
+import java.util.HashMap;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.api.schema.SchemaWriter;
+import org.apache.pulsar.client.impl.schema.SchemaDefinitionBuilderImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -96,5 +98,17 @@ public class SchemaDefinitionBuilderTest {
         Assert.assertTrue(definition.getSchemaWriterOpt().isPresent());
         Assert.assertSame(reader, definition.getSchemaReaderOpt().get());
         Assert.assertSame(writer, definition.getSchemaWriterOpt().get());
+    }
+
+    @Test
+    public void testJsr310ConversionsSetViaProperties() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(SchemaDefinitionBuilderImpl.JSR310_CONVERSION_ENABLED, "true");
+        SchemaDefinition<Object> definition = SchemaDefinition.builder()
+            .withPojo(Object.class)
+            .withProperties(properties)
+            .build();
+
+        Assert.assertTrue(definition.isJsr310ConversionEnabled());
     }
 }


### PR DESCRIPTION
When defining a schema using the SchemaDefinitionBuilderImpl, the code
was inspecting the incorrect property to determine whether JSR310
should be enabled. This commit changes the builder to inspect the
correct property when making this JSR310 enablement determination.
