### PR TITLE
Issue 12645: Pulsar Functions: detect .nar files and prevent spammy logs on functions boot [branch-2.7]

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
@@ -30,7 +30,10 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 
 /**
@@ -38,6 +41,7 @@ import org.slf4j.Logger;
  * operations.
  *
  */
+@Slf4j
 public class FileUtils {
 
     public static final long MILLIS_BETWEEN_ATTEMPTS = 50L;
@@ -219,6 +223,22 @@ public class FileUtils {
             Thread.sleep(millis);
         } catch (final InterruptedException ex) {
             /* do nothing */
+        }
+    }
+
+    public static boolean mayBeANarArchive(File jarFile) {
+        try (ZipFile zipFile = new ZipFile(jarFile);) {
+            ZipEntry entry = zipFile.getEntry("META-INF/bundled-dependencies");
+            if (entry == null || !entry.isDirectory()) {
+                log.info("Jar file {} does not contain META-INF/bundled-dependencies, it is not a NAR file", jarFile);
+                return false;
+            } else {
+                log.info("Jar file {} contains META-INF/bundled-dependencies, it may be a NAR file", jarFile);
+                return true;
+            }
+        } catch (IOException err) {
+            log.info("Cannot safely detect if {} is a NAR archive", jarFile, err);
+            return true;
         }
     }
 }


### PR DESCRIPTION
Master Issue: #12645

### Motivation

When Pulsar loads .jar file, it tries to unpack it a .nar and then it prints out the stack trace in  #12645, that is very misleading.

### Modifications

Detect the fact that we are going to load a .nar file, and do not try to unpack it if it is clear that it is not a .nar file.
We are going to preserve partially the previous behaviour and in case of FileNotFound we fallback to loading the file as .jar file as before.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 

   It is a small enhancement in logging

