### PR TITLE
[Python] Provide __str__ operator for BytesSchema

### DIFF
--- a/pulsar-client-cpp/python/pulsar/schema/schema.py
+++ b/pulsar-client-cpp/python/pulsar/schema/schema.py
@@ -58,6 +58,9 @@ class BytesSchema(Schema):
     def decode(self, data):
         return data
 
+    def __str__(self):
+        return 'BytesSchema'
+
 
 class StringSchema(Schema):
     def __init__(self):
@@ -69,6 +72,10 @@ class StringSchema(Schema):
 
     def decode(self, data):
         return data.decode('utf-8')
+
+    def __str__(self):
+        return 'StringSchema'
+
 
 
 class JsonSchema(Schema):


### PR DESCRIPTION
### Motivation

When generating the Python docs, we're always getting a diff in the generated HTML files:

```diff
diff --git content/api/python/2.10.0-SNAPSHOT/index.html content/api/python/2.10.0-SNAPSHOT/index.html
index 7ca1187b385..3024cd47437 100644
--- content/api/python/2.10.0-SNAPSHOT/index.html
+++ content/api/python/2.10.0-SNAPSHOT/index.html
@@ -3764,7 +3764,7 @@ producers and consumers.</p></div>

   <div class="item">
     <div class="name def" id="pulsar.Client.create_producer">
-    <p>def <span class="ident">create_producer</span>(</p><p>self, topic, producer_name=None, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7fe2f58e8b90&gt;, initial_sequence_id=None, send_timeout_millis=30000, compres
+    <p>def <span class="ident">create_producer</span>(</p><p>self, topic, producer_name=None, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7ff062143b90&gt;, initial_sequence_id=None, send_timeout_millis=30000, compres
     </div>


@@ -4018,7 +4018,7 @@ batched into single batch message:

   <div class="item">
     <div class="name def" id="pulsar.Client.create_reader">
-    <p>def <span class="ident">create_reader</span>(</p><p>self, topic, start_message_id, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7fe2ede71090&gt;, reader_listener=None, receiver_queue_size=1000, reader_name=None
+    <p>def <span class="ident">create_reader</span>(</p><p>self, topic, start_message_id, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7ff061239090&gt;, reader_listener=None, receiver_queue_size=1000, reader_name=None
     </div>


@@ -4235,7 +4235,7 @@ for ongoing operations to complete.</p></div>

   <div class="item">
     <div class="name def" id="pulsar.Client.subscribe">
-    <p>def <span class="ident">subscribe</span>(</p><p>self, topic, subscription_name, consumer_type=_pulsar.ConsumerType.Exclusive, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7fe2ede62f90&gt;, message_listener=None
+    <p>def <span class="ident">subscribe</span>(</p><p>self, topic, subscription_name, consumer_type=_pulsar.ConsumerType.Exclusive, schema=&lt;pulsar.schema.schema.BytesSchema object at 0x7ff06122af90&gt;, message_listener=None
     </div>
```

This is due to `BytesSchema` not having a `__str__()` method and thus returning a different string each time, like: `<pulsar.schema.schema.BytesSchema object at 0x7fe2f58e8b90>`.

