### PR TITLE
Fix flaky test: PersistentTopicsTest::testPeekWithSubscriptionNameNotExist

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.zookeeper.KeeperException;
@@ -668,18 +669,20 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testPeekWithSubscriptionNameNotExist() throws Exception {
         final String topicName = "testTopic";
-        final String topic = TopicName.get(
+        final TopicName topic = TopicName.get(
                 TopicDomain.persistent.value(),
                 testTenant,
                 testNamespace,
-                topicName).toString();
+                topicName);
         final String subscriptionName = "sub";
 
-        ((TopicsImpl) admin.topics()).createPartitionedTopicAsync(topic, 3, true).get();
+        RetentionPolicies retention = new RetentionPolicies(10,10);
+        admin.namespaces().setRetention(topic.getNamespace(), retention);
+        ((TopicsImpl) admin.topics()).createPartitionedTopicAsync(topic.toString(), 3, true).get();
 
         final String partitionedTopic = topic + "-partition-0";
 
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic.toString()).create();
         for (int i = 0; i < 100; ++i) {
             producer.send("test" + i);
         }


### PR DESCRIPTION
### Motivation

Flaky test was timing out because broker drops messages without sub and test waits forever to receive expected number of messages

```
Error:  testPeekWithSubscriptionNameNotExist(org.apache.pulsar.broker.admin.PersistentTopicsTest)  Time elapsed: 60.065 s  <<< FAILURE!
org.apache.pulsar.client.api.PulsarClientException$TimeoutException: request timeout {'durationMs': '30000', 'reqId':'682754951081867712', 'remote':'localhost/127.0.0.1:40055', 'local':'/127.0.0.1:53962'}
    at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:1008)
    at org.apache.pulsar.client.impl.ProducerBuilderImpl.create(ProducerBuilderImpl.java:91)
    at org.apache.pulsar.broker.admin.PersistentTopicsTest.testPeekWithSubscriptionNameNotExist(PersistentTopicsTest.java:682)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
    at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
    at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
    at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)

```