### PR TITLE
[pulsar-broker] Add git branch information for PulsarVersion

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -583,6 +583,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         LOG.info("Starting Pulsar Broker service; version: '{}'",
                 (brokerVersion != null ? brokerVersion : "unknown"));
         LOG.info("Git Revision {}", PulsarVersion.getGitSha());
+        LOG.info("Git Branch {}", PulsarVersion.getGitBranch());
         LOG.info("Built by {} on {} at {}",
                 PulsarVersion.getBuildUser(),
                 PulsarVersion.getBuildHost(),

--- a/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
+++ b/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
@@ -82,6 +82,10 @@ public class PulsarVersion {
         }
     }
 
+    public static String getGitBranch() {
+        return "${git.branch}";
+    }
+
     public static String getBuildUser() {
         String email = "${git.build.user.email}";
         String name = "${git.build.user.name}";


### PR DESCRIPTION
### Motivation

*To make it easier to trace the code, we can print git branch information when the broker starts.*

### Modifications

*Add a method PulsarVersion#getGitBranch, and print git branch information when the broker starts.*

*After the change:*
![image](https://user-images.githubusercontent.com/55134131/139758009-2f5aa96f-c2b9-426f-b4c1-c6ae0e676902.png)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [ ] doc-required 
- [x] no-need-doc 
- [ ] doc 