### PR TITLE
Docs: Pulsar standalone does not work on Windows, remove from docs, also suggest to use JDK11

### DIFF
--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -15,7 +15,7 @@ This tutorial guides you through every step of installing Pulsar locally.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JDK11+ is suggested.
 
 > **Tip**  
 > By default, Pulsar allocates 2G JVM heap memory to start. It can be changed in `conf/pulsar_env.sh` file under `PULSAR_MEM`. This is extra options passed into JVM. 

--- a/site2/website-next/docs/getting-started-standalone.md
+++ b/site2/website-next/docs/getting-started-standalone.md
@@ -20,7 +20,7 @@ This tutorial guides you through every step of installing Pulsar locally.
 
 ### System requirements
 
-Currently, Pulsar is available for 64-bit **macOS**, **Linux**, and **Windows**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions.
+Currently, Pulsar is available for 64-bit **macOS**, **Linux**. To use Pulsar, you need to install 64-bit JRE/JDK 8 or later versions, JDK11+ is suggested.
 
 :::tip
 


### PR DESCRIPTION
### Motivation
- Users often try to use Pulsar Standalone on Windows, but it does not work, because we do not have Windows scripts


### Modifications

- Do not mention Windows
- Suggest to use JDK11

