### PR TITLE
Optimize bookie quarantine strategy: Restart the upgrade in rotation, should not quarantine the bookie node

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -285,6 +287,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 + "This configuration is not precise control, in a concurrent scenario, the threshold will be exceeded."
     )
     private int maxTenants = 0;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            dynamic = true,
+            doc = "Mark whether to upgrade."
+    )
+    private AtomicBoolean upgrading = new AtomicBoolean(false);
+
     @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -291,7 +291,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_SERVER,
             dynamic = true,
-            doc = "Mark whether to upgrade."
+            doc = "Mark whether the bookkeeper cluster is being upgraded."
     )
     private AtomicBoolean upgrading = new AtomicBoolean(false);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -79,12 +79,14 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
             setDefaultEnsemblePlacementPolicy(rackawarePolicyZkCache, clientIsolationZkCache, bkConf, conf, zkClient);
         }
         try {
-            return BookKeeper.forConfig(bkConf)
+            BookKeeper bookKeeper = BookKeeper.forConfig(bkConf)
                     .allocator(PulsarByteBufAllocator.DEFAULT)
                     .setZookeeper(zkClient)
                     .eventLoopGroup(eventLoopGroup)
                     .statsLogger(statsLogger)
                     .build();
+            bookKeeper.setUpgrading(conf.getUpgrading());
+            return bookKeeper;
         } catch (InterruptedException | BKException e) {
             throw new IOException(e);
         }


### PR DESCRIPTION
### Motivation

When I restarted and upgraded pulsar and bookkeeper in rotation, I found that all bookie nodes were quarantine, which caused the client to be abnormal for a long time：
![image](https://user-images.githubusercontent.com/19296967/140854567-284ce8cb-dd7b-4494-bc45-7c5c1ac12844.png)



### Modifications
Therefore, bookkeeper needs to provide an interface to mark whether the cluster is restarting and upgrading in rotation.  should not  quarantine bookie at this time.
Corresponding bookkeeper's PR：https://github.com/apache/bookkeeper/pull/2884

When the bookkeeper cluster needs to be restarted and upgraded in turn, we mark the upgrade through dynamic configuration. At this time, the bookie node that fails to write due to the restart will not be quarantined.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  (Please explain why)
  



