### PR TITLE
[pulsar-admin] Check validity of --types for topic and namespace

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -317,15 +317,24 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--types",
-                "-t" }, description = "Subscription types enabled list (comma separated values)", required = true)
-        private String subTypes;
+        @Parameter(names = {"--types", "-t"}, description = "Subscription types enabled list (comma separated values)."
+                + " Possible values: (Exclusive, Shared, Failover, Key_Shared).", required = true)
+        private List<String> subTypes;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
             Set<SubscriptionType> types = new HashSet<>();
-            Lists.newArrayList(subTypes.split(",")).forEach(s -> types.add(SubscriptionType.valueOf(s)));
+            subTypes.forEach(s -> {
+                SubscriptionType subType;
+                try {
+                    subType = SubscriptionType.valueOf(s);
+                } catch (IllegalArgumentException exception) {
+                    throw new ParameterException(String.format("Illegal subscription type %s. Possible values: %s.", s,
+                            Arrays.toString(SubscriptionType.values())));
+                }
+                types.add(subType);
+            });
             getAdmin().namespaces().setSubscriptionTypesEnabled(namespace, types);
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1850,15 +1850,24 @@ public class CmdTopics extends CmdBase {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = { "--types",
-                "-t" }, description = "Subscription types enabled list (comma separated values)", required = true)
-        private String subTypes;
+        @Parameter(names = {"--types", "-t"}, description = "Subscription types enabled list (comma separated values)."
+                + " Possible values: (Exclusive, Shared, Failover, Key_Shared).", required = true)
+        private List<String> subTypes;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             Set<SubscriptionType> types = new HashSet<>();
-            Lists.newArrayList(subTypes.split(",")).forEach(s -> types.add(SubscriptionType.valueOf(s)));
+            subTypes.forEach(s -> {
+                SubscriptionType subType;
+                try {
+                    subType = SubscriptionType.valueOf(s);
+                } catch (IllegalArgumentException exception) {
+                    throw new ParameterException(String.format("Illegal subscription type %s. Possible values: %s.", s,
+                            Arrays.toString(SubscriptionType.values())));
+                }
+                types.add(subType);
+            });
             getTopics().setSubscriptionTypesEnabled(persistentTopic, types);
         }
     }


### PR DESCRIPTION
### Motivation
We should check the validity of the `--types` and give a more friendly prompt message when set subscription types for topic or namespace through `./bin/pulsar-admin topics set-subscription-types-enabled` or `./bin/pulsar-admin namespaces set-subscription-types-enabled`.
Currently, the lack of verification for `--types` will directly display the exception, as below:
```
./bin/pulsar-admin topics set-subscription-types-enabled --types Share tenant/ns/tp
java.lang.IllegalArgumentException: No enum constant org.apache.pulsar.client.api.SubscriptionType.Share
	at java.lang.Enum.valueOf(Enum.java:238)
	at org.apache.pulsar.client.api.SubscriptionType.valueOf(SubscriptionType.java:27)
	at org.apache.pulsar.admin.cli.CmdTopics$SetSubscriptionTypesEnabled.lambda$run$0(CmdTopics.java:1790)
	at java.util.ArrayList.forEach(ArrayList.java:1249)
	at org.apache.pulsar.admin.cli.CmdTopics$SetSubscriptionTypesEnabled.run(CmdTopics.java:1790)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:86)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:282)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:329)
```

### Modifications
- Improve the description information of the `--types`
- Throw `ParameterException` when `IllegalArgumentException` occurs when executing `SubscriptionType.valueOf(type)`

### Documentation
Automatically generate doc through code
- [x] `doc`
