### PR TITLE
docs(function): fix typo in pip install

### DIFF
--- a/site2/docs/functions-package.md
+++ b/site2/docs/functions-package.md
@@ -200,7 +200,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website-next/docs/functions-package.md
+++ b/site2/website-next/docs/functions-package.md
@@ -224,7 +224,7 @@ To package a function with **one python file** in Python, complete the following
 
    ```bash
    
-   pip install python-client==2.6.0
+   pip install pulsar-client==2.6.0
    
    ```
 

--- a/site2/website-next/versioned_docs/version-2.7.3/functions-package.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/functions-package.md
@@ -225,7 +225,7 @@ To package a function with **one python file** in Python, complete the following
 
    ```bash
    
-   pip install python-client==2.6.0
+   pip install pulsar-client==2.6.0
    
    ```
 

--- a/site2/website-next/versioned_docs/version-2.8.0/functions-package.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/functions-package.md
@@ -225,7 +225,7 @@ To package a function with **one python file** in Python, complete the following
 
    ```bash
    
-   pip install python-client==2.6.0
+   pip install pulsar-client==2.6.0
    
    ```
 

--- a/site2/website/versioned_docs/version-2.7.0/functions-package.md
+++ b/site2/website/versioned_docs/version-2.7.0/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.7.1/functions-package.md
+++ b/site2/website/versioned_docs/version-2.7.1/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.7.2/functions-package.md
+++ b/site2/website/versioned_docs/version-2.7.2/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.7.3/functions-package.md
+++ b/site2/website/versioned_docs/version-2.7.3/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.8.0/functions-package.md
+++ b/site2/website/versioned_docs/version-2.8.0/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.8.1/functions-package.md
+++ b/site2/website/versioned_docs/version-2.8.1/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.

--- a/site2/website/versioned_docs/version-2.8.2/functions-package.md
+++ b/site2/website/versioned_docs/version-2.8.2/functions-package.md
@@ -201,7 +201,7 @@ To package a function with **one python file** in Python, complete the following
     The implementation of a Python function depends on the Python client, so before deploying a Python function, you need to install the corresponding version of the Python client. 
 
     ```bash
-    pip install python-client==2.6.0
+    pip install pulsar-client==2.6.0
     ```
 
 3. Run the Python Function.


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

The command in https://pulsar.apache.org/docs/en/functions-package/#python should be wrong with `pip install python-client==2.6.0`, it should be the `pulsar-client`.

### Modifications

Fix wrong command in all related docs.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [] no-need-doc 
  
  (Please explain why)
  
- [x] doc 
  
  (If this PR contains doc changes)
