### PR TITLE
Fixed flaky test in LocalMemoryMetadataStoreTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LocalMemoryMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LocalMemoryMetadataStoreTest.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 public class LocalMemoryMetadataStoreTest {
@@ -84,7 +85,11 @@ public class LocalMemoryMetadataStoreTest {
 
         store2.delete("/test", Optional.empty()).join();
 
-        assertFalse(store1.exists("/test").join());
         assertFalse(store2.exists("/test").join());
+
+        // The exists will be updated based on the cache invalidation in store1
+        Awaitility.await().untilAsserted(() -> {
+            assertFalse(store1.exists("/test").join());
+        });
     }
 }


### PR DESCRIPTION
### Motivation

A recently added test has been failing on and off based on a cache invalidation race condition:

```
Error:  testSharedInstance(org.apache.pulsar.metadata.LocalMemoryMetadataStoreTest)  Time elapsed: 0.104 s  <<< FAILURE!
java.lang.AssertionError: expected [false] but found [true]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertFalse(Assert.java:67)
	at org.testng.Assert.assertFalse(Assert.java:77)
	at org.apache.pulsar.metadata.LocalMemoryMetadataStoreTest.testSharedInstance(LocalMemoryMetadataStoreTest.java:87)
```

Although it will not be immediate, eventually, the assertion will be true.