### PR TITLE
[pulsar-broker] add uniform load shedder strategy to distribute traffic uniformly across brokers

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1097,6 +1097,18 @@ loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.Overl
 # It only takes effect in the ThresholdShedder strategy.
 loadBalancerBrokerThresholdShedderPercentage=10
 
+# Message-rate percentage threshold between highest and least loaded brokers for
+# uniform load shedding. (eg: broker1 with 50K msgRate and broker2 with 30K msgRate
+# will have 66% msgRate difference and load balancer can unload bundles from broker-1
+# to broker-2)
+loadBalancerMsgRateDifferenceShedderThreshold=50
+
+# Message-throughput threshold between highest and least loaded brokers for
+# uniform load shedding. (eg: broker1 with 450MB msgRate and broker2 with 100MB msgRate
+# will have 4.5 times msgThroughout difference and load balancer can unload bundles
+# from broker-1 to broker-2)
+loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold=4
+
 # When calculating new resource usage, the history usage accounts for.
 # It only takes effect in the ThresholdShedder strategy.
 loadBalancerHistoryResourcePercentage=0.9

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1774,6 +1774,25 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerBrokerThresholdShedderPercentage = 10;
 
     @FieldContext(
+        dynamic = true,
+        category = CATEGORY_LOAD_BALANCER,
+        doc = "Message-rate percentage threshold between highest and least loaded brokers for "
+                + "uniform load shedding. (eg: broker1 with 50K msgRate and broker2 with 30K msgRate "
+                + "will have 66% msgRate difference and load balancer can unload bundles from broker-1 "
+                + "to broker-2)"
+    )
+    private int loadBalancerMsgRateDifferenceShedderThreshold = 50;
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_LOAD_BALANCER,
+        doc = "Message-throughput threshold between highest and least loaded brokers for "
+                + "uniform load shedding. (eg: broker1 with 450MB msgRate and broker2 with 100MB msgRate "
+                + "will have 4.5 times msgThroughout difference and load balancer can unload bundles "
+                + "from broker-1 to broker-2)"
+    )
+    private int loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold = 4;
+
+    @FieldContext(
             dynamic = true,
             category = CATEGORY_LOAD_BALANCER,
             doc = "Resource history Usage Percentage When adding new resource usage info"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1781,7 +1781,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 + "will have 66% msgRate difference and load balancer can unload bundles from broker-1 "
                 + "to broker-2)"
     )
-    private int loadBalancerMsgRateDifferenceShedderThreshold = 50;
+    private double loadBalancerMsgRateDifferenceShedderThreshold = 50;
     @FieldContext(
         dynamic = true,
         category = CATEGORY_LOAD_BALANCER,
@@ -1790,7 +1790,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 + "will have 4.5 times msgThroughout difference and load balancer can unload bundles "
                 + "from broker-1 to broker-2)"
     )
-    private int loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold = 4;
+    private double loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold = 4;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -37,6 +37,14 @@ import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between
+ * broker with highest load and broker with lowest load. If the difference is higher than configured thresholds
+ * {@link ServiceConfiguration#getLoadBalancerMsgRateDifferenceShedderThreshold()} and
+ * {@link ServiceConfiguration#getLoadBalancerMsgRateDifferenceShedderThreshold()} then it finds out bundles which can
+ * be unloaded to distribute traffic evenly across all brokers.
+ *
+ */
 public class UniformLoadShedder implements LoadSheddingStrategy {
 
     private static final Logger log = LoggerFactory.getLogger(UniformLoadShedder.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import static org.apache.pulsar.broker.namespace.NamespaceService.HEARTBEAT_NAMESPACE_PATTERN;
+import static org.apache.pulsar.broker.namespace.NamespaceService.HEARTBEAT_NAMESPACE_PATTERN_V2;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.util.Map;
+import org.apache.commons.lang3.mutable.MutableDouble;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.pulsar.broker.BrokerData;
+import org.apache.pulsar.broker.BundleData;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.TimeAverageMessageData;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UniformLoadShedder implements LoadSheddingStrategy {
+
+    private static final Logger log = LoggerFactory.getLogger(UniformLoadShedder.class);
+
+    private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
+
+    /**
+     * Attempt to shed some bundles off every broker which is overloaded.
+     *
+     * @param loadData
+     *            The load data to used to make the unloading decision.
+     * @param conf
+     *            The service configuration.
+     * @return A map from bundles to unload to the brokers on which they are loaded.
+     */
+    @Override
+    public Multimap<String, String> findBundlesForUnloading(final LoadData loadData, final ServiceConfiguration conf) {
+        selectedBundlesCache.clear();
+        Map<String, BrokerData> brokersData = loadData.getBrokerData();
+        Map<String, BundleData> loadBundleData = loadData.getBundleData();
+        Map<String, Long> recentlyUnloadedBundles = loadData.getRecentlyUnloadedBundles();
+
+        MutableObject<String> overloadedBroker = new MutableObject<>();
+        MutableObject<String> underloadedBroker = new MutableObject<>();
+        MutableDouble maxMsgRate = new MutableDouble(-1);
+        MutableDouble maxThroughputRate = new MutableDouble(-1);
+        MutableDouble minMsgRate = new MutableDouble(Integer.MAX_VALUE);
+        MutableDouble minThroughputgRate = new MutableDouble(Integer.MAX_VALUE);
+        brokersData.forEach((broker, data) -> {
+            double msgRate = data.getLocalData().getMsgRateIn() + data.getLocalData().getMsgRateOut();
+            double throughputRate = data.getLocalData().getMsgThroughputIn()
+                    + data.getLocalData().getMsgThroughputOut();
+            if (data.getLocalData().getBundles().size() > 1 // broker with one bundle can't be considered for
+                                                            // bundle unloading
+                    && (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue())) {
+                overloadedBroker.setValue(broker);
+                maxMsgRate.setValue(msgRate);
+                maxThroughputRate.setValue(throughputRate);
+            }
+            if (msgRate < minMsgRate.getValue() || throughputRate < minThroughputgRate.getValue()) {
+                underloadedBroker.setValue(broker);
+                minMsgRate.setValue(msgRate);
+                minThroughputgRate.setValue(throughputRate);
+            }
+        });
+
+        // find the difference between two brokers based on msgRate and throughout and check if the load distribution
+        // discrepancy is higher than threshold. if that matches then try to unload bundle from overloaded brokers to
+        // give chance of uniform load distribution.
+        double msgRateDifferencePercentage = ((maxMsgRate.getValue() - minMsgRate.getValue()) * 100)
+                / (minMsgRate.getValue());
+        double msgThroughputDifferenceRate = maxThroughputRate.getValue() / minThroughputgRate.getValue();
+
+        // if the threshold matches then find out how much load needs to be unloaded by considering number of msgRate
+        // and throughput.
+        boolean isMsgRateThresholdExceeded = conf.getLoadBalancerMsgRateDifferenceShedderThreshold() > 0
+                && msgRateDifferencePercentage > conf.getLoadBalancerMsgRateDifferenceShedderThreshold();
+        boolean isMsgThroughputThresholdExceeded = conf
+                .getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() > 0
+                && msgThroughputDifferenceRate > conf
+                        .getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold();
+
+        if (isMsgRateThresholdExceeded || isMsgThroughputThresholdExceeded) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Found bundles for uniform load balancing. "
+                                + "overloaded broker {} with (msgRate,throughput)= ({},{}) "
+                                + "and underloaded broker {} with (msgRate,throughput)= ({},{})",
+                        overloadedBroker.getValue(), maxMsgRate.getValue(), maxThroughputRate.getValue(),
+                        underloadedBroker.getValue(), minMsgRate.getValue(), minThroughputgRate.getValue());
+            }
+            MutableInt msgRateRequiredFromUnloadedBundles = new MutableInt(
+                    (int) ((maxMsgRate.getValue() - minMsgRate.getValue()) / 2));
+            MutableInt msgThroughtputRequiredFromUnloadedBundles = new MutableInt(
+                    (int) ((maxThroughputRate.getValue() - minThroughputgRate.getValue()) / 2));
+            LocalBrokerData overloadedBrokerData = brokersData.get(overloadedBroker.getValue()).getLocalData();
+
+            if (overloadedBrokerData.getBundles().size() > 1) {
+                // Sort bundles by throughput, then pick the bundle which can help to reduce load uniformly with
+                // under-loaded broker
+                loadBundleData.entrySet().stream()
+                        .filter(e -> !HEARTBEAT_NAMESPACE_PATTERN.matcher(e.getKey()).matches()
+                                && !HEARTBEAT_NAMESPACE_PATTERN_V2.matcher(e.getKey()).matches()
+                                && overloadedBrokerData.getBundles().contains(e.getKey()))
+                        .map((e) -> {
+                            String bundle = e.getKey();
+                            BundleData bundleData = e.getValue();
+                            TimeAverageMessageData shortTermData = bundleData.getShortTermData();
+                            double throughput = isMsgRateThresholdExceeded
+                                    ? shortTermData.getMsgRateIn() + shortTermData.getMsgRateOut()
+                                    : shortTermData.getMsgThroughputIn() + shortTermData.getMsgThroughputOut();
+                            return Triple.of(bundle, bundleData, throughput);
+                        }).filter(e -> !recentlyUnloadedBundles.containsKey(e.getLeft()))
+                        .filter(e -> overloadedBrokerData.getBundles().contains(e.getLeft()))
+                        .sorted((e1, e2) -> Double.compare(e2.getRight(), e1.getRight())).forEach((e) -> {
+                            String bundle = e.getLeft();
+                            BundleData bundleData = e.getMiddle();
+                            TimeAverageMessageData shortTermData = bundleData.getShortTermData();
+                            double throughput = shortTermData.getMsgThroughputIn()
+                                    + shortTermData.getMsgThroughputOut();
+                            double bundleMsgRate = shortTermData.getMsgRateIn() + shortTermData.getMsgRateOut();
+                            if (isMsgRateThresholdExceeded) {
+                                if (bundleMsgRate <= (msgRateRequiredFromUnloadedBundles.getValue()
+                                        + 1000/* delta */)) {
+                                    log.info("Found bundle to unload with msgRate {}", bundleMsgRate);
+                                    msgRateRequiredFromUnloadedBundles.add(-bundleMsgRate);
+                                    selectedBundlesCache.put(overloadedBroker.getValue(), bundle);
+                                }
+                            } else {
+                                if (throughput <= (msgThroughtputRequiredFromUnloadedBundles.getValue())) {
+                                    log.info("Found bundle to unload with throughput {}", throughput);
+                                    msgThroughtputRequiredFromUnloadedBundles.add(-throughput);
+                                    selectedBundlesCache.put(overloadedBroker.getValue(), bundle);
+                                }
+                            }
+                        });
+            }
+        }
+
+        return selectedBundlesCache;
+    }
+}

--- a/site2/docs/administration-load-balance.md
+++ b/site2/docs/administration-load-balance.md
@@ -152,7 +152,7 @@ This strategy will attempt to shed exactly one bundle on brokers which are overl
 `loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.OverloadShedder`
 
 ##### UniformLoadShedder
-This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between broker with highest load and broker with lowest load. If the difference is higher than configured thresholds `loadBalancerMsgRateDifferenceShedderThreshold` and `loadBalancerMsgRateDifferenceShedderThreshold` then it finds out bundles which can be unloaded to distribute traffic evenly across all brokers. Configure broker with below value to use this strategy.
+This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between broker with highest load and broker with lowest load. If the difference is higher than configured thresholds `loadBalancerMsgRateDifferenceShedderThreshold` and `loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold` then it finds out bundles which can be unloaded to distribute traffic evenly across all brokers. Configure broker with below value to use this strategy.
 `loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder`
 
 #### Broker overload thresholds

--- a/site2/docs/administration-load-balance.md
+++ b/site2/docs/administration-load-balance.md
@@ -141,6 +141,20 @@ loadBalancerSheddingIntervalMinutes=1
 loadBalancerSheddingGracePeriodMinutes=30
 ```
 
+Pulsar supports three types of shedding strategies:
+
+##### ThresholdShedder
+This strategy tends to shed the bundles if any broker's usage is above the configured threshold. It does this by first computing the average resource usage per broker for the whole cluster. The resource usage for each broker is calculated using the following method: LocalBrokerData#getMaxResourceUsageWithWeight). The weights for each resource are configurable. Historical observations are included in the running average based on the broker's setting for loadBalancerHistoryResourcePercentage. Once the average resource usage is calculated, a broker's current/historical usage is compared to the average broker usage. If a broker's usage is greater than the average usage per broker plus the loadBalancerBrokerThresholdShedderPercentage, this load shedder proposes removing enough bundles to bring the unloaded broker 5% below the current average broker usage. Note that recently unloaded bundles are not unloaded again. Configure broker with below value to use this strategy.
+`loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder`
+
+##### OverloadShedder
+This strategy will attempt to shed exactly one bundle on brokers which are overloaded, that is, whose maximum system resource usage exceeds loadBalancerBrokerOverloadedThresholdPercentage. To see which resources are considered when determining the maximum system resource. A bundle is recommended for unloading off that broker if and only if the following conditions hold: The broker has at least two bundles assigned and the broker has at least one bundle that has not been unloaded recently according to LoadBalancerSheddingGracePeriodMinutes. The unloaded bundle will be the most expensive bundle in terms of message rate that has not been recently unloaded. Note that this strategy does not take into account "underloaded" brokers when determining which bundles to unload. If you are looking for a strategy that spreads load evenly across all brokers, see ThresholdShedder. Configure broker with below value to use this strategy.
+`loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.OverloadShedder`
+
+##### UniformLoadShedder
+This strategy tends to distribute load uniformly across all brokers. This strategy checks laod difference between broker with highest load and broker with lowest load. If the difference is higher than configured thresholds `loadBalancerMsgRateDifferenceShedderThreshold` and `loadBalancerMsgRateDifferenceShedderThreshold` then it finds out bundles which can be unloaded to distribute traffic evenly across all brokers. Configure broker with below value to use this strategy.
+`loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder`
+
 #### Broker overload thresholds
 
 The determinations of when a broker is overloaded is based on threshold of CPU, network and memory usage. Whenever either of those metrics reaches the threshold, the system triggers the shedding (if enabled).

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -637,6 +637,8 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |loadBalancerNamespaceBundleMaxBandwidthMbytes|   |100|
 |loadBalancerNamespaceMaximumBundles|   |128|
 | loadBalancerBrokerThresholdShedderPercentage | The broker resource usage threshold. When the broker resource usage is greater than the pulsar cluster average resource usage, the threshold shedder is triggered to offload bundles from the broker. It only takes effect in the ThresholdShedder strategy. | 10 |
+| loadBalancerMsgRateDifferenceShedderThreshold | Message-rate percentage threshold between highest and least loaded brokers for uniform load shedding. | 50 |
+| loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold | Message-throughput threshold between highest and least loaded brokers for uniform load shedding. | 4 |
 | loadBalancerHistoryResourcePercentage | The history usage when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 0.9 |
 | loadBalancerBandwithInResourceWeight | The BandWithIn usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |
 | loadBalancerBandwithOutResourceWeight | The BandWithOut usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |


### PR DESCRIPTION
### Motivation
Pulsar Broker provides a [configurable way](https://github.com/apache/pulsar/blob/master/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#L1711) to configure various load shedding strategies based on usecases. It already has strategies to load balance based on broker resource utilization ([ThresholdShedder](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java)) or based on bundle usage threshold ([OverloadShedder](ache/pulsar/broker/loadbalance/impl/OverloadShedder.java)). 
We need another strategy to distribute load uniformly across all brokers. So, we are adding `UniformLoadShedder` strategy to achieve goal for uniform load in cluster.

### NOTE
`UniformLoadShedder` also requires isolation and broker weight mechanism to also use strategy in heterogeneous hardware.  I will create another PR for this enhancement.