### PR TITLE
Fix wrong property name in NamespaceIsolationDataImpl#secondary

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
@@ -59,7 +59,7 @@ public class NamespaceIsolationDataImpl implements NamespaceIsolationData {
     private List<String> primary;
 
     @ApiModelProperty(
-            name = "primary",
+            name = "secondary",
             value = "The list of secondary brokers for serving the list of namespaces in this isolation policy"
     )
     private List<String> secondary;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes  wrong property name in the annotation of org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl#secondary

### Motivation

Fix typo

### Modifications

Change "primary" to "secondary".

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: ( no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

  
- [x] `no-need-doc` 
  
Just fixed typo, no behavior is changed.



