### PR TITLE
[broker] Delete TopicPoliciesService#clean, not used anymore.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -508,16 +508,6 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         });
     }
 
-    @Override
-    public void clean(TopicName topicName) {
-        TopicName realTopicName = topicName;
-        if (topicName.isPartitioned()) {
-            //change persistent://tenant/namespace/xxx-partition-0  to persistent://tenant/namespace/xxx
-            realTopicName = TopicName.get(topicName.getPartitionedTopicName());
-        }
-        listeners.remove(realTopicName);
-    }
-
     @VisibleForTesting
     protected Map<TopicName, TopicPolicies> getPoliciesCache() {
         return policiesCache;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -120,14 +120,6 @@ public interface TopicPoliciesService {
 
     void unregisterListener(TopicName topicName, TopicPolicyListener<TopicPolicies> listener);
 
-    /**
-     * clean cache and listeners in TopicPolicies and so on.
-     * @param topicName
-     */
-    default void clean(TopicName topicName) {
-        throw new UnsupportedOperationException("Clean is not supported by default");
-    }
-
     class TopicPoliciesServiceDisabled implements TopicPoliciesService {
 
         @Override
@@ -174,11 +166,6 @@ public interface TopicPoliciesService {
 
         @Override
         public void unregisterListener(TopicName topicName, TopicPolicyListener<TopicPolicies> listener) {
-            //No-op
-        }
-
-        @Override
-        public void clean(TopicName topicName) {
             //No-op
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.TopicPoliciesCach
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.client.util.RetryUtil;
+import org.apache.pulsar.common.classification.InterfaceStability;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
@@ -34,6 +35,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 /**
  * Topic policies service.
  */
+@InterfaceStability.Evolving
 public interface TopicPoliciesService {
 
     TopicPoliciesService DISABLED = new TopicPoliciesServiceDisabled();


### PR DESCRIPTION

### Motivation

`TopicPoliciesService#clean` was introduced to solve listener leaking problem in #10466.
And this is already addressed in #12904 using `unregisterListener`.
So this method is no use any more, and I don't see any situations that we may use this again.

### Modifications

Delete TopicPoliciesService#clean

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Code clean up.