### PR TITLE
[pulsar-broker] Add stop replicator producer logic when start replicator cluster failed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -280,6 +280,7 @@ public class PersistentTopic extends AbstractTopic
                     log.warn("[{}] failed to start replication", topic, e);
                 }
                 if (!isReplicatorStarted) {
+                    stopReplProducers();
                     throw new NamingException(
                             PersistentTopic.this.getName() + " Failed to start replicator " + remoteCluster);
                 }


### PR DESCRIPTION
### Motivation

When create persistent topic in BrokerService#createPersistentTopic:
```
public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
                            public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
                            try {
                                PersistentTopic persistentTopic = isSystemTopic(topic)
                                        ? new SystemTopic(topic, ledger, BrokerService.this)
                                        : new PersistentTopic(topic, ledger, BrokerService.this); // @ Here may throw NamingException
                                ...
                                }).thenRun(() -> {
                                    ...
                                }).exceptionally((ex) -> {
                                    log.warn(
                                            "Replication or dedup check failed."
                                                    + " Removing topic from topics list {}, {}",
                                            topic, ex);
                                    persistentTopic.stopReplProducers().whenComplete((v, exception) -> {
                                        topics.remove(topic, topicFuture);
                                        topicFuture.completeExceptionally(ex);
                                    });

                                    return null;
                                });
                            } catch (NamingException | PulsarServerException e) {
                                log.warn("Failed to create topic {}-{}", topic, e.getMessage());
                                pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
                                topicFuture.completeExceptionally(e);
                            }
                        }
```

It may throw NamingException when `new PersistentTopic`. We don't stop replicator producers in the `NamingException` catch block. This will result in some replicator producers being created and keep in the remote clusters producers list.
Any later retry to add replicator producers fails with the below logs :

```
Nov 05 13:25:31 pulsar-broker-node-1 pulsar[11435]: 13:25:31.054 [ForkJoinPool.commonPool-worker-29] ERROR org.apache.pulsar.broker.service.ServerCnx - [/10.10.0.47:34976] Failed to add producer to topic persistent://SD/operator20018/groupsettings: producerId=17690, org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'pulsar.repl.ctp-pulsar-stage-cluster' is already connected to topic
Nov 05 13:25:33 pulsar-broker-node-1 pulsar[11435]: 13:25:33.351 [ForkJoinPool.commonPool-worker-29] ERROR org.apache.pulsar.broker.service.ServerCnx - [/10.10.0.47:34952] Failed to add producer to topic persistent://SD/operator20018/groupsettings: producerId=17694, org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name 'pulsar.repl.ctp-pulsar-stage-cluster' is already connected to topic
Nov 05 13:25:33 pulsar-broker-node-1 pulsar[11435]: 13:25:33.670 [ForkJoinPool.commonPool-worker-29] ERROR org.apache.pulsar.broker.service.ServerCnx - [/10.10.0.47:34970] Failed to add producer to topic persistent://SD/operator20018/groupsettings: producerId=17696,
```
### Documentation

- [ x ] `no-need-doc` 
  


