### PR TITLE
[metadata] Optimize put and get methods in AbstractMetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -139,6 +140,21 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<>(this, serde);
         metadataCaches.add(metadataCache);
         return metadataCache;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> get(String path) {
+        if (!isValidPath(path)) {
+            return FutureUtil.failedFuture(new MetadataStoreException.InvalidPathException(path));
+        }
+        return storeGet(path);
+    }
+
+    protected abstract CompletableFuture<Optional<GetResult>> storeGet(String path);
+
+    @Override
+    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
+        return put(path, value, expectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStore.java
@@ -90,10 +90,7 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
     }
 
     @Override
-    public CompletableFuture<Optional<GetResult>> get(String path) {
-        if (!isValidPath(path)) {
-            return FutureUtil.failedFuture(new MetadataStoreException.InvalidPathException(path));
-        }
+    public CompletableFuture<Optional<GetResult>> storeGet(String path) {
         synchronized (map) {
             Value v = map.get(path);
             if (v != null) {
@@ -138,11 +135,6 @@ public class LocalMemoryMetadataStore extends AbstractMetadataStore implements M
             Value v = map.get(path);
             return FutureUtils.value(v != null);
         }
-    }
-
-    @Override
-    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> expectedVersion) {
-        return put(path, value, expectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -128,7 +128,7 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
     }
 
     @Override
-    public CompletableFuture<Optional<GetResult>> get(String path) {
+    public CompletableFuture<Optional<GetResult>> storeGet(String path) {
         CompletableFuture<Optional<GetResult>> future = new CompletableFuture<>();
 
         try {
@@ -199,11 +199,6 @@ public class ZKMetadataStore extends AbstractMetadataStore implements MetadataSt
         }
 
         return future;
-    }
-
-    @Override
-    public CompletableFuture<Stat> put(String path, byte[] value, Optional<Long> optExpectedVersion) {
-        return put(path, value, optExpectedVersion, EnumSet.noneOf(CreateOption.class));
     }
 
     @Override


### PR DESCRIPTION
### Motivation

For the convenience to implement other metadata store, I am proposing two small optimizations to AbstractMetadataStore.
1. The implementation of `put` is the same in `LocalMemoryMetadataStore` and `ZKMetadataStore`, can be moved to AbstractMetadataStore. 
2. Add abstract method `storeGet` in AbstractMetadataStore, so that all subclass only need to implement "storeXXX" version methods. And we can add common code in `AbstractMetadataStore#get` like the path parameter check.

### Modifications

See above.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Code optimize. No user behavior changed.