### PR TITLE
[Issue-12768] [documentation] Fix JSON configuration examples

### DIFF
--- a/site2/docs/io-cassandra-sink.md
+++ b/site2/docs/io-cassandra-sink.md
@@ -28,11 +28,13 @@ Before using the Cassandra sink connector, you need to create a configuration fi
 
     ```json
     {
-        "roots": "localhost:9042",
-        "keyspace": "pulsar_test_keyspace",
-        "columnFamily": "pulsar_test_table",
-        "keyname": "key",
-        "columnName": "col"
+       "configs": {
+          "roots": "localhost:9042",
+          "keyspace": "pulsar_test_keyspace",
+          "columnFamily": "pulsar_test_table",
+          "keyname": "key",
+          "columnName": "col"
+       }
     }
     ```
 

--- a/site2/docs/io-cdc-debezium.md
+++ b/site2/docs/io-cdc-debezium.md
@@ -48,20 +48,22 @@ You can use one of the following methods to create a configuration file.
 
     ```json
     {
-        "database.hostname": "localhost",
-        "database.port": "3306",
-        "database.user": "debezium",
-        "database.password": "dbz",
-        "database.server.id": "184054",
-        "database.server.name": "dbserver1",
-        "database.whitelist": "inventory",
-        "database.history": "org.apache.pulsar.io.debezium.PulsarDatabaseHistory",
-        "database.history.pulsar.topic": "history-topic",
-        "database.history.pulsar.service.url": "pulsar://127.0.0.1:6650",
-        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
-        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-        "pulsar.service.url": "pulsar://127.0.0.1:6650",
-        "offset.storage.topic": "offset-topic"
+       "configs": {
+          "database.hostname": "localhost",
+          "database.port": "3306",
+          "database.user": "debezium",
+          "database.password": "dbz",
+          "database.server.id": "184054",
+          "database.server.name": "dbserver1",
+          "database.whitelist": "inventory",
+          "database.history": "org.apache.pulsar.io.debezium.PulsarDatabaseHistory",
+          "database.history.pulsar.topic": "history-topic",
+          "database.history.pulsar.service.url": "pulsar://127.0.0.1:6650",
+          "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+          "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+          "pulsar.service.url": "pulsar://127.0.0.1:6650",
+          "offset.storage.topic": "offset-topic"
+       }
     }
     ```
 

--- a/site2/docs/io-debezium-source.md
+++ b/site2/docs/io-debezium-source.md
@@ -68,19 +68,21 @@ You can use one of the following methods to create a configuration file.
 
     ```json
     {
-        "database.hostname": "localhost",
-        "database.port": "3306",
-        "database.user": "debezium",
-        "database.password": "dbz",
-        "database.server.id": "184054",
-        "database.server.name": "dbserver1",
-        "database.whitelist": "inventory",
-        "database.history": "org.apache.pulsar.io.debezium.PulsarDatabaseHistory",
-        "database.history.pulsar.topic": "history-topic",
-        "database.history.pulsar.service.url": "pulsar://127.0.0.1:6650",
-        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
-        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-        "offset.storage.topic": "offset-topic"
+       "configs": {
+          "database.hostname": "localhost",
+          "database.port": "3306",
+          "database.user": "debezium",
+          "database.password": "dbz",
+          "database.server.id": "184054",
+          "database.server.name": "dbserver1",
+          "database.whitelist": "inventory",
+          "database.history": "org.apache.pulsar.io.debezium.PulsarDatabaseHistory",
+          "database.history.pulsar.topic": "history-topic",
+          "database.history.pulsar.service.url": "pulsar://127.0.0.1:6650",
+          "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+          "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+          "offset.storage.topic": "offset-topic"
+       }
     }
     ```
 

--- a/site2/docs/io-dynamodb-source.md
+++ b/site2/docs/io-dynamodb-source.md
@@ -42,17 +42,19 @@ Before using the DynamoDB source connector, you need to create a configuration f
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
-        "awsRegion": "us-east-1",
-        "awsDynamodbStreamArn": "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable/stream/2015-05-11T21:21:33.291",
-        "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
-        "applicationName": "My test application",
-        "checkpointInterval": "30000",
-        "backoffTime": "4000",
-        "numRetries": "3",
-        "receiveQueueSize": 2000,
-        "initialPositionInStream": "TRIM_HORIZON",
-        "startAtTime": "2019-03-05T19:28:58.000Z"
+       "configs": {
+          "awsEndpoint": "https://some.endpoint.aws",
+          "awsRegion": "us-east-1",
+          "awsDynamodbStreamArn": "arn:aws:dynamodb:us-west-2:111122223333:table/TestTable/stream/2015-05-11T21:21:33.291",
+          "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
+          "applicationName": "My test application",
+          "checkpointInterval": "30000",
+          "backoffTime": "4000",
+          "numRetries": "3",
+          "receiveQueueSize": 2000,
+          "initialPositionInStream": "TRIM_HORIZON",
+          "startAtTime": "2019-03-05T19:28:58.000Z"
+       }
     }
     ```
 

--- a/site2/docs/io-elasticsearch-sink.md
+++ b/site2/docs/io-elasticsearch-sink.md
@@ -103,10 +103,12 @@ Before using the Elasticsearch sink connector, you need to create a configuratio
 
     ```json
     {
-        "elasticSearchUrl": "http://localhost:9200",
-        "indexName": "my_index",
-        "username": "scooby",
-        "password": "doobie"
+       "configs": {
+          "elasticSearchUrl": "http://localhost:9200",
+          "indexName": "my_index",
+          "username": "scooby",
+          "password": "doobie"
+       }
     }
     ```
 

--- a/site2/docs/io-file-source.md
+++ b/site2/docs/io-file-source.md
@@ -35,18 +35,20 @@ Before using the File source connector, you need to create a configuration file 
 
     ```json
     {
-        "inputDirectory": "/Users/david",
-        "recurse": true,
-        "keepFile": true,
-        "fileFilter": "[^\\.].*",
-        "pathFilter": "*",
-        "minimumFileAge": 0,
-        "maximumFileAge": 9999999999,
-        "minimumSize": 1,
-        "maximumSize": 5000000,
-        "ignoreHiddenFiles": true,
-        "pollingInterval": 5000,
-        "numWorkers": 1
+       "configs": {
+          "inputDirectory": "/Users/david",
+          "recurse": true,
+          "keepFile": true,
+          "fileFilter": "[^\\.].*",
+          "pathFilter": "*",
+          "minimumFileAge": 0,
+          "maximumFileAge": 9999999999,
+          "minimumSize": 1,
+          "maximumSize": 5000000,
+          "ignoreHiddenFiles": true,
+          "pollingInterval": 5000,
+          "numWorkers": 1
+       }
     }
     ```
 

--- a/site2/docs/io-flume-sink.md
+++ b/site2/docs/io-flume-sink.md
@@ -30,11 +30,13 @@ Before using the Flume sink connector, you need to create a configuration file t
 
     ```json
     {
-        "name": "a1",
-        "confFile": "sink.conf",
-        "noReloadConf": "false",
-        "zkConnString": "",
-        "zkBasePath": ""
+       "configs": {
+          "name": "a1",
+          "confFile": "sink.conf",
+          "noReloadConf": "false",
+          "zkConnString": "",
+          "zkBasePath": ""
+       }
     }
     ```
 

--- a/site2/docs/io-flume-source.md
+++ b/site2/docs/io-flume-source.md
@@ -30,11 +30,13 @@ Before using the Flume source connector, you need to create a configuration file
 
     ```json
     {
-        "name": "a1",
-        "confFile": "source.conf",
-        "noReloadConf": "false",
-        "zkConnString": "",
-        "zkBasePath": ""
+       "configs": {
+          "name": "a1",
+          "confFile": "source.conf",
+          "noReloadConf": "false",
+          "zkConnString": "",
+          "zkBasePath": ""
+       }
     }
     ```
 

--- a/site2/docs/io-hbase-sink.md
+++ b/site2/docs/io-hbase-sink.md
@@ -34,14 +34,16 @@ Before using the HBase sink connector, you need to create a configuration file t
 
     ```json
     {
-        "hbaseConfigResources": "hbase-site.xml",
-        "zookeeperQuorum": "localhost",
-        "zookeeperClientPort": "2181",
-        "zookeeperZnodeParent": "/hbase",
-        "tableName": "pulsar_hbase",
-        "rowKeyName": "rowKey",
-        "familyName": "info",
-        "qualifierNames": [ 'name', 'address', 'age']
+       "configs": {
+          "hbaseConfigResources": "hbase-site.xml",
+          "zookeeperQuorum": "localhost",
+          "zookeeperClientPort": "2181",
+          "zookeeperZnodeParent": "/hbase",
+          "tableName": "pulsar_hbase",
+          "rowKeyName": "rowKey",
+          "familyName": "info",
+          "qualifierNames": [ 'name', 'address', 'age']
+       }
     }
     ```
 

--- a/site2/docs/io-hdfs2-sink.md
+++ b/site2/docs/io-hdfs2-sink.md
@@ -36,12 +36,14 @@ Before using the HDFS2 sink connector, you need to create a configuration file t
 
     ```json
     {
-        "hdfsConfigResources": "core-site.xml",
-        "directory": "/foo/bar",
-        "filenamePrefix": "prefix",
-        "fileExtension": ".log",
-        "compression": "SNAPPY",
-        "subdirectoryPattern": "yyyy-MM-dd"
+       "configs": {
+          "hdfsConfigResources": "core-site.xml",
+          "directory": "/foo/bar",
+          "filenamePrefix": "prefix",
+          "fileExtension": ".log",
+          "compression": "SNAPPY",
+          "subdirectoryPattern": "yyyy-MM-dd"
+       }
     }
     ```
 

--- a/site2/docs/io-hdfs3-sink.md
+++ b/site2/docs/io-hdfs3-sink.md
@@ -35,10 +35,12 @@ Before using the HDFS3 sink connector, you need to create a configuration file t
 
     ```json
     {
-        "hdfsConfigResources": "core-site.xml",
-        "directory": "/foo/bar",
-        "filenamePrefix": "prefix",
-        "compression": "SNAPPY"
+       "configs": {
+          "hdfsConfigResources": "core-site.xml",
+          "directory": "/foo/bar",
+          "filenamePrefix": "prefix",
+          "compression": "SNAPPY"
+       }
     }
     ```
 

--- a/site2/docs/io-influxdb-sink.md
+++ b/site2/docs/io-influxdb-sink.md
@@ -44,22 +44,27 @@ The configuration of the InfluxDB sink connector has the following properties.
 ### Example
 Before using the InfluxDB sink connector, you need to create a configuration file through one of the following methods.
 #### InfluxDBv2
+
 * JSON
+
     ```json
     {
-        "influxdbUrl": "http://localhost:9999",
-        "organization": "example-org",
-        "bucket": "example-bucket",
-        "token": "xxxx",
-        "precision": "ns",
-        "logLevel": "NONE",
-        "gzipEnable": false,
-        "batchTimeMs": 1000,
-        "batchSize": 100
+       "configs": {
+          "influxdbUrl": "http://localhost:9999",
+          "organization": "example-org",
+          "bucket": "example-bucket",
+          "token": "xxxx",
+          "precision": "ns",
+          "logLevel": "NONE",
+          "gzipEnable": false,
+          "batchTimeMs": 1000,
+          "batchSize": 100
+       }
     }
     ```
   
 * YAML
+
     ```yaml
     configs:
         influxdbUrl: "http://localhost:9999"
@@ -79,14 +84,16 @@ Before using the InfluxDB sink connector, you need to create a configuration fil
 
     ```json
     {
-        "influxdbUrl": "http://localhost:8086",
-        "database": "test_db",
-        "consistencyLevel": "ONE",
-        "logLevel": "NONE",
-        "retentionPolicy": "autogen",
-        "gzipEnable": false,
-        "batchTimeMs": 1000,
-        "batchSize": 100
+       "configs": {
+          "influxdbUrl": "http://localhost:8086",
+          "database": "test_db",
+          "consistencyLevel": "ONE",
+          "logLevel": "NONE",
+          "retentionPolicy": "autogen",
+          "gzipEnable": false,
+          "batchTimeMs": 1000,
+          "batchSize": 100
+       }
     }
     ```
 

--- a/site2/docs/io-jdbc-sink.md
+++ b/site2/docs/io-jdbc-sink.md
@@ -32,10 +32,12 @@ The configuration of all JDBC sink connectors has the following properties.
 
     ```json
     {
-        "userName": "clickhouse",
-        "password": "password",
-        "jdbcUrl": "jdbc:clickhouse://localhost:8123/pulsar_clickhouse_jdbc_sink",
-        "tableName": "pulsar_clickhouse_jdbc_sink"
+       "configs" {
+          "userName": "clickhouse",
+          "password": "password",
+          "jdbcUrl": "jdbc:clickhouse://localhost:8123/pulsar_clickhouse_jdbc_sink",
+          "tableName": "pulsar_clickhouse_jdbc_sink"
+       }
     }
     ```
 
@@ -60,10 +62,12 @@ The configuration of all JDBC sink connectors has the following properties.
 
     ```json
     {
-        "userName": "mariadb",
-        "password": "password",
-        "jdbcUrl": "jdbc:mariadb://localhost:3306/pulsar_mariadb_jdbc_sink",
-        "tableName": "pulsar_mariadb_jdbc_sink"
+       "configs": {
+          "userName": "mariadb",
+          "password": "password",
+          "jdbcUrl": "jdbc:mariadb://localhost:3306/pulsar_mariadb_jdbc_sink",
+          "tableName": "pulsar_mariadb_jdbc_sink"
+       }
     }
     ```
 
@@ -90,10 +94,12 @@ Before using the JDBC PostgreSQL sink connector, you need to create a configurat
 
     ```json
     {
-        "userName": "postgres",
-        "password": "password",
-        "jdbcUrl": "jdbc:postgresql://localhost:5432/pulsar_postgres_jdbc_sink",
-        "tableName": "pulsar_postgres_jdbc_sink"
+       "configs": {
+          "userName": "postgres",
+          "password": "password",
+          "jdbcUrl": "jdbc:postgresql://localhost:5432/pulsar_postgres_jdbc_sink",
+          "tableName": "pulsar_postgres_jdbc_sink"
+       }
     }
     ```
 
@@ -120,8 +126,10 @@ For more information on **how to use this JDBC sink connector**, see [connect Pu
 
     ```json
     {
-        "jdbcUrl": "jdbc:sqlite:db.sqlite",
-        "tableName": "pulsar_sqlite_jdbc_sink"
+       "configs": {
+          "jdbcUrl": "jdbc:sqlite:db.sqlite",
+          "tableName": "pulsar_sqlite_jdbc_sink"
+       }
     }
     ```
 

--- a/site2/docs/io-kafka-sink.md
+++ b/site2/docs/io-kafka-sink.md
@@ -35,19 +35,20 @@ Before using the Kafka sink connector, you need to create a configuration file t
 
     ```json
     {
-        "bootstrapServers": "localhost:6667",
-        "topic": "test",
-        "acks": "1",
-        "batchSize": "16384",
-        "maxRequestSize": "1048576",
-        "producerConfigProperties":
-         {
-            "client.id": "test-pulsar-producer",
-            "security.protocol": "SASL_PLAINTEXT",
-            "sasl.mechanism": "GSSAPI",
-            "sasl.kerberos.service.name": "kafka",
-            "acks": "all" 
-         }
+       "configs": {
+          "bootstrapServers": "localhost:6667",
+          "topic": "test",
+          "acks": "1",
+          "batchSize": "16384",
+          "maxRequestSize": "1048576",
+          "producerConfigProperties": {
+             "client.id": "test-pulsar-producer",
+             "security.protocol": "SASL_PLAINTEXT",
+             "sasl.mechanism": "GSSAPI",
+             "sasl.kerberos.service.name": "kafka",
+             "acks": "all" 
+          }
+       }
     }
 
 * YAML

--- a/site2/docs/io-kafka-source.md
+++ b/site2/docs/io-kafka-source.md
@@ -68,11 +68,13 @@ Before using the Kafka source connector, you need to create a configuration file
 
     ```json
     {
-        "bootstrapServers": "pulsar-kafka:9092",
-        "groupId": "test-pulsar-io",
-        "topic": "my-topic",
-        "sessionTimeoutMs": "10000",
-        "autoCommitEnabled": false
+       "configs": {
+          "bootstrapServers": "pulsar-kafka:9092",
+          "groupId": "test-pulsar-io",
+          "topic": "my-topic",
+          "sessionTimeoutMs": "10000",
+          "autoCommitEnabled": false
+       }
     }
     ```
 

--- a/site2/docs/io-kinesis-sink.md
+++ b/site2/docs/io-kinesis-sink.md
@@ -50,12 +50,14 @@ Before using the Kinesis sink connector, you need to create a configuration file
 
     ```json
     {
-        "awsEndpoint": "some.endpoint.aws",
-        "awsRegion": "us-east-1",
-        "awsKinesisStreamName": "my-stream",
-        "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
-        "messageFormat": "ONLY_RAW_PAYLOAD",
-        "retainOrdering": "true"
+       "configs": {
+          "awsEndpoint": "some.endpoint.aws",
+          "awsRegion": "us-east-1",
+          "awsKinesisStreamName": "my-stream",
+          "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
+          "messageFormat": "ONLY_RAW_PAYLOAD",
+          "retainOrdering": "true"
+       }
     }
     ```
 

--- a/site2/docs/io-kinesis-source.md
+++ b/site2/docs/io-kinesis-source.md
@@ -43,17 +43,19 @@ Before using the Kinesis source connector, you need to create a configuration fi
 
     ```json
     {
-        "awsEndpoint": "https://some.endpoint.aws",
-        "awsRegion": "us-east-1",
-        "awsKinesisStreamName": "my-stream",
-        "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
-        "applicationName": "My test application",
-        "checkpointInterval": "30000",
-        "backoffTime": "4000",
-        "numRetries": "3",
-        "receiveQueueSize": 2000,
-        "initialPositionInStream": "TRIM_HORIZON",
-        "startAtTime": "2019-03-05T19:28:58.000Z"
+       "configs": {
+          "awsEndpoint": "https://some.endpoint.aws",
+          "awsRegion": "us-east-1",
+          "awsKinesisStreamName": "my-stream",
+          "awsCredentialPluginParam": "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}",
+          "applicationName": "My test application",
+          "checkpointInterval": "30000",
+          "backoffTime": "4000",
+          "numRetries": "3",
+          "receiveQueueSize": 2000,
+          "initialPositionInStream": "TRIM_HORIZON",
+          "startAtTime": "2019-03-05T19:28:58.000Z"
+       }
     }
     ```
 

--- a/site2/docs/io-mongo-sink.md
+++ b/site2/docs/io-mongo-sink.md
@@ -30,11 +30,13 @@ Before using the Mongo sink connector, you need to create a configuration file t
   
     ```json
     {
-        "mongoUri": "mongodb://localhost:27017",
-        "database": "pulsar",
-        "collection": "messages",
-        "batchSize": "2",
-        "batchTimeMs": "500"
+       "configs": {
+          "mongoUri": "mongodb://localhost:27017",
+          "database": "pulsar",
+          "collection": "messages",
+          "batchSize": "2",
+          "batchTimeMs": "500"
+       }
     }
     ```
 

--- a/site2/docs/io-netty-source.md
+++ b/site2/docs/io-netty-source.md
@@ -31,10 +31,12 @@ Before using the Netty source connector, you need to create a configuration file
 
     ```json
     {
-        "type": "tcp",
-        "host": "127.0.0.1",
-        "port": "10911",
-        "numberOfThreads": "1"
+       "configs": {
+          "type": "tcp",
+          "host": "127.0.0.1",
+          "port": "10911",
+          "numberOfThreads": "1"
+       }
     }
     ```
 

--- a/site2/docs/io-rabbitmq-sink.md
+++ b/site2/docs/io-rabbitmq-sink.md
@@ -41,20 +41,22 @@ Before using the RabbitMQ sink connector, you need to create a configuration fil
 
     ```json
     {
-        "host": "localhost",
-        "port": "5672",
-        "virtualHost": "/",
-        "username": "guest",
-        "password": "guest",
-        "queueName": "test-queue",
-        "connectionName": "test-connection",
-        "requestedChannelMax": "0",
-        "requestedFrameMax": "0",
-        "connectionTimeout": "60000",
-        "handshakeTimeout": "10000",
-        "requestedHeartbeat": "60",
-        "exchangeName": "test-exchange",
-        "routingKey": "test-key"
+       "configs": {
+          "host": "localhost",
+          "port": "5672",
+          "virtualHost": "/",
+          "username": "guest",
+          "password": "guest",
+          "queueName": "test-queue",
+          "connectionName": "test-connection",
+          "requestedChannelMax": "0",
+          "requestedFrameMax": "0",
+          "connectionTimeout": "60000",
+          "handshakeTimeout": "10000",
+          "requestedHeartbeat": "60",
+          "exchangeName": "test-exchange",
+          "routingKey": "test-key"
+       }
     }
     ```
 

--- a/site2/docs/io-rabbitmq-source.md
+++ b/site2/docs/io-rabbitmq-source.md
@@ -39,21 +39,23 @@ Before using the RabbitMQ source connector, you need to create a configuration f
 
     ```json
     {
-        "host": "localhost",
-        "port": "5672",
-        "virtualHost": "/",
-        "username": "guest",
-        "password": "guest",
-        "queueName": "test-queue",
-        "connectionName": "test-connection",
-        "requestedChannelMax": "0",
-        "requestedFrameMax": "0",
-        "connectionTimeout": "60000",
-        "handshakeTimeout": "10000",
-        "requestedHeartbeat": "60",
-        "prefetchCount": "0",
-        "prefetchGlobal": "false",
-        "passive": "false"
+       "configs": {
+          "host": "localhost",
+          "port": "5672",
+          "virtualHost": "/",
+          "username": "guest",
+          "password": "guest",
+          "queueName": "test-queue",
+          "connectionName": "test-connection",
+          "requestedChannelMax": "0",
+          "requestedFrameMax": "0",
+          "connectionTimeout": "60000",
+          "handshakeTimeout": "10000",
+          "requestedHeartbeat": "60",
+          "prefetchCount": "0",
+          "prefetchGlobal": "false",
+          "passive": "false"
+       }
     }
     ```
 

--- a/site2/docs/io-redis-sink.md
+++ b/site2/docs/io-redis-sink.md
@@ -41,14 +41,16 @@ Before using the Redis sink connector, you need to create a configuration file i
 
     ```json
     {
-        "redisHosts": "localhost:6379",
-        "redisPassword": "mypassword",
-        "redisDatabase": "0",
-        "clientMode": "Standalone",
-        "operationTimeout": "2000",
-        "batchSize": "1",
-        "batchTimeMs": "1000",
-        "connectTimeout": "3000"
+       "configs": {
+          "redisHosts": "localhost:6379",
+          "redisPassword": "mypassword",
+          "redisDatabase": "0",
+          "clientMode": "Standalone",
+          "operationTimeout": "2000",
+          "batchSize": "1",
+          "batchTimeMs": "1000",
+          "connectTimeout": "3000"
+       }
     }
     ```
 

--- a/site2/docs/io-solr-sink.md
+++ b/site2/docs/io-solr-sink.md
@@ -36,12 +36,14 @@ Before using the Solr sink connector, you need to create a configuration file th
 
     ```json
     {
-        "solrUrl": "localhost:2181,localhost:2182/chroot",
-        "solrMode": "SolrCloud",
-        "solrCollection": "techproducts",
-        "solrCommitWithinMs": 100,
-        "username": "fakeuser",
-        "password": "fake@123"
+       "configs": {
+          "solrUrl": "localhost:2181,localhost:2182/chroot",
+          "solrMode": "SolrCloud",
+          "solrCollection": "techproducts",
+          "solrCommitWithinMs": 100,
+          "username": "fakeuser",
+          "password": "fake@123"
+       }
     }
     ```
 


### PR DESCRIPTION


*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #12768 

### Motivation

The JSON configuration examples for the Pulsar IO connectors were wrong.

### Modifications

Corrected the JSON configuration examples for the connectors with such examples

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:
No

### Documentation

Check the box below and label this PR (if you have committer privilege).
  
- [ X] `doc` 
  
  (If this PR contains doc changes)


