### PR TITLE
[Java Client] Remove invalid call to Thread.currentThread().interrupt();

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1799,7 +1799,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     processOpSendMsg(opSendMsg);
                 }
             } catch (PulsarClientException e) {
-                Thread.currentThread().interrupt();
                 semaphoreRelease(batchMessageContainer.getNumMessagesInBatch());
             } catch (Throwable t) {
                 semaphoreRelease(batchMessageContainer.getNumMessagesInBatch());


### PR DESCRIPTION
### Motivation

- `Thread.currentThread().interrupt()` shouldn't be called when handling a `PulsarClientException`.
  - it must only be called when handling an `InterruptedException`.
  - this looks like a copy-paste bug introduced in
    https://github.com/apache/pulsar/pull/731/files#diff-d6fcf8aa2d0035cc386dca0942a452343d6854763c7fd397efa4e660c0069767R1183

### Modifications

- remove call to `Thread.currentThread().interrupt()`