### PR TITLE
[Functions] Prevent NPE while stopping a non started Pulsar LogAppender

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/LogAppender.java
@@ -108,7 +108,7 @@ public class LogAppender implements Appender {
                     .property("function", fqn)
                     .create();
         } catch (Exception e) {
-            throw new RuntimeException("Error starting LogTopic Producer", e);
+            throw new RuntimeException("Error starting LogTopic Producer for function " + fqn, e);
         }
         this.state = State.STARTED;
     }
@@ -116,8 +116,10 @@ public class LogAppender implements Appender {
     @Override
     public void stop() {
         this.state = State.STOPPING;
-        producer.closeAsync();
-        producer = null;
+        if (producer != null) {
+            producer.closeAsync();
+            producer = null;
+        }
         this.state = State.STOPPED;
     }
 


### PR DESCRIPTION
### Motivation

Exception in thread "FUNCTIONAME-0" java.lang.NullPointerException
at org.apache.pulsar.functions.instance.LogAppender.stop(LogAppender.java:111)
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.close(JavaInstanceRunnable.java:472)
at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:288)

### Modifications

Add a Null Check

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 



