### PR TITLE
Flaky tests: reduce SimpleProducerConsumerTest flakiness

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -116,9 +116,10 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(SimpleProducerConsumerTest.class);
-    private static final int RECEIVE_TIMEOUT_SECONDS = 15;
-    private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 500;
-    private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 2500;
+    private static final int TIMEOUT_MULTIPLIER = Integer.getInteger("SimpleProducerConsumerTest.receive.timeout.multiplier", 1);
+    private static final int RECEIVE_TIMEOUT_SECONDS = 5 * TIMEOUT_MULTIPLIER;
+    private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 200 * TIMEOUT_MULTIPLIER;
+    private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 1000 * TIMEOUT_MULTIPLIER;
 
     @BeforeMethod(alwaysRun = true)
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -116,9 +116,9 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(SimpleProducerConsumerTest.class);
-    private static final int RECEIVE_TIMEOUT_SECONDS = 3;
-    private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 100;
-    private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 500;
+    private static final int RECEIVE_TIMEOUT_SECONDS = 15;
+    private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 500;
+    private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 2500;
 
     @BeforeMethod(alwaysRun = true)
     @Override


### PR DESCRIPTION
### Motivation
We often see on our CI the test `SimpleProducerConsumerTest` failing due to:

```
java.lang.AssertionError: expected [30] but found [29]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
	at org.testng.Assert.assertEquals(Assert.java:122)
	at org.testng.Assert.assertEquals(Assert.java:907)
	at org.testng.Assert.assertEquals(Assert.java:917)
	at org.apache.pulsar.client.api.SimpleProducerConsumerTest.testMultiTopicsConsumerImplPauseForManualSubscription(SimpleProducerConsumerTest.java:3304)
```

### Modifications

- add a system property to multiply read timeouts for consumer

note: I'm aware this will not solve the whole problem, but I see them failing only on CI where the system is likely slower, and we can chase them by chances.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
