### PR TITLE
[Website] Builds using https://pulsar.incubator.apache.org as baseurl switch to TLP address

### DIFF
--- a/site2/website-next/docusaurus.config.js
+++ b/site2/website-next/docusaurus.config.js
@@ -3,7 +3,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
 const linkifyRegex = require("./plugins/remark-linkify-regex");
 
-const url = "https://pulsar.incubator.apache.org";
+const url = "https://pulsar.apache.org";
 const javadocUrl = url + "/api";
 const restApiUrl = url + "/admin-rest-api";
 const functionsApiUrl = url + "/functions-rest-api";

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -88,7 +88,7 @@ const renderEndpoint = (initializedPlugin, baseUrl, keyparts, restUrl) => {
     return rendered_content;
 };
 
-const url = 'https://pulsar.incubator.apache.org';
+const url = 'https://pulsar.apache.org';
 const javadocUrl = url + '/api';
 const restApiUrl = url + "/admin-rest-api";
 const functionsApiUrl = url + "/functions-rest-api";


### PR DESCRIPTION
### Motivation

The project graduated three years, but the base url in the website is still using the incubator url.

### Modifications

Changed the url is the docusaurus configurations.

### Verifying this change

- [X] The websites still build with this change.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [X] `no-need-doc` 
  
  The changes are in the website build configurations
  
