### PR TITLE
[C++] Fixed connection read error logging

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -584,9 +584,9 @@ void ClientConnection::handleRead(const boost::system::error_code& err, size_t b
     if (err || bytesTransferred == 0) {
         if (err) {
             if (err == boost::asio::error::operation_aborted) {
-                LOG_DEBUG(cnxString_ << "Read failed: " << err.message());
+                LOG_DEBUG(cnxString_ << "Read operation was canceled: " << err.message());
             } else {
-                LOG_ERROR(cnxString_ << "Read operation was cancelled");
+                LOG_ERROR(cnxString_ << "Read operation failed: " << err.message());
             }
         }  // else: bytesTransferred == 0, which means server has closed the connection
         close();


### PR DESCRIPTION
### Motivation

Fixed the logging statement when dealing with a read error to include the actual `err` object for context, since it was removed after #11882