### PR TITLE
Flaky Tests: AdminApiSchemaTest#testSchemaInfoApi

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -658,9 +658,12 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         final Map<String, String> map = new HashMap<>();
         map.put("key", null);
         map.put(null, "value"); // null key is not allowed for JSON, it's only for test here
-        ((SchemaInfoImpl)Schema.INT32.getSchemaInfo()).setProperties(map);
 
-        final Consumer<Integer> consumer = pulsarClient.newConsumer(Schema.INT32).topic(topic)
+        // leave INT32 instance unchanged
+        final Schema<Integer> integerSchema = Schema.INT32.clone();
+        ((SchemaInfoImpl) integerSchema.getSchemaInfo()).setProperties(map);
+
+        final Consumer<Integer> consumer = pulsarClient.newConsumer(integerSchema).topic(topic)
                 .subscriptionName("sub")
                 .subscribe();
         consumer.close();


### PR DESCRIPTION
### Motivation

I see `AdminApiSchemaTest#testSchemaInfoApi` failing in this way:

```
2021-10-22T01:01:52,307+0000 [jersey-client-async-executor-5] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:38587/admin/v2/schemas/schematest/test/test-INT32/schema] Failed to perform http post request: java.util.concurrent.CompletionException: org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector$RetryException: Could not complete the operation. Number of retries has been exhausted. Failed reason: Null key for a Map not allowed in JSON (use a converting NullKeySerializer?) (through reference chain: org.apache.pulsar.common.protocol.schema.PostSchemaPayload["properties"]->java.util.HashMap["null"])
```
It only fails with INT32 default shema.
I found another test (`SchemaTest#testNullKeyValueProperty`) which sets a null-key property to INT32 instance; so if it runs before, it makes AdminApiSchemaTest#testSchemaInfoApi fail.

### Modifications

Changed the `SchemaTest#testNullKeyValueProperty` test in order to leave the default INT32 implementation unchanged.

Alternatively, I could made the `properties` field final, at least for defaults `SchemaInfo`s but this would result in a breaking change.



This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  