### PR TITLE
[Authorization] Return if namespace policies are read only

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -299,7 +299,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             result.complete(null);
         } catch (NotFoundException e) {
             log.warn("[{}] Failed to set permissions for namespace {}: does not exist", role, namespaceName);
-            result.completeExceptionally(new IllegalArgumentException("Namespace does not exist " + namespaceName));
+            result.completeExceptionally(new IllegalArgumentException("Namespace does not exist" + namespaceName));
         } catch (BadVersionException e) {
             log.warn("[{}] Failed to set permissions for namespace {}: concurrent modification", role, namespaceName);
             result.completeExceptionally(new IllegalStateException(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -286,6 +286,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             validatePoliciesReadOnlyAccess();
         } catch (Exception e) {
             result.completeExceptionally(e);
+            return result;
         }
 
         try {
@@ -298,7 +299,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             result.complete(null);
         } catch (NotFoundException e) {
             log.warn("[{}] Failed to set permissions for namespace {}: does not exist", role, namespaceName);
-            result.completeExceptionally(new IllegalArgumentException("Namespace does not exist" + namespaceName));
+            result.completeExceptionally(new IllegalArgumentException("Namespace does not exist " + namespaceName));
         } catch (BadVersionException e) {
             log.warn("[{}] Failed to set permissions for namespace {}: concurrent modification", role, namespaceName);
             result.completeExceptionally(new IllegalStateException(


### PR DESCRIPTION
### Motivation

This is a minor fix to a flow control in the default `PulsarAuthorizationProvider` class. Currently, when the policies are "read only", the `grantPermissionAsync` method will complete the future with a failure but then proceed to attempt to update the policy anyway.

### Modifications

* Return from the method early when policies are marked as read only.

### Verifying this change

This section of the code does not have good test coverage, so it wouldn't be very easy to add a test for this small case. Since this fix is small and easy to understand, I think it is safe to merge it without adding a test. Ideally, we'll come back and add tests for this part of the code base.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
It is a small change to internal behavior.



