### PR TITLE
clean os even when statusFuture complete exceptionally

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaders;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Set;
@@ -888,14 +889,14 @@ public class FunctionsImpl extends ComponentResource implements Functions {
                         }).toCompletableFuture();
 
             statusFuture
-                    .thenAccept(status -> {
+                    .whenComplete((status, throwable) -> {
                         try {
                             os.close();
-                        } catch (Exception e) {
+                        } catch (IOException e) {
                             future.completeExceptionally(getApiException(e));
-                            return;
                         }
-
+                    })
+                    .thenAccept(status -> {
                         if (status.getStatusCode() < 200 || status.getStatusCode() >= 300) {
                             future.completeExceptionally(
                                     getApiException(Response


### PR DESCRIPTION
### Motivation
Current implementation doesn't clean the file channel `os` when `statusFuture` completes exceptionally.


### Modifications

Call `whenComplete` first to clean the `os` resource regardless of the `statusFuture` completes status.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
No
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


