### PR TITLE
[Protocol] Add guidance to send CloseProducer before sending Producer…

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -179,6 +179,10 @@ messages to the broker, referring to the producer id negotiated before.
 
 ![Producer interaction](assets/binary-protocol-producer.png)
 
+If the client does not receive a response indicating producer creation success or failure,
+the client should first send a command to close the original producer before sending a
+command to re-attempt producer creation.
+
 ##### Command Producer
 
 ```protobuf
@@ -275,6 +279,11 @@ Parameters:
 When receiving a `CloseProducer` command, the broker will stop accepting any
 more messages for the producer, wait until all pending messages are persisted
 and then reply `Success` to the client.
+
+If the client does not receive a response to a `Producer` command within a timeout,
+the client must first send a `CloseProducer` command before sending another
+`Producer` command. The client does not need to await a response to the `CloseProducer`
+command before sending the next `Producer` command.
 
 The broker can send a `CloseProducer` command to client when it's performing
 a graceful failover (eg: broker is being restarted, or the topic is being unloaded

--- a/site2/website-next/docs/developing-binary-protocol.md
+++ b/site2/website-next/docs/developing-binary-protocol.md
@@ -182,6 +182,10 @@ messages to the broker, referring to the producer id negotiated before.
 
 ![Producer interaction](/assets/binary-protocol-producer.png)
 
+If the client does not receive a response indicating producer creation success or failure,
+the client should first send a command to close the original producer before sending a
+command to re-attempt producer creation.
+
 ##### Command Producer
 
 ```protobuf
@@ -284,6 +288,11 @@ Parameters:
 When receiving a `CloseProducer` command, the broker will stop accepting any
 more messages for the producer, wait until all pending messages are persisted
 and then reply `Success` to the client.
+
+If the client does not receive a response to a `Producer` command within a timeout,
+the client must first send a `CloseProducer` command before sending another
+`Producer` command. The client does not need to await a response to the `CloseProducer`
+command before sending the next `Producer` command.
 
 The broker can send a `CloseProducer` command to client when it's performing
 a graceful failover (eg: broker is being restarted, or the topic is being unloaded


### PR DESCRIPTION
… in case of client side timeout

### Motivation

As discussed on the mailing list here, https://lists.apache.org/thread/tko0z4jg0oq0yf931rbow2zf9fq8wjt1, it is most ideal for the client to send a `CloseProducer` command before sending a subsequent `Producer` command when the client timeouts out the original `Producer` request.

This PR updates the protocol documentation. I will submit a PR to update the Java client once this PR is merged.

### Modifications

* Update current docs for protocol
* Update next docs for protocol

### Verifying this change

This is just a change to documentation.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: yes
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

Regarding the change to the wire protocol, this is simply an expansion on a currently ambiguous portion of the protocol. I've discussed this change on the mailing list.

### Documentation
- [x] `doc` 
  


