### PR TITLE
The count of topics on the bundle is less than 2，skip split

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -72,8 +72,8 @@ public class BundleSplitterTask implements BundleSplitStrategy {
             for (final Map.Entry<String, NamespaceBundleStats> entry : localData.getLastStats().entrySet()) {
                 final String bundle = entry.getKey();
                 final NamespaceBundleStats stats = entry.getValue();
-                if (stats.topics == 1) {
-                    log.info("namespace bundle {} only have 1 topic", bundle);
+                if (stats.topics < 2) {
+                    log.info("The count of topics on the bundle {} is less than 2，skip split!", bundle);
                     continue;
                 }
                 double totalMessageRate = 0;


### PR DESCRIPTION

### Motivation
The count of topics on the bundle is less than 2，skip split
https://github.com/apache/pulsar/blob/52dffda16facef0047081a4b6f0f4e06fecb6349/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java#L75-L78

### Documentation

- [x] no-need-doc

It's an internal change, no need doc