### PR TITLE
Add remote cluster info to replicator producer name.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -83,7 +83,8 @@ public abstract class AbstractReplicator {
                 .enableBatching(false)
                 .sendTimeout(0, TimeUnit.SECONDS) //
                 .maxPendingMessages(producerQueueSize) //
-                .producerName(getReplicatorName(replicatorPrefix, localCluster));
+                .producerName(String.format("%s%s%s", getReplicatorName(replicatorPrefix, localCluster),
+                        REPL_PRODUCER_NAME_DELIMITER, remoteCluster));
         STATE_UPDATER.set(this, State.Stopped);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -128,7 +128,7 @@ public class Producer {
 
         this.isRemote = producerName
                 .startsWith(cnx.getBrokerService().pulsar().getConfiguration().getReplicatorPrefix());
-        this.remoteCluster = isRemote ? producerName.split("\\.")[2].split(REPL_PRODUCER_NAME_DELIMITER)[0] : null;
+        this.remoteCluster = parseRemoteClusterName(producerName, isRemote);
 
         this.isEncrypted = isEncrypted;
         this.schemaVersion = schemaVersion;
@@ -136,6 +136,15 @@ public class Producer {
         this.topicEpoch = topicEpoch;
 
         this.clientAddress = cnx.clientSourceAddress();
+    }
+
+    private String parseRemoteClusterName(String producerName, boolean isRemote) {
+        if (isRemote) {
+            String clusterName = producerName.split("\\.")[2];
+            return clusterName.contains(REPL_PRODUCER_NAME_DELIMITER) ?
+                    clusterName.split(REPL_PRODUCER_NAME_DELIMITER)[1] : clusterName;
+        }
+        return null;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -141,8 +141,8 @@ public class Producer {
     private String parseRemoteClusterName(String producerName, boolean isRemote) {
         if (isRemote) {
             String clusterName = producerName.split("\\.")[2];
-            return clusterName.contains(REPL_PRODUCER_NAME_DELIMITER) ?
-                    clusterName.split(REPL_PRODUCER_NAME_DELIMITER)[1] : clusterName;
+            return clusterName.contains(REPL_PRODUCER_NAME_DELIMITER)
+                    ? clusterName.split(REPL_PRODUCER_NAME_DELIMITER)[1] : clusterName;
         }
         return null;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -142,7 +142,7 @@ public class Producer {
         if (isRemote) {
             String clusterName = producerName.split("\\.")[2];
             return clusterName.contains(REPL_PRODUCER_NAME_DELIMITER)
-                    ? clusterName.split(REPL_PRODUCER_NAME_DELIMITER)[1] : clusterName;
+                    ? clusterName.split(REPL_PRODUCER_NAME_DELIMITER)[0] : clusterName;
         }
         return null;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -713,6 +714,26 @@ public class ReplicatorTest extends ReplicatorTestBase {
         field.setAccessible(true);
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) field.get(replicator);
         assertNull(producer);
+    }
+
+    @Test(priority = 5, timeOut = 30000)
+    public void testReplicatorProducerName() throws Exception {
+        log.info("--- Starting ReplicatorTest::testReplicatorProducerName ---");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://pulsar/ns/testReplicatorProducerName");
+        final TopicName dest = TopicName.get(topicName);
+
+        @Cleanup
+        MessageProducer producer1 = new MessageProducer(url1, dest);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(pulsar2.getBrokerService().getTopicReference(topicName).isPresent());
+        });
+        Optional<Topic> topic = pulsar2.getBrokerService().getTopicReference(topicName);
+        assertTrue(topic.isPresent());
+        Set<String> remoteClusters = topic.get().getProducers().values().stream()
+                .map(org.apache.pulsar.broker.service.Producer::getRemoteCluster)
+                .collect(Collectors.toSet());
+        assertTrue(remoteClusters.contains("r1"));
     }
 
     /**


### PR DESCRIPTION
### Motivation

If the producer is the replicator client, the `remoteCluster` is not right ：

```
Producer{topic=PersistentTopic{topic=persistent://public/default/tp1-partition-0}, client=/127.0.0.1:54628, producerName=pulsar.repl.cluster3, producerId=0, remoteCluster=cluster3, isRemote=true}
```

### Modifications
- Add remote cluster-info to replicator producer builder.

### Documentation
  
- [ x ] `no-need-doc` 
  
