### PR TITLE
PIP-45: Added BookKeeper metadata adapter based on MetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractHierarchicalLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractHierarchicalLedgerManager.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.zookeeper.AsyncCallback;
+
+@Slf4j
+abstract class AbstractHierarchicalLedgerManager {
+    protected final MetadataStore store;
+    protected final ScheduledExecutorService scheduler;
+    protected final String ledgerRootPath;
+
+    AbstractHierarchicalLedgerManager(MetadataStore store,
+                                      ScheduledExecutorService scheduler,
+                                      String ledgerRootPath) {
+        this.store = store;
+        this.scheduler = scheduler;
+        this.ledgerRootPath = ledgerRootPath;
+    }
+
+    /**
+     * regex expression for name of top level parent znode for ledgers (in
+     * HierarchicalLedgerManager) or znode of a ledger (in FlatLedgerManager).
+     *
+     * @return
+     */
+    protected abstract String getLedgerParentNodeRegex();
+
+    /**
+     * whether the child of ledgersRootPath is a top level parent znode for
+     * ledgers (in HierarchicalLedgerManager) or znode of a ledger (in
+     * FlatLedgerManager).
+     */
+    public boolean isLedgerParentNode(String path) {
+        return path.matches(getLedgerParentNodeRegex());
+    }
+
+    /**
+     * Process hash nodes in a given path.
+     */
+    void asyncProcessLevelNodes(
+            final String path, final BookkeeperInternalCallbacks.Processor<String> processor,
+            final AsyncCallback.VoidCallback finalCb, final Object context,
+            final int successRc, final int failureRc) {
+
+        store.getChildren(path)
+                .thenAccept(levelNodes -> {
+                    if (levelNodes.isEmpty()) {
+                        finalCb.processResult(successRc, null, context);
+                        return;
+                    }
+
+                    AsyncListProcessor<String> listProcessor = new AsyncListProcessor<>(scheduler);
+                    // process its children
+                    listProcessor.process(levelNodes, processor, finalCb, context, successRc, failureRc);
+                }).exceptionally(ex -> {
+                    log.error("Error polling hash nodes of {}: {}", path, ex.getMessage());
+                    finalCb.processResult(failureRc, null, context);
+                    return null;
+                });
+    }
+
+    /**
+     * Process list one by one in asynchronize way. Process will be stopped immediately
+     * when error occurred.
+     */
+    private static class AsyncListProcessor<T> {
+        // use this to prevent long stack chains from building up in callbacks
+        ScheduledExecutorService scheduler;
+
+        /**
+         * Constructor.
+         *
+         * @param scheduler
+         *          Executor used to prevent long stack chains
+         */
+        public AsyncListProcessor(ScheduledExecutorService scheduler) {
+            this.scheduler = scheduler;
+        }
+
+        /**
+         * Process list of items.
+         *
+         * @param data
+         *          List of data to process
+         * @param processor
+         *          Callback to process element of list when success
+         * @param finalCb
+         *          Final callback to be called after all elements in the list are processed
+         * @param context
+         *          Context of final callback
+         * @param successRc
+         *          RC passed to final callback on success
+         * @param failureRc
+         *          RC passed to final callback on failure
+         */
+        public void process(final List<T> data, final BookkeeperInternalCallbacks.Processor<T> processor,
+                            final AsyncCallback.VoidCallback finalCb, final Object context,
+                            final int successRc, final int failureRc) {
+            if (data == null || data.size() == 0) {
+                finalCb.processResult(successRc, null, context);
+                return;
+            }
+            final int size = data.size();
+            final AtomicInteger current = new AtomicInteger(0);
+            T firstElement = data.get(0);
+
+            processor.process(firstElement, new AsyncCallback.VoidCallback() {
+                @Override
+                public void processResult(int rc, String path, Object ctx) {
+                    if (rc != successRc) {
+                        // terminal immediately
+                        finalCb.processResult(failureRc, null, context);
+                        return;
+                    }
+                    // process next element
+                    int next = current.incrementAndGet();
+                    if (next >= size) { // reach the end of list
+                        finalCb.processResult(successRc, null, context);
+                        return;
+                    }
+                    final T dataToProcess = data.get(next);
+                    final AsyncCallback.VoidCallback stub = this;
+                    scheduler.submit(() -> processor.process(dataToProcess, stub));
+                }
+            });
+        }
+
+    }
+
+    // get ledger from all level nodes
+    long getLedgerId(String... levelNodes) throws IOException {
+        return StringUtils.stringToHierarchicalLedgerId(levelNodes);
+    }
+
+    /**
+     * Process ledgers in a single zk node.
+     *
+     * <p>
+     * for each ledger found in this zk node, processor#process(ledgerId) will be triggerred
+     * to process a specific ledger. after all ledgers has been processed, the finalCb will
+     * be called with provided context object. The RC passed to finalCb is decided by :
+     * <ul>
+     * <li> All ledgers are processed successfully, successRc will be passed.
+     * <li> Either ledger is processed failed, failureRc will be passed.
+     * </ul>
+     * </p>
+     *
+     * @param path
+     *          Zk node path to store ledgers
+     * @param processor
+     *          Processor provided to process ledger
+     * @param finalCb
+     *          Callback object when all ledgers are processed
+     * @param ctx
+     *          Context object passed to finalCb
+     * @param successRc
+     *          RC passed to finalCb when all ledgers are processed successfully
+     * @param failureRc
+     *          RC passed to finalCb when either ledger is processed failed
+     */
+    protected void asyncProcessLedgersInSingleNode(
+            final String path, final BookkeeperInternalCallbacks.Processor<Long> processor,
+            final AsyncCallback.VoidCallback finalCb, final Object ctx,
+            final int successRc, final int failureRc) {
+        store.getChildren(path)
+                .thenAccept(ledgerNodes -> {
+                    Set<Long> activeLedgers = HierarchicalLedgerUtils.ledgerListToSet(ledgerNodes, ledgerRootPath, path);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Processing ledgers: {}", activeLedgers);
+                    }
+
+                    // no ledgers found, return directly
+                    if (activeLedgers.isEmpty()) {
+                        finalCb.processResult(successRc, null, ctx);
+                        return;
+                    }
+
+                    BookkeeperInternalCallbacks.MultiCallback
+                            mcb = new BookkeeperInternalCallbacks.MultiCallback(activeLedgers.size(), finalCb, ctx,
+                            successRc, failureRc);
+                    // start loop over all ledgers
+                    for (Long ledger : activeLedgers) {
+                        processor.process(ledger, mcb);
+                    }
+
+                }).exceptionally(ex -> {
+                    finalCb.processResult(failureRc, null, ctx);
+                    return null;
+                });
+    }
+
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import lombok.SneakyThrows;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.LegacyHierarchicalLedgerManagerFactory;
+import org.apache.bookkeeper.meta.exceptions.Code;
+import org.apache.bookkeeper.meta.exceptions.MetadataException;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+public abstract class AbstractMetadataDriver implements Closeable {
+
+    protected static final String METADATA_STORE_SCHEME = "metadata-store";
+
+    public static final String METADATA_STORE_INSTANCE = "metadata-store-instance";
+
+    protected MetadataStoreExtended store;
+    private boolean storeInstanceIsOwned;
+
+    protected RegistrationClient registrationClient;
+    protected RegistrationManager registrationManager;
+    protected LedgerManagerFactory ledgerManagerFactory;
+    protected LayoutManager layoutManager;
+    protected AbstractConfiguration conf;
+    protected String ledgersRootPath;
+
+    protected void initialize(AbstractConfiguration conf) throws MetadataException {
+        this.conf = conf;
+        this.ledgersRootPath = resolveLedgersRootPath();
+        createMetadataStore();
+        this.registrationClient = new PulsarRegistrationClient(store, ledgersRootPath);
+        this.registrationManager = new PulsarRegistrationManager(store, ledgersRootPath, conf);
+        this.layoutManager = new PulsarLayoutManager(store, ledgersRootPath);
+        this.ledgerManagerFactory = new PulsarLedgerManagerFactory();
+
+        try {
+            ledgerManagerFactory.initialize(conf, layoutManager, LegacyHierarchicalLedgerManagerFactory.CUR_VERSION);
+        } catch (IOException e) {
+            throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
+        }
+    }
+
+    @SneakyThrows
+    @Override
+    public void close() {
+        if (registrationClient != null) {
+            registrationClient.close();
+        }
+
+        if (registrationManager != null) {
+            registrationManager.close();
+        }
+
+        if (ledgerManagerFactory != null) {
+            ledgerManagerFactory.close();
+        }
+
+        if (store != null && storeInstanceIsOwned) {
+            store.close();
+        }
+    }
+
+    void createMetadataStore() throws MetadataException {
+        Object instance = conf.getProperty(METADATA_STORE_INSTANCE);
+        if (instance != null) {
+            // We have been passed a metadata store instance, so we're going to use that instead of creating a new
+            // instance
+            this.store = (MetadataStoreExtended) instance;
+            this.storeInstanceIsOwned = false;
+        } else {
+
+            String url;
+            try {
+                url = conf.getMetadataServiceUri().replaceFirst(METADATA_STORE_SCHEME + ":", "");
+            } catch (Exception e) {
+                throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
+            }
+            try {
+                this.store = MetadataStoreExtended.create(url,
+                        MetadataStoreConfig.builder()
+                                .sessionTimeoutMillis(conf.getZkTimeout())
+                                .build());
+                this.storeInstanceIsOwned = true;
+            } catch (MetadataStoreException e) {
+                throw new MetadataException(Code.METADATA_SERVICE_ERROR, e);
+            }
+        }
+    }
+
+    public String getScheme() {
+        return METADATA_STORE_SCHEME;
+    }
+
+    @SuppressWarnings("deprecation")
+    private String resolveLedgersRootPath() {
+        String metadataServiceUriStr = conf.getMetadataServiceUriUnchecked();
+        if (metadataServiceUriStr == null) {
+            return conf.getZkLedgersRootPath();
+        }
+        URI metadataServiceUri = URI.create(metadataServiceUriStr);
+        String path = metadataServiceUri.getPath();
+        return path == null ? "/ledgers" : path;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
+import org.apache.bookkeeper.server.service.BookieService;
+import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.Stat;
+
+@Slf4j
+public class BookieServiceInfoSerde implements MetadataSerde<BookieServiceInfo> {
+
+    private BookieServiceInfoSerde() {
+    }
+
+    static final BookieServiceInfoSerde INSTANCE = new BookieServiceInfoSerde();
+
+    @Override
+    public byte[] serialize(String path, BookieServiceInfo bookieServiceInfo) throws IOException {
+        if (log.isDebugEnabled()) {
+            log.debug("serialize BookieServiceInfo {}", bookieServiceInfo);
+        }
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            BookieServiceInfoFormat.Builder builder = BookieServiceInfoFormat.newBuilder();
+            List<BookieServiceInfoFormat.Endpoint> bsiEndpoints = bookieServiceInfo.getEndpoints().stream()
+                    .map(e -> BookieServiceInfoFormat.Endpoint.newBuilder()
+                                .setId(e.getId())
+                                .setPort(e.getPort())
+                                .setHost(e.getHost())
+                                .setProtocol(e.getProtocol())
+                                .addAllAuth(e.getAuth())
+                                .addAllExtensions(e.getExtensions())
+                                .build())
+                    .collect(Collectors.toList());
+
+            builder.addAllEndpoints(bsiEndpoints);
+            builder.putAllProperties(bookieServiceInfo.getProperties());
+
+            builder.build().writeTo(os);
+            return os.toByteArray();
+        }
+    }
+
+    @Override
+    public BookieServiceInfo deserialize(String path, byte[] content, Stat stat) throws IOException {
+        return null;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/CombinedLedgerRangeIterator.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/CombinedLedgerRangeIterator.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import org.apache.bookkeeper.meta.LedgerManager;
+
+public class CombinedLedgerRangeIterator implements LedgerManager.LedgerRangeIterator {
+    private final LedgerManager.LedgerRangeIterator iteratorA;
+    private final LedgerManager.LedgerRangeIterator iteratorB;
+
+    CombinedLedgerRangeIterator(LedgerManager.LedgerRangeIterator iteratorA,
+                                    LedgerManager.LedgerRangeIterator iteratorB) {
+        this.iteratorA = iteratorA;
+        this.iteratorB = iteratorB;
+    }
+
+    @Override
+    public boolean hasNext() throws IOException {
+        return iteratorA.hasNext() || iteratorB.hasNext();
+    }
+
+    @Override
+    public LedgerManager.LedgerRange next() throws IOException {
+        if (iteratorA.hasNext()) {
+            return iteratorA.next();
+        }
+        return iteratorB.next();
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/HierarchicalLedgerUtils.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/HierarchicalLedgerUtils.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.AbstractZkLedgerManager;
+
+@UtilityClass
+@Slf4j
+class HierarchicalLedgerUtils {
+    /**
+     * Get all ledger ids in the given zk path.
+     *
+     * @param ledgerNodes
+     *          List of ledgers in the given path
+     *          example:- {L1652, L1653, L1650}
+     * @param path
+     *          The zookeeper path of the ledger ids. The path should start with {@ledgerRootPath}
+     *          example (with ledgerRootPath = /ledgers):- /ledgers/00/0053
+     */
+    NavigableSet<Long> ledgerListToSet(List<String> ledgerNodes, String ledgerRootPath, String path) {
+        NavigableSet<Long> zkActiveLedgers = new TreeSet<>();
+
+        if (!path.startsWith(ledgerRootPath)) {
+            log.warn("Ledger path [{}] is not a valid path name, it should start wth {}", path, ledgerRootPath);
+            return zkActiveLedgers;
+        }
+
+        long ledgerIdPrefix = 0;
+        char ch;
+        for (int i = ledgerRootPath.length() + 1; i < path.length(); i++) {
+            ch = path.charAt(i);
+            if (ch < '0' || ch > '9') {
+                continue;
+            }
+            ledgerIdPrefix = ledgerIdPrefix * 10 + (ch - '0');
+        }
+
+        for (String ledgerNode : ledgerNodes) {
+            if (AbstractZkLedgerManager.isSpecialZnode(ledgerNode)) {
+                continue;
+            }
+            long ledgerId = ledgerIdPrefix;
+            for (int i = 0; i < ledgerNode.length(); i++) {
+                ch = ledgerNode.charAt(i);
+                if (ch < '0' || ch > '9') {
+                    continue;
+                }
+                ledgerId = ledgerId * 10 + (ch - '0');
+            }
+            zkActiveLedgers.add(ledgerId);
+        }
+        return zkActiveLedgers;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LegacyHierarchicalLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LegacyHierarchicalLedgerManager.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.zookeeper.AsyncCallback;
+
+class LegacyHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
+
+    LegacyHierarchicalLedgerManager(MetadataStore store,
+                                    ScheduledExecutorService scheduler,
+                                    String ledgerRootPath) {
+        super(store, scheduler, ledgerRootPath);
+    }
+
+    @Override
+    protected String getLedgerParentNodeRegex() {
+        return StringUtils.LEGACYHIERARCHICAL_LEDGER_PARENT_NODE_REGEX;
+    }
+
+    public void asyncProcessLedgers(final BookkeeperInternalCallbacks.Processor<Long> processor,
+                                    final AsyncCallback.VoidCallback finalCb, final Object context,
+                                    final int successRc, final int failureRc) {
+        // process 1st level nodes
+        asyncProcessLevelNodes(ledgerRootPath, (l1Node, cb1) -> {
+            if (!isLedgerParentNode(l1Node)) {
+                cb1.processResult(successRc, null, context);
+                return;
+            }
+
+            String l1NodePath = ledgerRootPath + "/" + l1Node;
+            // process level1 path, after all children of level1 process
+            // it callback to continue processing next level1 node
+            asyncProcessLevelNodes(l1NodePath, (l2Node, cb2) -> {
+                // process level1/level2 path
+                String l2NodePath = ledgerRootPath + "/" + l1Node + "/" + l2Node;
+                // process each ledger
+                // after all ledger are processed, cb2 will be call to continue processing next level2 node
+                asyncProcessLedgersInSingleNode(l2NodePath, processor, cb2,
+                        context, successRc, failureRc);
+            }, cb1, context, successRc, failureRc);
+        }, finalCb, context, successRc, failureRc);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LegacyHierarchicalLedgerRangeIterator.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LegacyHierarchicalLedgerRangeIterator.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+
+/**
+ * Hierarchical Ledger Manager which manages ledger meta in zookeeper using 2-level hierarchical znodes.
+ *
+ * <p>LegacyHierarchicalLedgerManager splits the generated id into 3 parts (2-4-4):
+ * <pre>&lt;level1 (2 digits)&gt;&lt;level2 (4 digits)&gt;&lt;level3 (4 digits)&gt;</pre>
+ * These 3 parts are used to form the actual ledger node path used to store ledger metadata:
+ * <pre>(ledgersRootPath)/level1/level2/L(level3)</pre>
+ * E.g Ledger 0000000001 is split into 3 parts <i>00</i>, <i>0000</i>, <i>0001</i>, which is stored in
+ * <i>(ledgersRootPath)/00/0000/L0001</i>. So each znode could have at most 10000 ledgers, which avoids
+ * errors during garbage collection due to lists of children that are too long.
+ */
+@Slf4j
+public class LegacyHierarchicalLedgerRangeIterator implements LedgerManager.LedgerRangeIterator {
+
+    private static final String MAX_ID_SUFFIX = "9999";
+    private static final String MIN_ID_SUFFIX = "0000";
+
+
+    private final MetadataStore store;
+    private final String ledgersRoot;
+
+    private Iterator<String> l1NodesIter = null;
+    private Iterator<String> l2NodesIter = null;
+    private String curL1Nodes = "";
+    private boolean iteratorDone = false;
+    private LedgerManager.LedgerRange nextRange = null;
+
+    public LegacyHierarchicalLedgerRangeIterator(MetadataStore store, String ledgersRoot) {
+        this.store = store;
+        this.ledgersRoot = ledgersRoot;
+    }
+
+    /**
+     * Iterate next level1 znode.
+     *
+     * @return false if have visited all level1 nodes
+     * @throws InterruptedException/KeeperException if error occurs reading zookeeper children
+     */
+    private boolean nextL1Node() throws ExecutionException, InterruptedException {
+        l2NodesIter = null;
+        while (l2NodesIter == null) {
+            if (l1NodesIter.hasNext()) {
+                curL1Nodes = l1NodesIter.next();
+            } else {
+                return false;
+            }
+            // Top level nodes are always exactly 2 digits long. (Don't pick up long hierarchical top level nodes)
+            if (!isLedgerParentNode(curL1Nodes)) {
+                continue;
+            }
+            List<String> l2Nodes = store.getChildren(ledgersRoot + "/" + curL1Nodes).get();
+            l2NodesIter = l2Nodes.iterator();
+            if (!l2NodesIter.hasNext()) {
+                l2NodesIter = null;
+                continue;
+            }
+        }
+        return true;
+    }
+
+    private synchronized void preload() throws IOException {
+        while (nextRange == null && !iteratorDone) {
+            boolean hasMoreElements = false;
+            try {
+                if (l1NodesIter == null) {
+                    List<String> l1Nodes = store.getChildren(ledgersRoot).get();
+                    l1NodesIter = l1Nodes.iterator();
+                    hasMoreElements = nextL1Node();
+                } else if (l2NodesIter == null || !l2NodesIter.hasNext()) {
+                    hasMoreElements = nextL1Node();
+                } else {
+                    hasMoreElements = true;
+                }
+            } catch (ExecutionException ke) {
+                throw new IOException("Error preloading next range", ke);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while preloading", ie);
+            }
+            if (hasMoreElements) {
+                nextRange = getLedgerRangeByLevel(curL1Nodes, l2NodesIter.next());
+                if (nextRange.size() == 0) {
+                    nextRange = null;
+                }
+            } else {
+                iteratorDone = true;
+            }
+        }
+    }
+
+    @Override
+    public synchronized boolean hasNext() throws IOException {
+        preload();
+        return nextRange != null && !iteratorDone;
+    }
+
+    @Override
+    public synchronized LedgerManager.LedgerRange next() throws IOException {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        LedgerManager.LedgerRange r = nextRange;
+        nextRange = null;
+        return r;
+    }
+
+    private static final ThreadLocal<StringBuilder> threadLocalNodeBuilder =
+            ThreadLocal.withInitial(() -> new StringBuilder());
+
+    /**
+     * Get a single node level1/level2.
+     *
+     * @param level1
+     *          1st level node name
+     * @param level2
+     *          2nd level node name
+     * @throws IOException
+     */
+    LedgerManager.LedgerRange getLedgerRangeByLevel(final String level1, final String level2)
+            throws IOException {
+        StringBuilder nodeBuilder = threadLocalNodeBuilder.get();
+        nodeBuilder.setLength(0);
+        nodeBuilder.append(ledgersRoot).append("/")
+                .append(level1).append("/").append(level2);
+        String nodePath = nodeBuilder.toString();
+        List<String> ledgerNodes = null;
+        try {
+            ledgerNodes = store.getChildren(nodePath).get();
+        } catch (ExecutionException e) {
+            throw new IOException("Error when get child nodes from zk", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Error when get child nodes from zk", e);
+        }
+        NavigableSet<Long> zkActiveLedgers =
+                HierarchicalLedgerUtils.ledgerListToSet(ledgerNodes, ledgersRoot, nodePath);
+        if (log.isDebugEnabled()) {
+            log.debug("All active ledgers from ZK for hash node "
+                    + level1 + "/" + level2 + " : " + zkActiveLedgers);
+        }
+
+        return new LedgerManager.LedgerRange(zkActiveLedgers.subSet(getStartLedgerIdByLevel(level1, level2), true,
+                getEndLedgerIdByLevel(level1, level2), true));
+    }
+
+    /**
+     * Get the smallest cache id in a specified node /level1/level2.
+     *
+     * @param level1
+     *          1st level node name
+     * @param level2
+     *          2nd level node name
+     * @return the smallest ledger id
+     */
+    private long getStartLedgerIdByLevel(String level1, String level2) throws IOException {
+        return StringUtils.stringToHierarchicalLedgerId(level1, level2, MIN_ID_SUFFIX);
+    }
+
+    /**
+     * Get the largest cache id in a specified node /level1/level2.
+     *
+     * @param level1
+     *          1st level node name
+     * @param level2
+     *          2nd level node name
+     * @return the largest ledger id
+     */
+    private long getEndLedgerIdByLevel(String level1, String level2) throws IOException {
+        return StringUtils.stringToHierarchicalLedgerId(level1, level2, MAX_ID_SUFFIX);
+    }
+
+    private boolean isLedgerParentNode(String path) {
+        return path.matches(StringUtils.LEGACYHIERARCHICAL_LEDGER_PARENT_NODE_REGEX);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LongHierarchicalLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LongHierarchicalLedgerManager.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.zookeeper.AsyncCallback;
+
+@Slf4j
+class LongHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
+    public LongHierarchicalLedgerManager(MetadataStore store, ScheduledExecutorService scheduler,
+                                         String ledgerRootPath) {
+        super(store, scheduler, ledgerRootPath);
+    }
+
+    public long getLedgerId(String pathName) throws IOException {
+        if (!pathName.startsWith(ledgerRootPath)) {
+            throw new IOException("it is not a valid hashed path name : " + pathName);
+        }
+        String hierarchicalPath = pathName.substring(ledgerRootPath.length() + 1);
+        return StringUtils.stringToLongHierarchicalLedgerId(hierarchicalPath);
+    }
+
+    public String getLedgerPath(long ledgerId) {
+        return ledgerRootPath + StringUtils.getLongHierarchicalLedgerPath(ledgerId);
+    }
+
+    //
+    // Active Ledger Manager
+    //
+
+    public void asyncProcessLedgers(final BookkeeperInternalCallbacks.Processor<Long> processor,
+                                    final AsyncCallback.VoidCallback finalCb,
+                                    final Object context, final int successRc, final int failureRc) {
+
+        // If it succeeds, proceed with our own recursive ledger processing for the 63-bit id ledgers
+        asyncProcessLevelNodes(ledgerRootPath,
+                new RecursiveProcessor(0, ledgerRootPath, processor, context, successRc, failureRc), finalCb, context,
+                successRc, failureRc);
+    }
+
+    private class RecursiveProcessor implements BookkeeperInternalCallbacks.Processor<String> {
+        private final int level;
+        private final String path;
+        private final BookkeeperInternalCallbacks.Processor<Long> processor;
+        private final Object context;
+        private final int successRc;
+        private final int failureRc;
+
+        private RecursiveProcessor(int level, String path, BookkeeperInternalCallbacks.Processor<Long> processor,
+                                   Object context, int successRc,
+                                   int failureRc) {
+            this.level = level;
+            this.path = path;
+            this.processor = processor;
+            this.context = context;
+            this.successRc = successRc;
+            this.failureRc = failureRc;
+        }
+
+        @Override
+        public void process(String lNode, AsyncCallback.VoidCallback cb) {
+            String nodePath = path + "/" + lNode;
+            if ((level == 0) && !isLedgerParentNode(lNode)) {
+                cb.processResult(successRc, null, context);
+                return;
+            } else if (level < 3) {
+                asyncProcessLevelNodes(nodePath,
+                        new RecursiveProcessor(level + 1, nodePath, processor, context, successRc, failureRc), cb,
+                        context, successRc, failureRc);
+            } else {
+                // process each ledger after all ledger are processed, cb will be call to continue processing next
+                // level4 node
+                asyncProcessLedgersInSingleNode(nodePath, processor, cb, context, successRc, failureRc);
+            }
+        }
+    }
+
+    @Override
+    protected String getLedgerParentNodeRegex() {
+        return StringUtils.LONGHIERARCHICAL_LEDGER_PARENT_NODE_REGEX;
+    }
+
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LongHierarchicalLedgerRangeIterator.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/LongHierarchicalLedgerRangeIterator.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.pulsar.metadata.api.MetadataStore;
+
+/**
+ * Iterates recursively through each metadata bucket.
+ */
+@Slf4j
+class LongHierarchicalLedgerRangeIterator implements LedgerManager.LedgerRangeIterator {
+
+    private final MetadataStore store;
+    private final String ledgerRootPath;
+    LedgerManager.LedgerRangeIterator rootIterator;
+
+
+    LongHierarchicalLedgerRangeIterator(MetadataStore store, String ledgerRootPath) {
+        this.store = store;
+        this.ledgerRootPath = ledgerRootPath;
+    }
+
+    /**
+     * Returns all children with path as a parent.  If path is non-existent,
+     * returns an empty list anyway (after all, there are no children there).
+     * Maps all exceptions (other than NoNode) to IOException in keeping with
+     * LedgerRangeIterator.
+     *
+     * @param path
+     * @return Iterator into set of all children with path as a parent
+     * @throws IOException
+     */
+    List<String> getChildrenAt(String path) throws IOException {
+        try {
+            return store.getChildren(path).get();
+        } catch (ExecutionException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to ", path);
+            }
+            throw new IOException(e);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while reading ledgers at path " + path, ie);
+        }
+    }
+
+    /**
+     * Represents the ledger range rooted at a leaf node, returns at most one LedgerRange.
+     */
+    class LeafIterator implements LedgerManager.LedgerRangeIterator {
+        // Null iff iteration is complete
+        LedgerManager.LedgerRange range;
+
+        LeafIterator(String path) throws IOException {
+            List<String> ledgerLeafNodes = getChildrenAt(path);
+            Set<Long> ledgerIds = HierarchicalLedgerUtils.ledgerListToSet(ledgerLeafNodes, ledgerRootPath, path);
+            if (log.isDebugEnabled()) {
+                log.debug("All active ledgers from ZK for hash node {}: {}", path, ledgerIds);
+            }
+            if (!ledgerIds.isEmpty()) {
+                range = new LedgerManager.LedgerRange(ledgerIds);
+            } // else, hasNext() should return false so that advance will skip us and move on
+        }
+
+        @Override
+        public boolean hasNext() throws IOException {
+            return range != null;
+        }
+
+        @Override
+        public LedgerManager.LedgerRange next() throws IOException {
+            if (range == null) {
+                throw new NoSuchElementException(
+                        "next() must only be called if hasNext() is true");
+            }
+            LedgerManager.LedgerRange ret = range;
+            range = null;
+            return ret;
+        }
+    }
+
+
+    /**
+     * The main constraint is that between calls one of two things must be true.
+     * 1) nextLevelIterator is null and thisLevelIterator.hasNext() == false: iteration complete, hasNext()
+     *    returns false
+     * 2) nextLevelIterator is non-null: nextLevelIterator.hasNext() must return true and nextLevelIterator.next()
+     *    must return the next LedgerRange
+     * The above means that nextLevelIterator != null ==> nextLevelIterator.hasNext()
+     * It also means that hasNext() iff nextLevelIterator != null
+     */
+    private class InnerIterator implements LedgerManager.LedgerRangeIterator {
+        final String path;
+        final int level;
+
+        // Always non-null
+        final Iterator<String> thisLevelIterator;
+        // non-null iff nextLevelIterator.hasNext() is true
+        LedgerManager.LedgerRangeIterator nextLevelIterator;
+
+        /**
+         * Builds InnerIterator.
+         *
+         * @param path Subpath for thisLevelIterator
+         * @param level Level of thisLevelIterator (must be <= 3)
+         * @throws IOException
+         */
+        InnerIterator(String path, int level) throws IOException {
+            this.path = path;
+            this.level = level;
+            thisLevelIterator = getChildrenAt(path).iterator();
+            advance();
+        }
+
+        /**
+         * Resolves the difference between cases 1 and 2 after nextLevelIterator is exhausted.
+         * Pre-condition: nextLevelIterator == null, thisLevelIterator != null
+         * Post-condition: nextLevelIterator == null && !thisLevelIterator.hasNext() OR
+         *                 nextLevelIterator.hasNext() == true and nextLevelIterator.next()
+         *                 yields the next result of next()
+         * @throws IOException Exception representing error
+         */
+        void advance() throws IOException {
+            while (thisLevelIterator.hasNext()) {
+                String node = thisLevelIterator.next();
+                if (level == 0 && !isLedgerParentNode(node)) {
+                    continue;
+                }
+                LedgerManager.LedgerRangeIterator nextIterator = level < 3
+                        ? new InnerIterator(path + "/" + node, level + 1)
+                        : new LeafIterator(path + "/" + node);
+                if (nextIterator.hasNext()) {
+                    nextLevelIterator = nextIterator;
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() throws IOException {
+            return nextLevelIterator != null;
+        }
+
+        @Override
+        public LedgerManager.LedgerRange next() throws IOException {
+            LedgerManager.LedgerRange ret = nextLevelIterator.next();
+            if (!nextLevelIterator.hasNext()) {
+                nextLevelIterator = null;
+                advance();
+            }
+            return ret;
+        }
+    }
+
+    private void bootstrap() throws IOException {
+        if (rootIterator == null) {
+            rootIterator = new InnerIterator(ledgerRootPath, 0);
+        }
+    }
+
+    @Override
+    public synchronized boolean hasNext() throws IOException {
+        bootstrap();
+        return rootIterator.hasNext();
+    }
+
+    @Override
+    public synchronized LedgerManager.LedgerRange next() throws IOException {
+        bootstrap();
+        return rootIterator.next();
+    }
+
+    /**
+     * whether the child of ledgersRootPath is a top level parent znode for
+     * ledgers (in HierarchicalLedgerManager) or znode of a ledger (in
+     * FlatLedgerManager).
+     *
+     */
+    public boolean isLedgerParentNode(String path) {
+        return path.matches(StringUtils.LONGHIERARCHICAL_LEDGER_PARENT_NODE_REGEX);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManager.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerLayout;
+import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+class PulsarLayoutManager implements LayoutManager {
+
+    @Getter(AccessLevel.PACKAGE)
+    private final MetadataStoreExtended store;
+
+    @Getter(AccessLevel.PACKAGE)
+    private final String ledgersRootPath;
+
+    private final String layoutPath;
+
+    PulsarLayoutManager(MetadataStoreExtended store, String ledgersRootPath) {
+        this.ledgersRootPath = ledgersRootPath;
+        this.store = store;
+        this.layoutPath = ledgersRootPath + "/" + BookKeeperConstants.LAYOUT_ZNODE;
+    }
+
+    @Override
+    public LedgerLayout readLedgerLayout() throws IOException {
+        try {
+            byte[] layoutData = store.get(layoutPath).get()
+                    .orElseThrow(() -> new BookieException.MetadataStoreException("Layout node not found"))
+                    .getValue();
+            return LedgerLayout.parseLayout(layoutData);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (BookieException | ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void storeLedgerLayout(LedgerLayout ledgerLayout) throws IOException {
+        try {
+            byte[] layoutData = ledgerLayout.serialize();
+
+            store.put(layoutPath, layoutData, Optional.of(-1L)).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof MetadataStoreException.BadVersionException) {
+                throw new LedgerLayoutExistsException(e);
+            } else {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Override
+    public void deleteLedgerLayout() throws IOException {
+        try {
+            store.delete(layoutPath, Optional.empty()).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManager.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.LedgerAuditorManager;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
+import org.apache.pulsar.metadata.api.coordination.LeaderElection;
+import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+
+@Slf4j
+class PulsarLedgerAuditorManager implements LedgerAuditorManager {
+
+    private static final String ELECTION_PATH = "leader";
+
+    private final CoordinationService coordinationService;
+    private final LeaderElection<String> leaderElection;
+    private LeaderElectionState leaderElectionState;
+    private String bookieId;
+
+    PulsarLedgerAuditorManager(MetadataStoreExtended store, String ledgersRoot) {
+        this.coordinationService = new CoordinationServiceImpl(store);
+        String electionPath = ledgersRoot + "/" + BookKeeperConstants.UNDER_REPLICATION_NODE
+                + "/" + ELECTION_PATH;
+
+        this.leaderElection =
+                coordinationService.getLeaderElection(String.class, electionPath, this::handleStateChanges);
+        this.leaderElectionState = LeaderElectionState.NoLeader;
+    }
+
+    private void handleStateChanges(LeaderElectionState state) {
+        log.info("Auditor leader election state: {} -- BookieId: {}", state, bookieId);
+
+        synchronized (this) {
+            this.leaderElectionState = state;
+            notifyAll();
+        }
+    }
+
+    @Override
+    public void tryToBecomeAuditor(String bookieId, Consumer<AuditorEvent> listener) {
+        this.bookieId = bookieId;
+
+        LeaderElectionState les = leaderElection.elect(bookieId).join();
+
+        synchronized (this) {
+            leaderElectionState = les;
+        }
+
+        while (true) {
+            try {
+                synchronized (this) {
+                    if (leaderElectionState == LeaderElectionState.Leading) {
+                        return;
+                    } else {
+                        wait();
+                    }
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public BookieId getCurrentAuditor() {
+        return leaderElection.getLeaderValue()
+                .join()
+                .map(BookieId::parse)
+                .orElse(null);
+    }
+
+    @Override
+    public void close() throws Exception {
+        leaderElection.close();
+        coordinationService.close();
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGenerator.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGenerator.java
@@ -1,0 +1,250 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.meta.LedgerIdGenerator;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+@Slf4j
+public class PulsarLedgerIdGenerator implements LedgerIdGenerator {
+
+    private final MetadataStoreExtended store;
+    private final String ledgerIdGenPath;
+    private final String shortIdGenPath;
+
+    private static final String IDGEN_NODE = "idgen-long";
+    private static final String IDGEN_SHORT_NODE = "idgen";
+
+    private static final String SHORT_ID_PREFIX = "ID-";
+
+    public PulsarLedgerIdGenerator(MetadataStoreExtended store, String ledgersRoot) {
+        this.store = store;
+        this.ledgerIdGenPath = ledgersRoot + "/" + IDGEN_NODE;
+        this.shortIdGenPath = ledgersRoot + "/" + IDGEN_SHORT_NODE;
+    }
+
+    @Override
+    public void generateLedgerId(BookkeeperInternalCallbacks.GenericCallback<Long> genericCallback) {
+        ledgerIdGenPathPresent()
+                .thenCompose(isIdGenPathPresent -> {
+                    if (isIdGenPathPresent) {
+                        // We've already started generating 63-bit ledger IDs.
+                        // Keep doing that.
+                        return generateLongLedgerId();
+                    } else {
+                        // We've not moved onto 63-bit ledgers yet.
+                        return generateShortLedgerId();
+                    }
+                }).thenAccept(ledgerId ->
+                genericCallback.operationComplete(BKException.Code.OK, ledgerId)
+        ).exceptionally(ex -> {
+            genericCallback.operationComplete(BKException.Code.MetaStoreException, -1L);
+            return null;
+        });
+
+    }
+
+    private CompletableFuture<Long> generateShortLedgerId() {
+        final String ledgerPrefix = this.ledgerIdGenPath + "/" + SHORT_ID_PREFIX;
+
+        return store.put(ledgerPrefix, new byte[0], Optional.of(-1L),
+                EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential))
+                .thenCompose(stat -> {
+                    // delete the znode for id generation
+                    store.delete(stat.getPath(), Optional.empty()).
+                            exceptionally(ex -> {
+                                log.warn("Exception during deleting node for id generation : {}", ex);
+                                return null;
+                            });
+
+                    // Extract ledger id from generated path
+                    long ledgerId;
+                    try {
+                        ledgerId = getLedgerIdFromGenPath(stat.getPath(), ledgerPrefix);
+                        if (ledgerId < 0 || ledgerId >= Integer.MAX_VALUE) {
+                            // 31-bit IDs overflowed. Start using 63-bit ids.
+                            return store.put(ledgerIdGenPath, new byte[0], Optional.empty())
+                                    .thenCompose(__ -> generateLongLedgerId());
+                        } else {
+                            return CompletableFuture.completedFuture(ledgerId);
+                        }
+                    } catch (IOException e) {
+                        log.error("Could not extract ledger-id from id gen path:" + stat.getPath(), e);
+                        return FutureUtil.failedFuture(e);
+                    }
+                });
+    }
+
+    private CompletableFuture<Long> generateLongLedgerId() {
+        final String hobPrefix = "HOB-";
+        final String ledgerPrefix = this.ledgerIdGenPath + "/" + hobPrefix;
+
+        return store.getChildren(ledgerIdGenPath).thenCompose(highOrderDirectories -> {
+            Optional<Long> largest = highOrderDirectories.stream().map((t) -> {
+                try {
+                    return Long.parseLong(t.replace(hobPrefix, ""));
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }).filter((t) -> t != null)
+                    .reduce(Math::max);
+
+            // If we didn't get any valid IDs from the directory...
+            if (!largest.isPresent()) {
+                // else, Start at HOB-0000000001;
+                return createHOBPathAndGenerateId(ledgerPrefix, 1);
+            }
+
+            // Found the largest.
+            // Get the low-order bits.
+            final Long highBits = largest.get();
+            return generateLongLedgerIdLowBits(ledgerPrefix, highBits)
+                    .thenApply(ledgerId -> {
+                        // Perform garbage collection on HOB- directories.
+                        // Keeping 3 should be plenty to prevent races
+                        if (highOrderDirectories.size() > 3) {
+                            Object[] highOrderDirs = highOrderDirectories.stream()
+                                    .map((t) -> {
+                                        try {
+                                            return Long.parseLong(t.replace(hobPrefix, ""));
+                                        } catch (NumberFormatException e) {
+                                            return null;
+                                        }
+                                    })
+                                    .filter((t) -> t != null)
+                                    .sorted()
+                                    .toArray();
+
+                            for (int i = 0; i < highOrderDirs.length - 3; i++) {
+                                String path = ledgerPrefix + formatHalfId(((Long) highOrderDirs[i]).intValue());
+                                if (log.isDebugEnabled()) {
+                                    log.debug("DELETING HIGH ORDER DIR: {}", path);
+                                }
+                                store.delete(path, Optional.of(0L));
+                            }
+                        }
+
+                        return ledgerId;
+                    });
+        });
+    }
+
+    /**
+     * Formats half an ID as 10-character 0-padded string.
+     * @param i - 32 bits of the ID to format
+     * @return a 10-character 0-padded string.
+     */
+    private String formatHalfId(int i) {
+        return String.format("%010d", i);
+    }
+
+    private CompletableFuture<Long> createHOBPathAndGenerateId(String ledgerPrefix, int hob) {
+        if (log.isDebugEnabled()) {
+            log.debug("Creating HOB path: {}", ledgerPrefix + formatHalfId(hob));
+        }
+
+        return store.put(ledgerPrefix + formatHalfId(hob), new byte[0], Optional.empty())
+                .thenCompose(__ ->
+                        // We just created a new HOB directory, try again
+                        generateLongLedgerId());
+    }
+
+    private CompletableFuture<Long> generateLongLedgerIdLowBits(final String ledgerPrefix, long highBits) {
+        String highPath = ledgerPrefix + formatHalfId((int) highBits);
+        return generateLedgerIdImpl(createLedgerPrefix(highPath, null))
+                .thenCompose(result -> {
+                    if (result >= 0L && result < 2147483647L) {
+                        return CompletableFuture.completedFuture((highBits << 32) | result);
+                    } else {
+                        // Lower bits are full. Need to expand and create another HOB node.
+                        Long newHighBits = highBits + 1;
+                        return createHOBPathAndGenerateId(ledgerPrefix, newHighBits.intValue());
+                    }
+                });
+    }
+
+    public CompletableFuture<Long> generateLedgerIdImpl(final String prefix) {
+        return store
+                .put(prefix, new byte[0], Optional.of(-1L), EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential))
+                .thenCompose(stat -> {
+
+                    // delete the znode for id generation
+                    store.delete(stat.getPath(), Optional.empty()).
+                            exceptionally(ex -> {
+                                log.warn("Exception during deleting node for id generation : {}", ex);
+                                return null;
+                            });
+
+                    try {
+                        long ledgerId = getLedgerIdFromGenPath(stat.getPath(), prefix);
+                        return CompletableFuture.completedFuture(ledgerId);
+                    } catch (IOException e) {
+                        log.error("Could not extract ledger-id from id gen path:" + stat.getPath(), e);
+                        return FutureUtil.failedFuture(e);
+                    }
+                });
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    /**
+     * Checks the existence of the long ledger id gen path. Existence indicates we have switched from the legacy
+     * algorithm to the new method of generating 63-bit ids. If the existence is UNKNOWN, it looks in zk to
+     * find out. If it previously checked in zk, it returns that value. This value changes when we run out
+     * of ids < Integer.MAX_VALUE, and try to create the long ledger id gen path.
+     */
+    public CompletableFuture<Boolean> ledgerIdGenPathPresent() {
+        return store.exists(ledgerIdGenPath);
+    }
+
+    private static long getLedgerIdFromGenPath(String nodeName, String ledgerPrefix) throws IOException {
+        try {
+            String[] parts = nodeName.split(ledgerPrefix);
+            long ledgerId = Long.parseLong(parts[parts.length - 1]);
+            return ledgerId;
+        } catch (NumberFormatException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static String createLedgerPrefix(String ledgersPath, String idGenZnodeName) {
+        String ledgerIdGenPath = null;
+        if (StringUtils.isBlank(idGenZnodeName)) {
+            ledgerIdGenPath = ledgersPath;
+        } else {
+            ledgerIdGenPath = ledgersPath + "/" + idGenZnodeName;
+        }
+
+        return ledgerIdGenPath + "/" + "ID-";
+    }
+
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManager.java
@@ -1,0 +1,415 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.LedgerMetadataBuilder;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerMetadataSerDe;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.util.StringUtils;
+import org.apache.bookkeeper.versioning.LongVersion;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.Stat;
+import org.apache.zookeeper.AsyncCallback;
+
+@Slf4j
+public class PulsarLedgerManager implements LedgerManager {
+
+    private final String ledgerRootPath;
+    private final MetadataStore store;
+    private final MetadataCache<LedgerMetadata> cache;
+    private final LedgerMetadataSerDe serde;
+
+    private final LegacyHierarchicalLedgerManager legacyLedgerManager;
+    private final LongHierarchicalLedgerManager longLedgerManager;
+
+    private final ScheduledExecutorService scheduler = Executors
+            .newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-bk-ledger-manager-scheduler"));
+
+    // ledger metadata listeners
+    protected final ConcurrentMap<Long, Set<BookkeeperInternalCallbacks.LedgerMetadataListener>> listeners =
+            new ConcurrentHashMap<>();
+
+    PulsarLedgerManager(MetadataStore store, String ledgersRootPath) {
+        this.ledgerRootPath = ledgersRootPath;
+        this.store = store;
+        this.legacyLedgerManager = new LegacyHierarchicalLedgerManager(store, scheduler, ledgerRootPath);
+        this.longLedgerManager = new LongHierarchicalLedgerManager(store, scheduler, ledgerRootPath);
+        this.serde = new LedgerMetadataSerDe();
+        this.cache = store.getMetadataCache(new MetadataSerde<LedgerMetadata>() {
+            @Override
+            public byte[] serialize(String path, LedgerMetadata value) throws IOException {
+                return serde.serialize(value);
+            }
+
+            @Override
+            public LedgerMetadata deserialize(String path, byte[] content, Stat stat) throws IOException {
+                return serde.parseConfig(content, getLedgerId(path), Optional.of(stat.getCreationTimestamp()));
+            }
+        });
+
+        store.registerListener(this::handleDataNotification);
+    }
+
+    @Override
+    public CompletableFuture<Versioned<LedgerMetadata>> createLedgerMetadata(long ledgerId,
+                                                                             LedgerMetadata inputMetadata) {
+        final LedgerMetadata metadata;
+        if (inputMetadata.getMetadataFormatVersion() > LedgerMetadataSerDe.METADATA_FORMAT_VERSION_2) {
+            metadata = LedgerMetadataBuilder.from(inputMetadata).withId(ledgerId).build();
+        } else {
+            metadata = inputMetadata;
+        }
+
+        final byte[] data;
+        try {
+            data = serde.serialize(metadata);
+        } catch (IOException ioe) {
+            return FutureUtil.failedFuture(new BKException.BKMetadataSerializationException(ioe));
+        }
+
+        return store.put(getLedgerPath(ledgerId), data, Optional.of(-1L))
+                .thenApply(stat -> new Versioned(metadata, new LongVersion(stat.getVersion())));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeLedgerMetadata(long ledgerId, Version version) {
+        Optional<Long> existingVersion = Optional.empty();
+        if (Version.NEW == version) {
+            log.error("Request to delete ledger {} metadata with version set to the initial one", ledgerId);
+            return FutureUtil.failedFuture(new BKException.BKMetadataVersionException());
+        } else if (Version.ANY != version) {
+            if (!(version instanceof LongVersion)) {
+                log.info("Not an instance of ZKVersion: {}", ledgerId);
+                return FutureUtil.failedFuture(new BKException.BKMetadataVersionException());
+            } else {
+                existingVersion = Optional.of(((LongVersion) version).getLongVersion());
+            }
+        }
+
+        return store.delete(getLedgerPath(ledgerId), existingVersion)
+                .thenRun(() -> {
+                    // removed listener on ledgerId
+                    Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
+                    if (null != listenerSet) {
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "Remove registered ledger metadata listeners on ledger {} after ledger is deleted.",
+                                    ledgerId);
+                        }
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("No ledger metadata listeners to remove from ledger {} when it's being deleted.",
+                                    ledgerId);
+                        }
+                    }
+                });
+    }
+
+    @Override
+    public CompletableFuture<Versioned<LedgerMetadata>> readLedgerMetadata(long ledgerId) {
+        CompletableFuture<Versioned<LedgerMetadata>> promise = new CompletableFuture<>();
+        String ledgerPath = getLedgerPath(ledgerId);
+        cache.getWithStats(ledgerPath)
+                .thenAccept(optRes -> {
+                    if (!optRes.isPresent()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("No such ledger: {} at path {}", ledgerId, ledgerPath);
+                        }
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsOnMetadataServerException());
+                    }
+
+                    Stat stat = optRes.get().getStat();
+                    LongVersion version = new LongVersion(stat.getVersion());
+                    LedgerMetadata metadata = optRes.get().getValue();
+                    promise.complete(new Versioned<>(metadata, version));
+                }).exceptionally(ex -> {
+                    log.error("Could not read metadata for ledger: {}: {}", ledgerId, ex.getMessage());
+                    promise.completeExceptionally(new BKException.ZKException(ex.getCause()));
+                    return null;
+                });
+        return promise;
+    }
+
+    @Override
+    public CompletableFuture<Versioned<LedgerMetadata>> writeLedgerMetadata(long ledgerId, LedgerMetadata metadata,
+                                                                            Version currentVersion) {
+
+        if (!(currentVersion instanceof LongVersion)) {
+            return FutureUtil.failedFuture(new BKException.BKMetadataVersionException());
+        }
+        final LongVersion zv = (LongVersion) currentVersion;
+
+        final byte[] data;
+        try {
+            data = serde.serialize(metadata);
+        } catch (IOException ioe) {
+            return FutureUtil.failedFuture(new BKException.BKMetadataSerializationException(ioe));
+        }
+
+        CompletableFuture<Versioned<LedgerMetadata>> promise = new CompletableFuture<>();
+
+        store.put(getLedgerPath(ledgerId),
+                        data, Optional.of(zv.getLongVersion()))
+                .thenAccept(stat -> {
+                    promise.complete(new Versioned<>(metadata, new LongVersion(stat.getVersion())));
+                }).exceptionally(ex -> {
+                    if (ex.getCause() instanceof MetadataStoreException.BadVersionException) {
+                        promise.completeExceptionally(new BKException.BKMetadataVersionException());
+                    } else {
+                        log.warn("Conditional update ledger metadata failed: {}", ex.getMessage());
+                        promise.completeExceptionally(new BKException.ZKException(ex.getCause()));
+                    }
+                    return null;
+                });
+        return promise;
+    }
+
+    @Override
+    public void registerLedgerMetadataListener(long ledgerId,
+                                               BookkeeperInternalCallbacks.LedgerMetadataListener listener) {
+        if (listener == null) {
+            return;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Registered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+        }
+        Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet =
+                listeners.computeIfAbsent(ledgerId, k -> new HashSet<>());
+        synchronized (listenerSet) {
+            listenerSet.add(listener);
+        }
+        new ReadLedgerMetadataTask(ledgerId).run();
+    }
+
+    @Override
+    public void unregisterLedgerMetadataListener(long ledgerId,
+                                                 BookkeeperInternalCallbacks.LedgerMetadataListener listener) {
+        Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
+        if (listenerSet == null) {
+            return;
+        }
+        synchronized (listenerSet) {
+            if (listenerSet.remove(listener)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Unregistered ledger metadata listener {} on ledger {}.", listener, ledgerId);
+                }
+            }
+            if (listenerSet.isEmpty()) {
+                listeners.remove(ledgerId, listenerSet);
+            }
+        }
+    }
+
+    private static final Pattern ledgerPathRegex = Pattern.compile("/L[0-9]+$");
+
+    private void handleDataNotification(Notification n) {
+        if (!n.getPath().startsWith(ledgerRootPath)
+                || !ledgerPathRegex.matcher(n.getPath()).matches()) {
+            return;
+        }
+
+        final long ledgerId;
+        try {
+            ledgerId = getLedgerId(n.getPath());
+        } catch (IOException ioe) {
+            log.warn("Received invalid ledger path {} : ", n.getPath(), ioe);
+            return;
+        }
+
+        switch (n.getType()) {
+            case Modified:
+                new ReadLedgerMetadataTask(ledgerId).run();
+                break;
+
+            case Deleted:
+                Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
+                if (listenerSet != null) {
+                    synchronized (listenerSet) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Removed ledger metadata listeners on ledger {} : {}",
+                                    ledgerId, listenerSet);
+                        }
+                        for (BookkeeperInternalCallbacks.LedgerMetadataListener l : listenerSet) {
+                            l.onChanged(ledgerId, null);
+                        }
+                        listeners.remove(ledgerId, listenerSet);
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("No ledger metadata listeners to remove from ledger {} after it's deleted.",
+                                ledgerId);
+                    }
+                }
+                break;
+
+            case Created:
+            case ChildrenChanged:
+            default:
+                if (log.isDebugEnabled()) {
+                    log.debug("Received event {} on {}.", n.getType(), n.getPath());
+                }
+                break;
+        }
+    }
+
+    @Override
+    public void asyncProcessLedgers(BookkeeperInternalCallbacks.Processor<Long> processor,
+                                    AsyncCallback.VoidCallback finalCb, Object context, int successRc, int failureRc) {
+        // Process the old 31-bit id ledgers first.
+        legacyLedgerManager.asyncProcessLedgers(processor, (rc, path, ctx) -> {
+            if (rc == failureRc) {
+                // If it fails, return the failure code to the callback
+                finalCb.processResult(rc, path, ctx);
+            } else {
+                // If it succeeds, proceed with our own recursive ledger processing for the 63-bit id ledgers
+                longLedgerManager.asyncProcessLedgers(processor, finalCb, context, successRc, failureRc);
+            }
+        }, context, successRc, failureRc);
+    }
+
+    @Override
+    public LedgerRangeIterator getLedgerRanges(long ledgerId) {
+        LedgerRangeIterator iteratorA = new LegacyHierarchicalLedgerRangeIterator(store, ledgerRootPath);
+        LedgerRangeIterator iteratorB = new LongHierarchicalLedgerRangeIterator(store, ledgerRootPath);
+        return new CombinedLedgerRangeIterator(iteratorA, iteratorB);
+    }
+
+    @Override
+    public void close() throws IOException {
+        scheduler.shutdownNow();
+        try {
+            scheduler.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException(ie);
+        }
+    }
+
+    private String getLedgerPath(long ledgerId) {
+        return this.ledgerRootPath + StringUtils.getHybridHierarchicalLedgerPath(ledgerId);
+    }
+
+    private long getLedgerId(String ledgerPath) throws IOException {
+        if (!ledgerPath.startsWith(ledgerRootPath)) {
+            throw new IOException("it is not a valid hashed path name : " + ledgerPath);
+        }
+        String hierarchicalPath = ledgerPath.substring(ledgerRootPath.length() + 1);
+        return StringUtils.stringToLongHierarchicalLedgerId(hierarchicalPath);
+    }
+
+
+    /**
+     * ReadLedgerMetadataTask class.
+     */
+    private class ReadLedgerMetadataTask implements Runnable {
+
+        final long ledgerId;
+
+        ReadLedgerMetadataTask(long ledgerId) {
+            this.ledgerId = ledgerId;
+        }
+
+        @Override
+        public void run() {
+            if (null != listeners.get(ledgerId)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Re-read ledger metadata for {}.", ledgerId);
+                }
+                readLedgerMetadata(ledgerId)
+                        .whenComplete((metadata, exception) -> handleMetadata(metadata, exception));
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Ledger metadata listener for ledger {} is already removed.", ledgerId);
+                }
+            }
+        }
+
+        private void handleMetadata(Versioned<LedgerMetadata> result, Throwable exception) {
+            if (exception == null) {
+                final Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet = listeners.get(ledgerId);
+                if (null != listenerSet) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Ledger metadata is changed for {} : {}.", ledgerId, result);
+                    }
+                    scheduler.submit(() -> {
+                        synchronized (listenerSet) {
+                            for (BookkeeperInternalCallbacks.LedgerMetadataListener listener : listenerSet) {
+                                listener.onChanged(ledgerId, result);
+                            }
+                        }
+                    });
+                }
+            } else if (BKException.getExceptionCode(exception)
+                    == BKException.Code.NoSuchLedgerExistsOnMetadataServerException) {
+                // the ledger is removed, do nothing
+                Set<BookkeeperInternalCallbacks.LedgerMetadataListener> listenerSet = listeners.remove(ledgerId);
+                if (null != listenerSet) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removed ledger metadata listener set on ledger {} as its ledger is deleted : {}",
+                                ledgerId, listenerSet.size());
+                    }
+                    // notify `null` as indicator that a ledger is deleted
+                    // make this behavior consistent with `NodeDeleted` watched event.
+                    synchronized (listenerSet) {
+                        for (BookkeeperInternalCallbacks.LedgerMetadataListener listener : listenerSet) {
+                            listener.onChanged(ledgerId, null);
+                        }
+                    }
+                }
+            } else {
+                log.warn("Failed on read ledger metadata of ledger {}: {}",
+                        ledgerId, BKException.getExceptionCode(exception));
+                scheduler.schedule(this, 10, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /**
+     * whether the child of ledgersRootPath is a top level parent znode for
+     * ledgers (in HierarchicalLedgerManager) or znode of a ledger (in
+     * FlatLedgerManager).
+     */
+    public boolean isLedgerParentNode(String path) {
+        return path.matches(StringUtils.HIERARCHICAL_LEDGER_PARENT_NODE_REGEX);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManagerFactory.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManagerFactory.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import java.io.IOException;
+import java.util.List;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.AbstractZkLedgerManager;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerAuditorManager;
+import org.apache.bookkeeper.meta.LedgerIdGenerator;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.replication.ReplicationException;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+@Slf4j
+public class PulsarLedgerManagerFactory implements LedgerManagerFactory {
+
+    private static final int CUR_VERSION = 1;
+
+    private AbstractConfiguration conf;
+    private MetadataStoreExtended store;
+    private String ledgerRootPath;
+
+    @Override
+    public LedgerManagerFactory initialize(AbstractConfiguration conf, LayoutManager layoutManager,
+                                           int factoryVersion) throws IOException {
+
+        checkArgument(layoutManager instanceof PulsarLayoutManager);
+
+        PulsarLayoutManager pulsarLayoutManager = (PulsarLayoutManager) layoutManager;
+
+        if (CUR_VERSION != factoryVersion) {
+            throw new IOException("Incompatible layout version found : " + factoryVersion);
+        }
+        this.conf = conf;
+        this.store = pulsarLayoutManager.getStore();
+        this.ledgerRootPath = pulsarLayoutManager.getLedgersRootPath();
+        return this;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // since metadata store instance is passed from outside
+        // we don't need to close it here
+    }
+
+    @Override
+    public int getCurrentVersion() {
+        return CUR_VERSION;
+    }
+
+
+    @Override
+    public LedgerIdGenerator newLedgerIdGenerator() {
+        return new PulsarLedgerIdGenerator(store, ledgerRootPath);
+    }
+
+    @Override
+    public LedgerManager newLedgerManager() {
+        return new PulsarLedgerManager(store, ledgerRootPath);
+    }
+
+    @Override
+    public LedgerUnderreplicationManager newLedgerUnderreplicationManager()
+            throws ReplicationException.CompatibilityException {
+        return new PulsarLedgerUnderreplicationManager(conf, store, ledgerRootPath);
+    }
+
+    @Override
+    public LedgerAuditorManager newLedgerAuditorManager() throws IOException, InterruptedException {
+        return new PulsarLedgerAuditorManager(store, ledgerRootPath);
+    }
+
+    @Override
+    public void format(AbstractConfiguration<?> abstractConfiguration, LayoutManager layoutManager)
+            throws InterruptedException, IOException {
+        // TODO: XXX
+    }
+
+    @Override
+    public boolean validateAndNukeExistingCluster(AbstractConfiguration<?> conf,
+                                                  LayoutManager layoutManager)
+            throws InterruptedException, IOException {
+        @Cleanup
+        PulsarLedgerManager ledgerManager = new PulsarLedgerManager(store, ledgerRootPath);
+
+        /*
+         * before proceeding with nuking existing cluster, make sure there
+         * are no unexpected nodes under ledgersRootPath
+         */
+        List<String> ledgersRootPathChildrenList = store.getChildren(ledgerRootPath).join();
+        for (String ledgersRootPathChildren : ledgersRootPathChildrenList) {
+            if ((!AbstractZkLedgerManager.isSpecialZnode(ledgersRootPathChildren))
+                    && (!ledgerManager.isLedgerParentNode(ledgersRootPathChildren))) {
+                log.error("Found unexpected node : {} under ledgersRootPath : {} so exiting nuke operation",
+                        ledgersRootPathChildren, ledgerRootPath);
+                return false;
+            }
+        }
+
+        // formatting ledgermanager deletes ledger znodes
+        format(conf, layoutManager);
+
+        // now delete all the special nodes recursively
+        for (String ledgersRootPathChildren : store.getChildren(ledgerRootPath).join()) {
+            if (AbstractZkLedgerManager.isSpecialZnode(ledgersRootPathChildren)) {
+                store.deleteRecursive(ledgerRootPath + "/" + ledgersRootPathChildren).join();
+            } else {
+                log.error("Found unexpected node : {} under ledgersRootPath : {} so exiting nuke operation",
+                        ledgersRootPathChildren, ledgerRootPath);
+                return false;
+            }
+        }
+
+        // finally deleting the ledgers rootpath
+        store.deleteRecursive(ledgerRootPath).join();
+
+        log.info("Successfully nuked existing cluster");
+        return true;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -1,0 +1,978 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.bookkeeper.proto.DataFormats.CheckAllLedgersFormat;
+import static org.apache.bookkeeper.proto.DataFormats.LedgerRereplicationLayoutFormat;
+import static org.apache.bookkeeper.proto.DataFormats.LockDataFormat;
+import static org.apache.bookkeeper.proto.DataFormats.PlacementPolicyCheckFormat;
+import static org.apache.bookkeeper.proto.DataFormats.ReplicasCheckFormat;
+import static org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.TextFormat;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.UnderreplicatedLedger;
+import org.apache.bookkeeper.net.DNS;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.proto.DataFormats;
+import org.apache.bookkeeper.replication.ReplicationEnableCb;
+import org.apache.bookkeeper.replication.ReplicationException;
+import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+
+@Slf4j
+public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicationManager {
+    static final String LAYOUT = "BASIC";
+
+    static final int LAYOUT_VERSION = 1;
+
+    private static final byte[] LOCK_DATA = getLockData();
+
+    private static class Lock {
+        private final String lockPath;
+        private final long ledgerNodeVersion;
+
+        Lock(String lockPath, long ledgerNodeVersion) {
+            this.lockPath = lockPath;
+            this.ledgerNodeVersion = ledgerNodeVersion;
+        }
+
+        String getLockPath() {
+            return lockPath;
+        }
+
+        long getLedgerNodeVersion() {
+            return ledgerNodeVersion;
+        }
+    }
+
+    private final Map<Long, Lock> heldLocks = new ConcurrentHashMap<>();
+
+    private static final Pattern ID_EXTRACTION_PATTERN = Pattern.compile("urL(\\d+)$");
+
+    private final AbstractConfiguration conf;
+    private final String basePath;
+    private final String urLedgerPath;
+    private final String urLockPath;
+    private final String layoutPath;
+    private final String lostBookieRecoveryDelayPath;
+    private final String checkAllLedgersCtimePath;
+    private final String placementPolicyCheckCtimePath;
+    private final String replicasCheckCtimePath;
+
+    private final MetadataStoreExtended store;
+
+    private BookkeeperInternalCallbacks.GenericCallback<Void> replicationEnabledListener;
+    private BookkeeperInternalCallbacks.GenericCallback<Void> lostBookieRecoveryDelayListener;
+
+    private static class PulsarUnderreplicatedLedger extends UnderreplicatedLedger {
+        PulsarUnderreplicatedLedger(long ledgerId) {
+            super(ledgerId);
+        }
+
+        @Override
+        protected void setCtime(long ctime) {
+            super.setCtime(ctime);
+        }
+
+        @Override
+        protected void setReplicaList(List<String> replicaList) {
+            super.setReplicaList(replicaList);
+        }
+    }
+
+    public PulsarLedgerUnderreplicationManager(AbstractConfiguration<?> conf, MetadataStoreExtended store,
+                                               String ledgerRootPath)
+            throws ReplicationException.CompatibilityException {
+        this.conf = conf;
+        this.basePath = getBasePath(ledgerRootPath);
+        layoutPath = basePath + '/' + BookKeeperConstants.LAYOUT_ZNODE;
+        urLedgerPath = basePath + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
+        urLockPath = basePath + '/' + BookKeeperConstants.UNDER_REPLICATION_LOCK;
+        lostBookieRecoveryDelayPath = basePath + '/' + BookKeeperConstants.LOSTBOOKIERECOVERYDELAY_NODE;
+        checkAllLedgersCtimePath = basePath + '/' + BookKeeperConstants.CHECK_ALL_LEDGERS_CTIME;
+        placementPolicyCheckCtimePath = basePath + '/' + BookKeeperConstants.PLACEMENT_POLICY_CHECK_CTIME;
+        replicasCheckCtimePath = basePath + '/' + BookKeeperConstants.REPLICAS_CHECK_CTIME;
+
+        this.store = store;
+        store.registerListener(this::handleNotification);
+
+        checkLayout();
+    }
+
+    static String getBasePath(String rootPath) {
+        return String.format("%s/%s", rootPath, BookKeeperConstants.UNDER_REPLICATION_NODE);
+    }
+
+    static String getUrLockPath(String rootPath) {
+        return String.format("%s/%s", getBasePath(rootPath), BookKeeperConstants.UNDER_REPLICATION_LOCK);
+    }
+
+    public static byte[] getLockData() {
+        DataFormats.LockDataFormat.Builder lockDataBuilder = DataFormats.LockDataFormat.newBuilder();
+        try {
+            lockDataBuilder.setBookieId(DNS.getDefaultHost("default"));
+        } catch (UnknownHostException uhe) {
+            // if we cant get the address, ignore. it's optional
+            // in the data structure in any case
+        }
+        return lockDataBuilder.build().toString().getBytes(UTF_8);
+    }
+
+    private void checkLayout() throws ReplicationException.CompatibilityException {
+        while (true) {
+            if (!store.exists(layoutPath).join()) {
+                LedgerRereplicationLayoutFormat.Builder builder = LedgerRereplicationLayoutFormat.newBuilder();
+                builder.setType(LAYOUT).setVersion(LAYOUT_VERSION);
+                store.put(layoutPath, builder.build().toString().getBytes(UTF_8), Optional.of(-1L)).join();
+            } else {
+                byte[] layoutData = store.get(layoutPath).join().get().getValue();
+
+                LedgerRereplicationLayoutFormat.Builder builder = LedgerRereplicationLayoutFormat.newBuilder();
+
+                try {
+                    TextFormat.merge(new String(layoutData, UTF_8), builder);
+                    LedgerRereplicationLayoutFormat layout = builder.build();
+                    if (!layout.getType().equals(LAYOUT)
+                            || layout.getVersion() != LAYOUT_VERSION) {
+                        throw new ReplicationException.CompatibilityException(
+                                "Incompatible layout found (" + LAYOUT + ":" + LAYOUT_VERSION + ")");
+                    }
+                } catch (TextFormat.ParseException pe) {
+                    throw new ReplicationException.CompatibilityException(
+                            "Invalid data found", pe);
+                }
+                break;
+            }
+        }
+    }
+
+    private long getLedgerId(String path) throws NumberFormatException {
+        Matcher m = ID_EXTRACTION_PATTERN.matcher(path);
+        if (m.find()) {
+            return Long.parseLong(m.group(1));
+        } else {
+            throw new NumberFormatException("Couldn't find ledgerid in path");
+        }
+    }
+
+    private static String getParentPath(String base, long ledgerId) {
+        String subdir1 = String.format("%04x", ledgerId >> 48 & 0xffff);
+        String subdir2 = String.format("%04x", ledgerId >> 32 & 0xffff);
+        String subdir3 = String.format("%04x", ledgerId >> 16 & 0xffff);
+        String subdir4 = String.format("%04x", ledgerId & 0xffff);
+
+        return String.format("%s/%s/%s/%s/%s",
+                base, subdir1, subdir2, subdir3, subdir4);
+    }
+
+    public static String getUrLedgerPath(String base, long ledgerId) {
+        return String.format("%s/urL%010d", getParentPath(base, ledgerId), ledgerId);
+    }
+
+    public static String getUrLedgerLockPath(String base, long ledgerId) {
+        return String.format("%s/urL%010d", base, ledgerId);
+    }
+
+    private String getUrLedgerPath(long ledgerId) {
+        return getUrLedgerPath(urLedgerPath, ledgerId);
+    }
+
+    private void handleNotification(Notification n) {
+        if (n.getPath().startsWith(basePath)) {
+            synchronized (this) {
+                // Notify that there were some changes on the under-replicated z-nodes
+                notifyAll();
+
+                if (n.getType() == NotificationType.Deleted) {
+                    if (n.getPath().equals(basePath + '/' + BookKeeperConstants.DISABLE_NODE)) {
+                        log.info("LedgerReplication is enabled externally through MetadataStore, "
+                                + "since DISABLE_NODE ZNode is deleted");
+                        if (replicationEnabledListener != null) {
+                            replicationEnabledListener.operationComplete(0, null);
+                        }
+                    } else if (n.getPath().equals(lostBookieRecoveryDelayPath)) {
+                        if (lostBookieRecoveryDelayListener != null) {
+                            lostBookieRecoveryDelayListener.operationComplete(0, null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public UnderreplicatedLedger getLedgerUnreplicationInfo(long ledgerId)
+            throws ReplicationException.UnavailableException {
+        try {
+            String path = getUrLedgerPath(ledgerId);
+
+            Optional<GetResult> optRes = store.get(path).get();
+            if (!optRes.isPresent()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Ledger: {} is not marked underreplicated", ledgerId);
+                }
+                return null;
+            }
+
+            byte[] data = optRes.get().getValue();
+
+            UnderreplicatedLedgerFormat.Builder builder = UnderreplicatedLedgerFormat.newBuilder();
+
+            TextFormat.merge(new String(data, UTF_8), builder);
+            UnderreplicatedLedgerFormat underreplicatedLedgerFormat = builder.build();
+            PulsarUnderreplicatedLedger underreplicatedLedger = new PulsarUnderreplicatedLedger(ledgerId);
+            List<String> replicaList = underreplicatedLedgerFormat.getReplicaList();
+            long ctime = (underreplicatedLedgerFormat.hasCtime() ? underreplicatedLedgerFormat.getCtime()
+                    : UnderreplicatedLedger.UNASSIGNED_CTIME);
+            underreplicatedLedger.setCtime(ctime);
+            underreplicatedLedger.setReplicaList(replicaList);
+            return underreplicatedLedger;
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting with metadata store", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while connecting metadata store", ie);
+        } catch (TextFormat.ParseException pe) {
+            throw new ReplicationException.UnavailableException("Error parsing proto message", pe);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> markLedgerUnderreplicatedAsync(long ledgerId, Collection<String> missingReplicas) {
+        if (log.isDebugEnabled()) {
+            log.debug("markLedgerUnderreplicated(ledgerId={}, missingReplica={})", ledgerId, missingReplicas);
+        }
+        final String path = getUrLedgerPath(ledgerId);
+        final CompletableFuture<Void> createFuture = new CompletableFuture<>();
+        tryMarkLedgerUnderreplicatedAsync(path, missingReplicas, createFuture);
+        return createFuture;
+    }
+
+    private void tryMarkLedgerUnderreplicatedAsync(final String path,
+                                                   final Collection<String> missingReplicas,
+                                                   final CompletableFuture<Void> finalFuture) {
+        final UnderreplicatedLedgerFormat.Builder builder = UnderreplicatedLedgerFormat.newBuilder();
+        if (conf.getStoreSystemTimeAsLedgerUnderreplicatedMarkTime()) {
+            builder.setCtime(System.currentTimeMillis());
+        }
+        missingReplicas.forEach(builder::addReplica);
+        final byte[] urLedgerData = builder.build().toString().getBytes(UTF_8);
+        store.put(path, urLedgerData, Optional.of(-1L))
+                .thenRun(() -> {
+                    FutureUtils.complete(finalFuture, null);
+                }).exceptionally(ex -> {
+                    if (ex.getCause() instanceof MetadataStoreException.BadVersionException) {
+                        // we need to handle the case where the ledger has been marked as underreplicated
+                        handleLedgerUnderreplicatedAlreadyMarked(path, missingReplicas, finalFuture);
+                    } else {
+                        FutureUtils.completeExceptionally(finalFuture, ex);
+                    }
+                    return null;
+                });
+    }
+
+
+    private void handleLedgerUnderreplicatedAlreadyMarked(final String path,
+                                                          final Collection<String> missingReplicas,
+                                                          final CompletableFuture<Void> finalFuture) {
+        // get the existing underreplicated ledger data
+        store.get(path).thenAccept(optRes -> {
+            if (!optRes.isPresent()) {
+                tryMarkLedgerUnderreplicatedAsync(path, missingReplicas, finalFuture);
+                return;
+            }
+
+            byte[] existingUrLedgerData = optRes.get().getValue();
+
+            // deserialize existing underreplicated ledger data
+            final UnderreplicatedLedgerFormat.Builder builder = UnderreplicatedLedgerFormat.newBuilder();
+            try {
+                TextFormat.merge(new String(existingUrLedgerData, UTF_8), builder);
+            } catch (TextFormat.ParseException e) {
+                // corrupted metadata in zookeeper
+                FutureUtils.completeExceptionally(finalFuture,
+                        new ReplicationException.UnavailableException(
+                                "Invalid underreplicated ledger data for ledger " + path, e));
+                return;
+            }
+            UnderreplicatedLedgerFormat existingUrLedgerFormat = builder.build();
+            boolean replicaAdded = false;
+            for (String missingReplica : missingReplicas) {
+                if (existingUrLedgerFormat.getReplicaList().contains(missingReplica)) {
+                    continue;
+                } else {
+                    builder.addReplica(missingReplica);
+                    replicaAdded = true;
+                }
+            }
+            if (!replicaAdded) { // no new missing replica is added
+                FutureUtils.complete(finalFuture, null);
+                return;
+            }
+            if (conf.getStoreSystemTimeAsLedgerUnderreplicatedMarkTime()) {
+                builder.setCtime(System.currentTimeMillis());
+            }
+            final byte[] newUrLedgerData = builder.build().toString().getBytes(UTF_8);
+
+            store.put(path, newUrLedgerData, Optional.of(optRes.get().getStat().getVersion()))
+                    .thenRun(() -> {
+                        FutureUtils.complete(finalFuture, null);
+                    }).exceptionally(ex -> {
+                        FutureUtils.completeExceptionally(finalFuture, ex);
+                        return null;
+                    });
+        }).exceptionally(ex -> {
+            FutureUtils.completeExceptionally(finalFuture, ex);
+            return null;
+        });
+    }
+
+    @Override
+    public void acquireUnderreplicatedLedger(long ledgerId) throws ReplicationException {
+        try {
+            internalAcquireUnderreplicatedLedger(ledgerId);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new ReplicationException.UnavailableException("Failed to acuire under-replicated ledger", e);
+        }
+    }
+
+    private void internalAcquireUnderreplicatedLedger(long ledgerId) throws ExecutionException, InterruptedException {
+        String lockPath = getUrLedgerLockPath(urLockPath, ledgerId);
+        store.put(lockPath, LOCK_DATA, Optional.of(-1L), EnumSet.of(CreateOption.Ephemeral)).get();
+    }
+
+    @Override
+    public void markLedgerReplicated(long ledgerId) throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("markLedgerReplicated(ledgerId={})", ledgerId);
+        }
+        try {
+            Lock l = heldLocks.get(ledgerId);
+            if (l != null) {
+                store.delete(getUrLedgerPath(ledgerId), Optional.of(l.getLedgerNodeVersion())).get();
+            }
+        } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof MetadataStoreException.NotFoundException) {
+                // this is ok
+            } else if (ee.getCause() instanceof MetadataStoreException.BadVersionException) {
+                // if this is the case, some has marked the ledger
+                // for rereplication again. Leave the underreplicated
+                // znode in place, so the ledger is checked.
+            } else {
+                log.error("Error deleting underreplicated ledger node", ee);
+                throw new ReplicationException.UnavailableException("Error contacting metadata store", ee);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting metadata store", ie);
+        } finally {
+            releaseUnderreplicatedLedger(ledgerId);
+        }
+    }
+
+    /**
+     * Get a list of all the underreplicated ledgers which have been
+     * marked for rereplication, filtered by the predicate on the replicas list.
+     *
+     * <p>Replicas list of an underreplicated ledger is the list of the bookies which are part of
+     * the ensemble of this ledger and are currently unavailable/down.
+     *
+     * @param predicate filter to use while listing under replicated ledgers. 'null' if filtering is not required.
+     * @return an iterator which returns underreplicated ledgers.
+     */
+    @Override
+    public Iterator<UnderreplicatedLedger> listLedgersToRereplicate(final Predicate<List<String>> predicate) {
+        final Queue<String> queue = new LinkedList<>();
+        queue.add(urLedgerPath);
+
+        return new Iterator<UnderreplicatedLedger>() {
+            final Queue<UnderreplicatedLedger> curBatch = new LinkedList<>();
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (curBatch.size() > 0) {
+                    return true;
+                }
+
+                while (queue.size() > 0 && curBatch.size() == 0) {
+                    String parent = queue.remove();
+                    try {
+                        for (String c : store.getChildren(parent).get()) {
+                            String child = parent + "/" + c;
+                            if (c.startsWith("urL")) {
+                                long ledgerId = getLedgerId(child);
+                                UnderreplicatedLedger underreplicatedLedger = getLedgerUnreplicationInfo(ledgerId);
+                                if (underreplicatedLedger != null) {
+                                    List<String> replicaList = underreplicatedLedger.getReplicaList();
+                                    if ((predicate == null) || predicate.test(replicaList)) {
+                                        curBatch.add(underreplicatedLedger);
+                                    }
+                                }
+                            } else {
+                                queue.add(child);
+                            }
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return false;
+                    } catch (Exception e) {
+                        throw new RuntimeException("Error reading list", e);
+                    }
+                }
+                return curBatch.size() > 0;
+            }
+
+            @Override
+            public UnderreplicatedLedger next() {
+                assert curBatch.size() > 0;
+                return curBatch.remove();
+            }
+        };
+    }
+
+    private long getLedgerToRereplicateFromHierarchy(String parent, long depth)
+            throws ExecutionException, InterruptedException {
+        if (depth == 4) {
+            List<String> children = new ArrayList<>(store.getChildren(parent).get());
+            Collections.shuffle(children);
+
+            while (!children.isEmpty()) {
+                String tryChild = children.get(0);
+                try {
+                    List<String> locks = store.getChildren(urLockPath).get();
+                    if (locks.contains(tryChild)) {
+                        children.remove(tryChild);
+                        continue;
+                    }
+
+                    Optional<GetResult> optRes = store.get(parent + "/" + tryChild).get();
+                    if (!optRes.isPresent()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("{}/{} doesn't exist", parent, tryChild);
+                        }
+                        children.remove(tryChild);
+                        continue;
+                    }
+
+                    long ledgerId = getLedgerId(tryChild);
+                    internalAcquireUnderreplicatedLedger(ledgerId);
+                    String lockPath = getUrLedgerLockPath(urLockPath, ledgerId);
+                    heldLocks.put(ledgerId, new Lock(lockPath, optRes.get().getStat().getVersion()));
+                    return ledgerId;
+                } catch (ExecutionException ee) {
+                    if (ee.getCause() instanceof MetadataStoreException.BadVersionException) {
+                        // If we fail to acquire the lock because it's already taken, we should simply try with
+                        // another ledger
+                        children.remove(tryChild);
+                    } else {
+                        throw ee;
+                    }
+                } catch (NumberFormatException nfe) {
+                    children.remove(tryChild);
+                }
+            }
+            return -1;
+        }
+
+        List<String> children = new ArrayList<>(store.getChildren(parent).join());
+        Collections.shuffle(children);
+
+        while (children.size() > 0) {
+            String tryChild = children.get(0);
+            String tryPath = parent + "/" + tryChild;
+            long ledger = getLedgerToRereplicateFromHierarchy(tryPath, depth + 1);
+            if (ledger != -1) {
+                return ledger;
+            }
+            children.remove(tryChild);
+        }
+        return -1;
+    }
+
+
+    @Override
+    public long pollLedgerToRereplicate() throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("pollLedgerToRereplicate()");
+        }
+        try {
+            return getLedgerToRereplicateFromHierarchy(urLedgerPath, 0);
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting metadata store", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while connecting metadata store", ie);
+        }
+    }
+
+    @Override
+    public long getLedgerToRereplicate() throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("getLedgerToRereplicate()");
+        }
+        while (true) {
+            try {
+                waitIfLedgerReplicationDisabled();
+
+                long ledger = getLedgerToRereplicateFromHierarchy(urLedgerPath, 0);
+                if (ledger != -1) {
+                    return ledger;
+                }
+
+                synchronized (this) {
+                    // nothing found, wait for a watcher to trigger
+                    this.wait(1000);
+                }
+            } catch (ExecutionException ee) {
+                throw new ReplicationException.UnavailableException("Error contacting metadata store", ee);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new ReplicationException.UnavailableException("Interrupted while connecting metadata store", ie);
+            }
+        }
+    }
+
+    private void waitIfLedgerReplicationDisabled() throws ReplicationException.UnavailableException,
+            InterruptedException {
+        ReplicationEnableCb cb = new ReplicationEnableCb();
+        if (!this.isLedgerReplicationEnabled()) {
+            this.notifyLedgerReplicationEnabled(cb);
+            cb.await();
+        }
+    }
+
+    @Override
+    public void releaseUnderreplicatedLedger(long ledgerId) throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("releaseLedger(ledgerId={})", ledgerId);
+        }
+        try {
+            Lock l = heldLocks.get(ledgerId);
+            if (l != null) {
+                store.delete(l.getLockPath(), Optional.empty()).get();
+            }
+        } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof MetadataStoreException.NotFoundException) {
+                // this is ok
+            } else {
+                log.error("Error deleting underreplicated ledger lock", ee);
+                throw new ReplicationException.UnavailableException("Error contacting metadata store", ee);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while connecting metadata store", ie);
+        }
+        heldLocks.remove(ledgerId);
+    }
+
+    @Override
+    public void close() throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("close()");
+        }
+        try {
+            for (Map.Entry<Long, Lock> e : heldLocks.entrySet()) {
+                store.delete(e.getValue().getLockPath(), Optional.empty()).get();
+            }
+        } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof MetadataStoreException.NotFoundException) {
+                // this is ok
+            } else {
+                log.error("Error deleting underreplicated ledger lock", ee);
+                throw new ReplicationException.UnavailableException("Error contacting metadata store", ee);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while connecting metadata store", ie);
+        }
+    }
+
+    @Override
+    public void disableLedgerReplication()
+            throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("disableLedegerReplication()");
+        }
+        try {
+            String path = basePath + '/' + BookKeeperConstants.DISABLE_NODE;
+            store.put(path, "".getBytes(UTF_8), Optional.of(-1L)).get();
+            log.info("Auto ledger re-replication is disabled!");
+        } catch (ExecutionException ee) {
+            log.error("Exception while stopping auto ledger re-replication", ee);
+            throw new ReplicationException.UnavailableException(
+                    "Exception while stopping auto ledger re-replication", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException(
+                    "Interrupted while stopping auto ledger re-replication", ie);
+        }
+    }
+
+    @Override
+    public void enableLedgerReplication()
+            throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("enableLedegerReplication()");
+        }
+        try {
+            store.delete(basePath + '/' + BookKeeperConstants.DISABLE_NODE, Optional.empty()).get();
+            log.info("Resuming automatic ledger re-replication");
+        } catch (ExecutionException ee) {
+            log.error("Exception while resuming ledger replication", ee);
+            throw new ReplicationException.UnavailableException(
+                    "Exception while resuming auto ledger re-replication", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException(
+                    "Interrupted while resuming auto ledger re-replication", ie);
+        }
+    }
+
+    @Override
+    public boolean isLedgerReplicationEnabled()
+            throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("isLedgerReplicationEnabled()");
+        }
+        try {
+            return !store.exists(basePath + '/' + BookKeeperConstants.DISABLE_NODE).get();
+        } catch (ExecutionException ee) {
+            log.error("Error while checking the state of "
+                    + "ledger re-replication", ee);
+            throw new ReplicationException.UnavailableException(
+                    "Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException(
+                    "Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public void notifyLedgerReplicationEnabled(final BookkeeperInternalCallbacks.GenericCallback<Void> cb)
+            throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("notifyLedgerReplicationEnabled()");
+        }
+
+        synchronized (this) {
+            replicationEnabledListener = cb;
+        }
+
+        try {
+            if (!store.exists(basePath + '/' + BookKeeperConstants.DISABLE_NODE).get()) {
+                log.info("LedgerReplication is enabled externally through metadata store, "
+                        + "since DISABLE_NODE node is deleted");
+                cb.operationComplete(0, null);
+                return;
+            }
+        } catch (ExecutionException ee) {
+            log.error("Error while checking the state of "
+                    + "ledger re-replication", ee);
+            throw new ReplicationException.UnavailableException(
+                    "Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException(
+                    "Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    /**
+     * Check whether the ledger is being replicated by any bookie.
+     */
+    @Override
+    public boolean isLedgerBeingReplicated(long ledgerId) throws ReplicationException {
+        try {
+            return store.exists(getUrLedgerLockPath(urLockPath, ledgerId)).get();
+        } catch (Exception e) {
+            throw new ReplicationException.UnavailableException("Failed to check if ledger is beinge replicated", e);
+        }
+    }
+
+    @Override
+    public boolean initializeLostBookieRecoveryDelay(int lostBookieRecoveryDelay) throws
+            ReplicationException.UnavailableException {
+        log.debug("initializeLostBookieRecoveryDelay()");
+        try {
+            store.put(lostBookieRecoveryDelayPath, Integer.toString(lostBookieRecoveryDelay).getBytes(UTF_8),
+                    Optional.of(-1L)).get();
+        } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof MetadataStoreException.BadVersionException) {
+                log.info("lostBookieRecoveryDelay node is already present, so using "
+                        + "existing lostBookieRecoveryDelay node value");
+                return false;
+            } else {
+                log.error("Error while initializing LostBookieRecoveryDelay", ee);
+                throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+        return true;
+    }
+
+    @Override
+    public void setLostBookieRecoveryDelay(int lostBookieRecoveryDelay) throws
+            ReplicationException.UnavailableException {
+        log.debug("setLostBookieRecoveryDelay()");
+        try {
+            store.put(lostBookieRecoveryDelayPath, Integer.toString(lostBookieRecoveryDelay).getBytes(UTF_8),
+                    Optional.empty()).get();
+
+        } catch (ExecutionException ee) {
+            log.error("Error while setting LostBookieRecoveryDelay ", ee);
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public int getLostBookieRecoveryDelay() throws ReplicationException.UnavailableException {
+        log.debug("getLostBookieRecoveryDelay()");
+        try {
+            byte[] data = store.get(lostBookieRecoveryDelayPath).get().get().getValue();
+            return Integer.parseInt(new String(data, UTF_8));
+        } catch (ExecutionException ee) {
+            log.error("Error while getting LostBookieRecoveryDelay ", ee);
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public void notifyLostBookieRecoveryDelayChanged(BookkeeperInternalCallbacks.GenericCallback<Void> cb) throws
+            ReplicationException.UnavailableException {
+        log.debug("notifyLostBookieRecoveryDelayChanged()");
+        synchronized (this) {
+            lostBookieRecoveryDelayListener = cb;
+        }
+        try {
+            if (!store.exists(lostBookieRecoveryDelayPath).get()) {
+                cb.operationComplete(0, null);
+                return;
+            }
+
+        } catch (ExecutionException ee) {
+            log.error("Error while checking the state of lostBookieRecoveryDelay", ee);
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public String getReplicationWorkerIdRereplicatingLedger(long ledgerId)
+            throws ReplicationException.UnavailableException {
+
+        try {
+            Optional<GetResult> optRes = store.get(getUrLedgerLockPath(urLockPath, ledgerId)).get();
+            if (!optRes.isPresent()) {
+                // this is ok.
+                return null;
+            }
+
+            byte[] lockData = optRes.get().getValue();
+            LockDataFormat.Builder lockDataBuilder = LockDataFormat.newBuilder();
+            TextFormat.merge(new String(lockData, UTF_8), lockDataBuilder);
+            LockDataFormat lock = lockDataBuilder.build();
+            return lock.getBookieId();
+        } catch (ExecutionException e) {
+            log.error("Error while getting ReplicationWorkerId rereplicating Ledger", e);
+            throw new ReplicationException.UnavailableException(
+                    "Error while getting ReplicationWorkerId rereplicating Ledger", e);
+        } catch (InterruptedException e) {
+            log.error("Got interrupted while getting ReplicationWorkerId rereplicating Ledger", e);
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", e);
+        } catch (TextFormat.ParseException e) {
+            log.error("Error while parsing ZK data of lock", e);
+            throw new ReplicationException.UnavailableException("Error while parsing ZK data of lock", e);
+        }
+    }
+
+    @Override
+    public void setCheckAllLedgersCTime(long checkAllLedgersCTime) throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("setCheckAllLedgersCTime");
+        }
+        try {
+            CheckAllLedgersFormat.Builder builder = CheckAllLedgersFormat.newBuilder();
+            builder.setCheckAllLedgersCTime(checkAllLedgersCTime);
+            byte[] checkAllLedgersFormatByteArray = builder.build().toByteArray();
+
+            store.put(checkAllLedgersCtimePath, checkAllLedgersFormatByteArray, Optional.empty()).get();
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public long getCheckAllLedgersCTime() throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("setCheckAllLedgersCTime");
+        }
+        try {
+            Optional<GetResult> optRes = store.get(checkAllLedgersCtimePath).get();
+            if (!optRes.isPresent()) {
+                log.warn("checkAllLedgersCtimeZnode is not yet available");
+                return -1;
+            }
+            byte[] data = optRes.get().getValue();
+            CheckAllLedgersFormat checkAllLedgersFormat = CheckAllLedgersFormat.parseFrom(data);
+            return checkAllLedgersFormat.hasCheckAllLedgersCTime() ? checkAllLedgersFormat.getCheckAllLedgersCTime()
+                    : -1;
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        } catch (InvalidProtocolBufferException ipbe) {
+            throw new ReplicationException.UnavailableException("Error while parsing ZK protobuf binary data", ipbe);
+        }
+    }
+
+    @Override
+    public void setPlacementPolicyCheckCTime(long placementPolicyCheckCTime) throws
+            ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("setPlacementPolicyCheckCTime");
+        }
+        try {
+            PlacementPolicyCheckFormat.Builder builder = PlacementPolicyCheckFormat.newBuilder();
+            builder.setPlacementPolicyCheckCTime(placementPolicyCheckCTime);
+            byte[] placementPolicyCheckFormatByteArray = builder.build().toByteArray();
+            store.put(placementPolicyCheckCtimePath, placementPolicyCheckFormatByteArray, Optional.empty()).get();
+        } catch (ExecutionException ke) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public long getPlacementPolicyCheckCTime() throws ReplicationException.UnavailableException {
+        if (log.isDebugEnabled()) {
+            log.debug("getPlacementPolicyCheckCTime");
+        }
+        try {
+            Optional<GetResult> optRes = store.get(placementPolicyCheckCtimePath).get();
+            if (!optRes.isPresent()) {
+                log.warn("placementPolicyCheckCtimeZnode is not yet available");
+                return -1;
+            }
+            byte[] data = optRes.get().getValue();
+            PlacementPolicyCheckFormat placementPolicyCheckFormat = PlacementPolicyCheckFormat.parseFrom(data);
+            return placementPolicyCheckFormat.hasPlacementPolicyCheckCTime()
+                    ? placementPolicyCheckFormat.getPlacementPolicyCheckCTime() : -1;
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        } catch (InvalidProtocolBufferException ipbe) {
+            throw new ReplicationException.UnavailableException("Error while parsing ZK protobuf binary data", ipbe);
+        }
+    }
+
+    @Override
+    public void setReplicasCheckCTime(long replicasCheckCTime) throws ReplicationException.UnavailableException {
+        try {
+            ReplicasCheckFormat.Builder builder = ReplicasCheckFormat.newBuilder();
+            builder.setReplicasCheckCTime(replicasCheckCTime);
+            byte[] replicasCheckFormatByteArray = builder.build().toByteArray();
+            store.put(replicasCheckCtimePath, replicasCheckFormatByteArray, Optional.empty()).get();
+            if (log.isDebugEnabled()) {
+                log.debug("setReplicasCheckCTime completed successfully");
+            }
+        } catch (ExecutionException ke) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ke);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        }
+    }
+
+    @Override
+    public long getReplicasCheckCTime() throws ReplicationException.UnavailableException {
+        try {
+            Optional<GetResult> optRes = store.get(replicasCheckCtimePath).get();
+            if (!optRes.isPresent()) {
+                log.warn("placementPolicyCheckCtimeZnode is not yet available");
+                return -1;
+            }
+            byte[] data = optRes.get().getValue();
+            ReplicasCheckFormat replicasCheckFormat = ReplicasCheckFormat.parseFrom(data);
+            if (log.isDebugEnabled()) {
+                log.debug("getReplicasCheckCTime completed successfully");
+            }
+            return replicasCheckFormat.hasReplicasCheckCTime() ? replicasCheckFormat.getReplicasCheckCTime() : -1;
+        } catch (ExecutionException ee) {
+            throw new ReplicationException.UnavailableException("Error contacting zookeeper", ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReplicationException.UnavailableException("Interrupted while contacting zookeeper", ie);
+        } catch (InvalidProtocolBufferException ipbe) {
+            throw new ReplicationException.UnavailableException("Error while parsing ZK protobuf binary data", ipbe);
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.MetadataBookieDriver;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.bookkeeper.meta.exceptions.MetadataException;
+import org.apache.bookkeeper.stats.StatsLogger;
+
+public class PulsarMetadataBookieDriver extends AbstractMetadataDriver implements MetadataBookieDriver {
+
+    // register myself
+    static {
+        MetadataDrivers.registerBookieDriver(METADATA_STORE_SCHEME, PulsarMetadataBookieDriver.class);
+    }
+
+    @Override
+    public MetadataBookieDriver initialize(ServerConfiguration serverConfiguration,
+                                           RegistrationManager.RegistrationListener registrationListener,
+                                           StatsLogger statsLogger) throws MetadataException {
+        super.initialize(serverConfiguration);
+        return this;
+    }
+
+    @Override
+    public RegistrationManager getRegistrationManager() {
+        return registrationManager;
+    }
+
+    @Override
+    public LedgerManagerFactory getLedgerManagerFactory() throws MetadataException {
+        return ledgerManagerFactory;
+    }
+
+    @Override
+    public LayoutManager getLayoutManager() {
+        return layoutManager;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataClientDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataClientDriver.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.MetadataClientDriver;
+import org.apache.bookkeeper.meta.MetadataDrivers;
+import org.apache.bookkeeper.meta.exceptions.MetadataException;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.pulsar.metadata.api.extended.SessionEvent;
+
+public class PulsarMetadataClientDriver extends AbstractMetadataDriver implements MetadataClientDriver {
+
+    // register myself to driver manager
+    static {
+        MetadataDrivers.registerClientDriver(METADATA_STORE_SCHEME, PulsarMetadataClientDriver.class);
+    }
+
+    @Override
+    public MetadataClientDriver initialize(ClientConfiguration clientConfiguration,
+                                           ScheduledExecutorService scheduledExecutorService,
+                                           StatsLogger statsLogger,
+                                           Optional<Object> optionalCtx) throws MetadataException {
+        super.initialize(clientConfiguration);
+        return this;
+    }
+
+    @Override
+    public RegistrationClient getRegistrationClient() {
+        return registrationClient;
+    }
+
+    @Override
+    public LedgerManagerFactory getLedgerManagerFactory() throws MetadataException {
+        return ledgerManagerFactory;
+    }
+
+    @Override
+    public LayoutManager getLayoutManager() {
+        return layoutManager;
+    }
+
+    @Override
+    public void setSessionStateListener(SessionStateListener sessionStateListener) {
+        store.registerSessionListener(event -> {
+            if (event == SessionEvent.SessionLost) {
+                sessionStateListener.onSessionExpired();
+            }
+        });
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
+import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
+import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+
+public class PulsarRegistrationClient implements RegistrationClient {
+
+    private final MetadataStore store;
+    private final String ledgersRootPath;
+    // registration paths
+    private final String bookieRegistrationPath;
+    private final String bookieAllRegistrationPath;
+    private final String bookieReadonlyRegistrationPath;
+
+    private final Map<RegistrationListener, Boolean> writableBookiesWatchers = new ConcurrentHashMap<>();
+    private final Map<RegistrationListener, Boolean> readOnlyBookiesWatchers = new ConcurrentHashMap<>();
+
+    public PulsarRegistrationClient(MetadataStore store,
+                                    String ledgersRootPath) {
+        this.store = store;
+        this.ledgersRootPath = ledgersRootPath;
+
+        // Following Bookie Network Address Changes is an expensive operation
+        // as it requires additional ZooKeeper watches
+        // we can disable this feature, in case the BK cluster has only
+        // static addresses
+        this.bookieRegistrationPath = ledgersRootPath + "/" + AVAILABLE_NODE;
+        this.bookieAllRegistrationPath = ledgersRootPath + "/" + COOKIE_NODE;
+        this.bookieReadonlyRegistrationPath = this.bookieRegistrationPath + "/" + READONLY;
+
+        store.registerListener(this::updatedBookies);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public CompletableFuture<Versioned<Set<BookieId>>> getWritableBookies() {
+        return getChildren(bookieRegistrationPath);
+    }
+
+    @Override
+    public CompletableFuture<Versioned<Set<BookieId>>> getAllBookies() {
+        CompletableFuture<Versioned<Set<BookieId>>> wb = getWritableBookies();
+        CompletableFuture<Versioned<Set<BookieId>>> rb = getReadOnlyBookies();
+        return wb.thenCombine(rb, (rw, ro) -> {
+            Set<BookieId> res = new HashSet<>();
+            res.addAll(rw.getValue());
+            res.addAll(ro.getValue());
+            return new Versioned<>(res, Version.NEW);
+        });
+    }
+
+    @Override
+    public CompletableFuture<Versioned<Set<BookieId>>> getReadOnlyBookies() {
+        return getChildren(bookieReadonlyRegistrationPath);
+    }
+
+    private CompletableFuture<Versioned<Set<BookieId>>> getChildren(String path) {
+        return store.getChildren(path)
+                .thenApply(PulsarRegistrationClient::convertToBookieAddresses)
+                .thenApply(s -> new Versioned<>(s, Version.NEW));
+    }
+
+    @Override
+    public CompletableFuture<Void> watchWritableBookies(RegistrationListener registrationListener) {
+        writableBookiesWatchers.put(registrationListener, Boolean.TRUE);
+        return getWritableBookies()
+                .thenAccept(registrationListener::onBookiesChanged);
+    }
+
+    @Override
+    public void unwatchWritableBookies(RegistrationListener registrationListener) {
+        writableBookiesWatchers.remove(registrationListener);
+    }
+
+    @Override
+    public CompletableFuture<Void> watchReadOnlyBookies(RegistrationListener registrationListener) {
+        readOnlyBookiesWatchers.put(registrationListener, Boolean.TRUE);
+        return getReadOnlyBookies()
+                .thenAccept(registrationListener::onBookiesChanged);
+    }
+
+    @Override
+    public void unwatchReadOnlyBookies(RegistrationListener registrationListener) {
+        readOnlyBookiesWatchers.remove(registrationListener);
+    }
+
+    private void updatedBookies(Notification n) {
+        if (n.getType() == NotificationType.Created || n.getType() == NotificationType.Deleted) {
+            if (n.getPath().startsWith(bookieReadonlyRegistrationPath)) {
+                getReadOnlyBookies().thenAccept(bookies ->
+                        readOnlyBookiesWatchers.keySet()
+                                .forEach(w -> w.onBookiesChanged(bookies)));
+            } else if (n.getPath().startsWith(bookieRegistrationPath)) {
+                getWritableBookies().thenAccept(bookies ->
+                        writableBookiesWatchers.keySet()
+                                .forEach(w -> w.onBookiesChanged(bookies)));
+            }
+        }
+    }
+
+    private static Set<BookieId> convertToBookieAddresses(List<String> children) {
+        // Read the bookie addresses into a set for efficient lookup
+        HashSet<BookieId> newBookieAddrs = new HashSet<>();
+        for (String bookieAddrString : children) {
+            if (READONLY.equals(bookieAddrString)) {
+                continue;
+            }
+            BookieId bookieAddr = BookieId.parse(bookieAddrString);
+            newBookieAddrs.add(bookieAddr);
+        }
+        return newBookieAddrs;
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationManager.java
@@ -1,0 +1,358 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
+import static org.apache.bookkeeper.util.BookKeeperConstants.COOKIE_NODE;
+import static org.apache.bookkeeper.util.BookKeeperConstants.INSTANCEID;
+import static org.apache.bookkeeper.util.BookKeeperConstants.READONLY;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.LegacyHierarchicalLedgerManagerFactory;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.bookkeeper.versioning.LongVersion;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
+import org.apache.pulsar.metadata.api.coordination.LockManager;
+import org.apache.pulsar.metadata.api.coordination.ResourceLock;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+
+@Slf4j
+public class PulsarRegistrationManager implements RegistrationManager {
+
+    private final MetadataStoreExtended store;
+    private final CoordinationService coordinationService;
+    private final LockManager<BookieServiceInfo> lockManager;
+    private final AbstractConfiguration<?> conf;
+
+    private final String ledgersRootPath;
+    private final String cookiePath;
+    private final String bookieRegistrationPath;
+    private final String bookieReadonlyRegistrationPath;
+
+    private final Map<BookieId, ResourceLock<BookieServiceInfo>> bookieRegistration = new ConcurrentHashMap<>();
+    private final Map<BookieId, ResourceLock<BookieServiceInfo>> bookieRegistrationReadOnly = new ConcurrentHashMap<>();
+
+    PulsarRegistrationManager(MetadataStoreExtended store, String ledgersRootPath, AbstractConfiguration<?> conf) {
+        this.store = store;
+        this.conf = conf;
+        this.coordinationService = new CoordinationServiceImpl(store);
+        this.lockManager = coordinationService.getLockManager(BookieServiceInfoSerde.INSTANCE);
+        this.ledgersRootPath = ledgersRootPath;
+        this.cookiePath = ledgersRootPath + "/" + COOKIE_NODE;
+        this.bookieRegistrationPath = ledgersRootPath + "/" + AVAILABLE_NODE;
+        this.bookieReadonlyRegistrationPath = this.bookieRegistrationPath + "/" + READONLY;
+    }
+
+    @Override
+    @SneakyThrows
+    public void close() {
+        for (ResourceLock<BookieServiceInfo> rwBookie : bookieRegistration.values()) {
+            rwBookie.release().get();
+        }
+
+        for (ResourceLock<BookieServiceInfo> roBookie : bookieRegistrationReadOnly.values()) {
+            roBookie.release().get();
+        }
+        coordinationService.close();
+    }
+
+    @Override
+    public String getClusterInstanceId() throws BookieException {
+        try {
+            return store.get(ledgersRootPath + "/" + INSTANCEID)
+                    .get()
+                    .map(res -> new String(res.getValue(), UTF_8))
+                    .orElseThrow(
+                            () -> new BookieException.MetadataStoreException("BookKeeper cluster not initialized"));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new BookieException.MetadataStoreException("Failed to get cluster instance id", e);
+        }
+    }
+
+    @Override
+    public void registerBookie(BookieId bookieId, boolean readOnly, BookieServiceInfo bookieServiceInfo)
+            throws BookieException {
+        String regPath = bookieRegistrationPath + "/" + bookieId;
+        String regPathReadOnly = bookieReadonlyRegistrationPath + "/" + bookieId;
+
+        try {
+            if (readOnly) {
+                ResourceLock<BookieServiceInfo> rwRegistration = bookieRegistration.remove(bookieId);
+                if (rwRegistration != null) {
+                    rwRegistration.release().get();
+                }
+
+                bookieRegistrationReadOnly.put(bookieId,
+                        lockManager.acquireLock(regPathReadOnly, bookieServiceInfo).get());
+            } else {
+                ResourceLock<BookieServiceInfo> roRegistration = bookieRegistrationReadOnly.remove(bookieId);
+                if (roRegistration != null) {
+                    roRegistration.release().get();
+                }
+
+                bookieRegistration.put(bookieId,
+                        lockManager.acquireLock(regPath, bookieServiceInfo).get());
+            }
+        } catch (ExecutionException ee) {
+            log.error("Exception registering ephemeral node for Bookie!", ee);
+            // Throw an IOException back up. This will cause the Bookie
+            // constructor to error out. Alternatively, we could do a System
+            // exit here as this is a fatal error.
+            throw new BookieException.MetadataStoreException(ee);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            log.error("Interrupted exception while registering Bookie!", ie);
+            // Throw an IOException back up. This will cause the Bookie
+            // constructor to error out. Alternatively, we could do a System
+            // exit here as this is a fatal error.
+            throw new BookieException.MetadataStoreException(ie);
+        }
+    }
+
+    @Override
+    public void unregisterBookie(BookieId bookieId, boolean readOnly) throws BookieException {
+        try {
+            if (readOnly) {
+                ResourceLock<BookieServiceInfo> roRegistration = bookieRegistrationReadOnly.get(bookieId);
+                if (roRegistration != null) {
+                    roRegistration.release().get();
+                }
+            } else {
+                ResourceLock<BookieServiceInfo> rwRegistration = bookieRegistration.get(bookieId);
+                if (rwRegistration != null) {
+                    rwRegistration.release().get();
+                }
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new BookieException.MetadataStoreException(ie);
+        } catch (ExecutionException e) {
+            throw new BookieException.MetadataStoreException(e);
+        }
+    }
+
+    @Override
+    public boolean isBookieRegistered(BookieId bookieId) throws BookieException {
+        String regPath = bookieRegistrationPath + "/" + bookieId;
+        String readonlyRegPath = bookieReadonlyRegistrationPath + "/" + bookieId;
+
+        try {
+            return (store.exists(regPath).get() || store.exists(readonlyRegPath).get());
+        } catch (ExecutionException e) {
+            log.error("Exception while checking registration ephemeral nodes for BookieId: {}", bookieId, e);
+            throw new BookieException.MetadataStoreException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("InterruptedException while checking registration ephemeral nodes for BookieId: {}", bookieId,
+                    e);
+            throw new BookieException.MetadataStoreException(e);
+        }
+    }
+
+    @Override
+    public void writeCookie(BookieId bookieId, Versioned<byte[]> cookieData) throws BookieException {
+        String path = this.cookiePath + "/" + bookieId;
+        try {
+            long version;
+            if (Version.NEW == cookieData.getVersion()) {
+                version = -1L;
+            } else {
+                if (!(cookieData.getVersion() instanceof LongVersion)) {
+                    throw new BookieException.BookieIllegalOpException(
+                            "Invalid version type, expected it to be LongVersion");
+                }
+                version = ((LongVersion) cookieData.getVersion()).getLongVersion();
+            }
+
+            store.put(path, cookieData.getValue(), Optional.of(version)).get();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new BookieException.MetadataStoreException("Interrupted writing cookie for bookie " + bookieId, ie);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof MetadataStoreException.BadVersionException) {
+                throw new BookieException.CookieExistException(bookieId.toString());
+            } else {
+                throw new BookieException.MetadataStoreException("Failed to write cookie for bookie " + bookieId);
+            }
+        }
+    }
+
+    @Override
+    public Versioned<byte[]> readCookie(BookieId bookieId) throws BookieException {
+        String path = this.cookiePath + "/" + bookieId;
+        try {
+            Optional<GetResult> res = store.get(path).get();
+            if (!res.isPresent()) {
+                throw new BookieException.CookieNotFoundException(bookieId.toString());
+            }
+
+            // sets stat version from MetadataStore
+            LongVersion version = new LongVersion(res.get().getStat().getVersion());
+            return new Versioned<>(res.get().getValue(), version);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new BookieException.MetadataStoreException(ie);
+        } catch (ExecutionException e) {
+            throw new BookieException.MetadataStoreException(e);
+        }
+    }
+
+    @Override
+    public void removeCookie(BookieId bookieId, Version version) throws BookieException {
+        String path = this.cookiePath + "/" + bookieId;
+        try {
+            store.delete(path, Optional.of(((LongVersion) version).getLongVersion())).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BookieException.MetadataStoreException("Interrupted deleting cookie for bookie " + bookieId, e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof MetadataStoreException.NotFoundException) {
+                throw new BookieException.CookieNotFoundException(bookieId.toString());
+            } else {
+                throw new BookieException.MetadataStoreException("Failed to delete cookie for bookie " + bookieId);
+            }
+        }
+
+        log.info("Removed cookie from {} for bookie {}.", cookiePath, bookieId);
+    }
+
+    @Override
+    public boolean prepareFormat() throws Exception {
+        boolean ledgerRootExists = store.exists(ledgersRootPath).get();
+        boolean availableNodeExists = store.exists(bookieRegistrationPath).get();
+        // Create ledgers root node if not exists
+        if (!ledgerRootExists) {
+            store.put(ledgersRootPath, new byte[0], Optional.empty()).get();
+        }
+        // create available bookies node if not exists
+        if (!availableNodeExists) {
+            store.put(bookieRegistrationPath, new byte[0], Optional.empty()).get();
+        }
+
+        // create readonly bookies node if not exists
+        if (!store.exists(bookieReadonlyRegistrationPath).get()) {
+            store.put(bookieReadonlyRegistrationPath, new byte[0], Optional.empty()).get();
+        }
+
+        return ledgerRootExists;
+    }
+
+    @Override
+    public boolean initNewCluster() throws Exception {
+        String instanceIdPath = ledgersRootPath + "/" + INSTANCEID;
+        log.info("Initializing metadata for new cluster, ledger root path: {}",
+                ledgersRootPath);
+
+        if (store.exists(instanceIdPath).get()) {
+            log.error("Ledger root path: {} already exists", ledgersRootPath);
+            return false;
+        }
+
+        store.put(ledgersRootPath, new byte[0], Optional.empty()).get();
+
+        // create INSTANCEID
+        String instanceId = UUID.randomUUID().toString();
+        store.put(instanceIdPath, instanceId.getBytes(UTF_8), Optional.of(-1L)).join();
+
+        log.info("Successfully initiated cluster. ledger root path: {} instanceId: {}",
+                ledgersRootPath, instanceId);
+        return true;
+    }
+
+    @Override
+    public boolean format() throws Exception {
+        // Clear underreplicated ledgers
+        store.deleteRecursive(PulsarLedgerUnderreplicationManager.getBasePath(ledgersRootPath)
+                + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH).get();
+
+        // Clear underreplicatedledger locks
+        store.deleteRecursive(PulsarLedgerUnderreplicationManager.getUrLockPath(ledgersRootPath)).get();
+
+        // Clear the cookies
+        store.deleteRecursive(cookiePath).get();
+
+        // Clear the INSTANCEID
+        if (store.exists(ledgersRootPath + "/" + BookKeeperConstants.INSTANCEID).get()) {
+            store.delete(ledgersRootPath + "/" + BookKeeperConstants.INSTANCEID, Optional.empty()).get();
+        }
+
+        // create INSTANCEID
+        String instanceId = UUID.randomUUID().toString();
+        store.put(ledgersRootPath + "/" + BookKeeperConstants.INSTANCEID,
+                instanceId.getBytes(StandardCharsets.UTF_8), Optional.of(-1L)).get();
+
+        log.info("Successfully formatted BookKeeper metadata");
+        return true;
+    }
+
+    @Override
+    public boolean nukeExistingCluster() throws Exception {
+        log.info("Nuking metadata of existing cluster, ledger root path: {}", ledgersRootPath);
+
+        if (!store.exists(ledgersRootPath + "/" + INSTANCEID).join()) {
+            log.info("There is no existing cluster with ledgersRootPath: {}, so exiting nuke operation",
+                    ledgersRootPath);
+            return true;
+        }
+
+        @Cleanup
+        RegistrationClient registrationClient = new PulsarRegistrationClient(store, ledgersRootPath);
+
+        Collection<BookieId> rwBookies = registrationClient.getWritableBookies().join().getValue();
+        if (rwBookies != null && !rwBookies.isEmpty()) {
+            log.error("Bookies are still up and connected to this cluster, "
+                    + "stop all bookies before nuking the cluster");
+            return false;
+        }
+
+        Collection<BookieId> roBookies = registrationClient.getReadOnlyBookies().join().getValue();
+        if (roBookies != null && !roBookies.isEmpty()) {
+            log.error("Readonly Bookies are still up and connected to this cluster, "
+                    + "stop all bookies before nuking the cluster");
+            return false;
+        }
+
+        LayoutManager layoutManager = new PulsarLayoutManager(store, ledgersRootPath);
+        LedgerManagerFactory ledgerManagerFactory = new PulsarLedgerManagerFactory();
+        ledgerManagerFactory.initialize(conf, layoutManager, LegacyHierarchicalLedgerManagerFactory.CUR_VERSION);
+        return ledgerManagerFactory.validateAndNukeExistingCluster(conf, layoutManager);
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/BKTestCluster.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/BKTestCluster.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.Bookie;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.common.allocator.PoolingPolicy;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.conf.TestBKConfiguration;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.replication.AutoRecoveryMain;
+import org.apache.bookkeeper.replication.ReplicationException.CompatibilityException;
+import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.util.IOUtils;
+import org.apache.bookkeeper.util.PortManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+
+/**
+ * A class runs several bookie servers for testing.
+ */
+@Slf4j
+class BKTestCluster implements AutoCloseable {
+
+    // Metadata service related variables
+    private final String metadataServiceUri;
+
+    // BookKeeper related variables
+    private final List<File> tmpDirs = new ArrayList<>();
+    private final List<BookieServer> bs = new ArrayList<>();
+    private final List<ServerConfiguration> bsConfs = new ArrayList<>();
+
+    protected final ServerConfiguration baseConf = TestBKConfiguration.newServerConfiguration();
+    protected final ClientConfiguration baseClientConf = TestBKConfiguration.newClientConfiguration();
+
+
+    public BKTestCluster(String metadataServiceUri, int numBookies) throws Exception {
+        this.metadataServiceUri = metadataServiceUri;
+        baseConf.setJournalRemovePagesFromCache(false);
+        System.setProperty("bookkeeper.metadata.bookie.drivers", PulsarMetadataBookieDriver.class.getName());
+        System.setProperty("bookkeeper.metadata.client.drivers", PulsarMetadataClientDriver.class.getName());
+        startBKCluster(numBookies);
+    }
+
+    private final Map<BookieServer, AutoRecoveryMain> autoRecoveryProcesses = new HashMap<>();
+
+    @Getter
+    boolean isAutoRecoveryEnabled = false;
+
+
+    @Override
+    public void close() throws Exception {
+        boolean failed = false;
+        // stop bookkeeper service
+        try {
+            stopBKCluster();
+        } catch (Exception e) {
+            log.error("Got Exception while trying to stop BKCluster", e);
+        }
+        // cleanup temp dirs
+        try {
+            cleanupTempDirs();
+        } catch (Exception e) {
+            log.error("Got Exception while trying to cleanupTempDirs", e);
+        }
+    }
+
+    private File createTempDir(String prefix, String suffix) throws IOException {
+        File dir = IOUtils.createTempDir(prefix, suffix);
+        tmpDirs.add(dir);
+        return dir;
+    }
+
+    /**
+     * Start cluster. Also, starts the auto recovery process for each bookie, if
+     * isAutoRecoveryEnabled is true.
+     *
+     * @throws Exception
+     */
+    private void startBKCluster(int numBookies) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store = MetadataStoreExtended.create(metadataServiceUri, MetadataStoreConfig.builder()
+                .build());
+        PulsarRegistrationManager rm = new PulsarRegistrationManager(store, "/ledgers", baseConf);
+        rm.initNewCluster();
+
+        baseConf.setMetadataServiceUri("metadata-store:" + metadataServiceUri);
+        baseClientConf.setMetadataServiceUri("metadata-store:" + metadataServiceUri);
+
+        // Create Bookie Servers (B1, B2, B3)
+        for (int i = 0; i < numBookies; i++) {
+            startNewBookie();
+        }
+    }
+
+    public BookKeeper newClient() throws Exception {
+        return new BookKeeper(baseClientConf);
+    }
+
+    /**
+     * Stop cluster. Also, stops all the auto recovery processes for the bookie
+     * cluster, if isAutoRecoveryEnabled is true.
+     *
+     * @throws Exception
+     */
+    protected void stopBKCluster() throws Exception {
+        for (BookieServer server : bs) {
+            server.shutdown();
+            AutoRecoveryMain autoRecovery = autoRecoveryProcesses.get(server);
+            if (autoRecovery != null && isAutoRecoveryEnabled()) {
+                autoRecovery.shutdown();
+                log.debug("Shutdown auto recovery for bookieserver:"
+                        + server.getBookieId());
+            }
+        }
+        bs.clear();
+    }
+
+    protected void cleanupTempDirs() throws Exception {
+        for (File f : tmpDirs) {
+            FileUtils.deleteDirectory(f);
+        }
+    }
+
+    private ServerConfiguration newServerConfiguration() throws Exception {
+        File f = createTempDir("bookie", "test");
+
+        int port;
+        if (baseConf.isEnableLocalTransport() || !baseConf.getAllowEphemeralPorts()) {
+            port = PortManager.nextFreePort();
+        } else {
+            port = 0;
+        }
+        return newServerConfiguration(port, f, new File[]{f});
+    }
+
+    private ClientConfiguration newClientConfiguration() {
+        return new ClientConfiguration(baseConf);
+    }
+
+    private ServerConfiguration newServerConfiguration(int port, File journalDir, File[] ledgerDirs) {
+        ServerConfiguration conf = new ServerConfiguration(baseConf);
+        conf.setBookiePort(port);
+        conf.setJournalDirName(journalDir.getPath());
+        String[] ledgerDirNames = new String[ledgerDirs.length];
+        for (int i = 0; i < ledgerDirs.length; i++) {
+            ledgerDirNames[i] = ledgerDirs[i].getPath();
+        }
+        conf.setLedgerDirNames(ledgerDirNames);
+        conf.setEnableTaskExecutionStats(true);
+        conf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
+        return conf;
+    }
+
+    protected void stopAllBookies() throws Exception {
+        stopAllBookies(true);
+    }
+
+    protected void stopAllBookies(boolean shutdownClient) throws Exception {
+        for (BookieServer server : bs) {
+            server.shutdown();
+        }
+        bsConfs.clear();
+        bs.clear();
+    }
+
+    protected void startAllBookies() throws Exception {
+        for (ServerConfiguration conf : bsConfs) {
+            bs.add(startBookie(conf));
+        }
+    }
+
+    /**
+     * Helper method to startup a new bookie server with the indicated port
+     * number. Also, starts the auto recovery process, if the
+     * isAutoRecoveryEnabled is set true.
+     *
+     * @throws IOException
+     */
+    public int startNewBookie()
+            throws Exception {
+        ServerConfiguration conf = newServerConfiguration();
+
+        bsConfs.add(conf);
+        log.info("Starting new bookie on port: {}", conf.getBookiePort());
+        BookieServer server = startBookie(conf);
+        bs.add(server);
+        return server.getLocalAddress().getPort();
+    }
+
+    /**
+     * Helper method to startup a bookie server using a configuration object.
+     * Also, starts the auto recovery process if isAutoRecoveryEnabled is true.
+     *
+     * @param conf
+     *            Server Configuration Object
+     *
+     */
+    protected BookieServer startBookie(ServerConfiguration conf)
+            throws Exception {
+        BookieServer server = new BookieServer(conf, NullStatsLogger.INSTANCE, null);
+        BookieId address = Bookie.getBookieId(conf);
+
+        @Cleanup
+        BookKeeperAdmin bkc = new BookKeeperAdmin(baseClientConf);
+
+        server.start();
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+            Assert.assertTrue(server.isRunning());
+        });
+
+        log.info("New bookie '{}' has been created.", address);
+
+        try {
+            startAutoRecovery(server, conf);
+        } catch (CompatibilityException ce) {
+            log.error("Exception while starting AutoRecovery!", ce);
+        } catch (UnavailableException ue) {
+            log.error("Exception while starting AutoRecovery!", ue);
+        }
+        return server;
+    }
+
+    private void startAutoRecovery(BookieServer bserver,
+                                   ServerConfiguration conf) throws Exception {
+        if (isAutoRecoveryEnabled()) {
+            AutoRecoveryMain autoRecoveryProcess = new AutoRecoveryMain(conf);
+            autoRecoveryProcess.start();
+            autoRecoveryProcesses.put(bserver, autoRecoveryProcess);
+            log.debug("Starting Auditor Recovery for the bookie:"
+                    + bserver.getBookieId());
+        }
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/EndToEndTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/EndToEndTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.client.api.WriteHandle;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test the zookeeper implementation of the ledger replication manager.
+ */
+@Slf4j
+public class EndToEndTest extends BaseMetadataStoreTest {
+    @Test(dataProvider = "impl")
+    public void testBasic(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        BKTestCluster bktc = new BKTestCluster(urlSupplier.get(), 1);
+
+        @Cleanup
+        BookKeeper bkc = bktc.newClient();
+
+        long ledgerId;
+        {
+            @Cleanup
+            WriteHandle wh = bkc.newCreateLedgerOp()
+                    .withEnsembleSize(1)
+                    .withWriteQuorumSize(1)
+                    .withAckQuorumSize(1)
+                    .withDigestType(DigestType.CRC32C)
+                    .withPassword(new byte[0])
+                    .execute()
+                    .join();
+
+            for (int i = 0; i < 10; i++) {
+                wh.append(("entry-" + i).getBytes(StandardCharsets.UTF_8));
+                log.info("Written entry {}", i);
+            }
+
+            ledgerId = wh.getId();
+        }
+
+        @Cleanup
+        ReadHandle rh = bkc.newOpenLedgerOp()
+                .withLedgerId(ledgerId)
+                .withPassword(new byte[0])
+                .execute()
+                .join();
+
+        @Cleanup
+        LedgerEntries les = rh.read(0, 9);
+        for (LedgerEntry le : les) {
+            log.info("Read entry: {}", new String(le.getEntryBytes()));
+        }
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
@@ -1,0 +1,483 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerMetadataBuilder;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManager.LedgerRangeIterator;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.versioning.Version;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test the ledger manager iterator.
+ */
+@Slf4j
+public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
+
+    private String newLedgersRoot() {
+        return "/ledgers-" + UUID.randomUUID();
+    }
+
+    /**
+     * Remove ledger using lm synchronously.
+     *
+     * @param lm
+     * @param ledgerId
+     * @throws InterruptedException
+     */
+    void removeLedger(LedgerManager lm, Long ledgerId) throws Exception {
+        lm.removeLedgerMetadata(ledgerId, Version.ANY).get();
+    }
+
+    /**
+     * Create ledger using lm synchronously.
+     *
+     * @param lm
+     * @param ledgerId
+     * @throws InterruptedException
+     */
+    void createLedger(LedgerManager lm, Long ledgerId) throws Exception {
+        createLedgerAsync(lm, ledgerId).get();
+    }
+
+    CompletableFuture<Versioned<LedgerMetadata>> createLedgerAsync(LedgerManager lm, long ledgerId) {
+        List<BookieId> ensemble = Lists.newArrayList(new BookieSocketAddress("192.0.2.1", 1234).toBookieId(),
+                new BookieSocketAddress("192.0.2.2", 1234).toBookieId(),
+                new BookieSocketAddress("192.0.2.3", 1234).toBookieId());
+        LedgerMetadata meta = LedgerMetadataBuilder.create()
+                .withId(ledgerId)
+                .withEnsembleSize(3).withWriteQuorumSize(3).withAckQuorumSize(2)
+                .withPassword("passwd".getBytes())
+                .withDigestType(BookKeeper.DigestType.CRC32.toApiDigestType())
+                .newEnsembleEntry(0L, ensemble)
+                .build();
+        return lm.createLedgerMetadata(ledgerId, meta);
+    }
+
+    static Set<Long> ledgerRangeToSet(LedgerRangeIterator lri) throws IOException {
+        Set<Long> ret = new TreeSet<>();
+        long last = -1;
+        while (lri.hasNext()) {
+            LedgerManager.LedgerRange lr = lri.next();
+            assertFalse("ledger range must not be empty", lr.getLedgers().isEmpty());
+            assertTrue("ledger ranges must not overlap", last < lr.start());
+            ret.addAll(lr.getLedgers());
+            last = lr.end();
+        }
+        return ret;
+    }
+
+    static Set<Long> getLedgerIdsByUsingAsyncProcessLedgers(LedgerManager lm) throws InterruptedException {
+        Set<Long> ledgersReadAsync = ConcurrentHashMap.newKeySet();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger finalRC = new AtomicInteger();
+
+        lm.asyncProcessLedgers((ledgerId, callback) -> {
+            ledgersReadAsync.add(ledgerId);
+            callback.processResult(BKException.Code.OK, null, null);
+        }, (rc, s, obj) -> {
+            finalRC.set(rc);
+            latch.countDown();
+        }, null, BKException.Code.OK, BKException.Code.ReadException);
+
+        latch.await();
+        assertEquals("Final RC of asyncProcessLedgers", BKException.Code.OK, finalRC.get());
+        return ledgersReadAsync;
+    }
+
+    @Test(dataProvider = "impl")
+    public void testIterateNoLedgers(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        if (lri.hasNext()) {
+            lri.next();
+        }
+
+        assertEquals(false, lri.hasNext());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testSingleLedger(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+
+        long id = 2020202;
+        createLedger(lm, id);
+
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        Set<Long> lids = ledgerRangeToSet(lri);
+        assertEquals(lids.size(), 1);
+        assertEquals(lids.iterator().next().longValue(), id);
+
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", lids, ledgersReadAsync);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testTwoLedgers(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+
+        Set<Long> ids = new TreeSet<>(Arrays.asList(101010101L, 2020340302L));
+        for (Long id : ids) {
+            createLedger(lm, id);
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testSeveralContiguousLedgers(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+
+        Set<Long> ids = new TreeSet<>();
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (long i = 0; i < 2000; ++i) {
+            futures.add(createLedgerAsync(lm, i));
+            ids.add(i);
+        }
+
+        FutureUtil.waitForAll(futures).get();
+
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testRemovalOfNodeJustTraversed(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+
+        /* For LHLM, first two should be leaves on the same node, second should be on adjacent level 4 node
+         * Removing all 3 once the iterator hits the first should result in the whole tree path ending
+         * at that node disappearing.  If this happens after the iterator stops at that leaf, it should
+         * result in a few NodeExists errors (handled silently) as the iterator fails back up the tree
+         * to the next path.
+         */
+        Set<Long> toRemove = new TreeSet<>(
+                Arrays.asList(
+                        3394498498348983841L,
+                        3394498498348983842L,
+                        3394498498348993841L));
+
+        long first = 2345678901234567890L;
+        // Nodes which should be listed anyway
+        Set<Long> mustHave = new TreeSet<>(
+                Arrays.asList(
+                        first,
+                        6334994393848474732L));
+
+        Set<Long> ids = new TreeSet<>();
+        ids.addAll(toRemove);
+        ids.addAll(mustHave);
+        for (Long id : ids) {
+            createLedger(lm, id);
+        }
+
+        Set<Long> found = new TreeSet<>();
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        while (lri.hasNext()) {
+            LedgerManager.LedgerRange lr = lri.next();
+            found.addAll(lr.getLedgers());
+
+            if (lr.getLedgers().contains(first)) {
+                for (long id : toRemove) {
+                    removeLedger(lm, id);
+                }
+                toRemove.clear();
+            }
+        }
+
+        for (long id : mustHave) {
+            assertTrue(found.contains(id));
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void validateEmptyL4PathSkipped(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = newLedgersRoot();
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, ledgersRoot);
+
+        Set<Long> ids = new TreeSet<>(
+                Arrays.asList(
+                        2345678901234567890L,
+                        3394498498348983841L,
+                        6334994393848474732L,
+                        7349370101927398483L));
+        for (Long id : ids) {
+            createLedger(lm, id);
+        }
+
+        String[] paths = {
+                ledgersRoot + "/633/4994/3938/4948", // Empty L4 path, must be skipped
+
+        };
+
+        for (String path : paths) {
+            store.put(path, "data".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+
+        lri = lm.getLedgerRanges(0);
+        int emptyRanges = 0;
+        while (lri.hasNext()) {
+            if (lri.next().getLedgers().isEmpty()) {
+                emptyRanges++;
+            }
+        }
+        assertEquals(0, emptyRanges);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testWithSeveralIncompletePaths(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = newLedgersRoot();
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, ledgersRoot);
+
+        Set<Long> ids = new TreeSet<>(
+                Arrays.asList(
+                        2345678901234567890L,
+                        3394498498348983841L,
+                        6334994393848474732L,
+                        7349370101927398483L));
+        for (Long id : ids) {
+            createLedger(lm, id);
+        }
+
+        String[] paths = {
+                ledgersRoot + "000/0000/0000", // top level, W-4292762
+                ledgersRoot + "/234/5678/9999", // shares two path segments with the first one, comes after
+                ledgersRoot + "/339/0000/0000", // shares one path segment with the second one, comes first
+                ledgersRoot + "/633/4994/3938/0000", // shares three path segments with the third one, comes first
+                ledgersRoot + "/922/3372/0000/0000", // close to max long, at end
+
+        };
+        for (String path : paths) {
+            store.put(path, "data".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
+        }
+
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+        assertNotNull(lri);
+        Set<Long> returnedIds = ledgerRangeToSet(lri);
+        assertEquals(ids, returnedIds);
+
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", ids, ledgersReadAsync);
+    }
+
+    @Test(dataProvider = "impl")
+    public void checkConcurrentModifications(String provider, Supplier<String> urlSupplier) throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = newLedgersRoot();
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, ledgersRoot);
+        final int numWriters = 10;
+        final int numCheckers = 10;
+        final int numLedgers = 100;
+        final long runtime = TimeUnit.NANOSECONDS.convert(2, TimeUnit.SECONDS);
+        final boolean longRange = true;
+
+        final Set<Long> mustExist = new TreeSet<>();
+        Random rng = new Random();
+        for (int i = 0; i < numLedgers; ++i) {
+            long lid = Math.abs(rng.nextLong());
+            if (!longRange) {
+                lid %= 1000000;
+            }
+            createLedger(lm, lid);
+            mustExist.add(lid);
+        }
+
+        final long start = MathUtils.nowInNano();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ArrayList<Future<?>> futures = new ArrayList<>();
+        ExecutorService executor = Executors.newCachedThreadPool();
+        final ConcurrentSkipListSet<Long> createdLedgers = new ConcurrentSkipListSet<>();
+        for (int i = 0; i < numWriters; ++i) {
+            Future<?> f = executor.submit(() -> {
+                @Cleanup
+                LedgerManager writerLM = new PulsarLedgerManager(store, ledgersRoot);
+                Random writerRNG = new Random(rng.nextLong());
+
+                latch.await();
+
+                while (MathUtils.elapsedNanos(start) < runtime) {
+                    long candidate = 0;
+                    do {
+                        candidate = Math.abs(writerRNG.nextLong());
+                        if (!longRange) {
+                            candidate %= 1000000;
+                        }
+                    } while (mustExist.contains(candidate) || !createdLedgers.add(candidate));
+
+                    createLedger(writerLM, candidate);
+                    removeLedger(writerLM, candidate);
+                }
+                return null;
+            });
+            futures.add(f);
+        }
+
+        for (int i = 0; i < numCheckers; ++i) {
+            Future<?> f = executor.submit(() -> {
+                @Cleanup
+                LedgerManager checkerLM = new PulsarLedgerManager(store, ledgersRoot);
+                latch.await();
+
+                while (MathUtils.elapsedNanos(start) < runtime) {
+                    LedgerRangeIterator lri = checkerLM.getLedgerRanges(0);
+                    Set<Long> returnedIds = ledgerRangeToSet(lri);
+                    for (long id : mustExist) {
+                        assertTrue(returnedIds.contains(id));
+                    }
+
+                    Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(checkerLM);
+                    for (long id : mustExist) {
+                        assertTrue(ledgersReadAsync.contains(id));
+                    }
+                }
+                return null;
+            });
+            futures.add(f);
+        }
+
+        latch.countDown();
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        executor.shutdownNow();
+    }
+
+    @Test(dataProvider = "impl")
+    public void hierarchicalLedgerManagerAsyncProcessLedgersTest(String provider, Supplier<String> urlSupplier)
+            throws Throwable {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        LedgerManager lm = new PulsarLedgerManager(store, newLedgersRoot());
+        LedgerRangeIterator lri = lm.getLedgerRanges(0);
+
+        Set<Long> ledgerIds = new TreeSet<>(Arrays.asList(1234L, 123456789123456789L));
+        for (Long ledgerId : ledgerIds) {
+            createLedger(lm, ledgerId);
+        }
+        Set<Long> ledgersReadThroughIterator = ledgerRangeToSet(lri);
+        assertEquals("Comparing LedgersIds read through Iterator", ledgerIds, ledgersReadThroughIterator);
+        Set<Long> ledgersReadAsync = getLedgerIdsByUsingAsyncProcessLedgers(lm);
+        assertEquals("Comparing LedgersIds read asynchronously", ledgerIds, ledgersReadAsync);
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -1,0 +1,728 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import com.google.protobuf.TextFormat;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
+import org.apache.bookkeeper.meta.LedgerUnderreplicationManager;
+import org.apache.bookkeeper.meta.UnderreplicatedLedger;
+import org.apache.bookkeeper.meta.ZkLedgerUnderreplicationManager;
+import org.apache.bookkeeper.net.DNS;
+import org.apache.bookkeeper.proto.DataFormats.UnderreplicatedLedgerFormat;
+import org.apache.bookkeeper.replication.ReplicationException.UnavailableException;
+import org.apache.bookkeeper.util.BookKeeperConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test the zookeeper implementation of the ledger replication manager.
+ */
+@Slf4j
+public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
+
+    private Future<Long> getLedgerToReplicate(LedgerUnderreplicationManager m) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                log.info("Starting thread checking for ledgers");
+                long l = m.getLedgerToRereplicate();
+                log.info("Get ledger id: {}", Long.toHexString(l));
+                return l;
+            } catch (Exception e) {
+                log.error("Error getting ledger id", e);
+                return -1L;
+            }
+        });
+    }
+
+    private MetadataStoreExtended store;
+    private LayoutManager layoutManager;
+    private LedgerManagerFactory lmf;
+    private LedgerUnderreplicationManager lum;
+
+    private String basePath;
+    private String urLedgerPath;
+
+    private void methodSetup(Supplier<String> urlSupplier) throws Exception {
+        String ledgersRoot = "/ledgers-" + UUID.randomUUID();
+        this.store = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        this.layoutManager = new PulsarLayoutManager(store, ledgersRoot);
+        this.lmf = new PulsarLedgerManagerFactory();
+
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setZkLedgersRootPath(ledgersRoot);
+        this.lmf.initialize(conf, layoutManager, 1);
+        this.lum = lmf.newLedgerUnderreplicationManager();
+
+        basePath = ledgersRoot + '/'
+                + BookKeeperConstants.UNDER_REPLICATION_NODE;
+        urLedgerPath = basePath
+                + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void methodCleanup() throws Exception {
+        if (lum != null) {
+            lum.close();
+        }
+        if (lmf != null) {
+            lmf.close();
+        }
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    /**
+     * Test basic interactions with the ledger underreplication
+     * manager.
+     * Mark some ledgers as underreplicated.
+     * Ensure that getLedgerToReplicate will block until it a ledger
+     * becomes available.
+     */
+    @Test(dataProvider = "impl")
+    public void testBasicInteraction(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        Set<Long> ledgers = new HashSet<>();
+        ledgers.add(0xdeadbeefL);
+        ledgers.add(0xbeefcafeL);
+        ledgers.add(0xffffbeefL);
+        ledgers.add(0xfacebeefL);
+        String missingReplica = "localhost:3181";
+
+        int count = ledgers.size();
+        for (long l : ledgers) {
+            lum.markLedgerUnderreplicated(l, missingReplica);
+        }
+
+        List<Future<Long>> futures = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            futures.add(getLedgerToReplicate(lum));
+        }
+
+        for (Future<Long> f : futures) {
+            Long l = f.get(5, TimeUnit.SECONDS);
+            assertTrue(ledgers.remove(l));
+        }
+
+        Future<Long> f = getLedgerToReplicate(lum);
+        try {
+            f.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // correct behaviour
+        }
+        Long newl = 0xfefefefefefeL;
+        lum.markLedgerUnderreplicated(newl, missingReplica);
+        assertEquals("Should have got the one just added", newl, f.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetList(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        Set<Long> ledgers = new HashSet<>();
+        ledgers.add(0xdeadbeefL);
+        ledgers.add(0xbeefcafeL);
+        ledgers.add(0xffffbeefL);
+        ledgers.add(0xfacebeefL);
+        String missingReplica = "localhost:3181";
+
+        for (long l : ledgers) {
+            lum.markLedgerUnderreplicated(l, missingReplica);
+        }
+
+        Set<Long> foundLedgers = new HashSet<>();
+        for (Iterator<UnderreplicatedLedger> it = lum.listLedgersToRereplicate(null); it.hasNext(); ) {
+            UnderreplicatedLedger ul = it.next();
+            foundLedgers.add(ul.getLedgerId());
+        }
+
+        assertEquals(foundLedgers, ledgers);
+    }
+
+    /**
+     * Test locking for ledger unreplication manager.
+     * If there's only one ledger marked for rereplication,
+     * and one client has it, it should be locked; another
+     * client shouldn't be able to get it. If the first client dies
+     * however, the second client should be able to get it.
+     */
+    @Test(dataProvider = "impl")
+    public void testLocking(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        String missingReplica = "localhost:3181";
+
+        LedgerUnderreplicationManager m1 = lmf.newLedgerUnderreplicationManager();
+
+        @Cleanup
+        LedgerUnderreplicationManager m2 = lmf.newLedgerUnderreplicationManager();
+
+        Long ledger = 0xfeadeefdacL;
+        m1.markLedgerUnderreplicated(ledger, missingReplica);
+        Future<Long> f = getLedgerToReplicate(m1);
+        Long l = f.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger I just marked", ledger, l);
+
+        f = getLedgerToReplicate(m2);
+        try {
+            f.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // correct behaviour
+        }
+
+        // Release the lock
+        m1.close();
+
+        l = f.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger I marked", ledger, l);
+    }
+
+
+    /**
+     * Test that when a ledger has been marked as replicated, it
+     * will not be offered to anther client.
+     * This test checked that by marking two ledgers, and acquiring
+     * them on a single client. It marks one as replicated and then
+     * the client is killed. We then check that another client can
+     * acquire a ledger, and that it's not the one that was previously
+     * marked as replicated.
+     */
+    @Test(dataProvider = "impl")
+    public void testMarkingAsReplicated(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        String missingReplica = "localhost:3181";
+
+        LedgerUnderreplicationManager m1 = lmf.newLedgerUnderreplicationManager();
+
+        @Cleanup
+        LedgerUnderreplicationManager m2 = lmf.newLedgerUnderreplicationManager();
+
+        Long ledgerA = 0xfeadeefdacL;
+        Long ledgerB = 0xdefadebL;
+        m1.markLedgerUnderreplicated(ledgerA, missingReplica);
+        m1.markLedgerUnderreplicated(ledgerB, missingReplica);
+
+        Future<Long> fA = getLedgerToReplicate(m1);
+        Future<Long> fB = getLedgerToReplicate(m1);
+
+        Long lA = fA.get(5, TimeUnit.SECONDS);
+        Long lB = fB.get(5, TimeUnit.SECONDS);
+
+        assertTrue("Should be the ledgers I just marked",
+                (lA.equals(ledgerA) && lB.equals(ledgerB))
+                        || (lA.equals(ledgerB) && lB.equals(ledgerA)));
+
+        Future<Long> f = getLedgerToReplicate(m2);
+        try {
+            f.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // correct behaviour
+        }
+        m1.markLedgerReplicated(lA);
+
+        // Release the locks
+        m1.close();
+
+        Long l = f.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger I marked", lB, l);
+    }
+
+    /**
+     * Test releasing of a ledger
+     * A ledger is released when a client decides it does not want
+     * to replicate it (or cannot at the moment).
+     * When a client releases a previously acquired ledger, another
+     * client should then be able to acquire it.
+     */
+    @Test(dataProvider = "impl")
+    public void testRelease(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        String missingReplica = "localhost:3181";
+
+        @Cleanup
+        LedgerUnderreplicationManager m1 = lmf.newLedgerUnderreplicationManager();
+
+        @Cleanup
+        LedgerUnderreplicationManager m2 = lmf.newLedgerUnderreplicationManager();
+
+        Long ledgerA = 0xfeadeefdacL;
+        Long ledgerB = 0xdefadebL;
+        m1.markLedgerUnderreplicated(ledgerA, missingReplica);
+        m1.markLedgerUnderreplicated(ledgerB, missingReplica);
+
+        Future<Long> fA = getLedgerToReplicate(m1);
+        Future<Long> fB = getLedgerToReplicate(m1);
+
+        Long lA = fA.get(5, TimeUnit.SECONDS);
+        Long lB = fB.get(5, TimeUnit.SECONDS);
+
+        assertTrue("Should be the ledgers I just marked",
+                (lA.equals(ledgerA) && lB.equals(ledgerB))
+                        || (lA.equals(ledgerB) && lB.equals(ledgerA)));
+
+        Future<Long> f = getLedgerToReplicate(m2);
+        try {
+            f.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // correct behaviour
+        }
+        m1.markLedgerReplicated(lA);
+        m1.releaseUnderreplicatedLedger(lB);
+
+        Long l = f.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger I marked", lB, l);
+    }
+
+    /**
+     * Test that when a failure occurs on a ledger, while the ledger
+     * is already being rereplicated, the ledger will still be in the
+     * under replicated ledger list when first rereplicating client marks
+     * it as replicated.
+     */
+    @Test(dataProvider = "impl")
+    public void testManyFailures(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        String missingReplica1 = "localhost:3181";
+        String missingReplica2 = "localhost:3182";
+
+        Long ledgerA = 0xfeadeefdacL;
+        lum.markLedgerUnderreplicated(ledgerA, missingReplica1);
+
+        Future<Long> fA = getLedgerToReplicate(lum);
+        Long lA = fA.get(5, TimeUnit.SECONDS);
+
+        lum.markLedgerUnderreplicated(ledgerA, missingReplica2);
+
+        assertEquals("Should be the ledger I just marked",
+                lA, ledgerA);
+        lum.markLedgerReplicated(lA);
+
+        Future<Long> f = getLedgerToReplicate(lum);
+        lA = f.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger I had marked previously",
+                lA, ledgerA);
+    }
+
+    /**
+     * If replicationworker has acquired lock on it, then
+     * getReplicationWorkerIdRereplicatingLedger should return
+     * ReplicationWorkerId (BookieId) of the ReplicationWorker that is holding
+     * lock. If lock for the underreplicated ledger is not yet acquired or if it
+     * is released then it is supposed to return null.
+     *
+     * @throws Exception
+     */
+    @Test(dataProvider = "impl")
+    public void testGetReplicationWorkerIdRereplicatingLedger(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        String missingReplica1 = "localhost:3181";
+        String missingReplica2 = "localhost:3182";
+
+        Long ledgerA = 0xfeadeefdacL;
+        lum.markLedgerUnderreplicated(ledgerA, missingReplica1);
+        lum.markLedgerUnderreplicated(ledgerA, missingReplica2);
+
+        // lock is not yet acquired so replicationWorkerIdRereplicatingLedger
+        // should
+        assertEquals("ReplicationWorkerId of the lock", null, lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+
+        Future<Long> fA = getLedgerToReplicate(lum);
+        Long lA = fA.get(5, TimeUnit.SECONDS);
+        assertEquals("Should be the ledger that was just marked", lA, ledgerA);
+
+        /*
+         * ZkLedgerUnderreplicationManager.getLockData uses
+         * DNS.getDefaultHost("default") as the bookieId.
+         *
+         */
+        assertEquals("ReplicationWorkerId of the lock", DNS.getDefaultHost("default"),
+                lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+
+        lum.markLedgerReplicated(lA);
+
+        assertEquals("ReplicationWorkerId of the lock", null, lum.getReplicationWorkerIdRereplicatingLedger(ledgerA));
+    }
+
+    /**
+     * Test that when a ledger is marked as underreplicated with
+     * the same missing replica twice, only marking as replicated
+     * will be enough to remove it from the list.
+     */
+    @Test(dataProvider = "impl")
+    public void test2reportSame(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        String missingReplica1 = "localhost:3181";
+
+        LedgerUnderreplicationManager m1 = lmf.newLedgerUnderreplicationManager();
+        LedgerUnderreplicationManager m2 = lmf.newLedgerUnderreplicationManager();
+
+        Long ledgerA = 0xfeadeefdacL;
+        m1.markLedgerUnderreplicated(ledgerA, missingReplica1);
+        m2.markLedgerUnderreplicated(ledgerA, missingReplica1);
+
+        // verify duplicate missing replica
+        UnderreplicatedLedgerFormat.Builder builderA = UnderreplicatedLedgerFormat
+                .newBuilder();
+        byte[] data = store.get(getUrLedgerZnode(ledgerA)).join().get().getValue();
+        TextFormat.merge(new String(data, Charset.forName("UTF-8")), builderA);
+        List<String> replicaList = builderA.getReplicaList();
+        assertEquals("Published duplicate missing replica : " + replicaList, 1,
+                replicaList.size());
+        assertTrue("Published duplicate missing replica : " + replicaList,
+                replicaList.contains(missingReplica1));
+
+        Future<Long> fA = getLedgerToReplicate(m1);
+        Long lA = fA.get(5, TimeUnit.SECONDS);
+
+        assertEquals("Should be the ledger I just marked",
+                lA, ledgerA);
+        m1.markLedgerReplicated(lA);
+
+        Future<Long> f = getLedgerToReplicate(m2);
+        try {
+            f.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // correct behaviour
+        }
+    }
+
+    /**
+     * Test that multiple LedgerUnderreplicationManagers should be able to take
+     * lock and release for same ledger.
+     */
+    @Test(dataProvider = "impl")
+    public void testMultipleManagersShouldBeAbleToTakeAndReleaseLock(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        String missingReplica1 = "localhost:3181";
+        final LedgerUnderreplicationManager m1 = lmf
+                .newLedgerUnderreplicationManager();
+        final LedgerUnderreplicationManager m2 = lmf
+                .newLedgerUnderreplicationManager();
+        Long ledgerA = 0xfeadeefdacL;
+        m1.markLedgerUnderreplicated(ledgerA, missingReplica1);
+        final int iterationCount = 100;
+        final CountDownLatch latch1 = new CountDownLatch(iterationCount);
+        final CountDownLatch latch2 = new CountDownLatch(iterationCount);
+        Thread thread1 = new Thread() {
+            @Override
+            public void run() {
+                takeLedgerAndRelease(m1, latch1, iterationCount);
+            }
+        };
+
+        Thread thread2 = new Thread() {
+            @Override
+            public void run() {
+                takeLedgerAndRelease(m2, latch2, iterationCount);
+            }
+        };
+        thread1.start();
+        thread2.start();
+
+        // wait until at least one thread completed
+        while (!latch1.await(50, TimeUnit.MILLISECONDS)
+                && !latch2.await(50, TimeUnit.MILLISECONDS)) {
+            Thread.sleep(50);
+        }
+
+        m1.close();
+        m2.close();
+
+        // After completing 'lock acquire,release' job, it should notify below
+        // wait
+        latch1.await();
+        latch2.await();
+    }
+
+    /**
+     * Test verifies failures of bookies which are resembling each other.
+     *
+     * <p>BK servers named like*********************************************
+     * 1.cluster.com, 2.cluster.com, 11.cluster.com, 12.cluster.com
+     * *******************************************************************
+     *
+     * <p>BKserver IP:HOST like*********************************************
+     * localhost:3181, localhost:318, localhost:31812
+     * *******************************************************************
+     */
+    @Test(dataProvider = "impl")
+    public void testMarkSimilarMissingReplica(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        List<String> missingReplica = new ArrayList<String>();
+        missingReplica.add("localhost:3181");
+        missingReplica.add("localhost:318");
+        missingReplica.add("localhost:31812");
+        missingReplica.add("1.cluster.com");
+        missingReplica.add("2.cluster.com");
+        missingReplica.add("11.cluster.com");
+        missingReplica.add("12.cluster.com");
+        verifyMarkLedgerUnderreplicated(missingReplica);
+    }
+
+    /**
+     * Test multiple bookie failures for a ledger and marked as underreplicated
+     * one after another.
+     */
+    @Test(dataProvider = "impl")
+    public void testManyFailuresInAnEnsemble(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        List<String> missingReplica = new ArrayList<String>();
+        missingReplica.add("localhost:3181");
+        missingReplica.add("localhost:3182");
+        verifyMarkLedgerUnderreplicated(missingReplica);
+    }
+
+    /**
+     * Test disabling the ledger re-replication. After disabling, it will not be
+     * able to getLedgerToRereplicate(). This calls will enter into infinite
+     * waiting until enabling rereplication process
+     */
+    @Test(dataProvider = "impl")
+    public void testDisableLedgerReplication(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        // simulate few urLedgers before disabling
+        final Long ledgerA = 0xfeadeefdacL;
+        final String missingReplica = "localhost:3181";
+
+        // disabling replication
+        lum.disableLedgerReplication();
+        log.info("Disabled Ledeger Replication");
+
+        try {
+            lum.markLedgerUnderreplicated(ledgerA, missingReplica);
+        } catch (UnavailableException e) {
+            log.error("Unexpected exception while marking urLedger", e);
+            fail("Unexpected exception while marking urLedger" + e.getMessage());
+        }
+
+        Future<Long> fA = getLedgerToReplicate(lum);
+        try {
+            fA.get(1, TimeUnit.SECONDS);
+            fail("Shouldn't be able to find a ledger to replicate");
+        } catch (TimeoutException te) {
+            // expected behaviour, as the replication is disabled
+        }
+    }
+
+    /**
+     * Test enabling the ledger re-replication. After enableLedegerReplication,
+     * should continue getLedgerToRereplicate() task
+     */
+    @Test(dataProvider = "impl")
+    public void testEnableLedgerReplication(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+
+        // simulate few urLedgers before disabling
+        final Long ledgerA = 0xfeadeefdacL;
+        final String missingReplica = "localhost:3181";
+        try {
+            lum.markLedgerUnderreplicated(ledgerA, missingReplica);
+        } catch (UnavailableException e) {
+            log.debug("Unexpected exception while marking urLedger", e);
+            fail("Unexpected exception while marking urLedger" + e.getMessage());
+        }
+
+        // disabling replication
+        lum.disableLedgerReplication();
+        log.debug("Disabled Ledeger Replication");
+
+        String znodeA = getUrLedgerZnode(ledgerA);
+        final CountDownLatch znodeLatch = new CountDownLatch(2);
+        String urledgerA = StringUtils.substringAfterLast(znodeA, "/");
+        String urLockLedgerA = basePath + "/locks/" + urledgerA;
+        store.registerListener(n -> {
+            if (n.getType() == NotificationType.Created && n.getPath().equals(urLockLedgerA)) {
+                znodeLatch.countDown();
+                log.debug("Recieved node creation event for the zNodePath:"
+                        + n.getPath());
+            }
+        });
+
+        // getLedgerToRereplicate is waiting until enable rereplication
+        Thread thread1 = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Long lA = lum.getLedgerToRereplicate();
+                    assertEquals("Should be the ledger I just marked", lA,
+                            ledgerA);
+                    znodeLatch.countDown();
+                } catch (UnavailableException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+        thread1.start();
+
+        try {
+            assertFalse("shouldn't complete", znodeLatch.await(1, TimeUnit.SECONDS));
+            assertEquals("Failed to disable ledger replication!", 2, znodeLatch
+                    .getCount());
+
+            lum.enableLedgerReplication();
+            znodeLatch.await(5, TimeUnit.SECONDS);
+            log.debug("Enabled Ledeger Replication");
+            assertEquals("Failed to disable ledger replication!", 0, znodeLatch
+                    .getCount());
+        } finally {
+            thread1.interrupt();
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testCheckAllLedgersCTime(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr1 = lmf.newLedgerUnderreplicationManager();
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
+        assertEquals(-1, underReplicaMgr1.getCheckAllLedgersCTime());
+        long curTime = System.currentTimeMillis();
+        underReplicaMgr2.setCheckAllLedgersCTime(curTime);
+        assertEquals(curTime, underReplicaMgr1.getCheckAllLedgersCTime());
+        curTime = System.currentTimeMillis();
+        underReplicaMgr2.setCheckAllLedgersCTime(curTime);
+        assertEquals(curTime, underReplicaMgr1.getCheckAllLedgersCTime());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testPlacementPolicyCheckCTime(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr1 = lmf.newLedgerUnderreplicationManager();
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
+
+        assertEquals(-1, underReplicaMgr1.getPlacementPolicyCheckCTime());
+        long curTime = System.currentTimeMillis();
+        underReplicaMgr2.setPlacementPolicyCheckCTime(curTime);
+
+        assertEquals(curTime, underReplicaMgr1.getPlacementPolicyCheckCTime());
+        curTime = System.currentTimeMillis();
+        underReplicaMgr2.setPlacementPolicyCheckCTime(curTime);
+
+        assertEquals(curTime, underReplicaMgr1.getPlacementPolicyCheckCTime());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testReplicasCheckCTime(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr1 = lmf.newLedgerUnderreplicationManager();
+        @Cleanup
+        LedgerUnderreplicationManager underReplicaMgr2 = lmf.newLedgerUnderreplicationManager();
+        assertEquals(-1, underReplicaMgr1.getReplicasCheckCTime());
+        long curTime = System.currentTimeMillis();
+        underReplicaMgr2.setReplicasCheckCTime(curTime);
+        assertEquals(curTime, underReplicaMgr1.getReplicasCheckCTime());
+        curTime = System.currentTimeMillis();
+        underReplicaMgr2.setReplicasCheckCTime(curTime);
+        assertEquals(curTime, underReplicaMgr1.getReplicasCheckCTime());
+    }
+
+    private void verifyMarkLedgerUnderreplicated(Collection<String> missingReplica) throws Exception {
+        Long ledgerA = 0xfeadeefdacL;
+        String znodeA = getUrLedgerZnode(ledgerA);
+        for (String replica : missingReplica) {
+            lum.markLedgerUnderreplicated(ledgerA, replica);
+        }
+
+        String urLedgerA = new String(store.get(znodeA).join().get().getValue());
+        UnderreplicatedLedgerFormat.Builder builderA = UnderreplicatedLedgerFormat
+                .newBuilder();
+        for (String replica : missingReplica) {
+            builderA.addReplica(replica);
+        }
+        List<String> replicaList = builderA.getReplicaList();
+
+        for (String replica : missingReplica) {
+            assertTrue("UrLedger:" + urLedgerA
+                    + " doesn't contain failed bookie :" + replica, replicaList
+                    .contains(replica));
+        }
+    }
+
+    private String getUrLedgerZnode(long ledgerId) {
+        return ZkLedgerUnderreplicationManager.getUrLedgerZnode(urLedgerPath, ledgerId);
+    }
+
+    private void takeLedgerAndRelease(final LedgerUnderreplicationManager m,
+                                      final CountDownLatch latch, int numberOfIterations) {
+        for (int i = 0; i < numberOfIterations; i++) {
+            try {
+                long ledgerToRereplicate = m.getLedgerToRereplicate();
+                m.releaseUnderreplicatedLedger(ledgerToRereplicate);
+            } catch (UnavailableException e) {
+                log.error("UnavailableException when "
+                        + "taking or releasing lock", e);
+            }
+            latch.countDown();
+        }
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLayoutManagerTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.LayoutManager;
+import org.apache.bookkeeper.meta.LayoutManager.LedgerLayoutExistsException;
+import org.apache.bookkeeper.meta.LedgerLayout;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarLayoutManagerTest extends BaseMetadataStoreTest {
+
+    private static final int managerVersion = 0xabcd;
+
+    private MetadataStoreExtended store;
+    private LayoutManager layoutManager;
+
+    private String ledgersRootPath;
+
+
+    private void methodSetup(Supplier<String> urlSupplier) throws Exception {
+        this.ledgersRootPath = "/ledgers-" + UUID.randomUUID();
+        this.store = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        this.layoutManager = new PulsarLayoutManager(store, ledgersRootPath);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void methodCleanup() throws Exception {
+        if (store != null) {
+            store.close();
+            store = null;
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testReadCreateDeleteLayout(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        // layout doesn't exist
+        try {
+            layoutManager.readLedgerLayout();
+            fail("should have failed");
+        } catch (IOException e) {
+            // Expected
+        }
+
+        // create the layout
+        LedgerLayout layout = new LedgerLayout(
+            PulsarLedgerManagerFactory.class.getName(),
+            managerVersion
+        );
+        layoutManager.storeLedgerLayout(layout);
+
+        // read the layout
+        LedgerLayout readLayout = layoutManager.readLedgerLayout();
+        assertEquals(layout, readLayout);
+
+        // attempts to create the layout again and it should fail
+        LedgerLayout newLayout = new LedgerLayout(
+            "new layout",
+            managerVersion + 1
+        );
+        try {
+            layoutManager.storeLedgerLayout(newLayout);
+            fail("Should fail storeLedgerLayout if layout already exists");
+        } catch (LedgerLayoutExistsException e) {
+            // expected
+        }
+
+        // read the layout again (layout should not be changed)
+        readLayout = layoutManager.readLedgerLayout();
+        assertEquals(layout, readLayout);
+
+        // delete the layout
+        layoutManager.deleteLedgerLayout();
+
+        // the layout should be gone now
+        try {
+            layoutManager.readLedgerLayout();
+            fail("should have failed");
+        } catch (IOException e) {
+            // Expected
+        }
+
+        // delete the layout again. it should fail since layout doesn't exist
+        try {
+            layoutManager.deleteLedgerLayout();
+            fail("Should fail deleteLedgerLayout is layout not found");
+        } catch (IOException ioe) {
+            assertTrue(ioe.getMessage().contains("NotFoundException"));
+        }
+    }
+
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.meta.LedgerAuditorManager;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarLedgerAuditorManagerTest extends BaseMetadataStoreTest {
+
+    private static final int managerVersion = 0xabcd;
+
+    private MetadataStoreExtended store1;
+    private MetadataStoreExtended store2;
+
+    private String ledgersRootPath;
+
+
+    private void methodSetup(Supplier<String> urlSupplier) throws Exception {
+        this.ledgersRootPath = "/ledgers-" + UUID.randomUUID();
+        this.store1 = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        this.store2 = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void methodCleanup() throws Exception {
+        if (store1 != null) {
+            store1.close();
+            store1 = null;
+        }
+
+        if (store2 != null) {
+            store2.close();
+            store2 = null;
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testSimple(String provider, Supplier<String> urlSupplier) throws Exception {
+        if (provider.equals("Memory")) {
+            // With memory provider there are not multiple sessions to test with
+            return;
+        }
+
+        methodSetup(urlSupplier);
+
+        LedgerAuditorManager lam1 = new PulsarLedgerAuditorManager(store1, ledgersRootPath);
+        assertNull(lam1.getCurrentAuditor());
+
+        lam1.tryToBecomeAuditor("bookie-1:3181", auditorEvent -> {
+            log.info("---- LAM-1 - Received auditor event: {}", auditorEvent);
+        });
+
+        assertEquals(BookieId.parse("bookie-1:3181"), lam1.getCurrentAuditor());
+
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        LedgerAuditorManager lam2 = new PulsarLedgerAuditorManager(store2, ledgersRootPath);
+        assertEquals(BookieId.parse("bookie-1:3181"), lam2.getCurrentAuditor());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        executor.execute(() -> {
+            try {
+                lam2.tryToBecomeAuditor("bookie-2:3181", auditorEvent -> {
+                    log.info("---- LAM-2 - Received auditor event: {}", auditorEvent);
+                });
+
+                // Lam2 is now auditor
+                latch.countDown();
+            } catch (Exception e) {
+                log.error("---- Failed to become auditor", e);
+            }
+        });
+
+        // LAM2 will be kept waiting until LAM1 goes away
+        assertFalse(latch.await(1, TimeUnit.SECONDS));
+
+        assertEquals(BookieId.parse("bookie-1:3181"), lam1.getCurrentAuditor());
+        assertEquals(BookieId.parse("bookie-1:3181"), lam2.getCurrentAuditor());
+
+        lam1.close();
+
+        // Now LAM2 will take over
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertEquals(BookieId.parse("bookie-2:3181"), lam2.getCurrentAuditor());
+    }
+
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.zookeeper.KeeperException;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarLedgerIdGeneratorTest extends BaseMetadataStoreTest {
+
+    @Test(dataProvider = "impl")
+    public void testGenerateLedgerId(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        @Cleanup
+        PulsarLedgerIdGenerator ledgerIdGenerator = new PulsarLedgerIdGenerator(store, "/ledgers");
+        // Create *nThread* threads each generate *nLedgers* ledger id,
+        // and then check there is no identical ledger id.
+        final int nThread = 2;
+        final int nLedgers = 2000;
+        // Multiply by two. We're going to do half in the old legacy space and half in the new.
+        final CountDownLatch countDownLatch = new CountDownLatch(nThread * nLedgers * 2);
+
+        final AtomicInteger errCount = new AtomicInteger(0);
+        final ConcurrentLinkedQueue<Long> ledgerIds = new ConcurrentLinkedQueue<Long>();
+        final BookkeeperInternalCallbacks.GenericCallback<Long>
+                cb = (rc, result) -> {
+            if (KeeperException.Code.OK.intValue() == rc) {
+                ledgerIds.add(result);
+            } else {
+                errCount.incrementAndGet();
+            }
+            countDownLatch.countDown();
+        };
+
+        long start = System.currentTimeMillis();
+
+        for (int i = 0; i < nThread; i++) {
+            new Thread(() -> {
+                for (int j = 0; j < nLedgers; j++) {
+                    ledgerIdGenerator.generateLedgerId(cb);
+                }
+            }).start();
+        }
+
+        // Go and create the long-id directory in zookeeper. This should cause the id generator to generate ids with the
+        // new algo once we clear it's stored status.
+        store.put("/ledgers/idgen-long", new byte[0], Optional.empty());
+
+        for (int i = 0; i < nThread; i++) {
+            new Thread(() -> {
+                for (int j = 0; j < nLedgers; j++) {
+                    ledgerIdGenerator.generateLedgerId(cb);
+                }
+            }).start();
+        }
+
+        assertTrue(countDownLatch.await(120, TimeUnit.SECONDS),
+                "Wait ledger id generation threads to stop timeout : ");
+        log.info("Number of generated ledger id: {}, time used: {}", ledgerIds.size(),
+                System.currentTimeMillis() - start);
+        assertEquals(errCount.get(), 0, "Error occur during ledger id generation : ");
+
+        Set<Long> ledgers = new HashSet<>();
+        while (!ledgerIds.isEmpty()) {
+            Long ledger = ledgerIds.poll();
+            assertNotNull(ledger, "Generated ledger id is null");
+            assertFalse(ledgers.contains(ledger), "Ledger id [" + ledger + "] conflict : ");
+            ledgers.add(ledger);
+        }
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataDriverBaseStaticTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataDriverBaseStaticTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.junit.Assert.assertEquals;
+import java.net.URI;
+import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
+import org.apache.bookkeeper.meta.LongHierarchicalLedgerManagerFactory;
+import org.apache.bookkeeper.meta.zk.ZKMetadataDriverBase;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test the static methods of {@link ZKMetadataDriverBase}.
+ */
+public class PulsarMetadataDriverBaseStaticTest {
+
+    @Test
+    public void testGetZKServersFromServiceUri() {
+        String uriStr = "zk://server1;server2;server3/ledgers";
+        URI uri = URI.create(uriStr);
+
+        String zkServers = ZKMetadataDriverBase.getZKServersFromServiceUri(uri);
+        assertEquals(
+            "server1,server2,server3",
+            zkServers);
+
+        uriStr = "zk://server1,server2,server3/ledgers";
+        uri = URI.create(uriStr);
+        zkServers = ZKMetadataDriverBase.getZKServersFromServiceUri(uri);
+        assertEquals(
+            "server1,server2,server3",
+            zkServers);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testResolveLedgerManagerFactoryNullUri() {
+        ZKMetadataDriverBase.resolveLedgerManagerFactory(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testResolveLedgerManagerFactoryNullScheme() {
+        ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("//127.0.0.1/ledgers"));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testResolveLedgerManagerFactoryUnknownScheme() {
+        ZKMetadataDriverBase.resolveLedgerManagerFactory(URI.create("unknown://127.0.0.1/ledgers"));
+    }
+
+    @Test
+    public void testResolveLedgerManagerFactoryUnspecifiedLayout() {
+        assertEquals(
+            null,
+            ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                        URI.create("zk://127.0.0.1/ledgers"))
+        );
+    }
+
+    @Test
+    public void testResolveLedgerManagerFactoryNullLayout() {
+        assertEquals(
+                null,
+                ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                        URI.create("zk+null://127.0.0.1/ledgers"))
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testResolveLedgerManagerFactoryFlat() {
+        assertEquals(
+            org.apache.bookkeeper.meta.FlatLedgerManagerFactory.class,
+            ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                URI.create("zk+flat://127.0.0.1/ledgers"))
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testResolveLedgerManagerFactoryMs() {
+        assertEquals(
+            org.apache.bookkeeper.meta.MSLedgerManagerFactory.class,
+            ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                URI.create("zk+ms://127.0.0.1/ledgers"))
+        );
+    }
+
+    @Test
+    public void testResolveLedgerManagerFactoryHierarchical() {
+        assertEquals(
+            HierarchicalLedgerManagerFactory.class,
+            ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                URI.create("zk+hierarchical://127.0.0.1/ledgers"))
+        );
+    }
+
+    @Test
+    public void testResolveLedgerManagerFactoryLongHierarchical() {
+        assertEquals(
+            LongHierarchicalLedgerManagerFactory.class,
+            ZKMetadataDriverBase.resolveLedgerManagerFactory(
+                URI.create("zk+longhierarchical://127.0.0.1/ledgers"))
+        );
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testResolveLedgerManagerFactoryUnknownLedgerManagerFactory() {
+        ZKMetadataDriverBase.resolveLedgerManagerFactory(
+            URI.create("zk+unknown://127.0.0.1/ledgers"));
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.conf.AbstractConfiguration;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.discover.RegistrationClient;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.versioning.Versioned;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.awaitility.Awaitility;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test of {@link RegistrationManager}.
+ */
+@Slf4j
+public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
+
+    private static Set<BookieId> prepareNBookies(int num) {
+        Set<BookieId> bookies = new HashSet<>();
+        for (int i = 0; i < num; i++) {
+            bookies.add(new BookieSocketAddress("127.0.0.1", 3181 + i).toBookieId());
+        }
+        return bookies;
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetWritableBookies(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
+
+        @Cleanup
+        RegistrationManager rm = new PulsarRegistrationManager(store, ledgersRoot, mock(AbstractConfiguration.class));
+
+        @Cleanup
+        RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
+
+        Set<BookieId> addresses = prepareNBookies(10);
+        List<String> children = Lists.newArrayList();
+        for (BookieId address : addresses) {
+            children.add(address.toString());
+            rm.registerBookie(address, false, new BookieServiceInfo());
+        }
+
+        Versioned<Set<BookieId>> result = result(rc.getWritableBookies());
+
+        assertEquals(addresses.size(), result.getValue().size());
+    }
+
+
+    @Test(dataProvider = "impl")
+    public void testGetReadonlyBookies(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
+
+        @Cleanup
+        RegistrationManager rm = new PulsarRegistrationManager(store, ledgersRoot, mock(AbstractConfiguration.class));
+
+        @Cleanup
+        RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
+
+        Set<BookieId> addresses = prepareNBookies(10);
+        List<String> children = Lists.newArrayList();
+        for (BookieId address : addresses) {
+            children.add(address.toString());
+            rm.registerBookie(address, true, new BookieServiceInfo());
+        }
+
+        Versioned<Set<BookieId>> result = result(rc.getReadOnlyBookies());
+
+        assertEquals(addresses.size(), result.getValue().size());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetAllBookies(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
+
+        @Cleanup
+        RegistrationManager rm = new PulsarRegistrationManager(store, ledgersRoot, mock(AbstractConfiguration.class));
+
+        @Cleanup
+        RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
+
+        Set<BookieId> addresses = prepareNBookies(10);
+        List<String> children = Lists.newArrayList();
+        for (BookieId address : addresses) {
+            children.add(address.toString());
+            boolean isReadOnly = children.size() % 2 == 0;
+            rm.registerBookie(address, isReadOnly, new BookieServiceInfo());
+        }
+
+        Versioned<Set<BookieId>> result = result(rc.getAllBookies());
+        assertEquals(addresses.size(), result.getValue().size());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testWatchWritableBookiesSuccess(String provider, Supplier<String> urlSupplier) throws Exception {
+        testWatchBookiesSuccess(provider, urlSupplier, true);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testWatchReadonlyBookiesSuccess(String provider, Supplier<String> urlSupplier) throws Exception {
+        testWatchBookiesSuccess(provider, urlSupplier, false);
+    }
+
+    private void testWatchBookiesSuccess(String provider, Supplier<String> urlSupplier, boolean isWritable)
+            throws Exception {
+
+        @Cleanup
+        MetadataStoreExtended store =
+                MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
+
+        @Cleanup
+        RegistrationManager rm = new PulsarRegistrationManager(store, ledgersRoot, mock(AbstractConfiguration.class));
+
+        @Cleanup
+        RegistrationClient rc = new PulsarRegistrationClient(store, ledgersRoot);
+
+        //
+        // 1. test watch bookies with a listener
+        //
+        Queue<Versioned<Set<BookieId>>> updates = new ConcurrentLinkedQueue<>();
+        Map<BookieId, Boolean> bookies = new ConcurrentHashMap<>();
+        RegistrationClient.RegistrationListener listener = (b) -> {
+            updates.add(b);
+            b.getValue().forEach(x -> bookies.put(x, true));
+        };
+
+        int BOOKIES = 10;
+        Set<BookieId> addresses = prepareNBookies(BOOKIES);
+
+        if (isWritable) {
+            result(rc.watchWritableBookies(listener));
+        } else {
+            result(rc.watchReadOnlyBookies(listener));
+        }
+
+        for (BookieId address : addresses) {
+            rm.registerBookie(address, !isWritable, new BookieServiceInfo());
+        }
+
+        Awaitility.await().untilAsserted(() -> {
+            assertFalse(updates.isEmpty());
+            assertEquals(BOOKIES, bookies.size());
+        });
+    }
+
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationManagerTest.java
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.bookkeeper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.util.UUID;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.bookie.BookieException;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
+import org.apache.bookkeeper.discover.RegistrationManager;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test of {@link RegistrationManager}.
+ */
+@Slf4j
+public class PulsarRegistrationManagerTest extends BaseMetadataStoreTest {
+
+    private MetadataStoreExtended store;
+    private RegistrationManager registrationManager;
+
+    private String ledgersRootPath;
+
+
+    private void methodSetup(Supplier<String> urlSupplier) throws Exception {
+        this.ledgersRootPath = "/ledgers-" + UUID.randomUUID();
+        this.store = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        this.registrationManager = new PulsarRegistrationManager(store, ledgersRootPath, new ServerConfiguration());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void methodCleanup() throws Exception {
+        if (registrationManager != null) {
+            registrationManager.close();
+            registrationManager = null;
+        }
+
+        if (store != null) {
+            store.close();
+            store = null;
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testPrepareFormat(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        registrationManager.prepareFormat();
+        assertTrue(store.exists(ledgersRootPath).join());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetClusterInstanceIdIfClusterNotInitialized(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        try {
+            registrationManager.getClusterInstanceId();
+            fail("Should fail getting cluster instance id if cluster not initialized");
+        } catch (BookieException.MetadataStoreException e) {
+            assertTrue(e.getMessage().contains("BookKeeper cluster not initialized"));
+        }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testGetClusterInstanceId(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertClusterNotExists();
+        registrationManager.initNewCluster();
+        String instanceId = registrationManager.getClusterInstanceId();
+        UUID uuid = UUID.fromString(instanceId);
+        log.info("Cluster instance id : {}", uuid);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testNukeNonExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertClusterNotExists();
+        assertTrue(registrationManager.nukeExistingCluster());
+        assertClusterNotExists();
+    }
+
+    @Test(dataProvider = "impl")
+    public void testNukeExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        assertTrue(registrationManager.nukeExistingCluster());
+        assertClusterNotExists();
+    }
+
+    @Test(dataProvider = "impl")
+    public void testInitNewClusterTwice(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        String instanceId = registrationManager.getClusterInstanceId();
+        assertFalse(registrationManager.initNewCluster());
+        assertClusterExists();
+        assertEquals(instanceId, registrationManager.getClusterInstanceId());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testPrepareFormatNonExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertFalse(registrationManager.prepareFormat());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testPrepareFormatExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        assertTrue(registrationManager.prepareFormat());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testNukeExistingClusterWithWritableBookies(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        testNukeExistingClusterWithBookies(false);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testNukeExistingClusterWithReadonlyBookies(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
+        testNukeExistingClusterWithBookies(true);
+    }
+
+    private void testNukeExistingClusterWithBookies(boolean readonly) throws Exception {
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        createNumBookies(3, readonly);
+        assertFalse(registrationManager.nukeExistingCluster());
+        assertClusterExists();
+        removeNumBookies(3, readonly);
+        assertTrue(registrationManager.nukeExistingCluster());
+        assertClusterNotExists();
+    }
+
+
+    @Test(dataProvider = "impl")
+    public void testNukeExistingClusterWithAllBookies(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        createNumBookies(1, false);
+        createNumBookies(2, true);
+        assertFalse(registrationManager.nukeExistingCluster());
+        assertClusterExists();
+        removeNumBookies(1, false);
+        removeNumBookies(2, true);
+        assertTrue(registrationManager.nukeExistingCluster());
+        assertClusterNotExists();
+    }
+
+    @Test(dataProvider = "impl")
+    public void testFormatNonExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertClusterNotExists();
+        assertTrue(registrationManager.format());
+        assertClusterExists();
+    }
+
+    @Test(dataProvider = "impl")
+    public void testFormatExistingCluster(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertClusterNotExists();
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        String clusterInstanceId = registrationManager.getClusterInstanceId();
+        assertTrue(registrationManager.format());
+        assertClusterExists();
+        assertNotEquals(clusterInstanceId, registrationManager.getClusterInstanceId());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testFormatExistingClusterWithBookies(String provider, Supplier<String> urlSupplier) throws Exception {
+        methodSetup(urlSupplier);
+        assertClusterNotExists();
+        assertTrue(registrationManager.initNewCluster());
+        assertClusterExists();
+        String clusterInstanceId = registrationManager.getClusterInstanceId();
+        createNumBookies(3, false);
+        assertTrue(registrationManager.format());
+        assertClusterExists();
+    }
+
+    private void createNumBookies(int numBookies, boolean readonly) throws Exception {
+        for (int i = 0; i < numBookies; i++) {
+            BookieId bookieId = BookieId.parse("bookie-" + i + ":3181");
+            registrationManager.registerBookie(bookieId, readonly, new BookieServiceInfo());
+        }
+    }
+
+    private void removeNumBookies(int numBookies, boolean readonly) throws Exception {
+        for (int i = 0; i < numBookies; i++) {
+            BookieId bookieId = BookieId.parse("bookie-" + i + ":3181");
+            registrationManager.unregisterBookie(bookieId, readonly);
+        }
+    }
+
+    private void assertClusterExists() {
+        assertTrue(store.exists(ledgersRootPath + "/INSTANCEID").join());
+    }
+
+    private void assertClusterNotExists() {
+        assertFalse(store.exists(ledgersRootPath + "/INSTANCEID").join());
+    }
+}


### PR DESCRIPTION
### Motivation

This PR adds an implementation of BK metadata driver that is based on top of `MetadataStore` API. This will be used to provide a single metadata backend implementation, shared between Pulsar & BookKeeper.

The code has been adapted from the existing ZK provider.

Eventually, at some point it will make sense to have this to live in BK repo, also with MetadataStore API. For now, it's much easier to continue the development in a single place.

