### PR TITLE
Wrong put the SSL_TRUSTSTORE_LOCATION_CONFIG to SSL_TRUSTSTORE_PASSWOR…

### DIFF
--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -116,7 +116,7 @@ public abstract class KafkaAbstractSink<K, V> implements Sink<byte[]> {
             props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, kafkaSinkConfig.getSslTruststoreLocation());
         }
         if (StringUtils.isNotEmpty(kafkaSinkConfig.getSslTruststorePassword())) {
-            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, kafkaSinkConfig.getSslTruststorePassword());
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, kafkaSinkConfig.getSslTruststorePassword());
         }
         props.put(ProducerConfig.ACKS_CONFIG, kafkaSinkConfig.getAcks());
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, String.valueOf(kafkaSinkConfig.getBatchSize()));


### PR DESCRIPTION
### Motivation
Kafka Connector sasl config parameters can't work

### Modifications

Fix the wrong put

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  bug fix, no need doc
  


