### PR TITLE
[pulsar-admin] Print topic internal info as formatted json

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -28,6 +28,8 @@ import com.beust.jcommander.converters.CommaParameterSplitter;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -599,7 +601,8 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String topic = validateTopicName(params);
-            String result = getTopics().getInternalInfo(topic);
+            String internalInfo = getTopics().getInternalInfo(topic);
+            JsonObject result = JsonParser.parseString(internalInfo).getAsJsonObject();
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             System.out.println(gson.toJson(result));
         }


### PR DESCRIPTION
### Motivation
Currently, we can get topic internal info through CLI `bin/pulsar-admin topics info-internal tn1/ns1/tp1`, but I find that what we get is an unformatted and unreadable result, as below:
```
"{\"version\":0,\"partitions\":{\"persistent://pulsar/application-f75e774c-7e1e-405a-aa57-bfee90b93923/topic-partition-0\":{\"version\":0,\"creationDate\":\"2021-11-10T12:17:01.397+08:00\",\"modificationDate\":\"2021-11-10T12:17:01.397+08:00\",\"ledgers\":[],\"cursors\":{}},\"persistent://pulsar/application-f75e774c-7e1e-405a-aa57-bfee90b93923/topic-partition-1\":{\"version\":0,\"creationDate\":\"2021-11-10T12:17:01.414+08:00\",\"modificationDate\":\"2021-11-10T12:17:01.414+08:00\",\"ledgers\":[],\"cursors\":{}}}}"
```

The purpose of this PR is to format topic internal info to make it clear and readable, as below:
```
{
  "version": 0,
  "partitions": {
    "persistent://pulsar/application-f75e774c-7e1e-405a-aa57-bfee90b93923/topic-partition-0": {
      "version": 0,
      "creationDate": "2021-11-10T12:17:01.397+08:00",
      "modificationDate": "2021-11-10T12:17:01.397+08:00",
      "ledgers": [],
      "cursors": {}
    },
    "persistent://pulsar/application-f75e774c-7e1e-405a-aa57-bfee90b93923/topic-partition-1": {
      "version": 0,
      "creationDate": "2021-11-10T12:17:01.414+08:00",
      "modificationDate": "2021-11-10T12:17:01.414+08:00",
      "ledgers": [],
      "cursors": {}
    }
  }
}
```

### Documentation
- [x] `no-need-doc` 
