### PR TITLE
[PIP 97][Authorization Service] Remove unused authenticate method

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -85,19 +85,6 @@ public class AuthenticationService implements Closeable {
         }
     }
 
-    public String authenticate(AuthenticationDataSource authData, String authMethodName)
-            throws AuthenticationException {
-        AuthenticationProvider provider = providers.get(authMethodName);
-        if (provider != null) {
-            return provider.authenticate(authData);
-        } else {
-            if (StringUtils.isNotBlank(anonymousUserRole)) {
-                return anonymousUserRole;
-            }
-            throw new AuthenticationException("Unsupported authentication mode: " + authMethodName);
-        }
-    }
-
     public String authenticateHttpRequest(HttpServletRequest request) throws AuthenticationException {
         AuthenticationException authenticationException = null;
         AuthenticationDataSource authData = new AuthenticationDataHttps(request);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
@@ -42,18 +42,6 @@ public class AuthenticationServiceTest {
     private static final String s_authentication_success = "authenticated";
 
     @Test(timeOut = 10000)
-    public void testAuthentication() throws Exception {
-        ServiceConfiguration config = new ServiceConfiguration();
-        Set<String> providersClassNames = Sets.newHashSet(MockAuthenticationProvider.class.getName());
-        config.setAuthenticationProviders(providersClassNames);
-        config.setAuthenticationEnabled(true);
-        AuthenticationService service = new AuthenticationService(config);
-        String result = service.authenticate(null, "auth");
-        assertEquals(result, s_authentication_success);
-        service.close();
-    }
-
-    @Test(timeOut = 10000)
     public void testAuthenticationHttp() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
         Set<String> providersClassNames = Sets.newHashSet(MockAuthenticationProvider.class.getName());


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/12105

### Motivation

This is the start of my work implementing PIP 97. 

When I removed the Discovery Service in https://github.com/apache/pulsar/pull/12119, I removed the last usage of the `AuthenticationService#authenticate` method. There is no need for this method, and instead of updating it to the async method (`provider.authenticate(authData)` was deprecated in PIP 97), it is better to remove it.

### Modifications

* Remove `AuthenticationService#authenticate`
* Remove the one test for the method

### Verifying this change

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
  
- [x] `no-need-doc` 
  
No docs need updating, as this is minor code cleanup.

