### PR TITLE
[ML] Add OpAddEntry to pendingAddEntries after the state check

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -721,7 +721,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (!beforeAddEntry(addOperation)) {
             return;
         }
-        pendingAddEntries.add(addOperation);
         final State state = STATE_UPDATER.get(this);
         if (state == State.Fenced) {
             addOperation.failed(new ManagedLedgerFencedException());
@@ -733,10 +732,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             addOperation.failed(new ManagedLedgerAlreadyClosedException("Managed ledger was already closed"));
             return;
         } else if (state == State.WriteFailed) {
-            pendingAddEntries.remove(addOperation);
             addOperation.failed(new ManagedLedgerAlreadyClosedException("Waiting to recover from failure"));
             return;
         }
+        pendingAddEntries.add(addOperation);
 
         if (state == State.ClosingLedger || state == State.CreatingLedger) {
             // We don't have a ready ledger to write into


### PR DESCRIPTION
### Motivation

- when the state was Fenced, Terminated or Closed, the OpAddEntry
  instance would remain in pendingAddEntries although the operation is failed
  immediately.

### Modifications

- add OpAddEntry to pendingAddEntries after the state check