### PR TITLE
Upgrade to BookKeeper 4.14.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -390,31 +390,31 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-1.2-api-2.14.0.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.14.2.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.14.2.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.14.2.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.14.2.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.14.2.jar
-    - org.apache.bookkeeper-circe-checksum-4.14.2.jar
-    - org.apache.bookkeeper-cpu-affinity-4.14.2.jar
-    - org.apache.bookkeeper-statelib-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-api-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-common-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-server-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.14.2.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.14.2.jar
-    - org.apache.bookkeeper.http-http-server-4.14.2.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.14.2.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.14.2.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.14.2.jar
-    - org.apache.distributedlog-distributedlog-common-4.14.2.jar
-    - org.apache.distributedlog-distributedlog-core-4.14.2-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.14.2.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.14.2.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.14.2.jar
+    - org.apache.bookkeeper-bookkeeper-common-4.14.3.jar
+    - org.apache.bookkeeper-bookkeeper-common-allocator-4.14.3.jar
+    - org.apache.bookkeeper-bookkeeper-proto-4.14.3.jar
+    - org.apache.bookkeeper-bookkeeper-server-4.14.3.jar
+    - org.apache.bookkeeper-bookkeeper-tools-framework-4.14.3.jar
+    - org.apache.bookkeeper-circe-checksum-4.14.3.jar
+    - org.apache.bookkeeper-cpu-affinity-4.14.3.jar
+    - org.apache.bookkeeper-statelib-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-api-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-common-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-java-client-base-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-proto-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-server-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-service-api-4.14.3.jar
+    - org.apache.bookkeeper-stream-storage-service-impl-4.14.3.jar
+    - org.apache.bookkeeper.http-http-server-4.14.3.jar
+    - org.apache.bookkeeper.http-vertx-http-server-4.14.3.jar
+    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.14.3.jar
+    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.14.3.jar
+    - org.apache.distributedlog-distributedlog-common-4.14.3.jar
+    - org.apache.distributedlog-distributedlog-core-4.14.3-tests.jar
+    - org.apache.distributedlog-distributedlog-core-4.14.3.jar
+    - org.apache.distributedlog-distributedlog-protocol-4.14.3.jar
+    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.14.3.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.21</commons-compress.version>
 
-    <bookkeeper.version>4.14.2</bookkeeper.version>
+    <bookkeeper.version>4.14.3</bookkeeper.version>
     <zookeeper.version>3.6.3</zookeeper.version>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -414,18 +414,18 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
   * Apache Bookkeeper
-    - bookkeeper-common-4.14.2.jar
-    - bookkeeper-common-allocator-4.14.2.jar
-    - bookkeeper-proto-4.14.2.jar
-    - bookkeeper-server-4.14.2.jar
-    - bookkeeper-stats-api-4.14.2.jar
-    - bookkeeper-tools-framework-4.14.2.jar
-    - circe-checksum-4.14.2.jar
-    - codahale-metrics-provider-4.14.2.jar
-    - cpu-affinity-4.14.2.jar
-    - http-server-4.14.2.jar
-    - prometheus-metrics-provider-4.14.2.jar
-    - codahale-metrics-provider-4.14.2.jar
+    - bookkeeper-common-4.14.3.jar
+    - bookkeeper-common-allocator-4.14.3.jar
+    - bookkeeper-proto-4.14.3.jar
+    - bookkeeper-server-4.14.3.jar
+    - bookkeeper-stats-api-4.14.3.jar
+    - bookkeeper-tools-framework-4.14.3.jar
+    - circe-checksum-4.14.3.jar
+    - codahale-metrics-provider-4.14.3.jar
+    - cpu-affinity-4.14.3.jar
+    - http-server-4.14.3.jar
+    - prometheus-metrics-provider-4.14.3.jar
+    - codahale-metrics-provider-4.14.3.jar
   * Apache Commons
     - commons-cli-1.2.jar
     - commons-codec-1.15.jar

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/BookKeeperTestClient.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.client;
 
 import java.io.IOException;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.meta.zk.ZKMetadataClientDriver;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 
@@ -32,7 +33,7 @@ public class BookKeeperTestClient extends BookKeeper {
     }
 
     public ZooKeeper getZkHandle() {
-        return super.getZkHandle();
+        return ((ZKMetadataClientDriver) metadataDriver).getZk();
     }
 
     public ClientConfiguration getConf() {


### PR DESCRIPTION
### Motivation

Upgrade BK to 4.14.3. This version solves the last direct metadata accesses to ZooKeeper for the bookies in garbage collection and the auto recovery leader election.