### PR TITLE
[Authorization] Support GET_BACKLOG_SIZE topic op after enable auth

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -583,6 +583,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             case EXPIRE_MESSAGES:
             case PEEK_MESSAGES:
             case RESET_CURSOR:
+            case GET_BACKLOG_SIZE:
             case SET_REPLICATED_SUBSCRIPTION_STATUS:
                 isAuthorizedFuture = canConsumeAsync(topicName, role, authData, authData.getSubscription());
                 break;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -218,6 +218,13 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
             assertTrue(e.getMessage().startsWith(
                     "Unauthorized to validateTopicOperation for operation [GET_STATS]"));
         }
+        try {
+            sub1Admin.topics().getBacklogSizeByMessageId(topicName, MessageId.earliest);
+            fail("should have failed with authorization exception");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().startsWith(
+                    "Unauthorized to validateTopicOperation for operation"));
+        }
 
         // grant topic consume authorization to the subscriptionRole
         tenantAdmin.topics().grantPermission(topicName, subscriptionRole,
@@ -239,8 +246,10 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(subscriptions.size(), 2);
 
         // now, subscriptionRole have consume authorization on topic, so it will successfully get topic internal stats
-        PersistentTopicInternalStats internalStats = superAdmin.topics().getInternalStats(topicName, true);
+        PersistentTopicInternalStats internalStats = sub1Admin.topics().getInternalStats(topicName, true);
         assertNotNull(internalStats);
+        Long backlogSize = sub1Admin.topics().getBacklogSizeByMessageId(topicName, MessageId.earliest);
+        assertEquals(backlogSize.longValue(), 0);
 
         // verify tenant is able to perform all subscription-admin api
         tenantAdmin.topics().skipAllMessages(topicName, subscriptionName);


### PR DESCRIPTION
### Motivation
Currently, we can get the backlog size of a topic through `bin/pulsar-admin topics get-backlog-size tn1/ns1/tp1`, however I found that `PulsarAuthorizationProvider` lacks support for topic operation `GET_BACKLOG_SIZE` when verifying the role's authorization, code as below: 
https://github.com/apache/pulsar/blob/b99f75e8874532f5a1867741cbb85ca6a2187132/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java#L2767
https://github.com/apache/pulsar/blob/b99f75e8874532f5a1867741cbb85ca6a2187132/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java#L569-L599

The purpose of this PR is to support role with `consume` topic authorization to `GET_BACKLOG_SIZE` of topic.

### Documentation 
- [x] `no-need-doc` 
 