### PR TITLE
Optimize OverloadShedder: Sort bundle by throughput in ascending order

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -121,8 +121,8 @@ public class OverloadShedder implements LoadSheddingStrategy {
                 }).filter(e ->
                         localData.getBundles().contains(e.getLeft())
                 ).sorted((e1, e2) -> {
-                    // Sort by throughput in reverse order
-                    return Double.compare(e2.getRight(), e1.getRight());
+                    // Sort by throughput in ascending order
+                    return Double.compare(e1.getRight(), e2.getRight());
                 }).forEach(e -> {
                     if (trafficMarkedToOffload.doubleValue() < minimumThroughputToOffload
                             || atLeastOneBundleSelected.isFalse()) {


### PR DESCRIPTION
### Motivation
In the OverloadShedder strategy, to select a bundle on the broker, first select the one with the largest throughput for unloading, and at least unload a bundle from the broker, which may cause repeated unloads between brokers.


### Modifications
In the OverloadShedder strategy, to select a bundle on the broker, first select the one with the largest throughput for unloading, and at least unload a bundle from the broker, which may cause repeated unloads between brokers：
https://github.com/apache/pulsar/blob/6b3fb4193857c324c748ea53ae5e6028137b2e35/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java#L123-L126

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  (The modification here will not change the original semantics of the method)
  


