### PR TITLE
[Authorization] Use AuthorizationService#grantPermissionAsync to gran…

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RestException;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 
 /**
  * Provider of authorization mechanism
@@ -236,14 +237,17 @@ public interface AuthorizationProvider extends Closeable {
     /**
      * Grant authorization-action permission on a topic to the given client
      *
+     * NOTE: used to complete with {@link IllegalArgumentException} when namespace not found or with
+     * {@link IllegalStateException} when failed to grant permission. This behavior is now deprecated.
+     * Please use the appropriate {@link MetadataStoreException}.
+     *
      * @param topicName
      * @param role
      * @param authDataJson
      *            additional authdata in json format
      * @return CompletableFuture
-     * @completesWith <br/>
-     *                IllegalArgumentException when namespace not found<br/>
-     *                IllegalStateException when failed to grant permission
+     * @completesWith null once the permissions are updated successfully.
+     * @completesWith {@link MetadataStoreException} when the MetadataStore is not updated.
      */
     CompletableFuture<Void> grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role,
             String authDataJson);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RestException;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,13 +152,15 @@ public class AuthorizationService {
     /**
      * Grant authorization-action permission on a topic to the given client
      *
+     * NOTE: used to complete with {@link IllegalArgumentException} when namespace not found or with
+     * {@link IllegalStateException} when failed to grant permission.
+     *
      * @param topicname
      * @param role
      * @param authDataJson
      *            additional authdata in json for targeted authorization provider
-     * @return IllegalArgumentException when namespace not found
-     * @throws IllegalStateException
-     *             when failed to grant permission
+     * @completesWith null when the permissions are updated successfully.
+     * @completesWith {@link MetadataStoreException} when the MetadataStore is not updated.
      */
     public CompletableFuture<Void> grantPermissionAsync(TopicName topicname, Set<AuthAction> actions, String role,
                                                         String authDataJson) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.service.BrokerServiceException.AlreadyRunningException;
 import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
@@ -259,24 +260,33 @@ public class PersistentTopicsBase extends AdminResource {
         validateTopicOwnership(topicName, authoritative);
     }
 
-    private void grantPermissions(String topicUri, String role, Set<AuthAction> actions) {
+    private void grantPermissions(TopicName topicUri, String role, Set<AuthAction> actions) {
         try {
-            namespaceResources().setPolicies(namespaceName, policies -> {
-                if (!policies.auth_policies.getTopicAuthentication().containsKey(topicUri)) {
-                    policies.auth_policies.getTopicAuthentication().put(topicUri, new HashMap<>());
-                }
-
-                policies.auth_policies.getTopicAuthentication().get(topicUri).put(role, actions);
-                return policies;
-            });
+            AuthorizationService authService = pulsar().getBrokerService().getAuthorizationService();
+            if (null != authService) {
+                authService.grantPermissionAsync(topicUri, actions, role, null/*additional auth-data json*/)
+                        .get();
+            } else {
+                throw new RestException(Status.NOT_IMPLEMENTED, "Authorization is not enabled");
+            }
             log.info("[{}] Successfully granted access for role {}: {} - topic {}", clientAppId(), role, actions,
                     topicUri);
-        } catch (MetadataStoreException.NotFoundException e) {
-            log.warn("[{}] Failed to grant permissions on topic {}: Namespace does not exist", clientAppId(), topicUri);
-            throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
-        } catch (Exception e) {
-            log.error("[{}] Failed to grant permissions for topic {}", clientAppId(), topicUri, e);
+        } catch (InterruptedException e) {
+            log.error("[{}] Failed to get permissions for topic {}", clientAppId(), topicUri, e);
             throw new RestException(e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof IllegalArgumentException) {
+                log.warn("[{}] Failed to set permissions for topic {}: Namespace does not exist", clientAppId(),
+                        topicUri, e);
+                throw new RestException(Status.NOT_FOUND, "Topic's namespace does not exist");
+            } else if (e.getCause() instanceof IllegalStateException) {
+                log.warn("[{}] Failed to set permissions for topic {}: {}",
+                        clientAppId(), topicUri, e.getCause().getMessage(), e);
+                throw new RestException(Status.CONFLICT, "Concurrent modification");
+            } else {
+                log.error("[{}] Failed to get permissions for topic {}", clientAppId(), topicUri, e);
+                throw new RestException(e);
+            }
         }
     }
 
@@ -290,10 +300,10 @@ public class PersistentTopicsBase extends AdminResource {
         if (numPartitions > 0) {
             for (int i = 0; i < numPartitions; i++) {
                 TopicName topicNamePartition = topicName.getPartition(i);
-                grantPermissions(topicNamePartition.toString(), role, actions);
+                grantPermissions(topicNamePartition, role, actions);
             }
         }
-        grantPermissions(topicName.toString(), role, actions);
+        grantPermissions(topicName, role, actions);
     }
 
     protected void internalDeleteTopicForcefully(boolean authoritative, boolean deleteSchema) {


### PR DESCRIPTION
…t topic permission

### Motivation

There are several motivating factors here.

1. The `AuthorizationProvider` interface has a method to grant permission for a role to a topic. However, that method is not currently used. The other methods in the interface for granting permission on namespaces and on subscriptions are used. This PR seeks to bring the implementation into alignment. Without this change, a custom authorization provider would not be able to create custom logic for topic level permissions.
2. The current implementation of`PulsarAuthorizationProvider#grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role, String authDataJson)` is surprising. It currently sets permissions using the namespace method instead of setting the permissions at the topic level. This could result in granting more permission than intended. However, the method is not actually called right now, so this unexpected behavior is irrelevant.

### Modifications

* Move the logic for granting topic permissions to the `PulsarAuthorizationProvider`. This change closely resembles the existing code in the `NamespacesBase` class.

### Verifying this change

There are already tests that cover the granting of permission at a topic level. For example, `PersistentTopicsTest` tests this. Existing test coverage should be sufficient for validating this change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  No behavior is changed here. The fundamental change is to rely on the `AuthorizationProvider` interface when granting topic level permissions.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


