### PR TITLE
[package management service] check service status before run commands

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -244,7 +244,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private AdditionalServlets brokerAdditionalServlets;
 
     // packages management service
-    private PackagesManagement packagesManagement;
+    private Optional<PackagesManagement> packagesManagement = Optional.empty();
     private PrometheusMetricsServlet metricsServlet;
     private List<PrometheusRawMetricsProvider> pendingMetricsProviders;
 
@@ -1544,16 +1544,22 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         }
     }
 
+    public PackagesManagement getPackagesManagement() throws UnsupportedOperationException {
+        return packagesManagement.orElseThrow(() -> new UnsupportedOperationException("Package Management Service "
+                + "is not enabled in the broker."));
+    }
+
     private void startPackagesManagementService() throws IOException {
         // TODO: using provider to initialize the packages management service.
-        this.packagesManagement = new PackagesManagementImpl();
+        PackagesManagement packagesManagementService = new PackagesManagementImpl();
+        this.packagesManagement = Optional.of(packagesManagementService);
         PackagesStorageProvider storageProvider = PackagesStorageProvider
             .newProvider(config.getPackagesManagementStorageProvider());
         DefaultPackagesStorageConfiguration storageConfiguration = new DefaultPackagesStorageConfiguration();
         storageConfiguration.setProperty(config.getProperties());
         PackagesStorage storage = storageProvider.getStorage(storageConfiguration);
         storage.initialize();
-        packagesManagement.initialize(storage);
+        packagesManagementService.initialize(storage);
     }
 
     public Optional<Integer> getListenPortHTTP() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
-import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -66,6 +65,8 @@ public class PackagesBase extends AdminResource {
             asyncResponse.resume(new RestException(Response.Status.NOT_FOUND, throwable.getMessage()));
         } else if (throwable instanceof WebApplicationException) {
             asyncResponse.resume(throwable);
+        } else if (throwable instanceof UnsupportedOperationException) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE, throwable.getMessage()));
         } else {
             log.error("Encountered unexpected error", throwable);
             asyncResponse.resume(new RestException(Response.Status.INTERNAL_SERVER_ERROR, throwable.getMessage()));
@@ -75,127 +76,94 @@ public class PackagesBase extends AdminResource {
 
     protected void internalGetMetadata(String type, String tenant, String namespace, String packageName,
                                                   String version, AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                    .thenCompose(name -> getPackagesManagement().getMeta(name))
-                    .thenAccept(asyncResponse::resume)
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
-        }
+        checkPermissions(tenant, namespace)
+                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+                .thenCompose(name -> getPackagesManagement().getMeta(name))
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalUpdateMetadata(String type, String tenant, String namespace, String packageName,
                                           String version, PackageMetadata metadata, AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                    .thenCompose(name -> getPackagesManagement().updateMeta(name, metadata))
-                    .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
-        }
+        checkPermissions(tenant, namespace)
+                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+                .thenCompose(name -> getPackagesManagement().updateMeta(name, metadata))
+                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected StreamingOutput internalDownload(String type, String tenant, String namespace,
                                                String packageName, String version) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            try {
-                checkPermissions(tenant, namespace).get();
-            } catch (InterruptedException e) {
-                throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage());
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof WebApplicationException) {
-                    throw (WebApplicationException) e.getCause();
-                } else {
-                    throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getCause().getMessage());
-                }
+        try {
+            checkPermissions(tenant, namespace).get();
+        } catch (InterruptedException e) {
+            throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof WebApplicationException) {
+                throw (WebApplicationException) e.getCause();
+            } else {
+                throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getCause().getMessage());
             }
-            try {
-                PackageName name = PackageName.get(type, tenant, namespace, packageName, version);
-                return output -> {
-                    try {
-                        getPackagesManagement().download(name, output).get();
-                    } catch (InterruptedException e) {
-                        throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage());
-                    } catch (ExecutionException e) {
-                        if (e.getCause() instanceof PackagesManagementException.NotFoundException) {
-                            throw new RestException(Response.Status.NOT_FOUND, e.getCause().getMessage());
-                        } else {
-                            throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getCause().getMessage());
-                        }
+        }
+        try {
+            PackageName name = PackageName.get(type, tenant, namespace, packageName, version);
+            return output -> {
+                try {
+                    getPackagesManagement().download(name, output).get();
+                } catch (InterruptedException e) {
+                    throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage());
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof PackagesManagementException.NotFoundException) {
+                        throw new RestException(Response.Status.NOT_FOUND, e.getCause().getMessage());
+                    } else {
+                        throw new RestException(Response.Status.INTERNAL_SERVER_ERROR, e.getCause().getMessage());
                     }
-                };
-            } catch (IllegalArgumentException illegalArgumentException) {
-                throw new RestException(Response.Status.PRECONDITION_FAILED, illegalArgumentException.getMessage());
-            }
-        } else {
-            throw new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker.");
+                } catch (UnsupportedOperationException e) {
+                    throw new RestException(Response.Status.SERVICE_UNAVAILABLE, e.getMessage());
+                }
+            };
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new RestException(Response.Status.PRECONDITION_FAILED, illegalArgumentException.getMessage());
         }
     }
 
     protected void internalUpload(String type, String tenant, String namespace, String packageName, String version,
                                   PackageMetadata metadata, InputStream uploadedInputStream,
                                   AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                    .thenCompose(name -> getPackagesManagement().upload(name, metadata, uploadedInputStream))
-                    .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
-        }
+        checkPermissions(tenant, namespace)
+                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+                .thenCompose(name -> getPackagesManagement().upload(name, metadata, uploadedInputStream))
+                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalDelete(String type, String tenant, String namespace, String packageName, String version,
                                   AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                    .thenCompose(name -> getPackagesManagement().delete(name))
-                    .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
-        }
+        checkPermissions(tenant, namespace)
+                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+                .thenCompose(name -> getPackagesManagement().delete(name))
+                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalListVersions(String type, String tenant, String namespace, String packageName,
                                                      AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, ""))
-                    .thenCompose(name -> getPackagesManagement().list(name))
-                    .thenAccept(asyncResponse::resume)
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
-        }
+        checkPermissions(tenant, namespace)
+                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, ""))
+                .thenCompose(name -> getPackagesManagement().list(name))
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalListPackages(String type, String tenant, String namespace, AsyncResponse asyncResponse) {
-        if (pulsar().getConfig().isEnablePackagesManagement()) {
-            try {
-                PackageType packageType = PackageType.getEnum(type);
-                checkPermissions(tenant, namespace)
-                        .thenCompose(ignore -> getPackagesManagement().list(packageType, tenant, namespace))
-                        .thenAccept(asyncResponse::resume)
-                        .exceptionally(e -> handleError(e.getCause(), asyncResponse));
-            } catch (IllegalArgumentException iae) {
-                asyncResponse.resume(new RestException(Response.Status.PRECONDITION_FAILED, iae.getMessage()));
-            }
-        } else {
-            asyncResponse.resume(new RestException(SERVICE_UNAVAILABLE,
-                    "Package Management Service is not enabled in the broker."));
+        try {
+            PackageType packageType = PackageType.getEnum(type);
+            checkPermissions(tenant, namespace)
+                    .thenCompose(ignore -> getPackagesManagement().list(packageType, tenant, namespace))
+                    .thenAccept(asyncResponse::resume)
+                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+        } catch (IllegalArgumentException iae) {
+            asyncResponse.resume(new RestException(Response.Status.PRECONDITION_FAILED, iae.getMessage()));
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
@@ -77,19 +77,19 @@ public class PackagesBase extends AdminResource {
     protected void internalGetMetadata(String type, String tenant, String namespace, String packageName,
                                                   String version, AsyncResponse asyncResponse) {
         checkPermissions(tenant, namespace)
-                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                .thenCompose(name -> getPackagesManagement().getMeta(name))
-                .thenAccept(asyncResponse::resume)
-                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+            .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+            .thenCompose(name -> getPackagesManagement().getMeta(name))
+            .thenAccept(asyncResponse::resume)
+            .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalUpdateMetadata(String type, String tenant, String namespace, String packageName,
                                           String version, PackageMetadata metadata, AsyncResponse asyncResponse) {
         checkPermissions(tenant, namespace)
-                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                .thenCompose(name -> getPackagesManagement().updateMeta(name, metadata))
-                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+            .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+            .thenCompose(name -> getPackagesManagement().updateMeta(name, metadata))
+            .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+            .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected StreamingOutput internalDownload(String type, String tenant, String namespace,
@@ -131,37 +131,37 @@ public class PackagesBase extends AdminResource {
                                   PackageMetadata metadata, InputStream uploadedInputStream,
                                   AsyncResponse asyncResponse) {
         checkPermissions(tenant, namespace)
-                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                .thenCompose(name -> getPackagesManagement().upload(name, metadata, uploadedInputStream))
-                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+            .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+            .thenCompose(name -> getPackagesManagement().upload(name, metadata, uploadedInputStream))
+            .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+            .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalDelete(String type, String tenant, String namespace, String packageName, String version,
                                   AsyncResponse asyncResponse) {
         checkPermissions(tenant, namespace)
-                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
-                .thenCompose(name -> getPackagesManagement().delete(name))
-                .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
-                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+            .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, version))
+            .thenCompose(name -> getPackagesManagement().delete(name))
+            .thenAccept(ignore -> asyncResponse.resume(Response.noContent().build()))
+            .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalListVersions(String type, String tenant, String namespace, String packageName,
                                                      AsyncResponse asyncResponse) {
         checkPermissions(tenant, namespace)
-                .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, ""))
-                .thenCompose(name -> getPackagesManagement().list(name))
-                .thenAccept(asyncResponse::resume)
-                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+            .thenCompose(ignore -> getPackageNameAsync(type, tenant, namespace, packageName, ""))
+            .thenCompose(name -> getPackagesManagement().list(name))
+            .thenAccept(asyncResponse::resume)
+            .exceptionally(e -> handleError(e.getCause(), asyncResponse));
     }
 
     protected void internalListPackages(String type, String tenant, String namespace, AsyncResponse asyncResponse) {
         try {
             PackageType packageType = PackageType.getEnum(type);
             checkPermissions(tenant, namespace)
-                    .thenCompose(ignore -> getPackagesManagement().list(packageType, tenant, namespace))
-                    .thenAccept(asyncResponse::resume)
-                    .exceptionally(e -> handleError(e.getCause(), asyncResponse));
+                .thenCompose(ignore -> getPackagesManagement().list(packageType, tenant, namespace))
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(e -> handleError(e.getCause(), asyncResponse));
         } catch (IllegalArgumentException iae) {
             asyncResponse.resume(new RestException(Response.Status.PRECONDITION_FAILED, iae.getMessage()));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Packages.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Packages.java
@@ -58,7 +58,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message = "Return the metadata of the specified package."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     public void getMeta(
@@ -82,7 +83,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message = "Update the metadata of the specified package successfully."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     @Consumes(MediaType.APPLICATION_JSON)
@@ -113,7 +115,8 @@ public class Packages extends PackagesBase {
         value = {
             @ApiResponse(code = 200, message = "Upload the specified package successfully."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -148,7 +151,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message = "Download the specified package successfully."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     public StreamingOutput download(
@@ -168,7 +172,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message = "Delete the specified package successfully."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     @ApiOperation(value = "Delete a package with the package name.")
@@ -195,7 +200,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message = "Return the package versions of the specified package."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     public void listPackageVersion(
@@ -219,7 +225,8 @@ public class Packages extends PackagesBase {
             @ApiResponse(code = 200, message =
                 "Return all the specified type package names in the specified namespace."),
             @ApiResponse(code = 412, message = "The package type is illegal."),
-            @ApiResponse(code = 500, message = "Internal server error.")
+            @ApiResponse(code = 500, message = "Internal server error."),
+            @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
         }
     )
     public void listPackages(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/PackagesApiNotEnabledTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/PackagesApiNotEnabledTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.v3;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.packages.management.core.common.PackageMetadata;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class PackagesApiNotEnabledTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        // not enable Package Management Service
+        conf.setEnablePackagesManagement(false);
+        super.internalSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 60000)
+    public void testPackagesOperationsWithoutPackagesServiceEnabled() {
+        // download package api should return 503 Service Unavailable exception
+        String unknownPackageName = "function://public/default/unknown@v1";
+        try {
+            admin.packages().download(unknownPackageName, "/test/unknown");
+            fail("should throw 503 error");
+        } catch (PulsarAdminException e) {
+            assertEquals(503, e.getStatusCode());
+        }
+
+        // get metadata api should return 503 Service Unavailable exception
+        try {
+            admin.packages().getMetadata(unknownPackageName);
+            fail("should throw 503 error");
+        } catch (PulsarAdminException e) {
+            assertEquals(503, e.getStatusCode());
+        }
+
+        // update metadata api should return 503 Service Unavailable exception
+        try {
+            admin.packages().updateMetadata(unknownPackageName,
+                    PackageMetadata.builder().description("unknown").build());
+            fail("should throw 503 error");
+        } catch (PulsarAdminException e) {
+            assertEquals(503, e.getStatusCode());
+        }
+
+        // list all the packages api should return 503 Service Unavailable exception
+        try {
+            admin.packages().listPackages("function", "unknown/unknown");
+            fail("should throw 503 error");
+        } catch (PulsarAdminException e) {
+            assertEquals(503, e.getStatusCode());
+        }
+
+        // list all the versions api should return 503 Service Unavailable exception
+        try {
+            admin.packages().listPackageVersions(unknownPackageName);
+            fail("should throw 503 error");
+        } catch (PulsarAdminException e) {
+            assertEquals(503, e.getStatusCode());
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/PackagesApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/PackagesApiTest.java
@@ -106,6 +106,7 @@ public class PackagesApiTest extends MockedPulsarServiceBaseTest {
         String unknownPackageName = "function://public/default/unknown@v1";
         try {
             admin.packages().download(unknownPackageName, "/test/unknown");
+            fail("should throw 404 error");
         } catch (PulsarAdminException e) {
             assertEquals(404, e.getStatusCode());
         }
@@ -113,6 +114,7 @@ public class PackagesApiTest extends MockedPulsarServiceBaseTest {
         // get the metadata of a non-existent package should return not found exception
         try {
             admin.packages().getMetadata(unknownPackageName);
+            fail("should throw 404 error");
         } catch (PulsarAdminException e) {
             assertEquals(404, e.getStatusCode());
         }
@@ -121,6 +123,7 @@ public class PackagesApiTest extends MockedPulsarServiceBaseTest {
         try {
             admin.packages().updateMetadata(unknownPackageName,
                 PackageMetadata.builder().description("unknown").build());
+            fail("should throw 404 error");
         } catch (PulsarAdminException e) {
             assertEquals(404, e.getStatusCode());
         }


### PR DESCRIPTION
### Motivation

`pulsar-admin` runs packages management services commands, but if the broker is not enabled the service, it will throw NPE. 

The root cause is https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java#L45-L47, the `PackagesManagement` might be null if the service is not enabled.

### Modifications

Check `isEnablePackagesManagement` before each internal request.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


