### PR TITLE
Optimize ThresholdShedder strategy:  the low-load Broker cannot be fully utilized

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -22,10 +22,10 @@ import static org.apache.pulsar.broker.namespace.NamespaceService.HEARTBEAT_NAME
 import static org.apache.pulsar.broker.namespace.NamespaceService.HEARTBEAT_NAMESPACE_PATTERN_V2;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.AtomicDouble;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,9 +36,9 @@ import org.apache.pulsar.broker.TimeAverageMessageData;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
-import com.google.common.util.concurrent.AtomicDouble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Load shedding strategy that unloads any broker that exceeds the average resource utilization of all brokers by a
@@ -112,8 +112,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
         }
 
         //4. Calculate the percentage of traffic to be migrated by each broker in overAvgUsageBrokers;
-        double percentOfTrafficToOffload = ADDITIONAL_THRESHOLD_PERCENT_MARGIN +
-                sumOfAcceptableTrafficFromBelowAvgUsageBrokers.get() / totalTrafficOfOverAvgUsageBrokers.get() ;
+        double percentOfTrafficToOffload = ADDITIONAL_THRESHOLD_PERCENT_MARGIN
+                + sumOfAcceptableTrafficFromBelowAvgUsageBrokers.get() / totalTrafficOfOverAvgUsageBrokers.get();
 
         //5. Select the bundle to unload
         overAvgUsageBrokers.forEach((broker, brokerData) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -78,7 +78,7 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             final LocalBrokerData localData = brokerData.getLocalData();
             final double currentUsage = brokerAvgResourceUsage.getOrDefault(broker, 0.0);
 
-            if (currentUsage < avgUsage + threshold) {
+            if (currentUsage > avgUsage - threshold && currentUsage < avgUsage + threshold) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] broker is not overloaded, ignoring at this point", broker);
                 }


### PR DESCRIPTION
### Motivation
Consider a large cluster with multiple nodes. If most of the nodes are relatively balanced, but only a few nodes have extremely low load, then according to the current logic, it may not be possible to trigger the balancing action, eg:
broke1 brokerAvgResourceUsage 80
......
broker100 brokerAvgResourceUsage 80

broker101 brokerAvgResourceUsage 10

The calculated avgUsage=(80*100+10)/101=79 at this time, if the threshold is set to the default value of 10, then any broker will satisfy currentUsage <avgUsage + threshold, so that the balancing operation will not be triggered, so some load Low machines cannot be fully utilized.


### Modifications
Here I define the equilibrium state as:
avgUsage-threshold< currentUsage <avgUsage + threshold
In this way, some nodes with extremely low load will not appear.
