### PR TITLE
[metadata] Add RocksdbMetadataStore

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -325,6 +325,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private long topicLoadTimeoutSeconds = 60;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Configuration file path for local metadata store. It's supported by RocksdbMetadataStore for now."
+    )
+    private String metadataStoreConfigPath = null;
+
+    @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "Enable backlog quota check. Enforces actions on topic when the quota is reached"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -331,6 +331,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MetadataStoreConfig.builder()
                         .sessionTimeoutMillis((int) config.getZooKeeperSessionTimeoutMillis())
                         .allowReadOnlyOperations(false)
+                        .configFilePath(config.getMetadataStoreConfigPath())
                         .build());
     }
 
@@ -912,6 +913,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MetadataStoreConfig.builder()
                         .sessionTimeoutMillis((int) config.getZooKeeperSessionTimeoutMillis())
                         .allowReadOnlyOperations(false)
+                        .configFilePath(config.getMetadataStoreConfigPath())
                         .build());
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -39,4 +39,10 @@ public class MetadataStoreConfig {
      */
     @Builder.Default
     private final boolean allowReadOnlyOperations = false;
+
+    /**
+     * Config file path for the underlying metadata store implementation.
+     */
+    @Builder.Default
+    private final String configFilePath = null;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -184,4 +184,12 @@ public class MetadataStoreException extends IOException {
             return new MetadataStoreException(t);
         }
     }
+
+    public static MetadataStoreException wrap(Throwable t) {
+        if (t instanceof MetadataStoreException) {
+            return (MetadataStoreException) t;
+        } else {
+            return new MetadataStoreException(t);
+        }
+    }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
@@ -19,10 +19,8 @@
 package org.apache.pulsar.metadata.api;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode
 public final class Notification {
     /**
      * The type of the event being notified.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
@@ -19,8 +19,10 @@
 package org.apache.pulsar.metadata.api;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode
 public final class Notification {
     /**
      * The type of the event being notified.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -139,6 +140,21 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<>(this, serde);
         metadataCaches.add(metadataCache);
         return metadataCache;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> get(String path) {
+        if (!isValidPath(path)) {
+            return FutureUtil.failedFuture(new MetadataStoreException.InvalidPathException(path));
+        }
+        return storeGet(path);
+    }
+
+    protected abstract CompletableFuture<Optional<GetResult>> storeGet(String path);
+
+    @Override
+    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
+        return put(path, value, expectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -328,4 +328,12 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
                 && path.startsWith("/")
                 && !path.endsWith("/");
     }
+
+    protected void notifyParentChildrenChanged(String path) {
+        String parent = parent(path);
+        while (parent != null) {
+            receivedNotification(new Notification(NotificationType.ChildrenChanged, parent));
+            parent = parent(parent);
+        }
+    }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -90,10 +90,7 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
     }
 
     @Override
-    public CompletableFuture<Optional<GetResult>> get(String path) {
-        if (!isValidPath(path)) {
-            return FutureUtil.failedFuture(new MetadataStoreException.InvalidPathException(path));
-        }
+    public CompletableFuture<Optional<GetResult>> storeGet(String path) {
         synchronized (map) {
             Value v = map.get(path);
             if (v != null) {
@@ -138,11 +135,6 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
             Value v = map.get(path);
             return FutureUtils.value(v != null);
         }
-    }
-
-    @Override
-    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
-        return put(path, value, expectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -218,12 +218,4 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
             }
         }
     }
-
-    private void notifyParentChildrenChanged(String path) {
-        String parent = parent(path);
-        while (parent != null) {
-            receivedNotification(new Notification(NotificationType.ChildrenChanged, parent));
-            parent = parent(parent);
-        }
-    }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
@@ -48,6 +48,8 @@ public class MetadataStoreFactoryImpl {
 
         if (metadataURL.startsWith("memory://")) {
             return new LocalMemoryMetadataStore(metadataURL, metadataStoreConfig);
+        } if (metadataURL.startsWith("rocksdb://")) {
+            return new RocksdbMetadataStore(metadataURL, metadataStoreConfig);
         } else {
             return new ZKMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -392,7 +392,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
     protected CompletableFuture<Void> storeDelete(String path, Optional<Long> expectedVersion) {
         try (Transaction transaction = db.beginTransaction(optionSync)) {
             byte[] pathBytes = toBytes(path);
-            byte[] oldValueData = transaction.get(optionDontCache, pathBytes);
+            byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes,false);
             MetaValue metaValue = MetaValue.parse(oldValueData);
             if (metaValue == null) {
                 throw new MetadataStoreException.NotFoundException(String.format("path %s not found.", path));
@@ -417,7 +417,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
                                                EnumSet<CreateOption> options) {
         try (Transaction transaction = db.beginTransaction(optionSync)) {
             byte[] pathBytes = toBytes(path);
-            byte[] oldValueData = transaction.get(optionDontCache, pathBytes);
+            byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes, false);
             MetaValue metaValue = MetaValue.parse(oldValueData);
             if (expectedVersion.isPresent()) {
                 if (metaValue == null && expectedVersion.get() != -1 ||

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -201,6 +201,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
             close();
             throw new MetadataStoreException("Error init metastore state", exception);
         }
+        log.info("new RocksdbMetadataStore,url={},instanceId={}", metadataStoreConfig, instanceId);
     }
 
     private long loadInstanceId() throws RocksDBException {
@@ -300,6 +301,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     public void close() throws MetadataStoreException {
+        log.info("close.instanceId={}", instanceId);
         db.close();
         optionSync.close();
         optionDontSync.close();
@@ -314,6 +316,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     public CompletableFuture<Optional<GetResult>> storeGet(String path) {
+        log.info("getChildrenFromStore.path={},instanceId={}", path, instanceId);
         try {
             byte[] value = db.get(optionCache, toBytes(path));
             if (value == null) {
@@ -340,6 +343,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     protected CompletableFuture<List<String>> getChildrenFromStore(String path) {
+        log.info("getChildrenFromStore.path={},instanceId={}", path,instanceId);
         try (RocksIterator iterator = db.newIterator(optionDontCache)) {
             Set<String> result = new HashSet<>();
             String firstKey = path.equals("/") ? path : path + "/";
@@ -374,6 +378,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     protected CompletableFuture<Boolean> existsFromStore(String path) {
+        log.info("existsFromStore.path={},instanceId={}", path,instanceId);
         try {
             byte[] value = db.get(optionDontCache, toBytes(path));
             if (log.isDebugEnabled()) {
@@ -390,6 +395,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     protected CompletableFuture<Void> storeDelete(String path, Optional<Long> expectedVersion) {
+        log.info("storeDelete.path={},instanceId={}", path,instanceId);
         try (Transaction transaction = db.beginTransaction(optionSync)) {
             byte[] pathBytes = toBytes(path);
             byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes,false);
@@ -415,6 +421,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
     @Override
     protected CompletableFuture<Stat> storePut(String path, byte[] data, Optional<Long> expectedVersion,
                                                EnumSet<CreateOption> options) {
+        log.info("storePut.path={},instanceId={}", path, instanceId);
         try (Transaction transaction = db.beginTransaction(optionSync)) {
             byte[] pathBytes = toBytes(path);
             byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes, false);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -1,0 +1,428 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
+import org.rocksdb.InfoLogLevel;
+import org.rocksdb.Options;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.Transaction;
+import org.rocksdb.TransactionDB;
+import org.rocksdb.TransactionDBOptions;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+/**
+ *
+ */
+@Slf4j
+public class RocksdbMetadataStore extends AbstractMetadataStore {
+    private static final byte[] SEQUENTIAL_ID_KEY = toBytes("__metadata_sequentialId_key");
+    private static final byte[] INSTANCE_ID_KEY = toBytes("__metadata_instanceId_key");
+
+    private final long instanceId;
+    private final AtomicLong sequentialIdGenerator;
+
+    private final TransactionDB db;
+
+    private final WriteOptions optionSync;
+    private final WriteOptions optionDontSync;
+
+    private final ReadOptions optionCache;
+    private final ReadOptions optionDontCache;
+
+    private final WriteBatch emptyBatch;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class MetaValue {
+        private static final int HEADER_SIZE = 8 + 8 + 8 + 8 + 1;
+
+        long version;
+        long owner;
+        long createdTimestamp;
+        long modifiedTimestamp;
+        boolean ephemeral;
+        byte[] data;
+
+        public byte[] serialize() {
+            byte[] result = new byte[HEADER_SIZE + data.length];
+            ByteBuffer buffer = ByteBuffer.wrap(result);
+            buffer.putLong(version);
+            buffer.putLong(owner);
+            buffer.putLong(createdTimestamp);
+            buffer.putLong(modifiedTimestamp);
+            buffer.put((byte) (ephemeral ? 1 : 0));
+            buffer.put(data);
+            return result;
+        }
+
+        public static MetaValue parse(byte[] dataBytes) throws MetadataStoreException {
+            if (dataBytes == null) {
+                return null;
+            }
+            if (dataBytes.length < HEADER_SIZE) {
+                throw new MetadataStoreException("Invalid MetaValue data");
+            }
+            ByteBuffer buffer = ByteBuffer.wrap(dataBytes);
+            MetaValue metaValue = new MetaValue();
+            metaValue.version = buffer.getLong();
+            metaValue.owner = buffer.getLong();
+            metaValue.createdTimestamp = buffer.getLong();
+            metaValue.modifiedTimestamp = buffer.getLong();
+            metaValue.ephemeral = buffer.get() > 0;
+            metaValue.data = new byte[buffer.remaining()];
+            buffer.get(metaValue.data);
+            return metaValue;
+        }
+    }
+
+    @VisibleForTesting
+    static byte[] toBytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @VisibleForTesting
+    static String toString(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @VisibleForTesting
+    static byte[] toBytes(long value) {
+        return ByteBuffer.wrap(new byte[8]).putLong(value).array();
+    }
+
+    @VisibleForTesting
+    static long toLong(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).getLong();
+    }
+
+    /**
+     * @param metadataURL         format "rocksdb://{storePath}"
+     * @param metadataStoreConfig
+     * @throws MetadataStoreException
+     */
+    public RocksdbMetadataStore(String metadataURL, MetadataStoreConfig metadataStoreConfig)
+            throws MetadataStoreException {
+        try {
+            RocksDB.loadLibrary();
+        } catch (Throwable t) {
+            throw new MetadataStoreException("Failed to load RocksDB JNI library", t);
+        }
+
+        this.optionSync = new WriteOptions();
+        this.optionDontSync = new WriteOptions();
+        this.optionCache = new ReadOptions();
+        this.optionDontCache = new ReadOptions();
+        this.emptyBatch = new WriteBatch();
+
+        try (Options options = new Options()) {
+            options.setCreateIfMissing(true);
+
+            String dataDir = metadataURL.substring("rocksdb://".length());
+            Path dataPath = FileSystems.getDefault().getPath(dataDir);
+            Files.createDirectories(dataPath);
+            configLog(options);
+            TransactionDBOptions transactionDBOptions = new TransactionDBOptions();
+            db = TransactionDB.open(options, transactionDBOptions, dataPath.toString());
+
+            sequentialIdGenerator = new AtomicLong(0);
+            byte[] value = db.get(SEQUENTIAL_ID_KEY);
+            if (value != null) {
+                sequentialIdGenerator.set(toLong(value));
+            } else {
+                db.put(INSTANCE_ID_KEY, toBytes(sequentialIdGenerator.get()));
+            }
+
+            value = db.get(INSTANCE_ID_KEY);
+            if (value != null) {
+                instanceId = toLong(value) + 1;
+            } else {
+                instanceId = 0;
+            }
+            db.put(INSTANCE_ID_KEY, toBytes(instanceId));
+
+
+        } catch (RocksDBException e) {
+            throw new MetadataStoreException("Error open RocksDB database", e);
+        } catch (MetadataStoreException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new MetadataStoreException(t);
+        }
+
+        optionSync.setSync(true);
+        optionDontSync.setSync(false);
+
+        optionCache.setFillCache(true);
+        optionDontCache.setFillCache(false);
+    }
+
+    private void configLog(Options options) throws IOException {
+        // Configure file path
+        String logPath = System.getProperty("pulsar.log.dir", "");
+        Path logPathSetting;
+        if (!logPath.isEmpty()) {
+            logPathSetting = FileSystems.getDefault().getPath(logPath + "/rocksdb-log");
+            Files.createDirectories(logPathSetting);
+            options.setDbLogDir(logPathSetting.toString());
+        }
+
+        // Configure log level
+        String logLevel = System.getProperty("pulsar.log.level", "info");
+        switch (logLevel) {
+            case "debug":
+                options.setInfoLogLevel(InfoLogLevel.DEBUG_LEVEL);
+                break;
+            case "info":
+                options.setInfoLogLevel(InfoLogLevel.INFO_LEVEL);
+                break;
+            case "warn":
+                options.setInfoLogLevel(InfoLogLevel.WARN_LEVEL);
+                break;
+            case "error":
+                options.setInfoLogLevel(InfoLogLevel.ERROR_LEVEL);
+                break;
+            default:
+                log.warn("Unrecognized RockDB log level: {}", logLevel);
+        }
+
+        // Keep log files for 1month
+        options.setKeepLogFileNum(30);
+        options.setLogFileTimeToRoll(TimeUnit.DAYS.toSeconds(1));
+    }
+
+    @Override
+    public void close() throws Exception {
+        db.close();
+        optionSync.close();
+        optionDontSync.close();
+        optionCache.close();
+        optionDontCache.close();
+        emptyBatch.close();
+        super.close();
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> get(String path) {
+        if (path.isEmpty()) {
+            return FutureUtil.failedFuture(new MetadataStoreException("Invalid path"));
+        }
+        try {
+            byte[] value = db.get(optionCache, toBytes(path));
+            if (value == null) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            MetaValue metaValue = MetaValue.parse(value);
+            if (metaValue.ephemeral && metaValue.owner != instanceId) {
+                delete(path, Optional.empty());
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+
+            GetResult result = new GetResult(metaValue.getData(),
+                    new Stat(path,
+                            metaValue.getVersion(),
+                            metaValue.getCreatedTimestamp(),
+                            metaValue.getModifiedTimestamp(),
+                            metaValue.ephemeral,
+                            metaValue.getOwner() == instanceId));
+            return CompletableFuture.completedFuture(Optional.of(result));
+        } catch (Throwable e) {
+            return FutureUtil.failedFuture(MetadataStoreException.wrap(e));
+        }
+    }
+
+    @Override
+    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
+        return put(path, value, expectedVersion, EnumSet.noneOf(CreateOption.class));
+    }
+
+    @Override
+    protected CompletableFuture<List<String>> getChildrenFromStore(String path) {
+        if (path.isEmpty()) {
+            return FutureUtil.failedFuture(new MetadataStoreException("Invalid path"));
+        }
+        try (RocksIterator iterator = db.newIterator(optionDontCache)) {
+            Set<String> result = new HashSet<>();
+            String firstKey = path.equals("/") ? path : path + "/";
+            String lastKey = path.equals("/") ? "0" : path + "0"; // '0' is lexicographically just after '/'
+            for (iterator.seek(toBytes(firstKey)); iterator.isValid(); iterator.next()) {
+                String currentPath = toString(iterator.key());
+                if (lastKey.compareTo(currentPath) <= 0) {
+                    //End of sub paths.
+                    break;
+                }
+                byte[] value = iterator.value();
+                if (value == null) {
+                    continue;
+                }
+                MetaValue metaValue = MetaValue.parse(value);
+                if (metaValue.ephemeral && metaValue.owner != instanceId) {
+                    delete(currentPath, Optional.empty());
+                    continue;
+                }
+                //check if it's direct child.
+                String relativePath = currentPath.substring(firstKey.length());
+                String child = relativePath.split("/", 2)[0];
+                result.add(child);
+            }
+            List<String> arrayResult = new ArrayList<>(result);
+            arrayResult.sort(Comparator.naturalOrder());
+            return CompletableFuture.completedFuture(arrayResult);
+        } catch (Throwable e) {
+            return FutureUtil.failedFuture(MetadataStoreException.wrap(e));
+        }
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> existsFromStore(String path) {
+        if (path.isEmpty()) {
+            return FutureUtil.failedFuture(new MetadataStoreException("Invalid path"));
+        }
+        try {
+            byte[] value = db.get(optionDontCache, toBytes(path));
+            if (log.isDebugEnabled()) {
+                if (value != null) {
+                    MetaValue metaValue = MetaValue.parse(value);
+                    log.debug("Get data from db:{}.", metaValue);
+                }
+            }
+            return CompletableFuture.completedFuture(value != null);
+        } catch (Throwable e) {
+            return FutureUtil.failedFuture(MetadataStoreException.wrap(e));
+        }
+    }
+
+    @Override
+    protected CompletableFuture<Void> storeDelete(String path, Optional<Long> expectedVersion) {
+        if (path.isEmpty()) {
+            return FutureUtil.failedFuture(new MetadataStoreException("Invalid path"));
+        }
+        try (Transaction transaction = db.beginTransaction(optionSync)) {
+            byte[] pathBytes = toBytes(path);
+            byte[] oldValueData = db.get(optionDontCache, pathBytes);
+            MetaValue metaValue = MetaValue.parse(oldValueData);
+            if (metaValue == null) {
+                throw new MetadataStoreException.NotFoundException(String.format("path %s not found.", path));
+            }
+            if (expectedVersion.isPresent() && !expectedVersion.get().equals(metaValue.getVersion())) {
+                throw new MetadataStoreException.BadVersionException(
+                        String.format("Version mismatch, actual=%s, expect=%s", metaValue.getVersion(),
+                                expectedVersion.get()));
+            }
+            db.delete(optionSync, pathBytes);
+            transaction.commit();
+            receivedNotification(new Notification(NotificationType.Deleted, path));
+            notifyParentChildrenChanged(path);
+            return CompletableFuture.completedFuture(null);
+        } catch (Throwable e) {
+            return FutureUtil.failedFuture(MetadataStoreException.wrap(e));
+        }
+    }
+
+    @Override
+    protected CompletableFuture<Stat> storePut(String path, byte[] data, Optional<Long> expectedVersion,
+                                               EnumSet<CreateOption> options) {
+        try (Transaction transaction = db.beginTransaction(optionSync)) {
+            byte[] pathBytes = toBytes(path);
+            byte[] oldValueData = db.get(pathBytes);
+            MetaValue metaValue = MetaValue.parse(oldValueData);
+            if (expectedVersion.isPresent()) {
+                if (metaValue == null && expectedVersion.get() != -1 ||
+                        metaValue != null && !expectedVersion.get().equals(metaValue.getVersion())) {
+                    throw new MetadataStoreException.BadVersionException(
+                            String.format("Version mismatch, actual=%s, expect=%s",
+                                    metaValue == null ? null : metaValue.getVersion(), expectedVersion.get()));
+                }
+            }
+
+            boolean created = false;
+            long timestamp = System.currentTimeMillis();
+            if (metaValue == null) {
+                // create new node
+                metaValue = new MetaValue();
+                metaValue.version = 0;
+                metaValue.createdTimestamp = timestamp;
+                metaValue.ephemeral = options.contains(CreateOption.Ephemeral);
+                if (options.contains(CreateOption.Sequential)) {
+                    path += sequentialIdGenerator.getAndIncrement();
+                    pathBytes = toBytes(path);
+                    db.put(SEQUENTIAL_ID_KEY, toBytes(sequentialIdGenerator.get()));
+                }
+                created = true;
+            } else {
+                // update old node
+                metaValue.version++;
+            }
+            metaValue.modifiedTimestamp = timestamp;
+            metaValue.owner = instanceId;
+            metaValue.data = data;
+
+            //handle Sequential
+            db.put(pathBytes, metaValue.serialize());
+
+            transaction.commit();
+
+            receivedNotification(
+                    new Notification(created ? NotificationType.Created : NotificationType.Modified, path));
+            if (created) {
+                notifyParentChildrenChanged(path);
+            }
+
+            return CompletableFuture.completedFuture(
+                    new Stat(path, metaValue.version, metaValue.createdTimestamp, metaValue.modifiedTimestamp,
+                            metaValue.ephemeral, true));
+        } catch (Throwable e) {
+            return FutureUtil.failedFuture(MetadataStoreException.wrap(e));
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -300,11 +300,11 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
 
     @Override
     public void close() throws MetadataStoreException {
+        db.close();
         optionSync.close();
         optionDontSync.close();
         optionCache.close();
         optionDontCache.close();
-        db.close();
         try {
             super.close();
         } catch (Throwable throwable) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -128,7 +128,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
     }
 
     @Override
-    public CompletableFuture<Optional<GetResult>> get(String path) {
+    public CompletableFuture<Optional<GetResult>> storeGet(String path) {
         CompletableFuture<Optional<GetResult>> future = new CompletableFuture<>();
 
         try {
@@ -233,11 +233,6 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
         }
 
         return future;
-    }
-
-    @Override
-    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> optExpectedVersion) {
-        return put(path, value, optExpectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -19,13 +19,12 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertTrue;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.File;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
-import org.apache.commons.io.FileUtils;
 import org.apache.pulsar.tests.TestRetrySupport;
+import org.assertj.core.util.Files;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -33,14 +32,11 @@ import org.testng.annotations.DataProvider;
 public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     protected TestZKServer zks;
 
-    private Path tempDir;
-
     @BeforeClass(alwaysRun = true)
     @Override
     public final void setup() throws Exception {
         incrementSetupNumber();
         zks = new TestZKServer();
-        tempDir = Files.createTempDirectory("BaseMetadataStoreTest");
     }
 
     @AfterClass(alwaysRun = true)
@@ -48,7 +44,12 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     public final void cleanup() throws Exception {
         markCurrentSetupNumberCleaned();
         zks.close();
-        FileUtils.deleteQuietly(tempDir.toFile());
+    }
+
+    private static String createTempFolder() {
+        File temp = Files.newTemporaryFolder();
+        temp.deleteOnExit();
+        return temp.getAbsolutePath();
     }
 
     @DataProvider(name = "impl")
@@ -61,7 +62,7 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         return new Object[][] {
                 { "ZooKeeper", stringSupplier(() -> zks.getConnectionString()) },
                 { "Memory", stringSupplier(() -> "memory://" + UUID.randomUUID()) },
-                { "RocksDB", stringSupplier(() -> "rocksdb://" + tempDir.toAbsolutePath()) },
+                { "RocksDB", stringSupplier(() -> "rocksdb://" + createTempFolder()) },
         };
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -58,9 +58,8 @@ public class CounterTest extends BaseMetadataStoreTest {
             // Test doesn't make sense for local memory since we're testing across different instances
             return;
         }
-
-        MetadataStoreExtended store1 = MetadataStoreExtended.create(urlSupplier.get(),
-                MetadataStoreConfig.builder().build());
+        String metadataUrl = urlSupplier.get();
+        MetadataStoreExtended store1 = MetadataStoreExtended.create(metadataUrl, MetadataStoreConfig.builder().build());
 
         CoordinationService cs1 = new CoordinationServiceImpl(store1);
 
@@ -77,8 +76,7 @@ public class CounterTest extends BaseMetadataStoreTest {
         // Delete all the empty container nodes
         zks.checkContainers();
 
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
-                MetadataStoreConfig.builder().build());
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(metadataUrl, MetadataStoreConfig.builder().build());
         @Cleanup
         CoordinationService cs2 = new CoordinationServiceImpl(store2);
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LeaderElectionTest.java
@@ -74,7 +74,7 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
     public void multipleMembers(String provider, Supplier<String> urlSupplier) throws Exception {
-        if (provider.equals("Memory")) {
+        if (provider.equals("Memory") || provider.equals("RocksDB")) {
             // There are no multiple session in local mem provider
             return;
         }
@@ -215,6 +215,11 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     @Test(dataProvider = "impl")
     public void revalidateLeaderWithDifferentSessionsSameValue(String provider, Supplier<String> urlSupplier)
             throws Exception {
+        if (provider.equals("Memory") || provider.equals("RocksDB")) {
+            // There are no multiple sessions for the local memory provider
+            return;
+        }
+
         @Cleanup
         MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(),
                 MetadataStoreConfig.builder().build());
@@ -246,7 +251,7 @@ public class LeaderElectionTest extends BaseMetadataStoreTest {
     @Test(dataProvider = "impl")
     public void revalidateLeaderWithDifferentSessionsDifferentValue(String provider, Supplier<String> urlSupplier)
             throws Exception {
-        if (provider.equals("Memory")) {
+        if (provider.equals("Memory") || provider.equals("RocksDB")) {
             // There are no multiple sessions for the local memory provider
             return;
         }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -234,7 +234,7 @@ public class LockManagerTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
     public void revalidateLockOnDifferentSession(String provider, Supplier<String> urlSupplier) throws Exception {
-        if (provider.equals("Memory")) {
+        if (provider.equals("Memory") || provider.equals("RocksDB")) {
             // Local memory provider doesn't really have the concept of multiple sessions
             return;
         }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.metadata;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -61,6 +62,6 @@ public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
         long n2 = Long.parseLong(seq2);
 
         assertNotEquals(seq1, seq2);
-        assertNotEquals(n1, n2);
+        assertTrue(n1 < n2);
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -29,11 +29,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -47,6 +51,7 @@ import org.apache.pulsar.metadata.api.Stat;
 import org.assertj.core.util.Lists;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class MetadataStoreTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
@@ -387,15 +392,60 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
             // Memory is not persistent.
             return;
         }
-        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        String metadataUrl = urlSupplier.get();
+        MetadataStore store = MetadataStoreFactory.create(metadataUrl, MetadataStoreConfig.builder().build());
         byte[] data = "testPersistent".getBytes(StandardCharsets.UTF_8);
         store.put("/a/b/c", data, Optional.of(-1L)).join();
         store.close();
 
-        store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        store = MetadataStoreFactory.create(metadataUrl, MetadataStoreConfig.builder().build());
         Optional<GetResult> result = store.get("/a/b/c").get();
         assertTrue(result.isPresent());
         assertEquals(result.get().getValue(), data);
         store.close();
+    }
+
+    @Test(dataProvider = "impl")
+    public void testConcurrentPutGetOneKey(String provider, Supplier<String> urlSupplier) throws Exception {
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        byte[] data = new byte[]{0};
+        String path = newKey();
+        int maxValue = 100;
+        store.put(path, data, Optional.of(-1L));
+
+        AtomicInteger successWrites = new AtomicInteger(0);
+        Runnable task = new Runnable() {
+            @SneakyThrows
+            @Override
+            public void run() {
+                byte value;
+                while (true) {
+                    GetResult readResult = store.get(path).get().get();
+                    value = (byte) (readResult.getValue()[0] + 1);
+                    if (value <= maxValue) {
+                        CompletableFuture<Void> putResult =
+                                store.put(path, new byte[]{value}, Optional.of(readResult.getStat().getVersion()))
+                                        .thenRun(successWrites::incrementAndGet);
+                        try {
+                            putResult.get();
+                        } catch (Exception ignore) {
+                        }
+                        log.info("Put value {} success:{}. ", value, !putResult.isCompletedExceptionally());
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+        CompletableFuture<Void> t1 = CompletableFuture.completedFuture(null).thenRunAsync(task);
+        CompletableFuture<Void> t2 = CompletableFuture.completedFuture(null).thenRunAsync(task);
+        task.run();
+        t1.join();
+        t2.join();
+        assertFalse(t1.isCompletedExceptionally());
+        assertFalse(t2.isCompletedExceptionally());
+
+        assertEquals(successWrites.get(), maxValue);
+        assertEquals(store.get(path).get().get().getValue()[0], maxValue);
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.api.Notification;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.assertj.core.util.Lists;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class RocksdbMetadataStoreTest {
+
+    private static MetadataStore store;
+    private static Path tempDir;
+
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        tempDir = Files.createTempDirectory("RocksdbMetadataStoreTest");
+        log.info("Temp dir:{}", tempDir.toAbsolutePath());
+        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+                MetadataStoreConfig.builder().build());
+        Assert.assertTrue(store instanceof RocksdbMetadataStore);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        store.close();
+        FileUtils.deleteQuietly(tempDir.toFile());
+    }
+
+    @Test
+    public void testConvert() {
+        String s = "testConvert";
+        Assert.assertEquals(s, RocksdbMetadataStore.toString(RocksdbMetadataStore.toBytes(s)));
+
+        long l = 12345;
+        Assert.assertEquals(l, RocksdbMetadataStore.toLong(RocksdbMetadataStore.toBytes(l)));
+    }
+
+    @Test
+    public void testMetadataStore() throws Exception {
+        String path = "/test";
+        byte[] data = "data".getBytes();
+
+        //test put
+        CompletableFuture<Stat> f = store.put(path, data, Optional.of(-1L));
+
+        CompletableFuture<Stat> failedPut = store.put(path, data, Optional.of(100L));
+        Assert.expectThrows(MetadataStoreException.BadVersionException.class, () -> {
+            try {
+                failedPut.get();
+            } catch (ExecutionException t) {
+                throw t.getCause();
+            }
+        });
+
+        Assert.assertNotNull(f.get());
+        log.info("put result:{}", f.get());
+        Assert.assertNotNull(store.put(path + "/a", data, Optional.of(-1L)));
+        Assert.assertNotNull(store.put(path + "/b", data, Optional.of(-1L)));
+        Assert.assertNotNull(store.put(path + "/c", data, Optional.of(-1L)));
+
+        //test get
+        CompletableFuture<Optional<GetResult>> readResult = store.get(path);
+        Assert.assertNotNull(readResult.get());
+        Assert.assertTrue(readResult.get().isPresent());
+        GetResult r = readResult.get().get();
+        Assert.assertEquals(path, r.getStat().getPath());
+        Assert.assertEquals(0, r.getStat().getVersion());
+        Assert.assertEquals(data, r.getValue());
+
+        //test get children
+        CompletableFuture<List<String>> childResult = store.getChildren(path);
+        Assert.assertNotNull(childResult.get());
+        Assert.assertEquals(Lists.newArrayList("a", "b", "c"), childResult.get());
+
+        //test delete
+        CompletableFuture<Void> failDeleteFuture = store.delete(path, Optional.of(r.getStat().getVersion() + 1));
+        Assert.expectThrows(MetadataStoreException.BadVersionException.class, () -> {
+            try {
+                failDeleteFuture.get();
+            } catch (ExecutionException t) {
+                throw t.getCause();
+            }
+        });
+
+        CompletableFuture<Void> deleteFuture;
+        deleteFuture = store.delete(path, Optional.empty());
+        Assert.assertNull(deleteFuture.get());
+        Assert.assertFalse(deleteFuture.isCompletedExceptionally());
+
+        //test exists
+        Assert.assertFalse(store.exists(path).get());
+    }
+
+    @Test
+    public void testSequential() throws Exception {
+        Assert.assertTrue(store instanceof MetadataStoreExtended);
+        MetadataStoreExtended extendedStore = (MetadataStoreExtended) store;
+        String path = "/test/Sequential";
+        byte[] data = "data".getBytes();
+        CompletableFuture<Stat> putFuture = extendedStore.put(path, data, Optional.of(-1L),
+                EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential));
+        Assert.assertNotNull(putFuture.get());
+        String path1 = putFuture.get().getPath();
+        log.info("testSequential, path1:{}", path1);
+        long id1 = Long.parseLong(path1.substring(path.length()));
+        log.info("testSequential, id1:{}", id1);
+        Assert.assertTrue(id1 >= 0);
+
+        String path2 = extendedStore.put(path, data, Optional.of(-1L),
+                EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential)).get().getPath();
+        long id2 = Long.parseLong(path2.substring(path.length()));
+        log.info("testSequential, path:{},id2:{}", path2, id2);
+        Assert.assertTrue(id2 > id1);
+    }
+
+    @Test
+    public void testNotification() throws ExecutionException, InterruptedException {
+        List<Notification> notificationHolder = new CopyOnWriteArrayList<>();
+        store.registerListener(notification -> {
+            log.info("NOTIFY:{}", notification);
+            notificationHolder.add(notification);
+        });
+
+        String path = "/test/Sequential";
+        byte[] data = "data".getBytes();
+        store.put(path, data, Optional.empty());
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Created, path)));
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, "/test")));
+        notificationHolder.clear();
+
+        store.put(path, "data1".getBytes(), Optional.empty());
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Modified, path)));
+        notificationHolder.clear();
+
+        store.put(path + "/a", data, Optional.empty());
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Created, path + "/a")));
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, path)));
+        notificationHolder.clear();
+
+        store.delete(path, Optional.empty());
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Deleted, path)));
+        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, "/test")));
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
@@ -19,54 +19,26 @@
 
 package org.apache.pulsar.metadata.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.EnumSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
-import org.apache.pulsar.metadata.api.Notification;
-import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
-import org.apache.pulsar.metadata.api.extended.CreateOption;
-import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.assertj.core.util.Lists;
-import org.awaitility.Awaitility;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
 public class RocksdbMetadataStoreTest {
-
-    private static MetadataStore store;
-    private static Path tempDir;
-
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        tempDir = Files.createTempDirectory("RocksdbMetadataStoreTest");
-        log.info("Temp dir:{}", tempDir.toAbsolutePath());
-        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
-                MetadataStoreConfig.builder().build());
-        Assert.assertTrue(store instanceof RocksdbMetadataStore);
-    }
-
-    @AfterClass
-    public static void afterClass() throws Exception {
-        store.close();
-        FileUtils.deleteQuietly(tempDir.toFile());
-    }
 
     @Test
     public void testConvert() {
@@ -78,7 +50,30 @@ public class RocksdbMetadataStoreTest {
     }
 
     @Test
-    public void testMetadataStore() throws Exception {
+    public void testMetaValue() throws Exception {
+        RocksdbMetadataStore.MetaValue metaValue = new RocksdbMetadataStore.MetaValue();
+        metaValue.setVersion(RandomUtils.nextLong());
+        metaValue.setOwner(RandomUtils.nextLong());
+        metaValue.setCreatedTimestamp(RandomUtils.nextLong());
+        metaValue.setModifiedTimestamp(RandomUtils.nextLong());
+        metaValue.setEphemeral(RandomUtils.nextBoolean());
+        metaValue.setData(String.valueOf(RandomUtils.nextDouble()).getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(RocksdbMetadataStore.MetaValue.parse(metaValue.serialize()), metaValue);
+    }
+
+    @Test
+    public void testOpenDbWithConfigFile() throws Exception {
+        MetadataStore store;
+        Path tempDir;
+        tempDir = Files.createTempDirectory("RocksdbMetadataStoreTest");
+        log.info("Temp dir:{}", tempDir.toAbsolutePath());
+        String optionFilePath =
+                getClass().getClassLoader().getResource("rocksdb_option_file_example.ini").getPath();
+        log.info("optionFilePath={}", optionFilePath);
+        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+                MetadataStoreConfig.builder().configFilePath(optionFilePath).build());
+        Assert.assertTrue(store instanceof RocksdbMetadataStore);
+
         String path = "/test";
         byte[] data = "data".getBytes();
 
@@ -100,6 +95,11 @@ public class RocksdbMetadataStoreTest {
         Assert.assertNotNull(store.put(path + "/b", data, Optional.of(-1L)));
         Assert.assertNotNull(store.put(path + "/c", data, Optional.of(-1L)));
 
+        //reopen db
+        store.close();
+        store = MetadataStoreFactory.create("rocksdb://" + tempDir.toAbsolutePath(),
+                MetadataStoreConfig.builder().configFilePath(optionFilePath).build());
+
         //test get
         CompletableFuture<Optional<GetResult>> readResult = store.get(path);
         Assert.assertNotNull(readResult.get());
@@ -109,78 +109,7 @@ public class RocksdbMetadataStoreTest {
         Assert.assertEquals(0, r.getStat().getVersion());
         Assert.assertEquals(data, r.getValue());
 
-        //test get children
-        CompletableFuture<List<String>> childResult = store.getChildren(path);
-        Assert.assertNotNull(childResult.get());
-        Assert.assertEquals(Lists.newArrayList("a", "b", "c"), childResult.get());
-
-        //test delete
-        CompletableFuture<Void> failDeleteFuture = store.delete(path, Optional.of(r.getStat().getVersion() + 1));
-        Assert.expectThrows(MetadataStoreException.BadVersionException.class, () -> {
-            try {
-                failDeleteFuture.get();
-            } catch (ExecutionException t) {
-                throw t.getCause();
-            }
-        });
-
-        CompletableFuture<Void> deleteFuture;
-        deleteFuture = store.delete(path, Optional.empty());
-        Assert.assertNull(deleteFuture.get());
-        Assert.assertFalse(deleteFuture.isCompletedExceptionally());
-
-        //test exists
-        Assert.assertFalse(store.exists(path).get());
-    }
-
-    @Test
-    public void testSequential() throws Exception {
-        Assert.assertTrue(store instanceof MetadataStoreExtended);
-        MetadataStoreExtended extendedStore = (MetadataStoreExtended) store;
-        String path = "/test/Sequential";
-        byte[] data = "data".getBytes();
-        CompletableFuture<Stat> putFuture = extendedStore.put(path, data, Optional.of(-1L),
-                EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential));
-        Assert.assertNotNull(putFuture.get());
-        String path1 = putFuture.get().getPath();
-        log.info("testSequential, path1:{}", path1);
-        long id1 = Long.parseLong(path1.substring(path.length()));
-        log.info("testSequential, id1:{}", id1);
-        Assert.assertTrue(id1 >= 0);
-
-        String path2 = extendedStore.put(path, data, Optional.of(-1L),
-                EnumSet.of(CreateOption.Ephemeral, CreateOption.Sequential)).get().getPath();
-        long id2 = Long.parseLong(path2.substring(path.length()));
-        log.info("testSequential, path:{},id2:{}", path2, id2);
-        Assert.assertTrue(id2 > id1);
-    }
-
-    @Test
-    public void testNotification() throws ExecutionException, InterruptedException {
-        List<Notification> notificationHolder = new CopyOnWriteArrayList<>();
-        store.registerListener(notification -> {
-            log.info("NOTIFY:{}", notification);
-            notificationHolder.add(notification);
-        });
-
-        String path = "/test/Sequential";
-        byte[] data = "data".getBytes();
-        store.put(path, data, Optional.empty());
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Created, path)));
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, "/test")));
-        notificationHolder.clear();
-
-        store.put(path, "data1".getBytes(), Optional.empty());
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Modified, path)));
-        notificationHolder.clear();
-
-        store.put(path + "/a", data, Optional.empty());
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Created, path + "/a")));
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, path)));
-        notificationHolder.clear();
-
-        store.delete(path, Optional.empty());
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.Deleted, path)));
-        Awaitility.await().until(()->notificationHolder.contains(new Notification(NotificationType.ChildrenChanged, "/test")));
+        store.close();
+        FileUtils.deleteQuietly(tempDir.toFile());
     }
 }

--- a/pulsar-metadata/src/test/resources/rocksdb_option_file_example.ini
+++ b/pulsar-metadata/src/test/resources/rocksdb_option_file_example.ini
@@ -1,3 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
 # This is a RocksDB option file.
 #
 # A typical RocksDB options file has four sections, which are

--- a/pulsar-metadata/src/test/resources/rocksdb_option_file_example.ini
+++ b/pulsar-metadata/src/test/resources/rocksdb_option_file_example.ini
@@ -1,0 +1,144 @@
+# This is a RocksDB option file.
+#
+# A typical RocksDB options file has four sections, which are
+# Version section, DBOptions section, at least one CFOptions
+# section, and one TableOptions section for each column family.
+# The RocksDB options file in general follows the basic INI
+# file format with the following extensions / modifications:
+#
+#  * Escaped characters
+#    We escaped the following characters:
+#     - \n -- line feed - new line
+#     - \r -- carriage return
+#     - \\ -- backslash \
+#     - \: -- colon symbol :
+#     - \# -- hash tag #
+#  * Comments
+#    We support # style comments.  Comments can appear at the ending
+#    part of a line.
+#  * Statements
+#    A statement is of the form option_name = value.
+#    Each statement contains a '=', where extra white-spaces
+#    are supported. However, we don't support multi-lined statement.
+#    Furthermore, each line can only contain at most one statement.
+#  * Sections
+#    Sections are of the form [SecitonTitle "SectionArgument"],
+#    where section argument is optional.
+#  * List
+#    We use colon-separated string to represent a list.
+#    For instance, n1:n2:n3:n4 is a list containing four values.
+#
+# Below is an example of a RocksDB options file:
+[Version]
+  rocksdb_version=4.3.0
+  options_file_version=1.1
+
+[DBOptions]
+  stats_dump_period_sec=600
+  max_manifest_file_size=18446744073709551615
+  bytes_per_sync=8388608
+  delayed_write_rate=2097152
+  WAL_ttl_seconds=0
+  WAL_size_limit_MB=0
+  max_subcompactions=1
+  wal_dir=
+  wal_bytes_per_sync=0
+  db_write_buffer_size=0
+  keep_log_file_num=1000
+  table_cache_numshardbits=4
+  max_file_opening_threads=1
+  writable_file_max_buffer_size=1048576
+  random_access_max_buffer_size=1048576
+  use_fsync=false
+  max_total_wal_size=0
+  max_open_files=-1
+  skip_stats_update_on_db_open=false
+  max_background_compactions=16
+  manifest_preallocation_size=4194304
+  max_background_flushes=7
+  is_fd_close_on_exec=true
+  max_log_file_size=0
+  advise_random_on_open=true
+  create_missing_column_families=false
+  paranoid_checks=true
+  delete_obsolete_files_period_micros=21600000000
+  log_file_time_to_roll=0
+  compaction_readahead_size=0
+  create_if_missing=true
+  use_adaptive_mutex=false
+  enable_thread_tracking=false
+  allow_fallocate=true
+  error_if_exists=false
+  recycle_log_file_num=0
+  skip_log_error_on_recovery=false
+  db_log_dir=
+  new_table_reader_for_compaction_inputs=true
+  allow_mmap_reads=false
+  allow_mmap_writes=false
+  use_direct_reads=false
+  use_direct_writes=false
+
+
+[CFOptions "default"]
+  compaction_style=kCompactionStyleLevel
+  compaction_filter=nullptr
+  num_levels=6
+  table_factory=BlockBasedTable
+  comparator=leveldb.BytewiseComparator
+  max_sequential_skip_in_iterations=8
+  soft_rate_limit=0.000000
+  max_bytes_for_level_base=1073741824
+  memtable_prefix_bloom_probes=6
+  memtable_prefix_bloom_bits=0
+  memtable_prefix_bloom_huge_page_tlb_size=0
+  max_successive_merges=0
+  arena_block_size=16777216
+  min_write_buffer_number_to_merge=1
+  target_file_size_multiplier=1
+  source_compaction_factor=1
+  max_bytes_for_level_multiplier=8
+  max_bytes_for_level_multiplier_additional=2:3:5
+  compaction_filter_factory=nullptr
+  max_write_buffer_number=8
+  level0_stop_writes_trigger=20
+  compression=kSnappyCompression
+  level0_file_num_compaction_trigger=4
+  purge_redundant_kvs_while_flush=true
+  max_write_buffer_size_to_maintain=0
+  memtable_factory=SkipListFactory
+  max_grandparent_overlap_factor=8
+  expanded_compaction_factor=25
+  hard_pending_compaction_bytes_limit=137438953472
+  inplace_update_num_locks=10000
+  level_compaction_dynamic_level_bytes=true
+  level0_slowdown_writes_trigger=12
+  filter_deletes=false
+  verify_checksums_in_compaction=true
+  min_partial_merge_operands=2
+  paranoid_file_checks=false
+  target_file_size_base=134217728
+  optimize_filters_for_hits=false
+  merge_operator=PutOperator
+  compression_per_level=kNoCompression:kNoCompression:kNoCompression:kSnappyCompression:kSnappyCompression:kSnappyCompression
+  compaction_measure_io_stats=false
+  prefix_extractor=nullptr
+  bloom_locality=0
+  write_buffer_size=134217728
+  disable_auto_compactions=false
+  inplace_update_support=false
+
+[TableOptions/BlockBasedTable "default"]
+  format_version=2
+  whole_key_filtering=true
+  no_block_cache=false
+  checksum=kCRC32c
+  filter_policy=rocksdb.BuiltinBloomFilter
+  block_size_deviation=10
+  block_size=8192
+  block_restart_interval=16
+  cache_index_and_filter_blocks=false
+  pin_l0_filter_and_index_blocks_in_cache=false
+  pin_top_level_index_and_filter=false
+  index_type=kBinarySearch
+  hash_index_allow_collision=true
+  flush_block_policy_factory=FlushBlockBySizePolicyFactory


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Add Metadata Store implemented with rocksdb.

This is part of the work to remove zk from standalone server. All metadata can be stored in rocksdb.

### Modifications

Add Metadata Store implemented with rocksdb.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as each test class extends `BaseMetadataStoreTest`

This change added tests and can be verified as follows:
  - org.apache.pulsar.metadata.impl.RocksdbMetadataStoreTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Not ready for user yet.