### PR TITLE
[Sink] Fix the marshal and unmarshal the sink config

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -575,6 +575,10 @@ public class SinkConfigUtils {
         if (!StringUtils.isEmpty(newConfig.getCustomRuntimeOptions())) {
             mergedConfig.setCustomRuntimeOptions(newConfig.getCustomRuntimeOptions());
         }
+        if (newConfig.getCleanupSubscription() != null) {
+            mergedConfig.setCleanupSubscription(newConfig.getCleanupSubscription());
+        }
+
         return mergedConfig;
     }
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -328,6 +328,7 @@ public class SinkConfigUtils {
             resources.setCpu(functionDetails.getResources().getCpu());
             resources.setRam(functionDetails.getResources().getRam());
             resources.setDisk(functionDetails.getResources().getDisk());
+            sinkConfig.setResources(resources);
         }
 
         if (isNotBlank(functionDetails.getRuntimeFlags())) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -45,7 +45,12 @@ import org.apache.pulsar.functions.utils.io.ConnectorUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -277,12 +282,11 @@ public class SinkConfigUtils {
         }
 
         switch (functionDetails.getSource().getSubscriptionType()) {
-            case SHARED:
-                sinkConfig.setRetainOrdering(false);
-                break;
             case FAILOVER:
                 sinkConfig.setRetainOrdering(true);
                 break;
+            default:
+                sinkConfig.setRetainOrdering(false);
         }
 
         sinkConfig.setProcessingGuarantees(convertProcessingGuarantee(functionDetails.getProcessingGuarantees()));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -290,6 +290,7 @@ public class SinkConfigUtils {
         // Set subscription position
         sinkConfig.setSourceSubscriptionPosition(
                 convertFromFunctionDetailsSubscriptionPosition(functionDetails.getSource().getSubscriptionPosition()));
+        sinkConfig.setCleanupSubscription(functionDetails.getSource().getCleanupSubscription());
 
         if (functionDetails.getSource().getTimeoutMs() != 0) {
             sinkConfig.setTimeoutMs(functionDetails.getSource().getTimeoutMs());

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -103,11 +103,13 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
         sinkConfig.setAutoAck(true);
         sinkConfig.setTimeoutMs(2000l);
         sinkConfig.setRuntimeFlags("-DKerberos");
+        sinkConfig.setCleanupSubscription(true);
+
         Function.FunctionDetails functionDetails = SinkConfigUtils.convert(sinkConfig, new SinkConfigUtils.ExtractedSinkDetails(null, null));
         SinkConfig convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
         assertEquals(
-                new Gson().toJson(sinkConfig),
-                new Gson().toJson(convertedConfig)
+                new Gson().toJson(convertedConfig),
+                new Gson().toJson(sinkConfig)
         );
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -105,6 +105,8 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
         sinkConfig.setRuntimeFlags("-DKerberos");
         sinkConfig.setCleanupSubscription(true);
 
+        sinkConfig.setResources(Resources.getDefaultResources());
+
         Function.FunctionDetails functionDetails = SinkConfigUtils.convert(sinkConfig, new SinkConfigUtils.ExtractedSinkDetails(null, null));
         SinkConfig convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
         assertEquals(

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -116,7 +116,7 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
     }
 
     @Test
-    private void testParseRetainOrderingField() throws IOException {
+    public void testParseRetainOrderingField() throws IOException {
         List<Boolean> testcases = Lists.newArrayList(true, false, null);
         for (Boolean testcase : testcases) {
             SinkConfig sinkConfig = createSinkConfig();
@@ -128,7 +128,7 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
     }
 
     @Test
-    private void testParseProcessingGuaranteesField() throws IOException {
+    public void testParseProcessingGuaranteesField() throws IOException {
         List<FunctionConfig.ProcessingGuarantees> testcases = Lists.newArrayList(
                 EFFECTIVELY_ONCE,
                 ATMOST_ONCE,
@@ -146,7 +146,7 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
     }
 
     @Test
-    private void testCleanSubscriptionField() throws IOException {
+    public void testCleanSubscriptionField() throws IOException {
         List<Boolean> testcases = Lists.newArrayList(true, false, null);
 
         for (Boolean testcase : testcases) {

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -367,6 +367,22 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
     }
 
     @Test
+    public void testMergeDifferentCleanupSubscription() {
+        SinkConfig sinkConfig = createSinkConfig();
+        SinkConfig newSinkConfig = createUpdatedSinkConfig("cleanupSubscription", false);
+        SinkConfig mergedConfig = SinkConfigUtils.validateUpdate(sinkConfig, newSinkConfig);
+        assertEquals(
+                mergedConfig.getCleanupSubscription().booleanValue(),
+                false
+        );
+        mergedConfig.setCleanupSubscription(sinkConfig.getCleanupSubscription());
+        assertEquals(
+                new Gson().toJson(sinkConfig),
+                new Gson().toJson(mergedConfig)
+        );
+    }
+
+    @Test
     public void testValidateConfig() throws IOException {
         mockStatic(ConnectorUtils.class);
         mockStatic(NarUnpacker.class);
@@ -410,6 +426,7 @@ public class SinkConfigUtilsTest extends PowerMockTestCase {
         sinkConfig.setAutoAck(true);
         sinkConfig.setTimeoutMs(2000l);
         sinkConfig.setArchive("DummyArchive.nar");
+        sinkConfig.setCleanupSubscription(true);
         return sinkConfig;
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -50,10 +50,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees.*;
+import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees.ATLEAST_ONCE;
+import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees.ATMOST_ONCE;
+import static org.apache.pulsar.common.functions.FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 /**
  * Unit test of {@link Reflections}.


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Recently, I tests the sink feature by `pulsarctl`, when getting sink info, found the following issues:

- Cannot get the `cleanupSubscription` field correctly
- Cannot get the `processingGuarantees` field correctly
- The `resources` always `null`


### Modifications

- Set value to `cleanupSubscription` field in `SinkConfig.convertFromDetails()`
- Set value to `resources` field in `SinkConfig.convertFromDetails()`
- Improves the set value to `processingGuarantees` in `SinkConfig.convertFromDetails()`
- Explicitly set the value for `processingGuarantees` 
- Added unit tests

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 



