### PR TITLE
Remove readerCaches and close reader when exception occurs in SystemTopicBasedTopicPoliciesService

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -228,6 +228,8 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 if (ex != null) {
                     log.error("[{}] Failed to create reader on __change_events topic", namespace, ex);
                     result.completeExceptionally(ex);
+                    readerCaches.remove(namespace);
+                    reader.closeAsync();
                 } else {
                     initPolicesCache(reader, result);
                     result.thenRun(() -> readMorePolicies(reader));


### PR DESCRIPTION
## Motivation
This is related to #12773.   As @codelipenghui has commented to remove the readerCaches and close reader.
But due to some reasons, that pr forget to do that.


### Documentation

- [ x ] `no-need-doc` 