### PR TITLE
[CAPI] Support setting priority for consumers

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -275,6 +275,12 @@ PULSAR_PUBLIC void pulsar_consumer_set_subscription_initial_position(
 PULSAR_PUBLIC void pulsar_consumer_configuration_set_property(pulsar_consumer_configuration_t *conf,
                                                               const char *name, const char *value);
 
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_priority_level(
+    pulsar_consumer_configuration_t *consumer_configuration, int priority_level);
+
+PULSAR_PUBLIC int pulsar_consumer_configuration_get_priority_level(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //
 // const;

--- a/pulsar-client-cpp/lib/c/c_ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ConsumerConfiguration.cc
@@ -185,3 +185,13 @@ int pulsar_consumer_get_subscription_initial_position(
     pulsar_consumer_configuration_t *consumer_configuration) {
     return consumer_configuration->consumerConfiguration.getSubscriptionInitialPosition();
 }
+
+void pulsar_consumer_configuration_set_priority_level(pulsar_consumer_configuration_t *consumer_configuration,
+                                                      int priority_level) {
+    consumer_configuration->consumerConfiguration.setPriorityLevel(priority_level);
+}
+
+int pulsar_consumer_configuration_get_priority_level(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    return consumer_configuration->consumerConfiguration.getPriorityLevel();
+}


### PR DESCRIPTION
### Motivation

We would like to make it possible for C API based client library to set the priority level for consumers.

### Modifications

Add methods to set/get priority level for consumers.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


