### PR TITLE
Fix false positive ownership check in OwnershipCache#checkOwnership

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -210,7 +210,13 @@ public class OwnershipCache {
             return CompletableFuture.completedFuture(true);
         }
         String bundlePath = ServiceUnitUtils.path(bundle);
-        return resolveOwnership(bundlePath).thenApply(Optional::isPresent);
+        return resolveOwnership(bundlePath).thenApply(optionalOwnedDataWithStat -> {
+            if (!optionalOwnedDataWithStat.isPresent()) {
+                return false;
+            }
+            Stat stat = optionalOwnedDataWithStat.get().getValue();
+            return stat.getEphemeralOwner() == localZkCache.getZooKeeper().getSessionId();
+        });
     }
 
     /**


### PR DESCRIPTION
…
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation


In OwnershipCache#checkOwnership, it will lookup in zk (`resolveOwnership`) if we can not find owner info in local cache.
It is possible that the bundle owner could be other brokers when resolveOwnership returning non-empty result.

PS. It's just on branch 2.8
In 2.9, the resolveOwnership method is removed. 

### Modifications

Just revert this code line to previous version, which should be correct. 

### Verifying this change

- [] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

  
- [x] `no-need-doc` 
  
Bug fix, no user behavior changed.
