### PR TITLE
Fix the typo of BookKeeper, missing k/K

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -72,13 +72,13 @@ public final class WorkerUtils {
 
     public static void uploadFileToBookkeeper(String packagePath, File sourceFile, Namespace dlogNamespace) throws IOException {
         try (FileInputStream uploadedInputStream = new FileInputStream(sourceFile)) {
-            uploadToBookeeper(dlogNamespace, uploadedInputStream, packagePath);
+            uploadToBookKeeper(dlogNamespace, uploadedInputStream, packagePath);
         }
     }
 
-    public static void uploadToBookeeper(Namespace dlogNamespace,
-                                         InputStream uploadedInputStream,
-                                         String destPkgPath)
+    public static void uploadToBookKeeper(Namespace dlogNamespace,
+                                          InputStream uploadedInputStream,
+                                          String destPkgPath)
             throws IOException {
 
         // if the dest directory does not exist, create it.

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1225,7 +1225,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         // Upload to bookkeeper
         try {
             log.info("Uploading function package to {}", path);
-            WorkerUtils.uploadToBookeeper(worker().getDlogNamespace(), uploadedInputStream, path);
+            WorkerUtils.uploadToBookKeeper(worker().getDlogNamespace(), uploadedInputStream, path);
         } catch (IOException e) {
             log.error("Error uploading file {}", path, e);
             throw new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -590,7 +590,7 @@ public class FunctionApiV2ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                     any(Namespace.class),
                     any(InputStream.class),
                     anyString());
@@ -632,7 +632,7 @@ public class FunctionApiV2ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                     any(Namespace.class),
                     any(InputStream.class),
                     anyString());
@@ -654,7 +654,7 @@ public class FunctionApiV2ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                     any(Namespace.class),
                     any(InputStream.class),
                     anyString());
@@ -1014,7 +1014,7 @@ public class FunctionApiV2ResourceTest {
     public void testUpdateFunctionSuccess() throws Exception {
         mockStatic(WorkerUtils.class);
         doNothing().when(WorkerUtils.class);
-        WorkerUtils.uploadToBookeeper(
+        WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());
@@ -1068,7 +1068,7 @@ public class FunctionApiV2ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                     any(Namespace.class),
                     any(InputStream.class),
                     anyString());
@@ -1091,7 +1091,7 @@ public class FunctionApiV2ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                     any(Namespace.class),
                     any(InputStream.class),
                     anyString());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -629,7 +629,7 @@ public class FunctionApiV3ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());
@@ -689,7 +689,7 @@ public class FunctionApiV3ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());
@@ -713,7 +713,7 @@ public class FunctionApiV3ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());
@@ -1071,7 +1071,7 @@ public class FunctionApiV3ResourceTest {
     public void testUpdateFunctionSuccess() throws Exception {
         mockStatic(WorkerUtils.class);
         doNothing().when(WorkerUtils.class);
-        WorkerUtils.uploadToBookeeper(
+        WorkerUtils.uploadToBookKeeper(
             any(Namespace.class),
             any(InputStream.class),
             anyString());
@@ -1119,7 +1119,7 @@ public class FunctionApiV3ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());
@@ -1142,7 +1142,7 @@ public class FunctionApiV3ResourceTest {
         try {
             mockStatic(WorkerUtils.class);
             doNothing().when(WorkerUtils.class);
-            WorkerUtils.uploadToBookeeper(
+            WorkerUtils.uploadToBookKeeper(
                 any(Namespace.class),
                 any(InputStream.class),
                 anyString());

--- a/site2/docs/administration-zk-bk.md
+++ b/site2/docs/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -209,7 +209,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website-next/docs/administration-zk-bk.md
+++ b/site2/website-next/docs/administration-zk-bk.md
@@ -315,7 +315,7 @@ The following is an example:
 
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 
 ```
 

--- a/site2/website-next/docs/reference-cli-tools.md
+++ b/site2/website-next/docs/reference-cli-tools.md
@@ -261,7 +261,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website-next/versioned_docs/version-2.7.1/administration-zk-bk.md
+++ b/site2/website-next/versioned_docs/version-2.7.1/administration-zk-bk.md
@@ -316,7 +316,7 @@ The following is an example:
 
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.7.3/administration-zk-bk.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/administration-zk-bk.md
@@ -316,7 +316,7 @@ The following is an example:
 
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.7.3/reference-cli-tools.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/reference-cli-tools.md
@@ -284,7 +284,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website-next/versioned_docs/version-2.8.0/administration-zk-bk.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/administration-zk-bk.md
@@ -316,7 +316,7 @@ The following is an example:
 
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.8.0/reference-cli-tools.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/reference-cli-tools.md
@@ -284,7 +284,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -2484,7 +2484,7 @@ https://github.com/apache/pulsar/releases/tag/v2.4.0
  * When creating namespace, use local cluster by default [#3571](https://github.com/apache/pulsar/pull/3571)
  * Tag BookKeeper ledgers created by Pulsar with topic/subscription names for info/debug purposes
    [#3525](https://github.com/apache/pulsar/pull/3525)
- * Enabled sticky reads in BooKeeper reads to increase IO efficiency with read-ahead [#3569](https://github.com/apache/pulsar/pull/3569)
+ * Enabled sticky reads in BookKeeper reads to increase IO efficiency with read-ahead [#3569](https://github.com/apache/pulsar/pull/3569)
  * Several optimization in Pulsar SQL Presto connector ([#3128](https://github.com/apache/pulsar/pull/3128),
     [#3135](https://github.com/apache/pulsar/pull/3135), [#3139](https://github.com/apache/pulsar/pull/3139),
     [#3144](https://github.com/apache/pulsar/pull/3144), [#3143](https://github.com/apache/pulsar/pull/3143))

--- a/site2/website/versioned_docs/version-2.1.0-incubating/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/administration-zk-bk.md
@@ -184,7 +184,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper)
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper)
 
 ```shell
 $ bin/pulsar-daemon start bookie
@@ -261,7 +261,7 @@ Flag | Description | Default
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.1.0-incubating/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/deploy-bare-metal-multi-cluster.md
@@ -238,7 +238,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper)
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper)
 
 ```shell
 $ bin/pulsar-daemon start bookie

--- a/site2/website/versioned_docs/version-2.1.0-incubating/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/reference-cli-tools.md
@@ -215,7 +215,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.2.0/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.2.0/deploy-bare-metal-multi-cluster.md
@@ -242,7 +242,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper)
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper)
 
 ```shell
 $ bin/pulsar-daemon start bookie

--- a/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.3.0/administration-zk-bk.md
@@ -184,7 +184,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper)
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper)
 
 ```shell
 $ bin/pulsar-daemon start bookie
@@ -263,7 +263,7 @@ Flag | Description | Default
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.3.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.3.0/reference-cli-tools.md
@@ -220,7 +220,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.3.1/deploy-bare-metal-multi-cluster.md
+++ b/site2/website/versioned_docs/version-2.3.1/deploy-bare-metal-multi-cluster.md
@@ -242,7 +242,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper)
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper)
 
 ```shell
 $ bin/pulsar-daemon start bookie

--- a/site2/website/versioned_docs/version-2.3.1/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.3.1/reference-cli-tools.md
@@ -220,7 +220,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.3.2/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.3.2/reference-cli-tools.md
@@ -220,7 +220,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.4.0/administration-zk-bk.md
@@ -184,7 +184,7 @@ BookKeeper bookies can be configured using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper) CLI tool:
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper) CLI tool:
 
 ```bash
 $ bin/bookkeeper bookie
@@ -269,7 +269,7 @@ Flag | Description | Default
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.4.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.4.0/reference-cli-tools.md
@@ -220,7 +220,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.5.0/administration-zk-bk.md
@@ -177,7 +177,7 @@ You can configure BookKeeper bookies using the [`conf/bookkeeper.conf`](referenc
 
 You can start up a bookie in two ways: in the foreground or as a background daemon.
 
-To start up a bookie in the foreground, use the [`bookeeper`](reference-cli-tools.md#bookkeeper) CLI tool:
+To start up a bookie in the foreground, use the [`bookkeeper`](reference-cli-tools.md#bookkeeper) CLI tool:
 
 ```bash
 $ bin/bookkeeper bookie
@@ -261,7 +261,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.5.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.5.0/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.5.1/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.5.1/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.5.2/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.5.2/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.0/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.6.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.6.0/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.1/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.6.1/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.6.1/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.2/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.6.2/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.6.2/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.6.3/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.3/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.6.3/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.6.3/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.6.4/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.6.4/administration-zk-bk.md
@@ -286,7 +286,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.6.4/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.6.4/reference-cli-tools.md
@@ -221,7 +221,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.0/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.7.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.7.0/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.7.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.1/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.7.1/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.7.1/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.7.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.2/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.7.2/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.7.2/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.7.3/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.7.3/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.7.3/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.7.3/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.8.0/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.8.0/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.8.0/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.8.0/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.8.1/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.8.1/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.8.1/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.8.1/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|

--- a/site2/website/versioned_docs/version-2.8.2/administration-zk-bk.md
+++ b/site2/website/versioned_docs/version-2.8.2/administration-zk-bk.md
@@ -287,7 +287,7 @@ The following is an example:
 ```shell
 $ pulsar-admin namespaces set-persistence my-tenant/my-ns \
   --bookkeeper-ack-quorum 3 \
-  --bookeeper-ensemble 2
+  --bookkeeper-ensemble 2
 ```
 
 #### REST API

--- a/site2/website/versioned_docs/version-2.8.2/reference-cli-tools.md
+++ b/site2/website/versioned_docs/version-2.8.2/reference-cli-tools.md
@@ -226,7 +226,7 @@ Options
 |Flag|Description|Default|
 |---|---|---|
 |`-a` , `--advertised-address`|The standalone broker advertised address||
-|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookeeper|
+|`--bookkeeper-dir`|Local bookies’ base data directory|data/standalone/bookkeeper|
 |`--bookkeeper-port`|Local bookies’ base port|3181|
 |`--no-broker`|Only start ZooKeeper and BookKeeper services, not the broker|false|
 |`--num-bookies`|The number of local bookies|1|


### PR DESCRIPTION
### Motivation
There are several typo of `BookKeeper`, missing k/K

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `doc` 
  
  This PR contains doc typo change.


