### PR TITLE
[C++] Fix request timeout for GetLastMessageId doesn't work

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1620,7 +1620,12 @@ Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consume
 
     pendingGetLastMessageIdRequests_.insert(std::make_pair(requestId, promise));
     lock.unlock();
-    sendRequestWithId(Commands::newGetLastMessageId(consumerId, requestId), requestId);
+    sendRequestWithId(Commands::newGetLastMessageId(consumerId, requestId), requestId)
+        .addListener([promise](Result result, const ResponseData& data) {
+            if (result != ResultOk) {
+                promise.setFailed(result);
+            }
+        });
     return promise.getFuture();
 }
 

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -19,6 +19,7 @@
 #ifndef LIB_FUTURE_H_
 #define LIB_FUTURE_H_
 
+#include <atomic>
 #include <functional>
 #include <mutex>
 #include <memory>
@@ -31,55 +32,114 @@ typedef std::unique_lock<std::mutex> Lock;
 namespace pulsar {
 
 template <typename Result, typename Type>
-struct InternalState {
-    std::mutex mutex;
-    std::condition_variable condition;
-    Result result;
-    Type value;
-    bool complete;
+class InternalState {
+   public:
+    using ListenerCallback = std::function<void(Result, const Type&)>;
 
-    std::list<typename std::function<void(Result, const Type&)> > listeners;
+    InternalState() = default;
+    InternalState(const InternalState&) = delete;
+    InternalState& operator=(const InternalState&) = delete;
+
+    static Result defaultResult() {
+        static Result result;
+        return result;
+    }
+
+    static Type defaultValue() {
+        static Type value;
+        return value;
+    }
+
+    bool completed() const noexcept { return completed_; }
+
+    void addListener(const ListenerCallback& callback) {
+        Lock lock(mutex_);
+        if (completed_) {
+            const auto result = result_;
+            const auto value = value_;
+            lock.unlock();
+            callback(result, value);
+        } else {
+            listeners_.emplace_back(callback);
+        }
+    }
+
+    Result wait(Type& value) {
+        Lock lock(mutex_);
+        while (!completed_) {
+            condition_.wait(lock);
+        }
+        value = value_;
+        return result_;
+    }
+
+    bool complete(const Type& value) {
+        if (completed_) {
+            return false;
+        }
+
+        Lock lock(mutex_);
+        value_ = value;
+        completed_ = true;
+        auto listeners = std::move(listeners_);
+        lock.unlock();
+
+        for (auto& callback : listeners) {
+            callback(defaultResult(), value);
+        }
+        condition_.notify_all();
+        return true;
+    }
+
+    bool completeExceptionally(Result result) {
+        if (completed_) {
+            return false;
+        }
+
+        Lock lock(mutex_);
+        result_ = result;
+        completed_ = true;
+        auto listeners = std::move(listeners_);
+        lock.unlock();
+
+        for (auto& callback : listeners) {
+            callback(result, defaultValue());
+        }
+        condition_.notify_all();
+        return true;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    mutable std::condition_variable condition_;
+    Result result_;
+    Type value_;
+    std::atomic_bool completed_{false};
+
+    std::list<ListenerCallback> listeners_;
 };
 
 template <typename Result, typename Type>
 class Future {
    public:
-    typedef std::function<void(Result, const Type&)> ListenerCallback;
+    using InternalState = InternalState<Result, Type>;
+    using InternalStatePtr = std::shared_ptr<InternalState>;
+    using ListenerCallback = typename InternalState::ListenerCallback;
 
-    Future& addListener(ListenerCallback callback) {
-        InternalState<Result, Type>* state = state_.get();
-        Lock lock(state->mutex);
+    Future(const Future&) = default;
+    Future& operator=(const Future&) = default;
 
-        if (state->complete) {
-            lock.unlock();
-            callback(state->result, state->value);
-        } else {
-            state->listeners.push_back(callback);
-        }
-
+    Future& addListener(const ListenerCallback& callback) {
+        state_->addListener(callback);
         return *this;
     }
 
-    Result get(Type& result) {
-        InternalState<Result, Type>* state = state_.get();
-        Lock lock(state->mutex);
-
-        if (!state->complete) {
-            // Wait for result
-            while (!state->complete) {
-                state->condition.wait(lock);
-            }
-        }
-
-        result = state->value;
-        return state->result;
-    }
+    Result get(Type& result) { return state_->wait(result); }
 
    private:
-    typedef std::shared_ptr<InternalState<Result, Type> > InternalStatePtr;
     Future(InternalStatePtr state) : state_(state) {}
 
-    std::shared_ptr<InternalState<Result, Type> > state_;
+    InternalStatePtr state_;
 
     template <typename U, typename V>
     friend class Promise;
@@ -88,64 +148,20 @@ class Future {
 template <typename Result, typename Type>
 class Promise {
    public:
-    Promise() : state_(std::make_shared<InternalState<Result, Type> >()) {}
+    using Future = Future<Result, Type>;
+    using InternalState = typename Future::InternalState;
+    using InternalStatePtr = typename Future::InternalStatePtr;
 
-    bool setValue(const Type& value) {
-        InternalState<Result, Type>* state = state_.get();
-        Lock lock(state->mutex);
+    bool setValue(const Type& value) const { return state_->complete(value); }
 
-        if (state->complete) {
-            return false;
-        }
+    bool setFailed(Result result) const { return state_->completeExceptionally(result); }
 
-        state->value = value;
-        state->result = Result();
-        state->complete = true;
+    bool isComplete() const { return state_->completed(); }
 
-        typename std::list<ListenerCallback>::iterator it;
-        for (it = state->listeners.begin(); it != state->listeners.end(); ++it) {
-            ListenerCallback& callback = *it;
-            callback(state->result, state->value);
-        }
-
-        state->listeners.clear();
-        state->condition.notify_all();
-        return true;
-    }
-
-    bool setFailed(Result result) {
-        InternalState<Result, Type>* state = state_.get();
-        Lock lock(state->mutex);
-
-        if (state->complete) {
-            return false;
-        }
-
-        state->result = result;
-        state->complete = true;
-
-        typename std::list<ListenerCallback>::iterator it;
-        for (it = state->listeners.begin(); it != state->listeners.end(); ++it) {
-            ListenerCallback& callback = *it;
-            callback(state->result, state->value);
-        }
-
-        state->listeners.clear();
-        state->condition.notify_all();
-        return true;
-    }
-
-    bool isComplete() const {
-        InternalState<Result, Type>* state = state_.get();
-        Lock lock(state->mutex);
-        return state->complete;
-    }
-
-    Future<Result, Type> getFuture() const { return Future<Result, Type>(state_); }
+    Future getFuture() const { return state_; }
 
    private:
-    typedef std::function<void(Result, const Type&)> ListenerCallback;
-    std::shared_ptr<InternalState<Result, Type> > state_;
+    InternalStatePtr state_{std::make_shared<InternalState>()};
 };
 
 class Void {};

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -36,7 +36,9 @@ class InternalState {
    public:
     using ListenerCallback = std::function<void(Result, const Type&)>;
 
-    InternalState() = default;
+    // There's a bug about the defaulted default constructor for GCC < 4.9.1, so we cannot use
+    // `InternalState() = default` here.
+    InternalState() {}
     InternalState(const InternalState&) = delete;
     InternalState& operator=(const InternalState&) = delete;
 
@@ -122,9 +124,9 @@ class InternalState {
 template <typename Result, typename Type>
 class Future {
    public:
-    using InternalState = InternalState<Result, Type>;
-    using InternalStatePtr = std::shared_ptr<InternalState>;
-    using ListenerCallback = typename InternalState::ListenerCallback;
+    using InternalStateType = InternalState<Result, Type>;
+    using InternalStatePtr = std::shared_ptr<InternalStateType>;
+    using ListenerCallback = typename InternalStateType::ListenerCallback;
 
     Future(const Future&) = default;
     Future& operator=(const Future&) = default;
@@ -148,9 +150,9 @@ class Future {
 template <typename Result, typename Type>
 class Promise {
    public:
-    using Future = Future<Result, Type>;
-    using InternalState = typename Future::InternalState;
-    using InternalStatePtr = typename Future::InternalStatePtr;
+    using FutureType = Future<Result, Type>;
+    using InternalStateType = typename FutureType::InternalStateType;
+    using InternalStatePtr = typename FutureType::InternalStatePtr;
 
     bool setValue(const Type& value) const { return state_->complete(value); }
 
@@ -158,10 +160,10 @@ class Promise {
 
     bool isComplete() const { return state_->completed(); }
 
-    Future getFuture() const { return state_; }
+    FutureType getFuture() const { return state_; }
 
    private:
-    InternalStatePtr state_{std::make_shared<InternalState>()};
+    InternalStatePtr state_{std::make_shared<InternalStateType>()};
 };
 
 class Void {};

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -111,7 +111,6 @@ class Promise {
             callback(DEFAULT_RESULT, value);
         }
 
-        state->listeners.clear();
         state->condition.notify_all();
         return true;
     }

--- a/pulsar-client-cpp/lib/Future.h
+++ b/pulsar-client-cpp/lib/Future.h
@@ -103,7 +103,8 @@ class Promise {
         state->result = DEFAULT_RESULT;
         state->complete = true;
 
-        const auto listeners = std::move(state->listeners);
+        decltype(state->listeners) listeners;
+        listeners.swap(state->listeners);
 
         lock.unlock();
 
@@ -127,7 +128,8 @@ class Promise {
         state->result = result;
         state->complete = true;
 
-        const auto listeners = std::move(state->listeners);
+        decltype(state->listeners) listeners;
+        listeners.swap(state->listeners);
 
         lock.unlock();
 

--- a/pulsar-client-cpp/tests/PromiseTest.cc
+++ b/pulsar-client-cpp/tests/PromiseTest.cc
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <lib/Future.h>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace pulsar;
+
+TEST(PromiseTest, testSetValue) {
+    Promise<int, std::string> promise;
+    std::thread t{[promise] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        promise.setValue("hello");
+    }};
+    t.detach();
+
+    std::string value;
+    ASSERT_EQ(promise.getFuture().get(value), 0);
+    ASSERT_EQ(value, "hello");
+}
+
+TEST(PromiseTest, testSetFailed) {
+    Promise<int, std::string> promise;
+    std::thread t{[promise] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        promise.setFailed(-1);
+    }};
+    t.detach();
+
+    std::string value;
+    ASSERT_EQ(promise.getFuture().get(value), -1);
+    ASSERT_EQ(value, "");
+}
+
+TEST(PromiseTest, testListeners) {
+    Promise<int, std::string> promise;
+    auto future = promise.getFuture();
+
+    bool resultSetFailed = true;
+    bool resultSetValue = true;
+    std::vector<int> results;
+    std::vector<std::string> values;
+
+    future
+        .addListener([promise, &resultSetFailed, &results, &values](int result, const std::string& value) {
+            resultSetFailed = promise.setFailed(-1L);
+            results.emplace_back(result);
+            values.emplace_back(value);
+        })
+        .addListener([promise, &resultSetValue, &results, &values](int result, const std::string& value) {
+            resultSetValue = promise.setValue("WRONG");
+            results.emplace_back(result);
+            values.emplace_back(value);
+        });
+
+    promise.setValue("hello");
+    std::string value;
+    ASSERT_EQ(future.get(value), 0);
+    ASSERT_EQ(value, "hello");
+
+    ASSERT_FALSE(resultSetFailed);
+    ASSERT_FALSE(resultSetValue);
+    ASSERT_EQ(results, (std::vector<int>(2, 0)));
+    ASSERT_EQ(values, (std::vector<std::string>(2, "hello")));
+}


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/11600 adds the timeout for GetLastMessageId request by using `sendRequestWithId` instead of `sendCommand`. However, it's still incorrect. Because when the request timeout exceeds, the future that is completed with `ResultTimeout` is what `sendRequestWithId` returns but not the `promise.getFuture()`. Therefore, even if the request was not responded in `operationTimeout` seconds, the future returned by `newGetLastMessageId` would still be not completed.

Besides, when I tried to complete the `promise` in `sendRequestWithId`'s callback, I found a deadlock issue if `ServerCnx#handleGetLastMessageId` hang forever (I just add a long `sleep` call in this method).

```
    frame #3: std::__1::mutex::lock() + 9
    frame #4: pulsar::Promise<pulsar::Result, pulsar::ResponseData>::setFailed(pulsar::Result) const [inlined] std::__1::unique_lock<std::__1::mutex>::unique_lock(this=<unavailable>, __m=0x00007ffb1b0044d8) at __mutex_base:119:61 [opt]
    frame #5: pulsar::Promise<pulsar::Result, pulsar::ResponseData>::setFailed(pulsar::Result) const [inlined] std::__1::unique_lock<std::__1::mutex>::unique_lock(this=<unavailable>, __m=0x00007ffb1b0044d8) at __mutex_base:119 [opt]
    frame #6: pulsar::Promise<pulsar::Result, pulsar::ResponseData>::setFailed(this=0x00007ffb1b0046e8, result=ResultConnectError) const at Future.h:118 [opt]
    frame #7: pulsar::ClientConnection::close(this=<unavailable>, result=ResultConnectError) at ClientConnection.cc:1556:27 [opt]
```

We can see `Promise::setFailed` stuck in `ClientConnection::close`:

```c++
     for (auto& kv : pendingRequests) {
         kv.second.promise.setFailed(ResultConnectError);
     }  
```

It's because the future's callback is called in `setFailed`. However, the callback also calls `setFailed`, which tries to acquire the same lock that is not reentrant. So deadlock happens.

### Modifications

Refactor the `Future`/`Promise` infrastructure. The current design is too old and the code style is bad. The important things of the refactoring are:
1. Change `completed_` field (the original `complete` field) to an atomic variable. So when checking if the future is completed, no lock is required.
2. Move the triggering of `listeners_` out of the locked code block. So that each listener (callback) will be triggered without acquiring any lock.
3. Move `conditional_variable::notify_all()` out of the locked code block as well. The notifying thread does not need to hold the lock, see https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all.
4. Move all related implementations into `InternalState` so that `Future` and `Promise` only need to call them directly.

Then add a `PromiseTest` to protect the refactoring. Based on the refactor, just add a callback to `sendRequestWithId` in `newGetLastMessageId` to make sure the request timeout works.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

It's hard to simulate the operation timeout. So I have to add the following code to `ServerCnx#handleGetLastMessageId`

```java
        try {
            Thread.sleep(1000000);
        } catch (InterruptedException e) {
            e.printStackTrace();
        }
```

and run a reader to call `hasMessageAvailable` with 3 seconds operation timeout. After it failed, the client exited after 6 seconds, which is twice the operation timeout. The logs are:

```
2021-11-02 20:39:39.685 ERROR [0x11b16de00] SampleConsumer:48 | Failed to check hasMessageAvailable: TimeOut
2021-11-02 20:39:39.685 INFO  [0x11b16de00] ClientImpl:492 | Closing Pulsar client with 0 producers and 1 consumers
2021-11-02 20:39:39.685 INFO  [0x11b16de00] ConsumerImpl:894 | [persistent://public/default/my-topic-0, reader-35479ac30a, 0] Closing consumer for topic persistent://public/default/my-topic-0
2021-11-02 20:39:43.686 ERROR [0x700006b1e000] ConsumerImpl:952 | [persistent://public/default/my-topic-0, reader-35479ac30a, 0] Failed to close consumer: TimeOut
2021-11-02 20:39:43.686 INFO  [0x700006b1e000] ClientConnection:1542 | [[::1]:60215 -> [::1]:6650] Connection closed
2021-11-02 20:39:43.687 INFO  [0x11b16de00] ClientConnection:255 | [[::1]:60215 -> [::1]:6650] Destroyed connection
```