### PR TITLE
Some depdency in integration tests scope should be test

### DIFF
--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -148,12 +148,14 @@
     <dependency>
   	  <groupId>org.elasticsearch.client</groupId>
   	  <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <scope>test</scope>
   	</dependency>
 
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>${rabbitmq-client.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation
Some depdency in integration tests scope should be test. Minial the depdency scope.
And the `mvn clean package -DskipTests` can be faster too.

### Modifications
Change the scope from compile to test

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
  
  little depdepncy scope change


