### PR TITLE
Add docs for nack backoff policy

### DIFF
--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -336,6 +336,7 @@ When you create a consumer, you can use the `loadConf` configuration. The follow
 `deadLetterPolicy`|DeadLetterPolicy|Dead letter policy for consumers.<br /><br />By default, some messages are probably redelivered many times, even to the extent that it never stops.<br /><br />By using the dead letter mechanism, messages have the max redelivery count. **When exceeding the maximum number of redeliveries, messages are sent to the Dead Letter Topic and acknowledged automatically**.<br /><br />You can enable the dead letter mechanism by setting `deadLetterPolicy`.<br /><br />**Example**<br /><br /><code>client.newConsumer()<br />.deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(10).build())<br />.subscribe();</code><br /><br />Default dead letter topic name is `{TopicName}-{Subscription}-DLQ`.<br /><br />To set a custom dead letter topic name:<br /><code>client.newConsumer()<br />.deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(10)<br />.deadLetterTopic("your-topic-name").build())<br />.subscribe();</code><br /><br />When specifying the dead letter policy while not specifying `ackTimeoutMillis`, you can set the ack timeout to 30000 millisecond.|None
 `autoUpdatePartitions`|boolean|If `autoUpdatePartitions` is enabled, a consumer subscribes to partition increasement automatically.<br /><br />**Note**: this is only for partitioned consumers.|true
 `replicateSubscriptionState`|boolean|If `replicateSubscriptionState` is enabled, a subscription state is replicated to geo-replicated clusters.|false
+`negativeAckRedeliveryBackoff`|NegativeAckRedeliveryBackoff|Interface for custom message is negativeAcked policy, users can specify a `NegativeAckRedeliveryBackoff` for a consumer.| `NegativeAckRedeliveryExponentialBackoff`
 
 You can configure parameters if you do not want to use the default configuration. For a full list, see the Javadoc for the {@inject: javadoc:ConsumerBuilder:/client/org/apache/pulsar/client/api/ConsumerBuilder} class. 
 
@@ -401,6 +402,25 @@ consumer.acknowledge(messages)
 >     .timeout(100, TimeUnit.MILLISECONDS)
 >     .build();
 > ```
+
+### NegativeAckRedeliveryBackoff
+
+The `NegativeAckRedeliveryBackoff` is to introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the redeliveryCount the message is retried. 
+
+```java
+Consumer consumer =  client.newConsumer()
+        .topic("my-topic")
+        .subscriptionName("my-subscription")
+        .negativeAckRedeliveryBackoff(NegativeAckRedeliveryExponentialBackoff.builder()
+                .minNackTimeMs(1000)
+                .maxNackTimeMs(60 * 1000)
+                .build())
+        .subscribe();
+```
+
+> Notice: 
+>   1. The negativeAckRedeliveryBackoff will not work with `consumer.negativeAcknowledge(MessageId messageId)` because we are not able to get the redelivery count from the message ID.
+>   2. The consumer crashes will trigger the redelivery of the unacked message, this case will not respect the `NegativeAckRedeliveryBackoff`, which means the message might get redelivered earlier than the delay time from the backoff.
 
 ### Multi-topic subscriptions
 

--- a/site2/docs/client-libraries-java.md
+++ b/site2/docs/client-libraries-java.md
@@ -336,7 +336,7 @@ When you create a consumer, you can use the `loadConf` configuration. The follow
 `deadLetterPolicy`|DeadLetterPolicy|Dead letter policy for consumers.<br /><br />By default, some messages are probably redelivered many times, even to the extent that it never stops.<br /><br />By using the dead letter mechanism, messages have the max redelivery count. **When exceeding the maximum number of redeliveries, messages are sent to the Dead Letter Topic and acknowledged automatically**.<br /><br />You can enable the dead letter mechanism by setting `deadLetterPolicy`.<br /><br />**Example**<br /><br /><code>client.newConsumer()<br />.deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(10).build())<br />.subscribe();</code><br /><br />Default dead letter topic name is `{TopicName}-{Subscription}-DLQ`.<br /><br />To set a custom dead letter topic name:<br /><code>client.newConsumer()<br />.deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(10)<br />.deadLetterTopic("your-topic-name").build())<br />.subscribe();</code><br /><br />When specifying the dead letter policy while not specifying `ackTimeoutMillis`, you can set the ack timeout to 30000 millisecond.|None
 `autoUpdatePartitions`|boolean|If `autoUpdatePartitions` is enabled, a consumer subscribes to partition increasement automatically.<br /><br />**Note**: this is only for partitioned consumers.|true
 `replicateSubscriptionState`|boolean|If `replicateSubscriptionState` is enabled, a subscription state is replicated to geo-replicated clusters.|false
-`negativeAckRedeliveryBackoff`|NegativeAckRedeliveryBackoff|Interface for custom message is negativeAcked policy, users can specify a `NegativeAckRedeliveryBackoff` for a consumer.| `NegativeAckRedeliveryExponentialBackoff`
+`negativeAckRedeliveryBackoff`|NegativeAckRedeliveryBackoff|Interface for custom message is negativeAcked policy. You can specify `NegativeAckRedeliveryBackoff` for a consumer.| `NegativeAckRedeliveryExponentialBackoff`
 
 You can configure parameters if you do not want to use the default configuration. For a full list, see the Javadoc for the {@inject: javadoc:ConsumerBuilder:/client/org/apache/pulsar/client/api/ConsumerBuilder} class. 
 
@@ -403,9 +403,9 @@ consumer.acknowledge(messages)
 >     .build();
 > ```
 
-### NegativeAckRedeliveryBackoff
+### Negative acknowledgment redelivery backoff
 
-The `NegativeAckRedeliveryBackoff` is to introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the redeliveryCount the message is retried. 
+The `NegativeAckRedeliveryBackoff` introduces a redelivery backoff mechanism. You can achieve redelivery with different delays by setting `redeliveryCount ` of messages. 
 
 ```java
 Consumer consumer =  client.newConsumer()
@@ -418,9 +418,9 @@ Consumer consumer =  client.newConsumer()
         .subscribe();
 ```
 
-> Notice: 
->   1. The negativeAckRedeliveryBackoff will not work with `consumer.negativeAcknowledge(MessageId messageId)` because we are not able to get the redelivery count from the message ID.
->   2. The consumer crashes will trigger the redelivery of the unacked message, this case will not respect the `NegativeAckRedeliveryBackoff`, which means the message might get redelivered earlier than the delay time from the backoff.
+> **Note** 
+>   - The `negativeAckRedeliveryBackoff` does not work with `consumer.negativeAcknowledge(MessageId messageId)` because you are not able to get the redelivery count from the message ID.
+>   - If a consumer crashes, it triggers the redelivery of unacked messages. In this case, `NegativeAckRedeliveryBackoff` does not take effect and the messages might get redelivered earlier than the delay time from the backoff.
 
 ### Multi-topic subscriptions
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -185,11 +185,11 @@ consumer.negativeAcknowledge(msg);
 > **Note**  
 > If batching is enabled, all messages in one batch are redelivered to the consumer.
 
-### Negative Redelivery Backoff
+### Negative redelivery backoff
 
-In general, the consumer is not able to process the message successfully, what we can use [Negative acknowledgement](concepts-messaging.md#Negative acknowledgement) and redeliver the message after processing the message failure so that the message can be redelivered to other consumers(for the Shared subscription).
+In general, consumers are not able to process messages successfully. In this case, you can use [negative acknowledgement](concepts-messaging.md#negative-acknowledgement) and redeliver the messages after processing message failures, so that the messages can be redelivered to other consumers (for the Shared subscription).
 
-But this is not flexible enough, so we introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the number of times the message is retried.
+But this is not flexible enough. A better way is to use the **redelivery backoff mechanism**.  You can redeliver messages with different delays by setting the number of times the messages is retried.
 
 If you want to use `Negative Redelivery Backoff`, you can use the following API.
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -189,7 +189,7 @@ consumer.negativeAcknowledge(msg);
 
 In general, the consumer is not able to process the message successfully, what we can use [Negative acknowledgement](concepts-messaging.md#Negative acknowledgement) and redeliver the message after processing the message failure so that the message can be redelivered to other consumers(for the Shared subscription).
 
-But this is not flexible enough, so the proposal is to introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the number of times the message is retried.
+But this is not flexible enough, so we introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the number of times the message is retried.
 
 If you want to use `Negative Redelivery Backoff`, you can use the following API.
 

--- a/site2/docs/concepts-messaging.md
+++ b/site2/docs/concepts-messaging.md
@@ -185,6 +185,21 @@ consumer.negativeAcknowledge(msg);
 > **Note**  
 > If batching is enabled, all messages in one batch are redelivered to the consumer.
 
+### Negative Redelivery Backoff
+
+In general, the consumer is not able to process the message successfully, what we can use [Negative acknowledgement](concepts-messaging.md#Negative acknowledgement) and redeliver the message after processing the message failure so that the message can be redelivered to other consumers(for the Shared subscription).
+
+But this is not flexible enough, so the proposal is to introduce a redelivery backoff mechanism which we can achieve redelivery with different delays according to the number of times the message is retried.
+
+If you want to use `Negative Redelivery Backoff`, you can use the following API.
+
+```java
+consumer.negativeAckRedeliveryBackoff(NegativeAckRedeliveryExponentialBackoff.builder()
+        .minNackTimeMs(1000)
+        .maxNackTimeMs(60 * 1000)
+        .build())
+```
+
 ### Acknowledgement timeout
 
 If a message is not consumed successfully, and you want the broker to redeliver this message automatically, then you can enable automatic redelivery mechanism for  unacknowledged messages. With automatic redelivery enabled, the client tracks the unacknowledged messages within the entire `acktimeout` time range, and sends a `redeliver unacknowledged messages` request to the broker automatically when the acknowledgement timeout is specified.


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>



### Motivation

In https://github.com/apache/pulsar/pull/12566, we impl the `NegativeAckRedeliveryBackoff` and the pr will add docs for this.

### Modifications

- Add options in `Configure consumer`
- Add docs for how to use

