### PR TITLE
[Config] Add readWorkerThreadsThrottlingEnabled to conf/bookkeeper.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -166,6 +166,11 @@ maxPendingReadRequestsPerThread=2500
 # avoid the executor queue to grow indefinitely
 maxPendingAddRequestsPerThread=10000
 
+# Use auto-throttling of the read-worker threads. This is done
+# to ensure the bookie is not using unlimited amount of memory
+# to respond to read-requests.
+readWorkerThreadsThrottlingEnabled=true
+
 # Option to enable busy-wait settings. Default is false.
 # WARNING: This option will enable spin-waiting on executors and IO threads in order to reduce latency during
 # context switches. The spinning will consume 100% CPU even when bookie is not doing any work. It is recommended to


### PR DESCRIPTION
### Motivation

- https://github.com/apache/bookkeeper/pull/2646 added "Auto-throttle read operations" which is enabled by default

### Modifications

- Add `readWorkerThreadsThrottlingEnabled=true` to `conf/bookkeeper.conf` since that is the default value in BookKeeper that gets used unless the setting is explicitly set to `false`. 

### Open questions

- Is `readWorkerThreadsThrottlingEnabled=true` a safe default?
  - There's a warning in https://netty.io/4.0/api/io/netty/channel/ChannelFuture.html about calling `.await()` and https://github.com/apache/bookkeeper/pull/2646 uses that `ChannelFuture.await()` to block.