### PR TITLE
Close Zk database on unit tests

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -100,6 +100,7 @@ public class TestZKServer implements AutoCloseable {
     public void stop() throws Exception {
         if (zks != null) {
             zks.shutdown();
+            zks.getZKDatabase().close();
             zks = null;
         }
 


### PR DESCRIPTION
### Motivation
Currently, we didn't close zkdatabase on TestZKServer close, that will make windows unit tests fail.

### Modifications

Close Zk database on unit test stops.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
little unit tests change.


