### PR TITLE
[broker] Avoid unnecessary recalculation of maxSubscriptionsPerTopic in AbstractTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -2145,9 +2145,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final int namespaceLevelMaxSub = 3;
         admin.namespaces().setMaxSubscriptionsPerTopic(myNamespace, namespaceLevelMaxSub);
         PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
-        Field field = PersistentTopic.class.getSuperclass().getDeclaredField("maxSubscriptionsPerTopic");
-        field.setAccessible(true);
-        Awaitility.await().until(() -> (int) field.get(persistentTopic) == namespaceLevelMaxSub);
+        Awaitility.await().until(() -> Integer.valueOf(namespaceLevelMaxSub)
+                .equals(persistentTopic.getMaxSubscriptionsPerTopic().getNamespaceValue()));
 
         try (PulsarClient client = PulsarClient.builder().operationTimeout(1000, TimeUnit.MILLISECONDS)
                 .serviceUrl(brokerUrl.toString()).build()) {
@@ -2174,7 +2173,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         }
         //Removed namespace-level policy, broker-level should take effect
         admin.namespaces().removeMaxSubscriptionsPerTopic(myNamespace);
-        Awaitility.await().until(() -> field.get(persistentTopic) == null);
+        Awaitility.await().until(() -> persistentTopic.getMaxSubscriptionsPerTopic().getNamespaceValue() == null);
         consumerList.add(pulsarClient.newConsumer(Schema.STRING)
                 .subscriptionName(UUID.randomUUID().toString()).topic(topic).subscribe());
         assertEquals(consumerList.size(), brokerLevelMaxSub);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import lombok.Getter;
+
+/**
+ * Policy value holder for different hierarchy level.
+ * Currently, we have three hierarchy with priority : topic > namespace > broker.
+ */
+public class PolicyHierarchyValue<T> {
+    private static final AtomicReferenceFieldUpdater<PolicyHierarchyValue, Object> VALUE_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(PolicyHierarchyValue.class, Object.class, "value");
+
+    private volatile T brokerValue;
+
+    @VisibleForTesting
+    @Getter
+    private volatile T namespaceValue;
+
+    private volatile T topicValue;
+
+    private volatile T value;
+
+    public PolicyHierarchyValue() {
+    }
+
+    public void updateBrokerValue(T brokerValue) {
+        this.brokerValue = brokerValue;
+        updateValue();
+    }
+
+    public void updateNamespaceValue(T namespaceValue) {
+        this.namespaceValue = namespaceValue;
+        updateValue();
+    }
+
+    public void updateTopicValue(T topicValue) {
+        this.topicValue = topicValue;
+        updateValue();
+    }
+
+    private void updateValue() {
+        VALUE_UPDATER.updateAndGet(this, (preValue) -> {
+            if (topicValue != null) {
+                return topicValue;
+            } else if (namespaceValue != null) {
+                return namespaceValue;
+            } else {
+                return brokerValue;
+            }
+        });
+    }
+
+    public T get() {
+        return value;
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValueTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.common.policies.data;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PolicyHierarchyValueTest {
+    @Test
+    public void testPolicyValue() {
+        PolicyHierarchyValue<Integer> value = new PolicyHierarchyValue<>();
+
+        value.updateBrokerValue(1);
+        Assert.assertEquals(value.get(), Integer.valueOf(1));
+
+        value.updateNamespaceValue(2);
+        Assert.assertEquals(value.get(), Integer.valueOf(2));
+
+        value.updateTopicValue(3);
+        Assert.assertEquals(value.get(), Integer.valueOf(3));
+
+        value.updateNamespaceValue(null);
+        Assert.assertEquals(value.get(), Integer.valueOf(3));
+
+        value.updateTopicValue(null);
+        Assert.assertEquals(value.get(), Integer.valueOf(1));
+    }
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Currently, `AbstractTopic#maxSubscriptionsPerTopic` stores the value of namespace level policy, but we have broker level setting in `org.apache.pulsar.broker.ServiceConfiguration#maxSubscriptionsPerTopic` and topic level setting in `org.apache.pulsar.common.policies.data.TopicPolicies#maxSubscriptionsPerTopic`.
And the real value we used of `maxSubscriptionsPerTopic` is calculated every time in `org.apache.pulsar.broker.service.persistent.PersistentTopic#checkMaxSubscriptionsPerTopicExceed`. It can be avoided by cache maxSubscriptionsPerTopic result locally.

As we have already registered listeners to namespace policy and topic policy updates, so we can cache the value locally in AbstractTopic to avoid the recalculation.

Finally, as some of other policies value have similar issues, I am introducing `PolicyHierarchyValue` to solve the hierarchy value storage and calculation.

### Modifications

Introduce `PolicyHierarchyValue` to store policy value in broker, namespace and topic level.
It provides corresponding `updateXX` methods, and recalculate real value in it.  And the `get()` method returns the policy value we should use directly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change is already covered by existing tests, such as `org.apache.pulsar.broker.admin.TopicPoliciesTest#testMaxSubscriptionsPerTopic`

And added PolicyHierarchyValueTest  for new class.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `doc` 
  
New class PolicyHierarchyValue comes with docs.
The rest is internal optimization, no user behavior changed.


