### PR TITLE
[Issue 12271][Modernizer] Add Maven Modernizer plugin to pulsar-metadata module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,6 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
-    <modernizer-maven-plugin.version>2.3.0</modernizer-maven-plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
+    <modernizer-maven-plugin.version>2.3.0</modernizer-maven-plugin.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -118,6 +118,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <version>${modernizer-maven-plugin.version}</version>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -118,23 +118,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.gaul</groupId>
-        <artifactId>modernizer-maven-plugin</artifactId>
-        <version>${maven-modernizer-plugin.version}</version>
-        <configuration>
-          <failOnViolations>true</failOnViolations>
-          <javaVersion>8</javaVersion>
-        </configuration>
-        <executions>
-          <execution>
-            <id>modernizer</id>
-            <goals>
-              <goal>modernizer</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -121,7 +121,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>${modernizer-maven-plugin.version}</version>
+        <version>${maven-modernizer-plugin.version}</version>
         <configuration>
           <failOnViolations>true</failOnViolations>
           <javaVersion>8</javaVersion>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -118,6 +118,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -19,7 +19,8 @@
 package org.apache.pulsar.metadata.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -221,9 +222,9 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
         }
 
         public PulsarZooKeeperClient build() throws IOException, KeeperException, InterruptedException {
-            checkNotNull(connectString);
+            requireNonNull(connectString);
             checkArgument(sessionTimeoutMs > 0);
-            checkNotNull(statsLogger);
+            requireNonNull(statsLogger);
             checkArgument(retryExecThreadCount > 0);
 
             if (null == connectRetryPolicy) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -22,7 +22,7 @@ import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +76,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
 
         Set<BookieId> addresses = prepareNBookies(10);
-        List<String> children = Lists.newArrayList();
+        List<String> children = new ArrayList<>();
         for (BookieId address : addresses) {
             children.add(address.toString());
             rm.registerBookie(address, false, new BookieServiceInfo());
@@ -103,7 +103,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
 
         Set<BookieId> addresses = prepareNBookies(10);
-        List<String> children = Lists.newArrayList();
+        List<String> children = new ArrayList<>();
         for (BookieId address : addresses) {
             children.add(address.toString());
             rm.registerBookie(address, true, new BookieServiceInfo());
@@ -129,7 +129,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
 
         Set<BookieId> addresses = prepareNBookies(10);
-        List<String> children = Lists.newArrayList();
+        List<String> children = new ArrayList<>();
         for (BookieId address : addresses) {
             children.add(address.toString());
             boolean isReadOnly = children.size() % 2 == 0;


### PR DESCRIPTION
Master Issue: #12271 

### Motivation

Apply Maven Modernizer plugin to detect uses of legacy APIs which can be replaced with modern APIs that are often more performant, safer, and idiomatic than the legacy equivalents

### Modifications

Add Maven Modernizer plugin to `pulsar-metadata` module and fix the violations.

### Verifying this change

- [ yes] Make sure that the change passes the CI checks.

This change is a code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: ( no)

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
    


