### PR TITLE
[Doc] add explanations for encryption context in WebSocket

### DIFF
--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -203,7 +203,7 @@ Server will push messages on the WebSocket session:
 }
 ```
 
-Below are the parameters in the WebSocket session.
+Below are the parameters in the WebSocket consumer response.
 
 - General parameters
 
@@ -231,7 +231,7 @@ Below are the parameters in the WebSocket session.
 
     Key | Type | Required? | Explanation
     :---|:-----|:----------|:-----------
-    `keyValue` | string | yes | Encryption key
+    `keyValue` | string | yes | Encryption key (Base64 encoding)
     `metadata` | key-value pairs | no | Application-defined metadata
 
 #### Acknowledging the message

--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -180,22 +180,59 @@ Server will push messages on the WebSocket session:
 
 ```json
 {
-  "messageId": "CAAQAw==",
-  "payload": "SGVsbG8gV29ybGQ=",
-  "properties": {"key1": "value1", "key2": "value2"},
-  "publishTime": "2016-08-30 16:45:57.785",
-  "redeliveryCount": 4
+  "messageId": "CAMQADAA",
+  "payload": "hvXcJvHW7kOSrUn17P2q71RA5SdiXwZBqw==",
+  "properties": {},
+  "publishTime": "2021-10-29T16:01:38.967-07:00",
+  "redeliveryCount": 0,
+  "encryptionContext": {
+    "keys": {
+      "client-rsa.pem": {
+        "keyValue": "jEuwS+PeUzmCo7IfLNxqoj4h7txbLjCQjkwpaw5AWJfZ2xoIdMkOuWDkOsqgFmWwxiecakS6GOZHs94x3sxzKHQx9Oe1jpwBg2e7L4fd26pp+WmAiLm/ArZJo6JotTeFSvKO3u/yQtGTZojDDQxiqFOQ1ZbMdtMZA8DpSMuq+Zx7PqLo43UdW1+krjQfE5WD+y+qE3LJQfwyVDnXxoRtqWLpVsAROlN2LxaMbaftv5HckoejJoB4xpf/dPOUqhnRstwQHf6klKT5iNhjsY4usACt78uILT0pEPd14h8wEBidBz/vAlC/zVMEqiDVzgNS7dqEYS4iHbf7cnWVCn3Hxw==",
+        "metadata": {}
+      }
+    },
+    "param": "Tfu1PxVm6S9D3+Hk",
+    "compressionType": "NONE",
+    "uncompressedMessageSize": 0,
+    "batchSize": {
+      "empty": false,
+      "present": true
+    }
+  }
 }
 ```
 
-Key | Type | Required? | Explanation
-:---|:-----|:----------|:-----------
-`messageId` | string | yes | Message ID
-`payload` | string | yes | Base-64 encoded payload
-`publishTime` | string | yes | Publish timestamp
-`redeliveryCount` | number | yes | Number of times this message was already delivered
-`properties` | key-value pairs | no | Application-defined properties
-`key` | string | no |  Original routing key set by producer
+Below are the parameters in the WebSocket session.
+
+- General parameters
+
+    Key | Type | Required? | Explanation
+    :---|:-----|:----------|:-----------
+    `messageId` | string | yes | Message ID
+    `payload` | string | yes | Base-64 encoded payload
+    `publishTime` | string | yes | Publish timestamp
+    `redeliveryCount` | number | yes | Number of times this message was already delivered
+    `properties` | key-value pairs | no | Application-defined properties
+    `key` | string | no |  Original routing key set by producer
+    `encryptionContext` | EncryptionContext | no | Encryption context that consumer can use to decrypt received messages
+    `param` | string | no | Initialization vector for cipher (Base64 encoding)
+    `batchSize` | string | no | Number of entries in a message (if it it a batch message)
+    `uncompressedMessageSize` | string | no | Message size before compression
+    `compressionType` | string | no | Algorithm used to compress the message payload
+
+- `encryptionContext` related parameter
+
+    Key | Type | Required? | Explanation
+    :---|:-----|:----------|:-----------
+    `keys` |key-EncryptionKey pairs | yes | Key in `key-EncryptionKey` pairs is an encryption key name. Value in `key-EncryptionKey` pairs is an encryption key object.
+
+- `encryptionKey` related parameters
+
+    Key | Type | Required? | Explanation
+    :---|:-----|:----------|:-----------
+    `keyValue` | string | yes | Encryption key
+    `metadata` | key-value pairs | no | Application-defined metadata
 
 #### Acknowledging the message
 

--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -215,7 +215,7 @@ Below are the parameters in the WebSocket session.
     `redeliveryCount` | number | yes | Number of times this message was already delivered
     `properties` | key-value pairs | no | Application-defined properties
     `key` | string | no |  Original routing key set by producer
-    `encryptionContext` | EncryptionContext | no | Encryption context that consumer can use to decrypt received messages
+    `encryptionContext` | EncryptionContext | no | Encryption context that consumers can use to decrypt received messages
     `param` | string | no | Initialization vector for cipher (Base64 encoding)
     `batchSize` | string | no | Number of entries in a message (if it it a batch message)
     `uncompressedMessageSize` | string | no | Message size before compression

--- a/site2/docs/client-libraries-websocket.md
+++ b/site2/docs/client-libraries-websocket.md
@@ -217,7 +217,7 @@ Below are the parameters in the WebSocket session.
     `key` | string | no |  Original routing key set by producer
     `encryptionContext` | EncryptionContext | no | Encryption context that consumers can use to decrypt received messages
     `param` | string | no | Initialization vector for cipher (Base64 encoding)
-    `batchSize` | string | no | Number of entries in a message (if it it a batch message)
+    `batchSize` | string | no | Number of entries in a message (if it is a batch message)
     `uncompressedMessageSize` | string | no | Message size before compression
     `compressionType` | string | no | Algorithm used to compress the message payload
 


### PR DESCRIPTION
- This PR adds docs for https://github.com/apache/pulsar/pull/12539
- This PR adds docs for `master`. Will apply the same doc changes to `2.8.2` and `2.9.1` later.
- Preview looks good:
![image](https://user-images.githubusercontent.com/50226895/141755876-5a7dd851-1bfc-4ff3-8714-054e57d1412e.png)
