### PR TITLE
[pulsar-admin] Check validity of --compatibility for namespace

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1833,7 +1833,14 @@ public class CmdNamespaces extends CmdBase {
             String namespace = validateNamespace(params);
 
             String strategyStr = strategyParam != null ? strategyParam.toUpperCase() : "";
-            getAdmin().namespaces().setSchemaCompatibilityStrategy(namespace, SchemaCompatibilityStrategy.valueOf(strategyStr));
+            SchemaCompatibilityStrategy strategy;
+            try {
+                strategy = SchemaCompatibilityStrategy.valueOf(strategyStr);
+            } catch (IllegalArgumentException exception) {
+                throw new ParameterException(String.format("Illegal schema compatibility strategy %s. " +
+                        "Possible values: %s", strategyStr, Arrays.toString(SchemaCompatibilityStrategy.values())));
+            }
+            getAdmin().namespaces().setSchemaCompatibilityStrategy(namespace, strategy);
         }
     }
 


### PR DESCRIPTION
### Motivation
We should check the validity of the `--compatibility` and give a more friendly prompt message when set schema compatibility strategy for namespace through `./bin/pulsar-admin namespaces set-schema-compatibility-strategy`.
Currently, the lack of verification for `--compatibility` will directly display the exception, as below:
```
./bin/pulsar-admin namespaces set-schema-compatibility-strategy -c ALWAYS_COMPATIBE tenant1/ns1
java.lang.IllegalArgumentException: No enum constant org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy.ALWAYS_COMPATIBE
	at java.lang.Enum.valueOf(Enum.java:238)
	at org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy.valueOf(SchemaCompatibilityStrategy.java:24)
	at org.apache.pulsar.admin.cli.CmdNamespaces$SetSchemaCompatibilityStrategy.run(CmdNamespaces.java:1833)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:86)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:282)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:329)
```

### Modifications
- Throw `ParameterException` when `IllegalArgumentException` occurs when executing `SchemaCompatibilityStrategy.valueOf()`

### Documentation
Automatically generate doc through code
- [x] `doc`
