### PR TITLE
ManagedLedger - EntryCacheImpl - move spammy log to TRACE level

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -158,8 +158,8 @@ public class EntryCacheImpl implements EntryCache {
         Pair<Integer, Long> removed = entries.removeRange(firstPosition, lastPosition, false);
         int entriesRemoved = removed.getLeft();
         long sizeRemoved = removed.getRight();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Invalidated entries up to {} - Entries removed: {} - Size removed: {}", ml.getName(),
+        if (log.isTraceEnabled()) {
+            log.trace("[{}] Invalidated entries up to {} - Entries removed: {} - Size removed: {}", ml.getName(),
                     lastPosition, entriesRemoved, sizeRemoved);
         }
 


### PR DESCRIPTION
### Motivation

When you enable DEBUG level in the broker you will be spammed by this log that I am moving to TRACE level

### Modifications

Move to TRACE level

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
