### PR TITLE
modify log level for disconnction

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -253,7 +253,7 @@ public class ClientCnx extends PulsarHandler {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         super.channelInactive(ctx);
-        log.info("{} Disconnected", ctx.channel());
+        log.warn("{} Disconnected", ctx.channel());
         if (!connectionFuture.isDone()) {
             connectionFuture.completeExceptionally(new PulsarClientException("Connection already closed"));
         }


### PR DESCRIPTION
Fixes #12755 

### Motivation

Make channel disconnection information easier to catch.

### Modifications

Update log level for disconnection from info to warn.

### Verifying this change

This change is a trivial rework



### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

  
- [x] `no-need-doc` 
  



