### PR TITLE
[Java Client] Avoid IllegalStateException in ClientCnx debug logs

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -541,7 +541,9 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleLookupResponse(CommandLookupTopicResponse lookupResult) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Broker lookup response: {}", lookupResult.getResponse());
+            CommandLookupTopicResponse.LookupType response =
+                    lookupResult.hasResponse() ? lookupResult.getResponse() : null;
+            log.debug("Received Broker lookup response: {} {}", lookupResult.getRequestId(), response);
         }
 
         long requestId = lookupResult.getRequestId();
@@ -577,7 +579,11 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse lookupResult) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Broker Partition response: {}", lookupResult.getPartitions());
+            CommandPartitionedTopicMetadataResponse.LookupType response =
+                    lookupResult.hasResponse() ? lookupResult.getResponse() : null;
+            int partitions = lookupResult.hasPartitions() ? lookupResult.getPartitions() : -1;
+            log.debug("Received Broker Partition response: {} {} {}", lookupResult.getRequestId(), response,
+                    partitions);
         }
 
         long requestId = lookupResult.getRequestId();


### PR DESCRIPTION
### Motivation

When running with debug logging, the Java Client can fail when it receives a valid response from the server. The Here is the stack trace. Note that we were running a custom build of the project, so the line numbers do not necessarily line up exactly. The issue is obvious though. If you look at the logic following each of the modified debug logs, you'll notice branching logic based on whether or not some fields are set. This change simply adds guards to ensure that we do not try to get fields that are not set.

```
14:38:58.824 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ClientCnx - [pulsar-proxy.mypulsar.svc.cluster.local/10.100.138.0:6650] Got exception java.lang.IllegalStateException: Field 'partitions' is not set
     at org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse.getPartitions(CommandPartitionedTopicMetadataResponse.java:38)                                                                 
     at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:569)                                                                                                                       
     at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:129)                                                                                                                       
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)                                                                                                  
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)                                                                                                  
     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)                                                                                                    
     at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)                                                                                                                
     at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)                                                                                                                    
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)                                                                                                  
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)                                                                                                  
     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)                                                                                                    
     at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)                                                                                                         
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)                                                                                                  
     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)                                                                                                  
     at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)                                                                                                                  
     at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795)                                                                                     
     at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480)                                                                                                                               
     at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)                                                                                                                                        
     at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)                                                                                                              
     at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)                                                                                                                                 
     at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)                                                                                                                  
     at java.base/java.lang.Thread.run(Thread.java:829)
```

### Modifications

* Update the `ClientCnx` class to check if fields are set before calling the associated `get` method for the field.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
  
- [x] `no-need-doc` 


