### PR TITLE
Option to not upload builtin connectors to BK for k8s runtime

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -211,6 +211,9 @@ functionRuntimeFactoryConfigs:
 #    narExtractionDirectory:
 #    # The classpath where function instance files stored
 #    functionInstanceClassPath:
+#    # Upload the builtin sources/sinks to BookKeeper.
+#    # True by default.
+#    uploadBuiltinSinksSources: true
 #    # the directory for dropping extra function dependencies
 #    # if it is not an absolute path, it is relative to `pulsarRootDir`
 #    extraFunctionDependenciesDir:

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -179,6 +179,11 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         category = CATEGORY_FUNCTIONS,
         doc = "The path to the location to locate builtin functions"
     )
+    private Boolean uploadBuiltinSinksSources = true;
+    @FieldContext(
+            category = CATEGORY_FUNCTIONS,
+            doc = "Should the builtin sources/sinks be uploaded for the externally managed runtimes?"
+    )
     private String functionsDirectory = "./functions";
     @FieldContext(
         category = CATEGORY_FUNC_METADATA_MNG,

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
@@ -77,8 +77,11 @@ public class FunctionUtils {
             return ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, FunctionDefinition.class);
         }
     }
-
     public static Functions searchForFunctions(String functionsDirectory) throws IOException {
+        return searchForFunctions(functionsDirectory, false);
+    }
+
+    public static Functions searchForFunctions(String functionsDirectory, boolean alwaysPopulatePath) throws IOException {
         Path path = Paths.get(functionsDirectory).toAbsolutePath();
         log.info("Searching for functions in {}", path);
 
@@ -96,7 +99,7 @@ public class FunctionUtils {
                     log.info("Found function {} from {}", cntDef, archive);
                     log.error(cntDef.getName());
                     log.error(cntDef.getFunctionClass());
-                    if (!StringUtils.isEmpty(cntDef.getFunctionClass())) {
+                    if (alwaysPopulatePath || !StringUtils.isEmpty(cntDef.getFunctionClass())) {
                         functions.functions.put(cntDef.getName(), archive);
                     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -88,7 +88,6 @@ import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
-import org.apache.pulsar.functions.worker.dlog.DLInputStream;
 import org.apache.pulsar.functions.worker.service.api.Component;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -32,6 +32,8 @@ import static org.apache.pulsar.functions.worker.rest.RestUtils.throwUnavailable
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+
+import java.io.FileInputStream;
 import java.nio.file.Files;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.api.StorageClient;
@@ -78,12 +80,15 @@ import org.apache.pulsar.functions.utils.ComponentTypeUtils;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 import org.apache.pulsar.functions.utils.FunctionConfigUtils;
 import org.apache.pulsar.functions.utils.FunctionMetaDataUtils;
+import org.apache.pulsar.functions.utils.functions.FunctionUtils;
+import org.apache.pulsar.functions.utils.functions.Functions;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeInfo;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.PulsarWorkerService;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.WorkerUtils;
+import org.apache.pulsar.functions.worker.dlog.DLInputStream;
 import org.apache.pulsar.functions.worker.service.api.Component;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
@@ -92,6 +97,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -282,21 +288,27 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         boolean isBuiltin = isFunctionCodeBuiltin(functionDetails);
         boolean isPkgUrlProvided = isNotBlank(functionPkgUrl);
         if (worker().getFunctionRuntimeManager().getRuntimeFactory().externallyManaged()) {
-            // For externally managed schedulers, the pkgUrl/builtin stuff should be copied to bk
+            // For externally managed schedulers, the pkgUrl/builtin stuff can be copied to bk
+            // if the function worker image does not include connectors
             if (isBuiltin) {
-                File sinkOrSource;
-                if (componentType == FunctionDetails.ComponentType.SOURCE) {
-                    String archiveName = functionDetails.getSource().getBuiltin();
-                    sinkOrSource = worker().getConnectorsManager().getSourceArchive(archiveName).toFile();
+                if (worker().getWorkerConfig().getUploadBuiltinSinksSources()) {
+                    File sinkOrSource;
+                    if (componentType == FunctionDetails.ComponentType.SOURCE) {
+                        String archiveName = functionDetails.getSource().getBuiltin();
+                        sinkOrSource = worker().getConnectorsManager().getSourceArchive(archiveName).toFile();
+                    } else {
+                        String archiveName = functionDetails.getSink().getBuiltin();
+                        sinkOrSource = worker().getConnectorsManager().getSinkArchive(archiveName).toFile();
+                    }
+                    packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
+                            sinkOrSource.getName()));
+                    packageLocationMetaDataBuilder.setOriginalFileName(sinkOrSource.getName());
+                    log.info("Uploading {} package to {}", ComponentTypeUtils.toString(componentType), packageLocationMetaDataBuilder.getPackagePath());
+                    WorkerUtils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), sinkOrSource, worker().getDlogNamespace());
                 } else {
-                    String archiveName = functionDetails.getSink().getBuiltin();
-                    sinkOrSource = worker().getConnectorsManager().getSinkArchive(archiveName).toFile();
+                    log.info("Skipping upload for the built-in package {}", ComponentTypeUtils.toString(componentType));
+                    packageLocationMetaDataBuilder.setPackagePath("builtin://" + getFunctionCodeBuiltin(functionDetails));
                 }
-                packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
-                        sinkOrSource.getName()));
-                packageLocationMetaDataBuilder.setOriginalFileName(sinkOrSource.getName());
-                log.info("Uploading {} package to {}", ComponentTypeUtils.toString(componentType), packageLocationMetaDataBuilder.getPackagePath());
-                WorkerUtils.uploadFileToBookkeeper(packageLocationMetaDataBuilder.getPackagePath(), sinkOrSource, worker().getDlogNamespace());
             } else if (isPkgUrlProvided) {
                 packageLocationMetaDataBuilder.setPackagePath(createPackagePath(tenant, namespace, componentName,
                         uploadedInputStreamAsFile.getName()));
@@ -1272,6 +1284,20 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
                 URI url = URI.create(pkgPath);
                 File file = new File(url.getPath());
                 Files.copy(file.toPath(), output);
+            } else if(pkgPath.startsWith(Utils.BUILTIN) && !worker().getWorkerConfig().getUploadBuiltinSinksSources()) {
+                String sType = pkgPath.replaceFirst("^builtin://", "");
+                final String connectorsDir = worker().getWorkerConfig().getConnectorsDirectory();
+                log.warn("Processing package {} ; looking at the dir {}", pkgPath, connectorsDir);
+                Functions sinksOrSources = FunctionUtils.searchForFunctions(connectorsDir, true);
+                Path narPath = sinksOrSources.getFunctions().get(sType);
+                if (narPath == null) {
+                    throw new IllegalStateException("Didn't find " + pkgPath + " in " + connectorsDir);
+                }
+                log.info("Loading {} from {}", pkgPath, narPath);
+                try (InputStream in = new FileInputStream(narPath.toString())) {
+                    IOUtils.copy(in, output, 1024);
+                    output.flush();
+                }
             } else {
                 WorkerUtils.downloadFromBookkeeper(worker().getDlogNamespace(), output, pkgPath);
             }

--- a/site2/docs/functions-runtime.md
+++ b/site2/docs/functions-runtime.md
@@ -131,6 +131,9 @@ functionRuntimeFactoryConfigs:
   narExtractionDirectory:
   # The classpath where function instance files stored
   functionInstanceClassPath:
+  # Upload the builtin sources/sinks to BookKeeper.
+  # True by default.
+  uploadBuiltinSinksSources: true
   # the directory for dropping extra function dependencies
   # if it is not an absolute path, it is relative to `pulsarRootDir`
   extraFunctionDependenciesDir:


### PR DESCRIPTION
### Motivation

When k8s runtime is being used the buitlin connectors get uploaded to BK and the uploaded version used later even after the pulsar upgrade. This means that after the upgrade one needs to delete and re-create the connectors.

### Modifications

Added option to skip the upload to the BK and use the connector package from the connectors directory.

### Verifying this change

Tested locally (minikube, k8s runtime).
I don't see any unit/integration test that cover k8s runtime e2e.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

Added new configuration parameter, default behavior stays the same.

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no) - *new configuration parameter*
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)


