### PR TITLE
Remove redundant null check for getInternalListener

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -83,7 +83,7 @@ public class ServiceConfigurationUtils {
 
     /**
      * Gets the internal advertised listener for broker-to-broker communication.
-     * @return an advertised listener
+     * @return a non-null advertised listener
      */
     public static AdvertisedListener getInternalListener(ServiceConfiguration config) {
         Map<String, AdvertisedListener> result = MultipleListenerValidator

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1412,7 +1412,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
      */
     protected String brokerUrl(ServiceConfiguration config) {
         AdvertisedListener internalListener = ServiceConfigurationUtils.getInternalListener(config);
-        return internalListener != null && internalListener.getBrokerServiceUrl() != null
+        return internalListener.getBrokerServiceUrl() != null
                 ? internalListener.getBrokerServiceUrl().toString() : null;
     }
 
@@ -1425,7 +1425,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
      */
     public String brokerUrlTls(ServiceConfiguration config) {
         AdvertisedListener internalListener = ServiceConfigurationUtils.getInternalListener(config);
-        return internalListener != null && internalListener.getBrokerServiceUrlTls() != null
+        return internalListener.getBrokerServiceUrlTls() != null
                 ? internalListener.getBrokerServiceUrlTls().toString() : null;
     }
 


### PR DESCRIPTION
### Motivation

`ServiceConfigurationUtils#getInternalListener` never returns null. The null check is redundant. Otherwise, the null check should also be performed in `CompactorTool#main`.

### Modifications

Remove the null check for `getInternalListener` and note the returned value is non-null in method description.