### PR TITLE
[pulsar-admin] Modify exception of set-properties for namespace

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2198,15 +2198,18 @@ public class CmdNamespaces extends CmdBase {
             String namespace = validateNamespace(params);
             Map<String, String> map = new HashMap<>();
             if (properties.size() == 0) {
-                throw new IllegalArgumentException("Required at least one property for the namespace.");
+                throw new ParameterException(String.format("Required at least one property for the namespace, " +
+                        "but found %d.", properties.size()));
             }
             for (String property : properties) {
                 if (!property.contains("=")) {
-                    throw new IllegalArgumentException("Invalid key value pair format.");
+                    throw new ParameterException(String.format("Invalid key value pair '%s', " +
+                            "valid format like 'a=a,b=b,c=c'.", property));
                 } else {
                     String[] keyValue = property.split("=");
                     if (keyValue.length != 2) {
-                        throw new IllegalArgumentException("Invalid key value pair format.");
+                        throw new ParameterException(String.format("Invalid key value pair '%s', " +
+                                "valid format like 'a=a,b=b,c=c'.", property));
                     }
                     map.put(keyValue[0], keyValue[1]);
                 }


### PR DESCRIPTION
### Motivation
when I execute `./pulsar-admin namespaces set-properties  --properties a=a=b test/app1 `, a prompt as below:
```
java.lang.IllegalArgumentException: Invalid key value pair format.
	at org.apache.pulsar.admin.cli.CmdNamespaces$SetPropertiesForNamespace.run(CmdNamespaces.java:2199)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:86)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:282)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:329)
```
we hope to display a readable prompt of `set-properties` for namespace when exception occurs.

### Modifications
- Chage `IllegalArgumentException` to `ParameterException`

### Documentation
- [x] `no-need-doc` 
