### PR TITLE
[tools] fix TestRunMain test

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.admin.cli;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.io.FileInputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -361,5 +362,9 @@ public class PulsarAdminTool {
         return lastExitCode;
     }
 
+    @VisibleForTesting
+    static void resetLastExitCode() {
+        lastExitCode = Integer.MIN_VALUE;
+    }
 
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -29,13 +29,15 @@ public class TestRunMain {
 
     @Test
     public void runMainNoArguments() throws Exception {
+        PulsarAdminTool.resetLastExitCode();
         PulsarAdminTool.setAllowSystemExit(false);
         PulsarAdminTool.main(new String[0]);
-        assertEquals(PulsarAdminTool.getLastExitCode(), 1);
+        assertEquals(PulsarAdminTool.getLastExitCode(), 0);
     }
 
     @Test
     public void runMainDummyConfigFile() throws Exception {
+        PulsarAdminTool.resetLastExitCode();
         PulsarAdminTool.setAllowSystemExit(false);
         Path dummyEmptyFile = Files.createTempFile("test", ".conf");
         PulsarAdminTool.main(new String[] {dummyEmptyFile.toAbsolutePath().toString()});


### PR DESCRIPTION
### Motivation
[PulsarAdminTool](https://github.com/apache/pulsar/blob/master/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java#L297) returns with exist-code `0` with empty argument.
[TestRunMain::runMainNoArguments](https://github.com/apache/pulsar/blob/master/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java#L34) checks incorrect assertion. this change was introduced by https://github.com/apache/pulsar/pull/12581
```
java.lang.AssertionError: expected [1] but found [0]
	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
	at org.testng.Assert.assertEquals(Assert.java:122)
	at org.testng.Assert.assertEquals(Assert.java:907)
	at org.testng.Assert.assertEquals(Assert.java:917)
	at org.apache.pulsar.admin.cli.TestRunMain.runMainNoArguments(TestRunMain.java:35)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

### Modification
- fix the test
-  add reset method to handle static code to avoid test failure due to previous tests.