### PR TITLE
[Issue #12495] Fix the serialization time attribute is not allowed to be empty by default

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1217,18 +1217,9 @@ public class BrokerService implements Closeable {
                 : CompletableFuture.completedFuture(null);
 
         maxTopicsCheck.thenCompose(__ -> getManagedLedgerConfig(topicName)).thenAccept(managedLedgerConfig -> {
-            if (isBrokerEntryMetadataEnabled()) {
+            if (hasBrokerEntryMetadataInterceptor()) {
                 // init managedLedger interceptor
-                Set<BrokerEntryMetadataInterceptor> interceptors = new HashSet<>();
-                for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
-                    // add individual AppendOffsetMetadataInterceptor for each topic
-                    if (interceptor instanceof AppendIndexMetadataInterceptor) {
-                        interceptors.add(new AppendIndexMetadataInterceptor());
-                    } else {
-                        interceptors.add(interceptor);
-                    }
-                }
-                managedLedgerConfig.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(interceptors));
+                managedLedgerConfig.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(new HashSet<>(brokerEntryMetadataInterceptors)));
             }
 
             managedLedgerConfig.setCreateIfMissing(createIfMissing);
@@ -2648,7 +2639,7 @@ public class BrokerService implements Closeable {
         return brokerEntryMetadataInterceptors;
     }
 
-    public boolean isBrokerEntryMetadataEnabled() {
+    public boolean hasBrokerEntryMetadataInterceptor() {
         return !brokerEntryMetadataInterceptors.isEmpty();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -434,7 +434,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     private void asyncAddEntry(ByteBuf headersAndPayload, PublishContext publishContext) {
-        if (brokerService.isBrokerEntryMetadataEnabled()) {
+        if (brokerService.hasBrokerEntryMetadataInterceptor()) {
             ledger.asyncAddEntry(headersAndPayload,
                     (int) publishContext.getNumberOfMessages(), this, publishContext);
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +49,7 @@ public class JSONSchema<T> extends AvroBaseStructSchema<T> {
     private static final ThreadLocal<ObjectMapper> JSON_MAPPER = ThreadLocal.withInitial(() -> {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return mapper;
     });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -48,8 +48,8 @@ public class JSONSchema<T> extends AvroBaseStructSchema<T> {
     // return shaded version of object mapper
     private static final ThreadLocal<ObjectMapper> JSON_MAPPER = ThreadLocal.withInitial(() -> {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return mapper;
     });

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Bar;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.DerivedFoo;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Foo;
+import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Empty;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.NestedBar;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.NestedBarList;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
@@ -271,6 +272,12 @@ public class JSONSchemaTest {
     public void testAllowNullDecodeWithInvalidContent() {
         JSONSchema<Foo> jsonSchema = JSONSchema.of(SchemaDefinition.<Foo>builder().withPojo(Foo.class).build());
         jsonSchema.decode(new byte[0]);
+    }
+
+    @Test
+    public void testAllowNullFieldClass() {
+        JSONSchema<Empty> jsonSchema = JSONSchema.of(SchemaDefinition.<Empty>builder().withPojo(Empty.class).build());
+        jsonSchema.encode(new Empty());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaTestUtils.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaTestUtils.java
@@ -53,6 +53,10 @@ public class SchemaTestUtils {
     }
 
     @Data
+    public static class Empty {
+    }
+
+    @Data
     public static class Bar {
         private boolean field1;
     }

--- a/site2/docs/schema-understand.md
+++ b/site2/docs/schema-understand.md
@@ -425,7 +425,6 @@ You can define the `schemaDefinition` to generate a `struct` schema.
                                                             .withSchemaWriter(writer)
                                                             .withSchemaReader(reader)
                                                             .build();
-    
     ```
    You can define `SchemaWriter` and `SchemaReader` as singletons
 

--- a/site2/docs/schema-understand.md
+++ b/site2/docs/schema-understand.md
@@ -410,6 +410,17 @@ You can define the `schemaDefinition` to generate a `struct` schema.
     User user = consumer.receive().getValue();
     ```
 
+4. Use a custom `Serialization` method, such as json configuration method, the following is the default
+
+   ```java
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+      mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      JacksonJsonWriter<User> writer = new JacksonJsonWriter<>(mapper);
+      JacksonJsonReader<User> reader = new JacksonJsonReader<>(mapper, User.class);    
+    ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Auto Schema

--- a/site2/docs/schema-understand.md
+++ b/site2/docs/schema-understand.md
@@ -413,19 +413,19 @@ You can define the `schemaDefinition` to generate a `struct` schema.
 4. Use a custom `Serialization` method, such as json configuration method, the following is the default
 
    ```java
-      ObjectMapper mapper = new ObjectMapper();
-      mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-      mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-      mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-      JacksonJsonWriter<User> writer = new JacksonJsonWriter<>(mapper);
-      JacksonJsonReader<User> reader = new JacksonJsonReader<>(mapper, User.class);
+   ObjectMapper mapper = new ObjectMapper();
+   mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+   mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+   JacksonJsonWriter<User> writer = new JacksonJsonWriter<>(mapper);
+   JacksonJsonReader<User> reader = new JacksonJsonReader<>(mapper, User.class);
    
-      SchemaDefinition<User> schemaDefinition = SchemaDefinition.<User>builder()
-                                                            .withPojo(User.class)
-                                                            .withSchemaWriter(writer)
-                                                            .withSchemaReader(reader)
-                                                            .build();
-    ```
+   SchemaDefinition<User> schemaDefinition = SchemaDefinition.<User>builder()
+                                                         .withPojo(User.class)
+                                                         .withSchemaWriter(writer)
+                                                         .withSchemaReader(reader)
+                                                         .build();
+   ```
    You can define `SchemaWriter` and `SchemaReader` as singletons
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/docs/schema-understand.md
+++ b/site2/docs/schema-understand.md
@@ -418,8 +418,16 @@ You can define the `schemaDefinition` to generate a `struct` schema.
       mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
       mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
       JacksonJsonWriter<User> writer = new JacksonJsonWriter<>(mapper);
-      JacksonJsonReader<User> reader = new JacksonJsonReader<>(mapper, User.class);    
+      JacksonJsonReader<User> reader = new JacksonJsonReader<>(mapper, User.class);
+   
+      SchemaDefinition<User> schemaDefinition = SchemaDefinition.<User>builder()
+                                                            .withPojo(User.class)
+                                                            .withSchemaWriter(writer)
+                                                            .withSchemaReader(reader)
+                                                            .build();
+    
     ```
+   You can define `SchemaWriter` and `SchemaReader` as singletons
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 


### PR DESCRIPTION
Motivation
fix #12495

Implement
When the message object json is serialized, the attribute should be allowed to be empty by default

Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (yes)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)