### PR TITLE
Fix wrong isEmpty method of ConcurrentOpenLongPairRangeSet

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSet.java
@@ -153,14 +153,12 @@ public class ConcurrentOpenLongPairRangeSet<T extends Comparable<T>> implements 
         if (rangeBitSetMap.isEmpty()) {
             return true;
         }
-        AtomicBoolean isEmpty = new AtomicBoolean(false);
-        rangeBitSetMap.forEach((key, val) -> {
-            if (!isEmpty.get()) {
-                return;
+        for (BitSet rangeBitSet : rangeBitSetMap.values()) {
+            if (!rangeBitSet.isEmpty()) {
+                return false;
             }
-            isEmpty.set(val.isEmpty());
-        });
-        return isEmpty.get();
+        }
+        return true;
     }
 
     @Override

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentOpenLongPairRangeSetTest.java
@@ -19,7 +19,9 @@
 package org.apache.pulsar.common.util.collections;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +38,17 @@ import com.google.common.collect.TreeRangeSet;
 public class ConcurrentOpenLongPairRangeSetTest {
 
     static final LongPairConsumer<LongPair> consumer = (key, value) -> new LongPair(key, value);
+
+    @Test
+    public void testIsEmpty() {
+        ConcurrentOpenLongPairRangeSet<LongPair> set = new ConcurrentOpenLongPairRangeSet<>(consumer);
+        assertTrue(set.isEmpty());
+        // lowerValueOpen and upperValue are both -1 so that an empty set will be added
+        set.addOpenClosed(0, -1, 0, -1);
+        assertTrue(set.isEmpty());
+        set.addOpenClosed(1, 1, 1, 5);
+        assertFalse(set.isEmpty());
+    }
 
     @Test
     public void testAddForSameKey() {


### PR DESCRIPTION
### Motivation

The `ConcurrentOpenLongPairRangeSet#isEmpty` implementation is wrong. See 

```java
        AtomicBoolean isEmpty = new AtomicBoolean(false);
        rangeBitSetMap.forEach((key, val) -> {
            if (!isEmpty.get()) { // [1] isEmpty is always false, so this condition always meets
                return;
            isEmpty.set(val.isEmpty()); // it never reaches here
        });
        return isEmpty.get(); // [2] So if rangeBitSetMap is not empty, isEmpty() always return true
```

The comment of `[1]` should be `isEmpty.get()`, not `!isEmpty.get()`. However, the implementation is still bad because `forEach` method will iterate over the whole map. If the map has many entries, the performance cost will not be ignorable.

### Modifications

- Fix `ConcurrentOpenLongPairRangeSet#isEmpty`. Instead of calling `forEach`, here we use a trivial for loop and break the loop if there is an entry whose value is a non-empty set.
- Add a test (`testIsEmpty`), which adds an empty set to `ConcurrentOpenLongPairRangeSet`. Before this patch, the `isEmpty()` returns false, which is incorrect.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added test `ConcurrentOpenLongPairRangeSetTest#testIsEmpty`.