### PR TITLE
[Broker] Return from callback early if producerFuture is complete or …

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1288,6 +1288,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (!isActive()) {
             log.info("[{}] Connection is no longer active. Skipping creation for produceId={} to topic {}.",
                     remoteAddress, topicName, producerId);
+            producerFuture.completeExceptionally(
+                    new IllegalStateException("Connection closed before producer creation"));
+            producers.remove(producerId, producerFuture);
             return;
         } else if (producerFuture.isDone()) {
             log.info("[{}] Producer closed by client side timeout. Skipping creation for produceId={} to topic {}.",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1284,10 +1284,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              boolean userProvidedProducerName, TopicName topicName,
                              ProducerAccessMode producerAccessMode,
                              Optional<Long> topicEpoch, CompletableFuture<Producer> producerFuture){
-        CompletableFuture<Void> producerQueuedFuture = new CompletableFuture<>();
-        Producer producer = new Producer(topic, ServerCnx.this, producerId, producerName,
-                getPrincipal(), isEncrypted, metadata, schemaVersion, epoch,
-                userProvidedProducerName, producerAccessMode, topicEpoch);
         // Skip acquiring the topic's lock within addProducer if the producer will fail creation anyway.
         if (!isActive()) {
             log.info("[{}] Connection is no longer active. Skipping creation for produceId={} to topic {}.",
@@ -1298,6 +1294,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     remoteAddress, topicName, producerId);
             return;
         }
+        CompletableFuture<Void> producerQueuedFuture = new CompletableFuture<>();
+        Producer producer = new Producer(topic, ServerCnx.this, producerId, producerName,
+                getPrincipal(), isEncrypted, metadata, schemaVersion, epoch,
+                userProvidedProducerName, producerAccessMode, topicEpoch);
         topic.addProducer(producer, producerQueuedFuture).thenAccept(newTopicEpoch -> {
             if (isActive()) {
                 if (producerFuture.complete(producer)) {


### PR DESCRIPTION
…connection is closed

### Motivation

When producer creation times out on the client side, the producer sends a `CloseProducer` command and then a `Producer` command. Each time it tries to create a producer, it registers a callback on the same future because `getOrCreateTopic` loads from a cache. If the future completes after the timeout, multiple callbacks will run. We don't need to run the callbacks if the producer's future is complete or if the connection is no longer active.

My only open question is whether or not we should add an info or a debug log in the conditional. Note that if the future was already completed, we would have logged its closure. We'd also log the closure of the connection.

### Modifications

* Update `ServerCnx#handlProducer` to return early if the producer's future is complete or if the connection is no longer active.

### Verifying this change

This change is covered by existing tests.

### Does this pull request potentially affect one of the following parts:

This change is not breaking in any way.

### Documentation

- [x] `no-need-doc` 

This is an internal optimization.
