### PR TITLE
[pulsar-client] Fix pending queue-size stats for batch messages

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.client.api.BatcherBuilder;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Message;
@@ -1924,7 +1925,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     public int getPendingQueueSize() {
-        return pendingMessages.size();
+        if (!isBatchMessagingEnabled()) {
+            return pendingMessages.size();
+        }
+        MutableInt size = new MutableInt(0);
+        pendingMessages.forEach(op -> {
+            size.add(Math.max(op.numMessagesInBatch, 1));
+        });
+        return size.getValue();
     }
 
     @Override


### PR DESCRIPTION
### Motivation
Right now, pulsar-client prints stats with incorrect pending queue size for the batch messages. if the user configures batch-message size 100 (or batch delay is 10ms) and publishes 1000 messages then the producer prints stats with  < 10 pending messages instead 1000 messages which is published by user. It confuses the user because the user sees a different counter than actual published messages. it creates confusion when the user gets ProducerQueueFull Error and stats prints queue size is 10 and allowed pending-messages are 1000.

### Modification
Show correct pending messages for batch messages.