### PR TITLE
Reduced severity of log "refreshing key manager" in KeyManagerProxy

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/KeyManagerProxy.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/KeyManagerProxy.java
@@ -73,20 +73,23 @@ public class KeyManagerProxy extends X509ExtendedKeyManager {
                 TimeUnit.SECONDS);
     }
 
-    public void updateKeyManagerSafely() {
+    private void updateKeyManagerSafely() {
         try {
+            if (log.isDebugEnabled()) {
+                log.debug("refreshing key manager for {} {}", certFile.getFileName(), keyFile.getFileName());
+            }
             updateKeyManager();
         } catch (Exception e) {
             log.warn("Failed to update key Manager for {}, {}", certFile.getFileName(), keyFile.getFileName(), e);
         }
     }
 
-    public void updateKeyManager()
+    private void updateKeyManager()
             throws CertificateException, KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
         if (keyManager != null && !certFile.checkAndRefresh() && !keyFile.checkAndRefresh()) {
             return;
         }
-        log.info("refreshing key manager for {} {}", certFile.getFileName(), keyFile.getFileName());
+
         X509Certificate certificate;
         PrivateKey privateKey = null;
         KeyStore keyStore;


### PR DESCRIPTION
### Motivation

Each time the `pulsar-admin` tool is launched with TLS certificates configured, it is printing an info log "refreshing key manager for my-cert.pem` at least twice.

This is noisy in that we shouldn't have any extra output in `pulsar-admin` in order to make it possible to use it from scripts. Also, it's a bit confusing since it's technically the first time we're reading those certs and not a refresh.