### PR TITLE
PulsarAdmin: Fix last exit code storage

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -334,7 +334,7 @@ public class PulsarAdminTool {
     }
 
     private static void exit(int code) {
-        lastExitCode = lastExitCode;
+        lastExitCode = code;
         if (allowSystemExit) {
             // we are using halt and not System.exit, we do not mind about shutdown hooks
             // they are only slowing down the tool

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -31,7 +31,7 @@ public class TestRunMain {
     public void runMainNoArguments() throws Exception {
         PulsarAdminTool.setAllowSystemExit(false);
         PulsarAdminTool.main(new String[0]);
-        assertEquals(PulsarAdminTool.getLastExitCode(), 0);
+        assertEquals(PulsarAdminTool.getLastExitCode(), 1);
     }
 
     @Test

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -39,6 +39,6 @@ public class TestRunMain {
         PulsarAdminTool.setAllowSystemExit(false);
         Path dummyEmptyFile = Files.createTempFile("test", ".conf");
         PulsarAdminTool.main(new String[] {dummyEmptyFile.toAbsolutePath().toString()});
-        assertEquals(PulsarAdminTool.getLastExitCode(), 0);
+        assertEquals(PulsarAdminTool.getLastExitCode(), 1);
     }
 }


### PR DESCRIPTION
This line was actually assigning the method argument to itself instead of setting the static field of the same name.


### Motivation

Fix a simple mistake.

### Modifications

Trivial change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
- [x] `no-need-doc` This is a trivial change that does not impact the API or schema.
- [ ] `doc` 
