### PR TITLE
k8s runtime: force deletion to avoid hung function worker during connector restart

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -216,6 +216,10 @@ functionRuntimeFactoryConfigs:
 #    extraFunctionDependenciesDir:
 #    # Additional memory padding added on top of the memory requested by the function per on a per instance basis
 #    percentMemoryPadding: 10
+#    # The duration in seconds before the StatefulSet deleted on function stop/restart.
+#    # Value must be non-negative integer. The value zero indicates delete immediately.
+#    # Default is 5 seconds.
+#    gracePeriodSeconds: 5
 
 ## A set of the minimum amount of resources functions must request.
 ## Support for this depends on function runtime.

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -567,7 +567,6 @@ public class KubernetesRuntime implements Runtime {
     public void deleteStatefulSet() throws InterruptedException {
         String statefulSetName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
         final V1DeleteOptions options = new V1DeleteOptions();
-        options.setGracePeriodSeconds(5L);
         // gracePeriodSeconds == 0 to force pod deletion and
         // avoid cases when pod hangs during termination
         // https://amalgjose.com/2021/07/28/how-to-delete-a-kubernetes-pod-which-is-stuck-in-terminating-state/

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -149,6 +149,7 @@ public class KubernetesRuntime implements Runtime {
     private int percentMemoryPadding;
     private double cpuOverCommitRatio;
     private double memoryOverCommitRatio;
+    private int gracePeriodSeconds;
     private final Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider;
     private final AuthenticationConfig authConfig;
     private Integer grpcPort;
@@ -186,6 +187,7 @@ public class KubernetesRuntime implements Runtime {
                       int percentMemoryPadding,
                       double cpuOverCommitRatio,
                       double memoryOverCommitRatio,
+                      int gracePeriodSeconds,
                       Optional<KubernetesFunctionAuthProvider> functionAuthDataCacheProvider,
                       boolean authenticationEnabled,
                       Integer grpcPort,
@@ -212,6 +214,7 @@ public class KubernetesRuntime implements Runtime {
         this.percentMemoryPadding = percentMemoryPadding;
         this.cpuOverCommitRatio = cpuOverCommitRatio;
         this.memoryOverCommitRatio = memoryOverCommitRatio;
+        this.gracePeriodSeconds = gracePeriodSeconds;
         this.authenticationEnabled = authenticationEnabled;
         this.manifestCustomizer = manifestCustomizer;
         this.functionInstanceClassPath = functionInstanceClassPath;
@@ -567,12 +570,7 @@ public class KubernetesRuntime implements Runtime {
     public void deleteStatefulSet() throws InterruptedException {
         String statefulSetName = createJobName(instanceConfig.getFunctionDetails(), this.jobName);
         final V1DeleteOptions options = new V1DeleteOptions();
-        // gracePeriodSeconds == 0 to force pod deletion and
-        // avoid cases when pod hangs during termination
-        // https://amalgjose.com/2021/07/28/how-to-delete-a-kubernetes-pod-which-is-stuck-in-terminating-state/
-        // https://www.ibm.com/support/pages/kubernetes-pods-are-stuck-terminating-state
-        // https://github.com/kubernetes-client/java/issues/770
-        options.setGracePeriodSeconds(0L);
+        options.setGracePeriodSeconds((long)gracePeriodSeconds);
         options.setPropagationPolicy("Foreground");
 
         String fqfn = FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails());
@@ -588,7 +586,7 @@ public class KubernetesRuntime implements Runtime {
                         response = appsClient.deleteNamespacedStatefulSetCall(
                                 statefulSetName,
                                 jobNamespace, null, null,
-                                0, null, "Foreground",
+                                gracePeriodSeconds, null, "Foreground",
                                 options, null)
                                 .execute();
                     } catch (ApiException e) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactory.java
@@ -103,6 +103,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
     private String narExtractionDirectory;
     private String functionInstanceClassPath;
     private String downloadDirectory;
+    private int gracePeriodSeconds;
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
@@ -200,6 +201,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
         this.percentMemoryPadding = factoryConfig.getPercentMemoryPadding();
         this.cpuOverCommitRatio = factoryConfig.getCpuOverCommitRatio();
         this.memoryOverCommitRatio = factoryConfig.getMemoryOverCommitRatio();
+        this.gracePeriodSeconds = factoryConfig.getGracePeriodSeconds();
         this.pulsarServiceUrl = StringUtils.isEmpty(factoryConfig.getPulsarServiceUrl())
                 ? workerConfig.getPulsarServiceUrl() : factoryConfig.getPulsarServiceUrl();
         this.pulsarAdminUrl = StringUtils.isEmpty(factoryConfig.getPulsarAdminUrl())
@@ -318,6 +320,7 @@ public class KubernetesRuntimeFactory implements RuntimeFactory {
             percentMemoryPadding,
             cpuOverCommitRatio,
             memoryOverCommitRatio,
+            gracePeriodSeconds,
             authProvider,
             authenticationEnabled,
             grpcPort,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeFactoryConfig.java
@@ -161,5 +161,11 @@ public class KubernetesRuntimeFactoryConfig {
             doc = "The classpath where function instance files stored"
     )
     private String functionInstanceClassPath = "";
+    @FieldContext(
+            doc = "The duration in seconds before the StatefulSet deleted on function stop/restart. " +
+                    "Value must be non-negative integer. The value zero indicates delete immediately. " +
+                    "Default is 5 seconds."
+    )
+    protected int gracePeriodSeconds = 5;
 
 }

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -136,8 +136,8 @@ functionRuntimeFactoryConfigs:
   extraFunctionDependenciesDir:
   # Additional memory padding added on top of the memory requested by the function per on a per instance basis
   percentMemoryPadding: 10
-  # The duration in seconds before the StatefulSet deleted on function stop/restart.
-  # Value must be non-negative integer. The value zero indicates delete immediately.
+  # The duration (in seconds) before the StatefulSet is deleted after a function stops or restarts.
+  # Value must be a non-negative integer. 0 indicates the StatefulSet is deleted immediately.
   # Default is 5 seconds.
   gracePeriodSeconds: 5
 ```

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -136,6 +136,10 @@ functionRuntimeFactoryConfigs:
   extraFunctionDependenciesDir:
   # Additional memory padding added on top of the memory requested by the function per on a per instance basis
   percentMemoryPadding: 10
+  # The duration in seconds before the StatefulSet deleted on function stop/restart.
+  # Value must be non-negative integer. The value zero indicates delete immediately.
+  # Default is 5 seconds.
+  gracePeriodSeconds: 5
 ```
 
 If you run functions worker embedded in a broker on Kubernetes, you can use the default settings. 


### PR DESCRIPTION
### Motivation

Restart of connector via `pulsar-admin source restart` (debezium postgres, but reprod with another too) failed and the function worker became non-responsive, repeatedly logging

```
19:43:58.139 [function-web-27-6] ERROR org.apache.pulsar.functions.worker.rest.api.ComponentImpl - Failed to restart Source: public/default/cassandra-source-ks1-table1
org.apache.pulsar.client.admin.PulsarAdminException$TimeoutException: java.util.concurrent.TimeoutException
        at org.apache.pulsar.client.admin.internal.SourcesImpl.restartSource(SourcesImpl.java:474) ~[com.datastax.oss-pulsar-client-admin-original-2.7.2.1.1.8-SNAPSHOT.jar:2.7.2.1.1.8-SNAPSHOT]
        at org.apache.pulsar.functions.worker.FunctionRuntimeManager.restartFunctionInstances(FunctionRuntimeManager.java:427) ~[com.datastax.oss-pulsar-functions-worker-2.7.2.1.1.8-SNAPSHOT.jar:2.7.2.1.1.8-SNAPSHOT]
        at org.apache.pulsar.functions.worker.rest.api.ComponentImpl.restartFunctionInstances(ComponentImpl.java:699) [com.datastax.oss-pulsar-functions-worker-2.7.2.1.1.8-SNAPSHOT.jar:2.7.2.1.1.8-SNAPSHOT]
        at org.apache.pulsar.functions.worker.rest.api.v3.SourcesApiV3Resource.restartSource(SourcesApiV3Resource.java:187) [com.datastax.oss-pulsar-functions-worker-2.7.2.1.1.8-SNAPSHOT.jar:2.7.2.1.1.8-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
...
Caused by: java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1886) ~[?:?]
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2021) ~[?:?]
        at org.apache.pulsar.client.admin.internal.SourcesImpl.restartSource(SourcesImpl.java:467) ~[com.datastax.oss-pulsar-client-admin-original-2.7.2.1.1.8-SNAPSHOT.jar:2.7.2.1.1.8-SNAPSHOT]
```

### Modifications

the rootcause tracked to the k8s client call timing out.
Looks like V1DeleteOptions weren't passed to the corresponding calls, and `Foreground` policy was not passed properly AFAICT from the k8s-client github/issues.
I also moved grace period for deleteNamespacedStatefulSetCall into the config.

### Verifying this change

Tested on the env.
Don't know how to unit test this. 

### Does this pull request potentially affect one of the following parts:

NO, AFAIK.
New config parameter is added, keeps the same value as hardcoded one it replaced.

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

- [X] `doc` 


