### PR TITLE
[DO NOT MERGE - WIP][Doc] Add doc for using the Avro JSON schema definition in Python client

### DIFF
--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -259,8 +259,10 @@ If using custom JSON definition schema, users need to use Python dict to produce
 and the `_record_cls` param should be None when generating `AvroSchema` object.
 
 ```
+from fastavro.schema import load_schema
+from pulsar.schema import *
+
 schema_definition = load_schema("examples/company.avsc")
-# schema_definition = avro.schema.parse(open("examples/company.avsc", "rb").read()).to_json()
 avro_schema = AvroSchema(None, schema_definition=schema_definition)
 
 producer = client.create_producer(


### PR DESCRIPTION
### Motivation

Currently, there is a lack of how to use the Avro JSON schema definition in the Python client.

### Modifications

Add doc for using custom Avro JSON schema definition in Python client.


