### PR TITLE
[c++] Define and expose PULSAR_VERSION macro

### DIFF
--- a/pulsar-client-cpp/.gitignore
+++ b/pulsar-client-cpp/.gitignore
@@ -47,6 +47,9 @@ lib*.so*
 /perf/perfConsumer
 /system-test/SystemTest
 
+# Files generated from templates by CMAKE
+include/pulsar/Version.h
+
 # IDE generated files
 .csettings
 .cproject

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -21,6 +21,10 @@ cmake_minimum_required(VERSION 3.4)
 project (pulsar-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
+execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/../src/gen-pulsar-version-macro.py OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PVM)
+set(PVM_COMMENT "This is generated from Version.h.in by CMAKE. DO NOT EDIT DIRECTLY")
+configure_file(templates/Version.h.in include/pulsar/Version.h @ONLY)
+
 if (VCPKG_TRIPLET)
     message(STATUS "Use vcpkg, triplet is ${VCPKG_TRIPLET}")
     set(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/vcpkg_installed/${VCPKG_TRIPLET}")

--- a/pulsar-client-cpp/include/pulsar/c/version.h
+++ b/pulsar-client-cpp/include/pulsar/c/version.h
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <pulsar/Version.h>

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -20,7 +20,7 @@
 file(GLOB PULSAR_SOURCES *.cc *.h lz4/*.cc lz4/*.h checksum/*.cc checksum/*.h stats/*.cc stats/*.h c/*.cc c/*.h auth/*.cc auth/*.h auth/athenz/*.cc auth/athenz/*.h)
 
 execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/../src/get-project-version.py OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PV)
-set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -D_PULSAR_VERSION_=\\\"${PV}\\\"")
+set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -D_PULSAR_VERSION_INTERNAL_=\\\"${PV}\\\"")
 
 if (NOT PROTOC_PATH)
     set(PROTOC_PATH protoc)

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -18,7 +18,7 @@
  */
 #include "Commands.h"
 #include "MessageImpl.h"
-#include "Version.h"
+#include "VersionInternal.h"
 #include "pulsar/MessageBuilder.h"
 #include "LogUtils.h"
 #include "PulsarApi.pb.h"
@@ -215,7 +215,7 @@ SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication, const
     BaseCommand cmd;
     cmd.set_type(BaseCommand::CONNECT);
     CommandConnect* connect = cmd.mutable_connect();
-    connect->set_client_version(_PULSAR_VERSION_);
+    connect->set_client_version(_PULSAR_VERSION_INTERNAL_);
     connect->set_auth_method_name(authentication->getAuthMethodName());
     connect->set_protocol_version(ProtocolVersion_MAX);
 
@@ -243,7 +243,7 @@ SharedBuffer Commands::newAuthResponse(const AuthenticationPtr& authentication, 
     BaseCommand cmd;
     cmd.set_type(BaseCommand::AUTH_RESPONSE);
     CommandAuthResponse* authResponse = cmd.mutable_authresponse();
-    authResponse->set_client_version(_PULSAR_VERSION_);
+    authResponse->set_client_version(_PULSAR_VERSION_INTERNAL_);
 
     AuthData* authData = authResponse->mutable_response();
     authData->set_auth_method_name(authentication->getAuthMethodName());

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -151,7 +151,7 @@ void HTTPLookupService::handleNamespaceTopicsHTTPRequest(NamespaceTopicsPromise 
 Result HTTPLookupService::sendHTTPRequest(const std::string completeUrl, std::string &responseData) {
     CURL *handle;
     CURLcode res;
-    std::string version = std::string("Pulsar-CPP-v") + _PULSAR_VERSION_;
+    std::string version = std::string("Pulsar-CPP-v") + _PULSAR_VERSION_INTERNAL_;
     handle = curl_easy_init();
 
     if (!handle) {

--- a/pulsar-client-cpp/lib/HTTPLookupService.h
+++ b/pulsar-client-cpp/lib/HTTPLookupService.h
@@ -22,7 +22,7 @@
 #include <lib/LookupService.h>
 #include <lib/ClientImpl.h>
 #include <lib/Url.h>
-#include <lib/Version.h>
+#include <lib/VersionInternal.h>
 
 namespace pulsar {
 class HTTPLookupService : public LookupService, public std::enable_shared_from_this<HTTPLookupService> {

--- a/pulsar-client-cpp/lib/VersionInternal.h
+++ b/pulsar-client-cpp/lib/VersionInternal.h
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef LIB_VERSION_H_
-#define LIB_VERSION_H_
+#ifndef LIB_VERSION_INTERNAL_H_
+#define LIB_VERSION_INTERNAL_H_
 
-#ifndef _PULSAR_VERSION_
-#define _PULSAR_VERSION_ "1.17"
+#ifndef _PULSAR_VERSION_INTERNAL_
+#define _PULSAR_VERSION_INTERNAL_ "1.17"
 #endif
 
-#endif /* LIB_VERSION_H_ */
+#endif /* LIB_VERSION_INTERNAL_H_ */

--- a/pulsar-client-cpp/lib/VersionInternal.h
+++ b/pulsar-client-cpp/lib/VersionInternal.h
@@ -20,7 +20,7 @@
 #define LIB_VERSION_INTERNAL_H_
 
 #ifndef _PULSAR_VERSION_INTERNAL_
-#define _PULSAR_VERSION_INTERNAL_ "1.17"
+#define _PULSAR_VERSION_INTERNAL_ "unknown"
 #endif
 
 #endif /* LIB_VERSION_INTERNAL_H_ */

--- a/pulsar-client-cpp/templates/Version.h.in
+++ b/pulsar-client-cpp/templates/Version.h.in
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @PVM_COMMENT@
+ */
+#ifndef PULSAR_VERSION_H_
+#define PULSAR_VERSION_H_
+
+#define PULSAR_VERSION @PVM@
+
+#endif /* PULSAR_VERSION_H_ */

--- a/pulsar-client-cpp/tests/VersionTest.cc
+++ b/pulsar-client-cpp/tests/VersionTest.cc
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/Version.h>
+#include <gtest/gtest.h>
+
+TEST(VersionTest, testMacro) {
+#ifdef PULSAR_VERSION
+    ASSERT_GE(PULSAR_VERSION, 2000000);
+    ASSERT_LE(PULSAR_VERSION, 999999999);
+#else
+    FAIL();
+#endif
+}

--- a/src/gen-pulsar-version-macro.py
+++ b/src/gen-pulsar-version-macro.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import xml.etree.ElementTree as ET
+import re
+from os.path import dirname, realpath, join
+
+# Derive the POM path from the current script location
+TOP_LEVEL_PATH = dirname(dirname(realpath(__file__)))
+POM_PATH = join(TOP_LEVEL_PATH, 'pom.xml')
+
+root = ET.XML(open(POM_PATH).read())
+m = re.search(r'^(\d+)\.(\d+)\.(\d+)', root.find('{http://maven.apache.org/POM/4.0.0}version').text)
+
+version_macro = 0
+for i in range(3):
+    version_macro += int(m.group(3 - i)) * (1000 ** i)
+print(version_macro)


### PR DESCRIPTION
### Motivation

[Pulsar Node.js client library](https://github.com/apache/pulsar-client-node) is a wrapping of the C++ client library. If we add a new feature to the Node.js client that uses a recently implemented C function, users will be forced to upgrade the C++ client, even if they don't use that feature. Otherwise, a compile error will  occur when installing the Node.js client.

### Modifications

To solve the above issue, define and expose a macro named `PULSAR_VERSION` in the C++ client. The value of `PULSAR_VERSION` is an integer determined by the following calculation:
```
PULSAR_VERSION = <MAJOR_VERSION> * 10^6 + <MINOR_VERSION> * 10^3 + <PATCH_VERSION>
```
For example, if the version of Pulsar is 2.8.1, `PULSAR_VERSION` is `2008001`.

On the Node.js client side, we will no longer have to force users to upgrade the C++ client by using this macro as follows:
```cpp
#include <pulsar/c/version.h>

#if PULSAR_VERSION >= 2008001
/* Some processing using a C function implemented in Pulsar 2.8.1 or later */
#else
/* Alternative processing */
#endif
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc`


