### PR TITLE
fix 12614, waitingForPingResponse needs to be modified with volatile for concurrent sence 

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -36,7 +36,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
     protected SocketAddress remoteAddress;
     private int remoteEndpointProtocolVersion = ProtocolVersion.v0.getValue();
     private final long keepAliveIntervalSeconds;
-    private boolean waitingForPingResponse = false;
+    private volatile boolean waitingForPingResponse = false;
     private ScheduledFuture<?> keepAliveTask;
 
     public int getRemoteEndpointProtocolVersion() {


### PR DESCRIPTION
Fixes #12614

Master Issue: #12614


waitingForPingResponse was used in PulsarHandler for check if or not close connection.

and it was set value in different thread , so it must to be modified with volatile.