### PR TITLE
feat(cli): support sql-worker in pulsar-daemon

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -362,7 +362,7 @@ elif [ $COMMAND == "sql" ]; then
     exec $JAVA -cp "${PRESTO_HOME}/lib/*" io.prestosql.cli.Presto --server localhost:8081 "${@}"
 elif [ $COMMAND == "sql-worker" ]; then
     check_presto_libraries
-    exec ${PRESTO_HOME}/bin/launcher --etc-dir ${PULSAR_PRESTO_CONF} "${@}"
+    exec ${PRESTO_HOME}/bin/launcher run --etc-dir ${PULSAR_PRESTO_CONF} "${@}"
 elif [ $COMMAND == "tokens" ]; then
     exec $JAVA $OPTS org.apache.pulsar.utils.auth.tokens.TokensCliUtils $@
 elif [ $COMMAND == "version" ]; then

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -30,6 +30,7 @@ where command is one of:
     functions-worker    Run a functions worker server
     standalone          Run a standalone Pulsar service
     proxy               Run a Proxy Pulsar service
+    sql-worker          Run a sql worker service
 
 where argument is one of:
     -force (accepted only with stop command): Decides whether to stop the server forcefully if not stopped by normal shutdown
@@ -100,6 +101,9 @@ case $command in
         echo "doing $startStop $command ..."
         ;;
     (proxy)
+        echo "doing $startStop $command ..."
+        ;;
+    (sql-worker)
         echo "doing $startStop $command ..."
         ;;
     (*)

--- a/site2/docs/reference-cli-tools.md
+++ b/site2/docs/reference-cli-tools.md
@@ -42,6 +42,7 @@ Commands:
 * `websocket`
 * `zookeeper`
 * `zookeeper-shell`
+* `sql-worker`
 
 Example:
 ```bash

--- a/site2/docs/sql-getting-started.md
+++ b/site2/docs/sql-getting-started.md
@@ -22,8 +22,13 @@ To query data in Pulsar with Pulsar SQL, complete the following steps.
 2. Start a Pulsar SQL worker.
 
 ```bash
-./bin/pulsar sql-worker run
+./bin/pulsar sql-worker
 ```
+
+> **Tip**  
+> If the service runs as a background process using the `pulsar-daemon start sql-worker` command, then use the `pulsar-daemon stop sql-worker`  command to stop the service.
+> 
+> For more information, see [pulsar-daemon](https://pulsar.apache.org/docs/en/reference-cli-tools/#pulsar-daemon).
 
 3. After initializing Pulsar standalone cluster and the SQL worker, run SQL CLI.
 


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Pulsar sql-worker only supports in pulsar shell cli and not support in pulsar-daemon. So, users have to open two terminals to use pulsar sql, one for sql-worker and one for sql-cli.

### Modifications

I changed the pulsar shell cli and pulsar-daemon shell cli to support sql-worker in pulsar-daemon.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


