### PR TITLE
Fix invalid firstSentAt in log message when timeout first time

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1228,7 +1228,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         "%s : createdAt %s ns ago, firstSentAt %s ns ago, lastSentAt %s ns ago, retryCount %s",
                         te.getMessage(),
                         ns - this.createdAt,
-                        ns - this.firstSentAt,
+                        this.firstSentAt <= 0 ? ns - this.lastSentAt : ns - this.firstSentAt,
                         ns - this.lastSentAt,
                         retryCount
                     );


### PR DESCRIPTION
Simple fix to `firstSentAt` when it first timed out.

An example of abnormal output:
```
org.apache.pulsar.client.api.PulsarClientException$TimeoutException: The producer XXX can not send message to the topic YYY within given timeout : createdAt 30004180480 ns ago, firstSentAt 32225437594084969 ns ago, lastSentAt 30004087361 ns ago, retryCount 1
```