### PR TITLE
[issue 12880][kafka-connect-adaptor] Override original Pulsar topic name by topic config property

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -230,7 +230,7 @@ public class KafkaConnectSink implements Sink<GenericObject> {
     @SuppressWarnings("rawtypes")
     protected SinkRecord toSinkRecord(Record<GenericObject> sourceRecord) {
         final int partition = sourceRecord.getPartitionIndex().orElse(0);
-        final String topic = sourceRecord.getTopicName().orElse(topicName);
+        final String topic = getTopicName(sourceRecord);
         final Object key;
         final Object value;
         final Schema keySchema;
@@ -286,6 +286,13 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                 offset,
                 timestamp,
                 timestampType);
+    }
+
+    protected String getTopicName(Record<GenericObject> sourceRecord) {
+        if (topicName.isEmpty()) {
+            return sourceRecord.getTopicName().get();
+        }
+        return topicName;
     }
 
     @VisibleForTesting

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -92,7 +92,7 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase  {
         file = Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
 
         props = Maps.newHashMap();
-        props.put("topic", "test-topic");
+        props.put("topic", "");
         props.put("offsetStorageTopic", offsetTopicName);
         props.put("kafkaConnectorSinkClass", "org.apache.kafka.connect.file.FileStreamSinkConnector");
 


### PR DESCRIPTION
Fixes #12880

### Motivation
Override original Pulsar topic name by topic config property.

### Does this pull request potentially affect one of the following parts: 

*If `yes` was chosen, please highlight the changes*

Changes (fixes) default behaviour of KafkaConnectSink and its descendants.

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no) 
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (This PR fixes existing functionality, so it is compliant with existing documentation. However it should be mentioned in release notes. Since the topic config property is mandatory and preceding to this PR it was ignored, users should be asked to replace possible dummy values by empty string value, in case they do not want to override pulsar topic name passed to Kafka sinks.)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


