### PR TITLE
[Java Client] Let producer reconnect for state RegisteringSchema

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -156,6 +156,7 @@ public class ConnectionHandler {
         switch (state) {
             case Uninitialized:
             case Connecting:
+            case RegisteringSchema:
             case Ready:
                 // Ok
                 return true;


### PR DESCRIPTION
### Motivation

In the Java Client, if a producer is in the `RegisteringSchema` state, it is a valid state for it to reconnect. Fix the `ConnectionHandler` to align with this behavior.

### Modifications

* Update the `isValidStateForReconnection` method to return `true` for state `RegisteringSchema`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

This update does not contain breaking changes.

### Documentation

- [x] `no-need-doc` 

This is an implementation detail, so no need to update any documentation.

