### PR TITLE
[CAPI] Support getting/setting replicateSubscriptionState perameter for consumers

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -281,6 +281,24 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_priority_level(
 PULSAR_PUBLIC int pulsar_consumer_configuration_get_priority_level(
     pulsar_consumer_configuration_t *consumer_configuration);
 
+/**
+ * Check whether the replicated subscription is enabled.
+ *
+ * @param consumer_configuration the consumer configuration object
+ * @return whether the replicated subscription is enabled.
+ */
+PULSAR_PUBLIC int pulsar_consumer_is_replicate_subscription_state_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
+/**
+ * Enable or disable replicated subscription
+ *
+ * @param consumer_configuration the consumer configuration object
+ * @param enabled int parameter. 0 means disabling replicated subscriptions. 1 means enabling replicated subscriptions.
+ */
+PULSAR_PUBLIC void pulsar_consumer_set_replicate_subscription_state_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration, int enabled);
+
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //
 // const;
@@ -298,3 +316,4 @@ PULSAR_PUBLIC int pulsar_consumer_configuration_get_priority_level(
 #ifdef __cplusplus
 }
 #endif
+

--- a/pulsar-client-cpp/lib/c/c_ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/c/c_ConsumerConfiguration.cc
@@ -195,3 +195,13 @@ int pulsar_consumer_configuration_get_priority_level(
     pulsar_consumer_configuration_t *consumer_configuration) {
     return consumer_configuration->consumerConfiguration.getPriorityLevel();
 }
+
+int pulsar_consumer_is_replicate_subscription_state_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    return consumer_configuration->consumerConfiguration.isReplicateSubscriptionStateEnabled();
+}
+
+void pulsar_consumer_set_replicate_subscription_state_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration, int enabled) {
+    consumer_configuration->consumerConfiguration.setReplicateSubscriptionStateEnabled(enabled);
+}


### PR DESCRIPTION
[CAPI] Support getting/setting replicateSubscriptionState perameter for consumers

### Motivation
We would like to make it possible for C API based client library to
get/set the replicateSubscriptionState perameter for consumers.

### Modifications
Add methods to set/get replicateSubscriptionState perameter for
consumers.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
- [ ] `no-need-doc` 
  
  [CAPI] Support getting/setting replicateSubscriptionState perameter, no need to change the document.
  
- [x] `doc` 