### PR TITLE
[pulsar-admin] Check validity of --actions for topic and namespace

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -167,8 +168,15 @@ abstract class CliCommand {
 
     static Set<AuthAction> getAuthActions(List<String> actions) {
         Set<AuthAction> res = Sets.newTreeSet();
+        AuthAction authAction;
         for (String action : actions) {
-            res.add(AuthAction.valueOf(action));
+            try {
+                authAction = AuthAction.valueOf(action);
+            } catch (IllegalArgumentException exception) {
+                throw new ParameterException(String.format("Illegal auth action '%s'. Possible values: %s",
+                        action, Arrays.toString(AuthAction.values())));
+            }
+            res.add(authAction);
         }
 
         return res;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -210,7 +210,8 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume)", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
+                "functions,packages)", required = true)
         private List<String> actions;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -125,7 +125,8 @@ public class CmdPersistentTopics extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume)", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
+                "functions,packages)", required = true)
         private List<String> actions;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -287,7 +287,8 @@ public class CmdTopics extends CmdBase {
         @Parameter(names = "--role", description = "Client role to which grant permissions", required = true)
         private String role;
 
-        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume)", required = true, splitter = CommaParameterSplitter.class)
+        @Parameter(names = "--actions", description = "Actions to be granted (produce,consume,sources,sinks," +
+                "functions,packages)", required = true)
         private List<String> actions;
 
         @Override


### PR DESCRIPTION
### Motivation
We should check the validity of the `--actions` and give a more friendly prompt message when granting permission to topic or namespace through `./bin/pulsar-admin topics grant-permission` or `./bin/pulsar-admin namespaces grant-permission`.
Currently, the lack of verification for `--action` will directly display the exception, as below:
```
./bin/pulsar-admin topics grant-permission tenant/ns/tp --role rl --actions producer
java.lang.IllegalArgumentException: No enum constant org.apache.pulsar.common.policies.data.AuthAction.producer
	at java.lang.Enum.valueOf(Enum.java:238)
	at org.apache.pulsar.common.policies.data.AuthAction.valueOf(AuthAction.java:24)
	at org.apache.pulsar.admin.cli.CliCommand.getAuthActions(CliCommand.java:171)
	at org.apache.pulsar.admin.cli.CmdTopics$GrantPermissions.run(CmdTopics.java:293)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:86)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:282)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:329)
```

### Modifications
- Improve the description information of the `--action`
- Throw `ParameterException` when `IllegalArgumentException` occurs when executing `AuthAction.valueOf(action)`

### Documentation
Automatically generate doc through code
- [x] `doc`
