### PR TITLE
[broker] Fix topic policy listener deleted by mistake.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3136,25 +3136,19 @@ public class PersistentTopic extends AbstractTopic
         }
     }
 
-    private TopicName getPartitionedTopicName() {
-        TopicName topicName = TopicName.get(topic);
-        if (topicName.isPartitioned()) {
-            return TopicName.get(topicName.getPartitionedTopicName());
-        }
-        return topicName;
-    }
-
     private void registerTopicPolicyListener() {
         if (brokerService.pulsar().getConfig().isSystemTopicEnabled()
                 && brokerService.pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
-            brokerService.getPulsar().getTopicPoliciesService().registerListener(getPartitionedTopicName(), this);
+            brokerService.getPulsar().getTopicPoliciesService()
+                    .registerListener(TopicName.getPartitionedTopicName(topic), this);
         }
     }
 
     private void unregisterTopicPolicyListener() {
         if (brokerService.pulsar().getConfig().isSystemTopicEnabled()
                 && brokerService.pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
-            brokerService.getPulsar().getTopicPoliciesService().unregisterListener(getPartitionedTopicName(), this);
+            brokerService.getPulsar().getTopicPoliciesService()
+                    .unregisterListener(TopicName.getPartitionedTopicName(topic), this);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1155,8 +1155,7 @@ public class PersistentTopic extends AbstractTopic
 
                                             subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
 
-                                            brokerService.pulsar().getTopicPoliciesService()
-                                                    .clean(TopicName.get(topic));
+                                            unregisterTopicPolicyListener();
 
                                             log.info("[{}] Topic deleted", topic);
                                             deleteFuture.complete(null);
@@ -1262,7 +1261,7 @@ public class PersistentTopic extends AbstractTopic
 
                                 subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
 
-                                brokerService.pulsar().getTopicPoliciesService().clean(TopicName.get(topic));
+                                unregisterTopicPolicyListener();
                                 log.info("[{}] Topic closed", topic);
                                 closeFuture.complete(null);
                             })
@@ -3137,16 +3136,25 @@ public class PersistentTopic extends AbstractTopic
         }
     }
 
+    private TopicName getPartitionedTopicName() {
+        TopicName topicName = TopicName.get(topic);
+        if (topicName.isPartitioned()) {
+            return TopicName.get(topicName.getPartitionedTopicName());
+        }
+        return topicName;
+    }
+
     private void registerTopicPolicyListener() {
         if (brokerService.pulsar().getConfig().isSystemTopicEnabled()
                 && brokerService.pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
-            TopicName topicName = TopicName.get(topic);
-            TopicName cloneTopicName = topicName;
-            if (topicName.isPartitioned()) {
-                cloneTopicName = TopicName.get(topicName.getPartitionedTopicName());
-            }
+            brokerService.getPulsar().getTopicPoliciesService().registerListener(getPartitionedTopicName(), this);
+        }
+    }
 
-            brokerService.getPulsar().getTopicPoliciesService().registerListener(cloneTopicName, this);
+    private void unregisterTopicPolicyListener() {
+        if (brokerService.pulsar().getConfig().isSystemTopicEnabled()
+                && brokerService.pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
+            brokerService.getPulsar().getTopicPoliciesService().unregisterListener(getPartitionedTopicName(), this);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -39,14 +38,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.Cleanup;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicPoliciesCacheNotInitException;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.systopic.TopicPoliciesSystemTopicClient;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.BackoffBuilder;
@@ -264,8 +261,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         final String topic = "persistent://" + NAMESPACE1 + "/test" + UUID.randomUUID();
         TopicName topicName = TopicName.get(topic);
         admin.topics().createPartitionedTopic(topic, 3);
-        @Cleanup
-        Producer<byte[]> producers = pulsarClient.newProducer().topic(topic).create();
+        pulsarClient.newProducer().topic(topic).create().close();
 
         Map<TopicName, List<TopicPolicyListener<TopicPolicies>>> listMap =
                 systemTopicBasedTopicPoliciesService.getListeners();
@@ -275,9 +271,9 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         });
 
         admin.topics().unload(topicName.getPartition(0).toString());
-        assertFalse(listMap.get(topicName).isEmpty());
+        assertEquals(listMap.get(topicName).size(), 2);
         admin.topics().unload(topicName.getPartition(1).toString());
-        assertFalse(listMap.get(topicName).isEmpty());
+        assertEquals(listMap.get(topicName).size(), 1);
         admin.topics().unload(topicName.getPartition(2).toString());
         assertNull(listMap.get(topicName));
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -90,6 +90,14 @@ public class TopicName implements ServiceUnitId {
         }
     }
 
+    public static TopicName getPartitionedTopicName(String topic) {
+        TopicName topicName = TopicName.get(topic);
+        if (topicName.isPartitioned()) {
+            return TopicName.get(topicName.getPartitionedTopicName());
+        }
+        return topicName;
+    }
+
     public static boolean isValid(String topic) {
         try {
             get(topic);


### PR DESCRIPTION
### Motivation

Here is the current way of dealing topic policy listeners in PersistentTopic, for example topic name is "A", with 3 partitions.
- Register: call TopicPoliciesService.registerListener("A", listener), for all 3 partitions of topic "A".
- Clean: call TopicPoliciesService.clean("A-partition-x"), here is the problem it will delete all listeners of all partitions of topic "A", if any partition is closed.

This means, if we calls `admin.topics().unload("A-partition-0")`,  "A-partition-1" and "A-partition-2" will not be able to receive topic policy update callbacks any more.

A detailed case is designed in the new unit test `testListenerCleanupByPartition`.

### Modifications

With previous optimization of #12654 , now we can use `org.apache.pulsar.broker.service.TopicPoliciesService#unregisterListener` to do the clean up.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - testListenerCleanupByPartition

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Bug fix.