### PR TITLE
[Normative Issues ] Fix inaccurate naming and simplify interceptor settings.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1289,18 +1289,9 @@ public class BrokerService implements Closeable {
                 : CompletableFuture.completedFuture(null);
 
         maxTopicsCheck.thenCompose(__ -> getManagedLedgerConfig(topicName)).thenAccept(managedLedgerConfig -> {
-            if (isBrokerEntryMetadataEnabled()) {
+            if (hasBrokerEntryMetadataInterceptor()) {
                 // init managedLedger interceptor
-                Set<BrokerEntryMetadataInterceptor> interceptors = new HashSet<>();
-                for (BrokerEntryMetadataInterceptor interceptor : brokerEntryMetadataInterceptors) {
-                    // add individual AppendOffsetMetadataInterceptor for each topic
-                    if (interceptor instanceof AppendIndexMetadataInterceptor) {
-                        interceptors.add(new AppendIndexMetadataInterceptor());
-                    } else {
-                        interceptors.add(interceptor);
-                    }
-                }
-                managedLedgerConfig.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(interceptors));
+                managedLedgerConfig.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(new HashSet<>(brokerEntryMetadataInterceptors)));
             }
 
             managedLedgerConfig.setCreateIfMissing(createIfMissing);
@@ -2720,7 +2711,7 @@ public class BrokerService implements Closeable {
         return brokerEntryMetadataInterceptors;
     }
 
-    public boolean isBrokerEntryMetadataEnabled() {
+    public boolean hasBrokerEntryMetadataInterceptor() {
         return !brokerEntryMetadataInterceptors.isEmpty();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -432,7 +432,7 @@ public class PersistentTopic extends AbstractTopic
     }
 
     private void asyncAddEntry(ByteBuf headersAndPayload, PublishContext publishContext) {
-        if (brokerService.isBrokerEntryMetadataEnabled()) {
+        if (brokerService.hasBrokerEntryMetadataInterceptor()) {
             ledger.asyncAddEntry(headersAndPayload,
                     (int) publishContext.getNumberOfMessages(), this, publishContext);
         } else {


### PR DESCRIPTION
### Modifications
1.Method naming is not precise enough. 
2.BrokerEntryMetadataInterceptor does not need to be traversed and added, because it is already a top-level interface

### Verifying this change
No need to write documentation and unit tests.