### PR TITLE
[Java Client] Make userProvidedProducerName final

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -115,7 +115,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     // Globally unique producer name
     private String producerName;
-    private boolean userProvidedProducerName = false;
+    private final boolean userProvidedProducerName;
 
     private String connectionId;
     private String connectedSince;
@@ -161,9 +161,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         super(client, topic, conf, producerCreatedFuture, schema, interceptors);
         this.producerId = client.newProducerId();
         this.producerName = conf.getProducerName();
-        if (StringUtils.isNotBlank(producerName)) {
-            this.userProvidedProducerName = true;
-        }
+        this.userProvidedProducerName = StringUtils.isNotBlank(producerName);
         this.partitionIndex = partitionIndex;
         this.pendingMessages = createPendingMessagesQueue();
         if (conf.getMaxPendingMessages() > 0) {


### PR DESCRIPTION
### Motivation

The `userProvidedProducerName` variable in the Java Client `ProducerImpl` can easily be made `final`. Making it final helps make it clear that this value should not change once the producer is created.

### Modifications

* Make `userProvidedProducerName` final.
* Update the way `userProvidedProducerName` is instantiated.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation
- [x] `no-need-doc` 
  
 This is a very minor internal change.

