### PR TITLE
Even if always compatible is set, Consumers cannot be created

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -378,9 +378,6 @@ public abstract class AbstractTopic implements Topic {
 
     @Override
     public CompletableFuture<Void> checkSchemaCompatibleForConsumer(SchemaData schema) {
-        if (SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE.equals(schemaCompatibilityStrategy)) {
-            return CompletableFuture.completedFuture(null);
-        }
         String base = TopicName.get(getName()).getPartitionedTopicName();
         String id = TopicName.get(base).getSchemaName();
         return brokerService.pulsar()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -378,6 +378,9 @@ public abstract class AbstractTopic implements Topic {
 
     @Override
     public CompletableFuture<Void> checkSchemaCompatibleForConsumer(SchemaData schema) {
+        if (SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE.equals(schemaCompatibilityStrategy)) {
+            return CompletableFuture.completedFuture(null);
+        }
         String base = TopicName.get(getName()).getPartitionedTopicName();
         String id = TopicName.get(base).getSchemaName();
         return brokerService.pulsar()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -270,6 +270,9 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     @Override
     public CompletableFuture<Void> checkConsumerCompatibility(String schemaId, SchemaData schemaData,
                                                               SchemaCompatibilityStrategy strategy) {
+        if (SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE.equals(strategy)) {
+            return CompletableFuture.completedFuture(null);
+        }
         return getSchema(schemaId).thenCompose(existingSchema -> {
             if (existingSchema != null && !existingSchema.schema.isDeleted()) {
                 if (strategy == SchemaCompatibilityStrategy.BACKWARD

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -270,7 +270,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     @Override
     public CompletableFuture<Void> checkConsumerCompatibility(String schemaId, SchemaData schemaData,
                                                               SchemaCompatibilityStrategy strategy) {
-        if (SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE.equals(strategy)) {
+        if (SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE == strategy) {
             return CompletableFuture.completedFuture(null);
         }
         return getSchema(schemaId).thenCompose(existingSchema -> {


### PR DESCRIPTION
### Motivation
When the Producer's schema is set to AUTO_PRODUCE_BYTES. Even if always compatible is set, Consumers cannot be created. And return Exception `Topic does not have schema to check`

### Documentation
- [ x ] `no-need-doc` 


