### PR TITLE
Revert "BookkeeperClientFactory should pass in the ZK instance" (#12764)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -81,7 +81,6 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         try {
             return BookKeeper.forConfig(bkConf)
                     .allocator(PulsarByteBufAllocator.DEFAULT)
-                    .setZookeeper(zkClient)
                     .eventLoopGroup(eventLoopGroup)
                     .statsLogger(statsLogger)
                     .build();


### PR DESCRIPTION
Related: #12764

### Modifications
This reverts commit 33580ca6c28f612d3eeb250341a0cb8883961afc.

This change is a trivial rework / code cleanup without any test coverage.

- [x] no-need-doc