### PR TITLE
[Issue 12558] fix flaky-test: SimpleProducerConsumerTestStreamingDispatcherTest.testConcurrentConsumerReceiveWhileReconnect

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -113,7 +113,7 @@ import org.testng.annotations.Test;
 @Test(groups = "flaky")
 public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(SimpleProducerConsumerTest.class);
-    private static final int RECEIVE_TIMEOUT_SECONDS = 3;
+    private static final int RECEIVE_TIMEOUT_SECONDS = 10;
     private static final int RECEIVE_TIMEOUT_SHORT_MILLIS = 100;
     private static final int RECEIVE_TIMEOUT_MEDIUM_MILLIS = 500;
 


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/12558

restartBroker() and produce messages may cost more time than RECEIVE_TIMEOUT_SECONDS, which is set to 3 second, `consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)`  will time out in some cases. 

![image](https://user-images.githubusercontent.com/5668441/141043037-37f79e0f-36db-4bb2-af4f-0177c565cec7.png)


