### PR TITLE
Fix Classloader Leak When register source/sink

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
@@ -59,19 +59,19 @@ public class ThreadRuntime implements Runtime {
     private static final int THREAD_SHUTDOWN_TIMEOUT_MILLIS = 10_000;
 
     @Getter
-    private InstanceConfig instanceConfig;
+    private final InstanceConfig instanceConfig;
     private JavaInstanceRunnable javaInstanceRunnable;
-    private ThreadGroup threadGroup;
-    private FunctionCacheManager fnCache;
-    private String jarFile;
-    private ClientBuilder clientBuilder;
-    private PulsarClient pulsarClient;
-    private PulsarAdmin pulsarAdmin;
-    private String stateStorageImplClass;
-    private String stateStorageServiceUrl;
-    private SecretsProvider secretsProvider;
-    private FunctionCollectorRegistry collectorRegistry;
-    private String narExtractionDirectory;
+    private final ThreadGroup threadGroup;
+    private final FunctionCacheManager fnCache;
+    private final String jarFile;
+    private final ClientBuilder clientBuilder;
+    private final PulsarClient pulsarClient;
+    private final PulsarAdmin pulsarAdmin;
+    private final String stateStorageImplClass;
+    private final String stateStorageServiceUrl;
+    private final SecretsProvider secretsProvider;
+    private final FunctionCollectorRegistry collectorRegistry;
+    private final String narExtractionDirectory;
     private final Optional<ConnectorsManager> connectorsManager;
 
     ThreadRuntime(InstanceConfig instanceConfig,
@@ -149,7 +149,7 @@ public class ThreadRuntime implements Runtime {
             } catch (FileNotFoundException e) {
                 // this is usually like
                 // java.io.FileNotFoundException: /tmp/pulsar-nar/xxx.jar-unpacked/xxxxx/META-INF/MANIFEST.MF'
-                log.error("The file {} does not look like a .nar file", jarFile, e);
+                log.error("The file {} does not look like a .nar file {}", jarFile, e.toString());
             }
         }
         if (!loadedAsNar) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/thread/ThreadRuntime.java
@@ -149,7 +149,7 @@ public class ThreadRuntime implements Runtime {
             } catch (FileNotFoundException e) {
                 // this is usually like
                 // java.io.FileNotFoundException: /tmp/pulsar-nar/xxx.jar-unpacked/xxxxx/META-INF/MANIFEST.MF'
-                log.error("The file {} does not look like a .nar file", jarFile, e.toString());
+                log.error("The file {} does not look like a .nar file", jarFile, e);
             }
         }
         if (!loadedAsNar) {
@@ -215,7 +215,6 @@ public class ThreadRuntime implements Runtime {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void stop() {
         if (fnThread != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ClassLoaderUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/ClassLoaderUtils.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class ClassLoaderUtils {
+
+    public static void closeClassLoaderIfNeed(ClassLoader classLoader) throws IOException {
+        if (classLoader instanceof Closeable) {
+            ((Closeable) classLoader).close();
+        }
+    }
+
+}

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -744,6 +745,9 @@ public class SinksImpl extends ComponentImpl implements Sinks<PulsarWorkerServic
 
         SinkConfigUtils.ExtractedSinkDetails sinkDetails = SinkConfigUtils.validateAndExtractDetails(
                 sinkConfig, classLoader, worker().getWorkerConfig().getValidateConnectorConfig());
+        if (classLoader instanceof URLClassLoader) {
+            ((URLClassLoader) classLoader).close();
+        }
         return SinkConfigUtils.convert(sinkConfig, sinkDetails);
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SinksImpl.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -55,6 +54,7 @@ import org.apache.pulsar.functions.auth.FunctionAuthData;
 import org.apache.pulsar.functions.instance.InstanceUtils;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
+import org.apache.pulsar.functions.utils.ClassLoaderUtils;
 import org.apache.pulsar.functions.utils.ComponentTypeUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.SinkConfigUtils;
@@ -745,9 +745,7 @@ public class SinksImpl extends ComponentImpl implements Sinks<PulsarWorkerServic
 
         SinkConfigUtils.ExtractedSinkDetails sinkDetails = SinkConfigUtils.validateAndExtractDetails(
                 sinkConfig, classLoader, worker().getWorkerConfig().getValidateConnectorConfig());
-        if (classLoader instanceof URLClassLoader) {
-            ((URLClassLoader) classLoader).close();
-        }
+        ClassLoaderUtils.closeClassLoaderIfNeed(classLoader);
         return SinkConfigUtils.convert(sinkConfig, sinkDetails);
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -705,7 +706,7 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
                                                                  final String namespace,
                                                                  final String sourceName,
                                                                  final SourceConfig sourceConfig,
-                                                                 final File sourcePackageFile) {
+                                                                 final File sourcePackageFile) throws IOException {
         // The rest end points take precedence over whatever is there in sourceconfig
         sourceConfig.setTenant(tenant);
         sourceConfig.setNamespace(namespace);
@@ -741,6 +742,9 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
         SourceConfigUtils.ExtractedSourceDetails sourceDetails
                 = SourceConfigUtils.validateAndExtractDetails(
                         sourceConfig, classLoader, worker().getWorkerConfig().getValidateConnectorConfig());
+        if (classLoader instanceof URLClassLoader) {
+            ((URLClassLoader) classLoader).close();
+        }
         return SourceConfigUtils.convert(sourceConfig, sourceDetails);
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/SourcesImpl.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -55,6 +54,7 @@ import org.apache.pulsar.functions.auth.FunctionAuthData;
 import org.apache.pulsar.functions.instance.InstanceUtils;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
+import org.apache.pulsar.functions.utils.ClassLoaderUtils;
 import org.apache.pulsar.functions.utils.ComponentTypeUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.SourceConfigUtils;
@@ -742,9 +742,7 @@ public class SourcesImpl extends ComponentImpl implements Sources<PulsarWorkerSe
         SourceConfigUtils.ExtractedSourceDetails sourceDetails
                 = SourceConfigUtils.validateAndExtractDetails(
                         sourceConfig, classLoader, worker().getWorkerConfig().getValidateConnectorConfig());
-        if (classLoader instanceof URLClassLoader) {
-            ((URLClassLoader) classLoader).close();
-        }
+        ClassLoaderUtils.closeClassLoaderIfNeed(classLoader);
         return SourceConfigUtils.convert(sourceConfig, sourceDetails);
     }
 


### PR DESCRIPTION
### Motivation
During register source/sink, use classloader for validate, but not close when register are done.
And the classloader will not use for run.

### Modifications
- Close the classloader when register source/sink
- Fix a log not correct in ThreadRuntime

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  Bug fix


