### PR TITLE
Flaky tests: ElasticSearchClientTests tests time out

### DIFF
--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -201,7 +201,7 @@ public class ElasticSearchClientTests {
                 assertEquals(mockRecord.failed, 0);
                 assertEquals(client.totalHits(index), 2);
 
-                ChaosContainer<?> chaosContainer = new ChaosContainer<>(container.getContainerName(), "15s");
+                ChaosContainer<?> chaosContainer = ChaosContainer.pauseContainerForSeconds(container.getContainerName(), 15);
                 chaosContainer.start();
 
                 client.bulkIndex(mockRecord, Pair.of("3", "{\"a\":3}"));
@@ -248,12 +248,12 @@ public class ElasticSearchClientTests {
                 });
                 client.flush();
                 Awaitility.await().untilAsserted(() -> {
-                    assertEquals(mockRecord.acked, 5);
                     assertEquals(mockRecord.failed, 0);
+                    assertEquals(mockRecord.acked, 5);
                     assertEquals(client.totalHits(index), 5);
                 });
 
-                ChaosContainer<?> chaosContainer = new ChaosContainer<>(container.getContainerName(), "30s");
+                ChaosContainer<?> chaosContainer = ChaosContainer.pauseContainerForSeconds(container.getContainerName(), 30);
                 chaosContainer.start();
                 Thread.sleep(1000L);
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
 public class ChaosContainer<SELF extends ChaosContainer<SELF>> extends GenericContainer<SELF> {
 
     public static final String PUMBA_IMAGE = Optional.ofNullable(System.getenv("PUMBA_IMAGE"))
-            .orElse("gaiaadm/pumba:latest");
+            .orElse("gaiaadm/pumba:0.8.0");
 
     private final List<String> logs = new ArrayList<>();
     private Consumer<ChaosContainer> beforeStop;

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
@@ -18,27 +18,65 @@
  */
 package org.apache.pulsar.io.elasticsearch.testcontainers;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 // see https://github.com/alexei-led/pumba
 @Slf4j
 public class ChaosContainer<SELF extends ChaosContainer<SELF>> extends GenericContainer<SELF> {
 
-  public static final String PUMBA_IMAGE = Optional.ofNullable(System.getenv("PUMBA_IMAGE"))
-          .orElse("gaiaadm/pumba:latest");
+    public static final String PUMBA_IMAGE = Optional.ofNullable(System.getenv("PUMBA_IMAGE"))
+            .orElse("gaiaadm/pumba:latest");
 
-  public ChaosContainer(String targetContainer, String pause) {
-    super(PUMBA_IMAGE);
-    setCommand("--log-level info --interval 60s pause --duration " + pause + " " + targetContainer);
-    addFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", BindMode.READ_WRITE);
-    setWaitStrategy(Wait.forLogMessage(".*pausing container.*", 1));
-    withLogConsumer(o -> {
-      log.info("pumba> {}", o.getUtf8String());
-    });
-  }
+    private final List<String> logs = new ArrayList<>();
+    private Consumer<ChaosContainer> beforeStop;
+
+    public static ChaosContainer pauseContainerForSeconds(String targetContainer, int seconds) {
+        return new ChaosContainer(targetContainer, "pause --duration " + seconds + "s", Wait.forLogMessage(".*pausing container.*", 1),
+                (Consumer<ChaosContainer>) chaosContainer -> Awaitility
+                        .await()
+                        .atMost(seconds + 5, TimeUnit.SECONDS)
+                        .until(() -> {
+                                    boolean found = chaosContainer.logs.stream().anyMatch((Predicate<String>) line -> line.contains("stop pausing container"));
+                                    if (!found) {
+                                        log.debug("ChaosContainer stop requested. waiting for \"stop pausing container\" log");
+                                        log.debug(String.join("\n", chaosContainer.logs));
+                                    }
+                                    return found;
+                                }
+                        ));
+    }
+
+    private ChaosContainer(String targetContainer, String command, WaitStrategy waitStrategy, Consumer<ChaosContainer> beforeStop) {
+        super(PUMBA_IMAGE);
+        setCommand("--log-level info " + command + " " + targetContainer);
+        addFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", BindMode.READ_WRITE);
+        setWaitStrategy(waitStrategy);
+        withLogConsumer(o -> {
+            final String string = o.getUtf8String();
+            log.info("pumba> {}", string);
+            logs.add(string);
+        });
+        this.beforeStop = beforeStop;
+    }
+
+    @Override
+    public void stop() {
+        if (getContainerId() != null && beforeStop != null) {
+            beforeStop.accept(this);
+        }
+        super.stop();
+    }
 }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/testcontainers/ChaosContainer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.io.elasticsearch.testcontainers;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.testcontainers.containers.BindMode;


### PR DESCRIPTION
### Motivation
I often see `ElasticSearchClientTests` tests failing in this way
`org.testng.internal.thread.ThreadTimeoutException: Method org.apache.pulsar.io.elasticsearch.ElasticSearchClientTests.testBulkRetry() didn't finish within the time-out 300000`

The problem is when you stop ChaosContainer, you have to wait the docker container to stop the current chaos command (`pause` in this case). Currenty, if the `stop()` method is called before the actual `stop pause`, the ElasticSearch container is stopped forever and the subsequent tests will fail.     

### Modifications

Before stopping `ChaosContainer`, we wait for the `stop pause` command checking the container logs.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 
 
- [x] `no-need-doc` 
