### PR TITLE
Don't create AvroData for each KafkaSourceRecord

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -69,15 +69,12 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
         return record;
     }
 
-    private static Map<String, String> PROPERTIES = Collections.emptyMap();
-    private static Optional<Long> RECORD_SEQUENCE = Optional.empty();
-    private static long FLUSH_TIMEOUT_MS = 2000;
+    private static final AvroData avroData = new AvroData(1000);
 
     private class KafkaSourceRecord extends AbstractKafkaSourceRecord<KeyValue<byte[], byte[]>> implements KVRecord<byte[], byte[]> {
 
         KafkaSourceRecord(SourceRecord srcRecord) {
             super(srcRecord);
-            AvroData avroData = new AvroData(1000);
             byte[] keyBytes = keyConverter.fromConnectData(
                     srcRecord.topic(), srcRecord.keySchema(), srcRecord.key());
             this.key = keyBytes != null ? Optional.of(Base64.getEncoder().encodeToString(keyBytes)) : Optional.empty();


### PR DESCRIPTION
### Motivation

KCA Source / KafkaSourceRecord instantiates new AvroData object that can be reused.
Unfortunate side-effect is that AvroData constructor creates new logger (that's confluent's doing) and uses too much PCu using so.

![image](https://user-images.githubusercontent.com/8622884/142289055-bdba862e-0328-4ba1-8d31-59f8905cc761.png)

### Modifications

Moved AvroData to a static final; removed unused fields.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*
NO

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).
  
- [x] `no-need-doc` 
  
