### PR TITLE
Upgrade debezium to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <presto.version>332</presto.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala-library.version>2.13.6</scala-library.version>
-    <debezium.version>1.7.0.Final</debezium.version>
+    <debezium.version>1.7.1.Final</debezium.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.18.0</opencensus.version>
     <hbase.version>2.3.0</hbase.version>


### PR DESCRIPTION

### Motivation

Upgrading debezium from 1.7.0 to 1.7.1
Mostly to pick up fix for https://issues.redhat.com/browse/DBZ-4137 (debezium-postgres doesn't handle null default values, doesn't work when numeric fields have non-null default value and decimal handling mode is set to double)

### Modifications

Upgraded the dependency

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
Existing debezium's integration tests should be enough.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): *YES*
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Need to update docs? 

- [X] `no-need-doc` 
  