### PR TITLE
[branch-2.8] Remove pulsar-dashboard from the publish process of pulsar images

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -65,25 +65,21 @@ set -e
 docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:latest
-docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:latest
 docker tag pulsar-standalone:latest ${docker_registry_org}/pulsar-standalone:latest
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
 docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
-docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
 docker tag pulsar-standalone:latest ${docker_registry_org}/pulsar-standalone:$MVN_VERSION
 
 # Push all images and tags
 docker push ${docker_registry_org}/pulsar:latest
 docker push ${docker_registry_org}/pulsar-all:latest
 docker push ${docker_registry_org}/pulsar-grafana:latest
-docker push ${docker_registry_org}/pulsar-dashboard:latest
 docker push ${docker_registry_org}/pulsar-standalone:latest
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
-docker push ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-standalone:$MVN_VERSION
 
 echo "Finished pushing images to ${docker_registry_org}"


### PR DESCRIPTION

### Motivation


Remove pulsar-dashboard image from the publish process of pulsar images since it had been removed from branch-2.8.
See also https://github.com/apache/pulsar/pull/11284 and https://github.com/apache/pulsar/pull/12534

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


