### PR TITLE
[Java Client] Use info, not warn, log level when successfully registe…

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -648,7 +648,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     callback.sendComplete((PulsarClientException.IncompatibleSchemaException) t);
                 }
             } else {
-                log.warn("[{}] [{}] GetOrCreateSchema succeed", topic, producerName);
+                log.info("[{}] [{}] GetOrCreateSchema succeed", topic, producerName);
                 SchemaHash schemaHash = SchemaHash.of(msg.getSchemaInternal());
                 schemaCache.putIfAbsent(schemaHash, v);
                 msg.getMessageBuilder().setSchemaVersion(v);


### PR DESCRIPTION
…ring schema

### Motivation

Use `INFO` log level when a successful event happens. The Pulsar Coding Guide mentions that `WARN` is only for "bad" events. https://pulsar.apache.org/en/coding-guide/#logging-levels

> WARN and ERROR indicate something that is BAD. Use WARN if you aren't totally sure it is bad, and ERROR if you are.

### Modifications

* Switch `warn` to `log` in the java client

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment:  no

### Documentation
  
- [x] `no-need-doc` 