### PR TITLE
[pulsar-client] add pending-queue size metrics to producer stats

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -49,6 +49,8 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import lombok.Cleanup;
+
 @Test(groups = "broker-api")
 public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(SimpleProducerConsumerStatTest.class);
@@ -431,6 +433,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
                 .topic("persistent://my-property/tp1/my-ns/my-topic1");
 
+        @Cleanup
         Producer<byte[]> producer = producerBuilder.enableBatching(false).create();
 
         stopBroker();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -424,4 +424,22 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         producer.close();
         log.info("-- Exiting {} test --", methodName);
     }
+
+    @Test
+    public void testProducerPendingQueueSizeStats() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic1");
+
+        Producer<byte[]> producer = producerBuilder.enableBatching(false).create();
+
+        stopBroker();
+
+        int numMessages = 120;
+        for (int i = 0; i < numMessages; i++) {
+            String message = "my-message-" + i;
+            producer.sendAsync(message.getBytes());
+        }
+        assertEquals(producer.getStats().getPendingQueueSize(), numMessages);
+    }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerStats.java
@@ -111,4 +111,9 @@ public interface ProducerStats extends Serializable {
      */
     long getTotalAcksReceived();
 
+    /**
+     * @return current pending send-message queue size of the producer
+     */
+    int getPendingQueueSize();
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsDisabled.java
@@ -127,4 +127,9 @@ public class ProducerStatsDisabled implements ProducerStatsRecorder {
     public double getSendLatencyMillisMax() {
         return 0;
     }
+
+    @Override
+    public int getPendingQueueSize() {
+        return 0;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -299,6 +299,11 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
         return latencyPctValues[5];
     }
 
+    @Override
+    public int getPendingQueueSize() {
+        return producer.getPendingQueueSize();
+    }
+
     public void cancelStatsTimeout() {
         this.updateStats();
         if (statTimeout != null) {


### PR DESCRIPTION
### Motivation
Add pending-queue size metrics to producer stats to create monitoring at client side and monitor various scenarios : timeout, high latency, memory, etc..

### Modification 
Add API `ProducerStats::getPendingQueueSize` to retrieve pending-queue size metrics for a producer.