### PR TITLE
[Test] Fix flaky test in TransactionProduceTest::ackAbortTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -284,7 +284,7 @@ public class TransactionProduceTest extends TransactionTestBase {
         final String subscriptionName = "ackAbortTest";
         Transaction txn = pulsarClient
                 .newTransaction()
-                .withTransactionTimeout(5, TimeUnit.SECONDS)
+                .withTransactionTimeout(30, TimeUnit.SECONDS)
                 .build().get();
         log.info("init transaction {}.", txn);
 


### PR DESCRIPTION

### Motivation
The transaction timeout in `TransactionProduceTest::ackAbortTest` is too short, and if the test takes longer time, it will cause transaction to abort automatically and clear the pendingAcks, causing subsequent checks to fail. 
```log
Error:  ackAbortTest(org.apache.pulsar.broker.transaction.TransactionProduceTest)  Time elapsed: 40.68 s  <<< FAILURE!
org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a lambda expression in org.apache.pulsar.broker.transaction.TransactionProduceTest expected [10] but found [0] within 10 seconds.
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:165)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
```

### Modifications

Increase the timeout of the transaction in `TransactionProduceTest::ackAbortTest`.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


### Documentation

- [x] `no-need-doc` 
  
This is just a fix for test.
  

