### PR TITLE
Remove Unused variable init and unused method In AdminResource Since 2018

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -278,7 +278,6 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected Policies getNamespacePolicies(NamespaceName namespaceName) {
         try {
-            final String namespace = namespaceName.toString();
             Policies policies = namespaceResources().getPolicies(namespaceName)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Namespace does not exist"));
             // fetch bundles from LocalZK-policies
@@ -318,17 +317,6 @@ public abstract class AdminResource extends PulsarWebResource {
                 return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
             }
         });
-    }
-
-    protected void mergeNamespaceWithDefaults(Policies policies, String namespace, String namespacePath) {
-        final ServiceConfiguration config = pulsar().getConfiguration();
-
-        if (policies.max_consumers_per_subscription < 1) {
-            policies.max_consumers_per_subscription = config.getMaxConsumersPerSubscription();
-        }
-
-        final String cluster = config.getClusterName();
-
     }
 
     protected BacklogQuota namespaceBacklogQuota(NamespaceName namespace,


### PR DESCRIPTION
### Modifications
Remove Unused variable init and unused method In AdminResource Since 2018.
And I think the `getNamespacePolicies` is a bit hot path.

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
  
 optimize of code, no need doc.


