### PR TITLE
topicName need trim

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -212,7 +212,7 @@ public class PerformanceConsumer {
         if (arguments.topic != null && arguments.topic.size() != arguments.numTopics) {
             // keep compatibility with the previous version
             if (arguments.topic.size() == 1) {
-                String prefixTopicName = TopicName.get(arguments.topic.get(0)).toString();
+                String prefixTopicName = TopicName.get(arguments.topic.get(0)).toString().trim();
                 List<String> defaultTopics = Lists.newArrayList();
                 for (int i = 0; i < arguments.numTopics; i++) {
                     defaultTopics.add(String.format("%s-%d", prefixTopicName, i));


### PR DESCRIPTION
When using the perf command, the incoming topic name does not have trim, which may cause the parsed topic name to contain spaces. When automatic topic creation is enabled, topics with spaces will also be automatically created:
![image](https://user-images.githubusercontent.com/19296967/138241993-2580a2e4-67f3-4926-a04c-98f60d71b6b0.png)

Perf command used：nohup sh pulsar-perf consume -st Exclusive -ss chenlin_t1 test1 > log1 &
Note that there is a space after test1.