### PR TITLE
[Pulsar SQL] Support query chunked messages feature in Pulsar SQL

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2364,8 +2364,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         return topicNameWithoutPartition;
     }
 
-    @Data
-    public static class ChunkedMessageCtx {
+    static class ChunkedMessageCtx {
 
         protected int totalChunks = -1;
         protected ByteBuf chunkedMsgBuffer;
@@ -2373,7 +2372,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         protected MessageIdImpl[] chunkedMessageIds;
         protected long receivedTime = 0;
 
-        public static ChunkedMessageCtx get(int numChunksFromMsg, ByteBuf chunkedMsgBuffer) {
+        static ChunkedMessageCtx get(int numChunksFromMsg, ByteBuf chunkedMsgBuffer) {
             ChunkedMessageCtx ctx = RECYCLER.get();
             ctx.totalChunks = numChunksFromMsg;
             ctx.chunkedMsgBuffer = chunkedMsgBuffer;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -61,7 +61,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -61,6 +61,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
@@ -2363,7 +2364,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         return topicNameWithoutPartition;
     }
 
-    static class ChunkedMessageCtx {
+    @Data
+    public static class ChunkedMessageCtx {
 
         protected int totalChunks = -1;
         protected ByteBuf chunkedMsgBuffer;
@@ -2371,7 +2373,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         protected MessageIdImpl[] chunkedMessageIds;
         protected long receivedTime = 0;
 
-        static ChunkedMessageCtx get(int numChunksFromMsg, ByteBuf chunkedMsgBuffer) {
+        public static ChunkedMessageCtx get(int numChunksFromMsg, ByteBuf chunkedMsgBuffer) {
             ChunkedMessageCtx ctx = RECYCLER.get();
             ctx.totalChunks = numChunksFromMsg;
             ctx.chunkedMsgBuffer = chunkedMsgBuffer;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -483,7 +483,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // `MessageMetadata`, if we want to re-serialize the `SEND` command using a same `MessageMetadata`,
                     // we need to reset the ByteBuf of the schemaVersion in `MessageMetadata`, I think we need to
                     // reset `ByteBuf` objects in `MessageMetadata` after call the method `MessageMetadata#writeTo()`.
-                    msg.getMessageBuilder().setSchemaVersion(msg.getSchemaVersion());
+                    if (chunkId > 0 && msg.getMessageBuilder().hasSchemaVersion()) {
+                        msg.getMessageBuilder().setSchemaVersion(msg.getMessageBuilder().getSchemaVersion());
+                    }
                     serializeAndSendMessage(msg, payload, sequenceId, uuid, chunkId, totalChunks,
                             readStartIndex, ClientCnx.getMaxMessageSize(), compressedPayload, compressed,
                             compressedPayload.readableBytes(), uncompressedSize, callback);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -479,6 +479,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 }
                 String uuid = totalChunks > 1 ? String.format("%s-%d", producerName, sequenceId) : null;
                 for (int chunkId = 0; chunkId < totalChunks; chunkId++) {
+                    // Need to reset the schemaVersion, because the schemaVersion is a ByteBuf object in
+                    // `MessageMetadata`, if we want to re-serialize the `SEND` command using a same `MessageMetadata`,
+                    // we need to reset the ByteBuf of the schemaVersion in `MessageMetadata`, I think we need to
+                    // reset `ByteBuf` objects in `MessageMetadata` after call the method `MessageMetadata#writeTo()`.
+                    msg.getMessageBuilder().setSchemaVersion(msg.getSchemaVersion());
                     serializeAndSendMessage(msg, payload, sequenceId, uuid, chunkId, totalChunks,
                             readStartIndex, ClientCnx.getMaxMessageSize(), compressedPayload, compressed,
                             compressedPayload.readableBytes(), uncompressedSize, callback);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -478,13 +478,15 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     sequenceId = msgMetadata.getSequenceId();
                 }
                 String uuid = totalChunks > 1 ? String.format("%s-%d", producerName, sequenceId) : null;
+                byte[] schemaVersion = totalChunks > 1 && msg.getMessageBuilder().hasSchemaVersion() ?
+                        msg.getMessageBuilder().getSchemaVersion() : null;
                 for (int chunkId = 0; chunkId < totalChunks; chunkId++) {
                     // Need to reset the schemaVersion, because the schemaVersion is based on a ByteBuf object in
                     // `MessageMetadata`, if we want to re-serialize the `SEND` command using a same `MessageMetadata`,
                     // we need to reset the ByteBuf of the schemaVersion in `MessageMetadata`, I think we need to
                     // reset `ByteBuf` objects in `MessageMetadata` after call the method `MessageMetadata#writeTo()`.
-                    if (chunkId > 0 && msg.getMessageBuilder().hasSchemaVersion()) {
-                        msg.getMessageBuilder().setSchemaVersion(msg.getMessageBuilder().getSchemaVersion());
+                    if (chunkId > 0 && schemaVersion != null) {
+                        msg.getMessageBuilder().setSchemaVersion(schemaVersion);
                     }
                     serializeAndSendMessage(msg, payload, sequenceId, uuid, chunkId, totalChunks,
                             readStartIndex, ClientCnx.getMaxMessageSize(), compressedPayload, compressed,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -479,7 +479,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 }
                 String uuid = totalChunks > 1 ? String.format("%s-%d", producerName, sequenceId) : null;
                 for (int chunkId = 0; chunkId < totalChunks; chunkId++) {
-                    // Need to reset the schemaVersion, because the schemaVersion is a ByteBuf object in
+                    // Need to reset the schemaVersion, because the schemaVersion is based on a ByteBuf object in
                     // `MessageMetadata`, if we want to re-serialize the `SEND` command using a same `MessageMetadata`,
                     // we need to reset the ByteBuf of the schemaVersion in `MessageMetadata`, I think we need to
                     // reset `ByteBuf` objects in `MessageMetadata` after call the method `MessageMetadata#writeTo()`.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
@@ -121,4 +121,33 @@ public interface RawMessage {
      * @return true if the key is base64 encoded, false otherwise
      */
     boolean hasBase64EncodedKey();
+
+    /**
+     * Get uuid of chunked message.
+     *
+     * @return uuid
+     */
+    String getUUID();
+
+    /**
+     * Get chunkId of chunked message.
+     *
+     * @return chunkId
+     */
+    int getChunkId();
+
+    /**
+     * Get chunk num of chunked message.
+     *
+     * @return chunk num
+     */
+    int getNumChunksFromMsg();
+
+    /**
+     * Get chunk message total size in bytes.
+     *
+     * @return chunked message total size in bytes
+     */
+    int getTotalChunkMsgSize();
+
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -81,6 +81,14 @@ public class RawMessageImpl implements RawMessage {
         return msg;
     }
 
+    public RawMessage updatePayloadForChunkedMessage(ByteBuf chunkedTotalPayload) {
+        if (!msgMetadata.getMetadata().hasNumChunksFromMsg() || msgMetadata.getMetadata().getNumChunksFromMsg() <= 1) {
+            throw new RuntimeException("The update payload operation only support chunked messages.");
+        }
+        payload = chunkedTotalPayload;
+        return this;
+    }
+
     @Override
     public Map<String, String> getProperties() {
         if (singleMessageMetadata != null && singleMessageMetadata.getPropertiesCount() > 0) {
@@ -168,6 +176,42 @@ public class RawMessageImpl implements RawMessage {
             return singleMessageMetadata.isPartitionKeyB64Encoded();
         }
         return msgMetadata.getMetadata().isPartitionKeyB64Encoded();
+    }
+
+    @Override
+    public String getUUID() {
+        if (msgMetadata.getMetadata().hasUuid()) {
+            return msgMetadata.getMetadata().getUuid();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public int getChunkId() {
+        if (msgMetadata.getMetadata().hasChunkId()) {
+            return msgMetadata.getMetadata().getChunkId();
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public int getNumChunksFromMsg() {
+        if (msgMetadata.getMetadata().hasNumChunksFromMsg()) {
+            return msgMetadata.getMetadata().getNumChunksFromMsg();
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public int getTotalChunkMsgSize() {
+        if (msgMetadata.getMetadata().hasTotalChunkMsgSize()) {
+            return msgMetadata.getMetadata().getTotalChunkMsgSize();
+        } else {
+            return -1;
+        }
     }
 
     public int getBatchSize() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -83,7 +83,7 @@ public class RawMessageImpl implements RawMessage {
 
     public RawMessage updatePayloadForChunkedMessage(ByteBuf chunkedTotalPayload) {
         if (!msgMetadata.getMetadata().hasNumChunksFromMsg() || msgMetadata.getMetadata().getNumChunksFromMsg() <= 1) {
-            throw new RuntimeException("The update payload operation only support chunked messages.");
+            throw new RuntimeException("The update payload operation only support multi chunked messages.");
         }
         payload = chunkedTotalPayload;
         return this;

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -777,7 +777,7 @@ public class PulsarRecordCursor implements RecordCursor {
         ChunkedMessageCtx chunkedMsgCtx = chunkedMessagesMap.get(uuid);
         if (chunkedMsgCtx == null || chunkedMsgCtx.chunkedMsgBuffer == null
                 || chunkId != (chunkedMsgCtx.lastChunkedMessageId + 1) || chunkId >= numChunks) {
-            // Means we lost the first chunk, it will happens when the beginning chunk didn't belong to this split.
+            // Means we lost the first chunk, it will happen when the beginning chunk didn't belong to this split.
             log.info("Received unexpected chunk. messageId: %s, last-chunk-id: %s chunkId: %s, totalChunks: %s",
                     message.getMessageId(),
                     (chunkedMsgCtx != null ? chunkedMsgCtx.lastChunkedMessageId : null), chunkId,
@@ -810,6 +810,7 @@ public class PulsarRecordCursor implements RecordCursor {
         chunkedMessagesMap.remove(uuid);
         ByteBuf unCompressedPayload = chunkedMsgCtx.chunkedMsgBuffer;
         chunkedMsgCtx.recycle();
+        // The chunked message complete, we use the entire payload to instead of the last chunk payload.
         return ((RawMessageImpl) message).updatePayloadForChunkedMessage(unCompressedPayload);
     }
 

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestReadChunkedMessages.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestReadChunkedMessages.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.sql.presto;
+
+import com.google.common.collect.Sets;
+import io.prestosql.spi.connector.ConnectorContext;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.testing.TestingConnectorContext;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test read chunked messages.
+ */
+@Test
+@Slf4j
+public class TestReadChunkedMessages extends MockedPulsarServiceBaseTest {
+
+    private final static int MAX_MESSAGE_SIZE = 1024 * 1024;
+
+    @EqualsAndHashCode
+    @Data
+    static class Movie {
+        private String name;
+        private Long publishTime;
+        private byte[] binaryData;
+    }
+
+    @EqualsAndHashCode
+    @Data
+    static class MovieMessage {
+        private Movie movie;
+        private String messageId;
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setMaxMessageSize(MAX_MESSAGE_SIZE);
+        conf.setManagedLedgerMaxEntriesPerLedger(5);
+        conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        internalSetup();
+
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+
+        // so that clients can test short names
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("public/default");
+        admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        internalCleanup();
+    }
+
+    @Test
+    public void queryTest() throws Exception {
+        String topic = "chunk-topic";
+        TopicName topicName = TopicName.get(topic);
+        int messageCnt = 20;
+        Set<MovieMessage> messageSet = prepareChunkedData(topic, messageCnt);
+        SchemaInfo schemaInfo = Schema.AVRO(Movie.class).getSchemaInfo();
+
+        PulsarConnectorConfig connectorConfig = new PulsarConnectorConfig();
+        connectorConfig.setWebServiceUrl(pulsar.getWebServiceAddress());
+        PulsarSplitManager pulsarSplitManager = new PulsarSplitManager(new PulsarConnectorId("1"), connectorConfig);
+        Collection<PulsarSplit> splits = pulsarSplitManager.getSplitsForTopic(
+                topicName.getPersistenceNamingEncoding(),
+                pulsar.getManagedLedgerFactory(),
+                new ManagedLedgerConfig(),
+                3,
+                new PulsarTableHandle("1", topicName.getNamespace(), topic, topic),
+                schemaInfo,
+                topic,
+                TupleDomain.all(),
+                null);
+
+        List<PulsarColumnHandle> columnHandleList = TestPulsarConnector.getColumnColumnHandles(
+                topicName, schemaInfo, PulsarColumnHandle.HandleKeyValueType.NONE, true);
+        ConnectorContext prestoConnectorContext = new TestingConnectorContext();
+
+        for (PulsarSplit split : splits) {
+            queryAndCheck(columnHandleList, split, connectorConfig, prestoConnectorContext, messageSet);
+        }
+        Assert.assertTrue(messageSet.isEmpty());
+    }
+
+    private Set<MovieMessage> prepareChunkedData(String topic, int messageCnt) throws PulsarClientException, InterruptedException {
+        pulsarClient.newConsumer(Schema.AVRO(Movie.class))
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscribe()
+                .close();
+        Producer<Movie> producer = pulsarClient.newProducer(Schema.AVRO(Movie.class))
+                .topic(topic)
+                .enableBatching(false)
+                .enableChunking(true)
+                .create();
+        Set<MovieMessage> messageSet = new LinkedHashSet<>();
+        CountDownLatch countDownLatch = new CountDownLatch(messageCnt);
+        for (int i = 0; i < messageCnt; i++) {
+            final double dataTimes = (i % 5) * 0.5;
+            byte[] movieBinaryData = RandomUtils.nextBytes((int) (MAX_MESSAGE_SIZE * dataTimes));
+            final int length = movieBinaryData.length;
+            final int index = i;
+
+            Movie movie = new Movie();
+            movie.setName("movie-" + i);
+            movie.setPublishTime(System.currentTimeMillis());
+            movie.setBinaryData(movieBinaryData);
+            producer.newMessage().value(movie).sendAsync()
+                    .whenComplete((msgId, throwable) -> {
+                        if (throwable != null) {
+                            log.error("Failed to produce message.", throwable);
+                            countDownLatch.countDown();
+                            return;
+                        }
+                        MovieMessage movieMessage = new MovieMessage();
+                        movieMessage.setMovie(movie);
+                        MessageIdImpl messageId = (MessageIdImpl) msgId;
+                        movieMessage.setMessageId("(" + messageId.getLedgerId() + "," + messageId.getEntryId() + ",0)");
+                        messageSet.add(movieMessage);
+                        countDownLatch.countDown();
+                    });
+        }
+        countDownLatch.await();
+        Assert.assertEquals(messageCnt, messageSet.size());
+        producer.close();
+        return messageSet;
+    }
+
+    private void queryAndCheck(List<PulsarColumnHandle> columnHandleList,
+                               PulsarSplit split,
+                               PulsarConnectorConfig connectorConfig,
+                               ConnectorContext prestoConnectorContext,
+                               Set<MovieMessage> messageSet) {
+        PulsarRecordCursor pulsarRecordCursor = new PulsarRecordCursor(
+                columnHandleList, split, connectorConfig, pulsar.getManagedLedgerFactory(),
+                new ManagedLedgerConfig(), new PulsarConnectorMetricsTracker(new NullStatsProvider()),
+                new PulsarDispatchingRowDecoderFactory(prestoConnectorContext.getTypeManager()));
+
+        AtomicInteger receiveMsgCnt = new AtomicInteger(messageSet.size());
+        while (pulsarRecordCursor.advanceNextPosition()) {
+            Movie movie = new Movie();
+            MovieMessage movieMessage = new MovieMessage();
+            movieMessage.setMovie(movie);
+            for (int i = 0; i < columnHandleList.size(); i++) {
+                switch (columnHandleList.get(i).getName()) {
+                    case "binaryData":
+                        movie.setBinaryData(pulsarRecordCursor.getSlice(i).getBytes());
+                        break;
+                    case "name":
+                        movie.setName(new String(pulsarRecordCursor.getSlice(i).getBytes()));
+                        break;
+                    case "publishTime":
+                        movie.setPublishTime(pulsarRecordCursor.getLong(i));
+                        break;
+                    case "__message_id__":
+                        movieMessage.setMessageId(new String(pulsarRecordCursor.getSlice(i).getBytes()));
+                    default:
+                        // do nothing
+                        break;
+                }
+            }
+
+            Assert.assertTrue(messageSet.contains(movieMessage));
+            messageSet.remove(movieMessage);
+            receiveMsgCnt.decrementAndGet();
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

Currently, the Pulsar SQL didn't support query chunked messages.

### Modifications

Add a chunked message map in `PulsarRecordCursor` to maintain incomplete chunked messages, if one chunked message was received completely, it will be offered in the message queue to wait for deserialization.

### Verifying this change

Add a unit test to verify querying chunked messages normally.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


