### PR TITLE
[broker]Optimize topicMaxMessageSize with topic local cache.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -994,12 +994,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "Check between intervals to see if max message size of topic policy has updated. default is 60s"
-    )
-    private int maxMessageSizeCheckIntervalInSeconds = 60;
-
-    @FieldContext(
-            category = CATEGORY_SERVER,
             doc = "The number of partitions per partitioned topic.\n"
                 + "If try to create or update partitioned topics by exceeded number of partitions, then fail."
     )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -1968,6 +1968,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         assertNull(admin.topicPolicies().getMaxMessageSize(topic));
         // set msg size
         admin.topicPolicies().setMaxMessageSize(topic, 10);
+        Awaitility.await().until(() -> pulsar.getTopicPoliciesService().getTopicPolicies(TopicName.get(topic)) != null);
         if (isPartitioned) {
             for (int i = 0; i <3; i++) {
                 String partitionName = TopicName.get(topic).getPartition(i).toString();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.google.common.collect.Sets;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -32,6 +32,7 @@ public class HierarchyTopicPolicies {
     final PolicyHierarchyValue<InactiveTopicPolicies> inactiveTopicPolicies;
     final PolicyHierarchyValue<Integer> maxSubscriptionsPerTopic;
     final Map<BacklogQuotaType, PolicyHierarchyValue<BacklogQuota>> backLogQuotaMap;
+    final PolicyHierarchyValue<Integer> topicMaxMessageSize;
 
     public HierarchyTopicPolicies() {
         inactiveTopicPolicies = new PolicyHierarchyValue<>();
@@ -40,5 +41,6 @@ public class HierarchyTopicPolicies {
                 .put(BacklogQuotaType.destination_storage, new PolicyHierarchyValue<>())
                 .put(BacklogQuotaType.message_age, new PolicyHierarchyValue<>())
                 .build();
+        topicMaxMessageSize = new PolicyHierarchyValue<>();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
 
@@ -32,11 +31,9 @@ public class PolicyHierarchyValue<T> {
 
     private volatile T brokerValue;
 
-    @VisibleForTesting
     @Getter
     private volatile T namespaceValue;
 
-    @VisibleForTesting
     @Getter
     private volatile T topicValue;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
@@ -36,6 +36,8 @@ public class PolicyHierarchyValue<T> {
     @Getter
     private volatile T namespaceValue;
 
+    @VisibleForTesting
+    @Getter
     private volatile T topicValue;
 
     private volatile T value;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Currently, , we update the value of `Topic#topicMaxMessageSize` in an interval of  `maxMessageSizeCheckIntervalInSeconds` (default as 60s). 
So if we update this value, we will have a delay, max to 60s by default, before it take effects.
We can reduce the latency by updating the value with notification.

Further, we can avoid the blank updates in `isExceedMaximumMessageSize`.

### Modifications

1. Move `topicMaxMessageSize` to HierarchyTopicPolicies , and update by `onUpdate` listener, like other topic policies.
2. Deprecates `maxMessageSizeCheckIntervalInSeconds`, since it has no use any more.
3. Remove `lastTopicMaxMessageSizeCheckTimeStamp` and `topicMaxMessageSizeCheckIntervalMs`, no use any more.
4. Move method `registerTopicPolicyListener` up to AbstractTopic level, since `topicMaxMessageSize` also effect non-persist topics.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

*(example:)*
  - org.apache.pulsar.broker.admin.TopicPoliciesTest#testTopicMaxMessageSize, and added test case for non-persisitent topics.
  - Add org.apache.pulsar.broker.admin.TopicPoliciesTest#testTopicPolicyInitValue to cover  the case that topic loading old settings.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `doc` 

Doc updated in comments.
And checked with old configuration doc, no `maxMessageSizeCheckIntervalInSeconds` found, and no need to add since it is deprecated.


