### PR TITLE
[Broker] Synchronize updates to the inactiveProducers map in MessageD…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -138,7 +138,7 @@ public class MessageDeduplication {
     private CompletableFuture<Void> recoverSequenceIdsMap() {
         // Load the sequence ids from the snapshot in the cursor properties
         managedCursor.getProperties().forEach((k, v) -> {
-            inactiveProducers.put(k, System.currentTimeMillis());
+            producerRemoved(k);
             highestSequencedPushed.put(k, v);
             highestSequencedPersisted.put(k, v);
         });
@@ -169,7 +169,7 @@ public class MessageDeduplication {
                     long sequenceId = Math.max(md.getHighestSequenceId(), md.getSequenceId());
                     highestSequencedPushed.put(producerName, sequenceId);
                     highestSequencedPersisted.put(producerName, sequenceId);
-                    inactiveProducers.put(producerName, System.currentTimeMillis());
+                    producerRemoved(producerName);
 
                     entry.release();
                 }


### PR DESCRIPTION
…eduplication

### Motivation

In https://github.com/apache/pulsar/pull/12493, we introduced potentially concurrent updates to the `inactiveProducers` map without any synchronization.

### Modifications

* Ensure that we only update the `inactiveProducers` map using proper synchronization.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

No breaking changes.

### Documentation
  
- [x] `no-need-doc` 
