### PR TITLE
Allow WebSocketHttpServletRequestWrapperTest run on windows

### DIFF
--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/LookupProtocolTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/LookupProtocolTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.websocket;
 import java.lang.reflect.Field;
 
 import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
@@ -68,7 +68,7 @@ public class WebSocketHttpServletRequestWrapperTest {
         WebSocketProxyConfiguration config = PulsarConfigurationLoader.create(
                 this.getClass().getClassLoader().getResource("websocket.conf").getFile(),
                 WebSocketProxyConfiguration.class);
-        String publicKeyPath = this.getClass().getClassLoader().getResource("my-public.key").getFile();
+        String publicKeyPath = "file://" + this.getClass().getClassLoader().getResource("my-public.key").getFile();
         config.getProperties().setProperty("tokenPublicKey", publicKeyPath);
         WebSocketService service = new WebSocketService(config);
         service.start();


### PR DESCRIPTION
### Motivation
Allow unit tests run on windows

### Modifications

Change the file path to compat windows and unix

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  Simple unit tests change


