### PR TITLE
[PIP 97][SASL Authentication] Remove Deprecated SASL AuthenticationDataSource#authenticate Implementation

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -119,9 +119,8 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
                                             SocketAddress remoteAddress,
                                             SSLSession sslSession) throws AuthenticationException {
         try {
-            return new SaslAuthenticationState(
-                new SaslAuthenticationDataSource(
-                    new PulsarSaslServer(jaasCredentialsContainer.getSubject(), allowedIdsPattern)));
+            PulsarSaslServer server = new PulsarSaslServer(jaasCredentialsContainer.getSubject(), allowedIdsPattern);
+            return new SaslAuthenticationState(server);
         } catch (Throwable t) {
             log.error("Failed create sasl auth state" , t);
             throw new AuthenticationException(t.getMessage());

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationDataSource.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationDataSource.java
@@ -18,17 +18,12 @@
  */
 package org.apache.pulsar.broker.authentication;
 
-import javax.naming.AuthenticationException;
-
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.common.api.AuthData;
 
 @Slf4j
 public class SaslAuthenticationDataSource implements AuthenticationDataSource {
     private static final long serialVersionUID = 1L;
 
-    // server side token data, that will passed to sasl client side.
-    protected AuthData serverSideToken;
     private PulsarSaslServer pulsarSaslServer;
 
     public SaslAuthenticationDataSource(PulsarSaslServer saslServer) {
@@ -38,16 +33,6 @@ public class SaslAuthenticationDataSource implements AuthenticationDataSource {
     @Override
     public boolean hasDataFromCommand() {
         return true;
-    }
-
-    @Override
-    public AuthData authenticate(AuthData data) throws AuthenticationException {
-        serverSideToken = pulsarSaslServer.response(data);
-        return serverSideToken;
-    }
-
-    public boolean isComplete() {
-        return this.pulsarSaslServer.isComplete();
     }
 
     public String getAuthorizationID() {

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationState.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationState.java
@@ -39,16 +39,17 @@ public class SaslAuthenticationState implements AuthenticationState {
     private final long stateId;
     private static final AtomicLong stateIdGenerator = new AtomicLong(0L);
     private final SaslAuthenticationDataSource authenticationDataSource;
+    private PulsarSaslServer pulsarSaslServer;
 
-    public SaslAuthenticationState(AuthenticationDataSource authenticationDataSource) {
+    public SaslAuthenticationState(PulsarSaslServer server) {
         stateId = stateIdGenerator.incrementAndGet();
-        checkArgument(authenticationDataSource instanceof SaslAuthenticationDataSource);
-        this.authenticationDataSource = (SaslAuthenticationDataSource)authenticationDataSource;
+        this.authenticationDataSource = new SaslAuthenticationDataSource(server);
+        this.pulsarSaslServer = server;
     }
 
     @Override
     public String getAuthRole() {
-        return authenticationDataSource.getAuthorizationID();
+        return pulsarSaslServer.getAuthorizationID();
     }
 
     @Override
@@ -58,7 +59,7 @@ public class SaslAuthenticationState implements AuthenticationState {
 
     @Override
     public boolean isComplete() {
-        return authenticationDataSource.isComplete();
+        return pulsarSaslServer.isComplete();
     }
 
     /**
@@ -67,7 +68,7 @@ public class SaslAuthenticationState implements AuthenticationState {
      */
     @Override
     public AuthData authenticate(AuthData authData) throws AuthenticationException {
-        return authenticationDataSource.authenticate(authData);
+        return pulsarSaslServer.response(authData);
     }
 
     @Override


### PR DESCRIPTION
Master Issue: PIP 97 https://github.com/apache/pulsar/issues/12105

### Motivation

When the SASL Authentication Provider was created in https://github.com/apache/pulsar/pull/3821, it introduced an `authenticate` method into the `AuthenticationDataSource`. This method is not necessary, and was marked as deprecated in PIP 97: https://github.com/apache/pulsar/issues/12105. This PR breaks the SASL Authentication Provider's reliance on the `AuthenticationDataSource#authenticate` method.

As an added benefit, the `AuthenticationDataSource` is only a data source now. It is no longer overloaded as a data source _and_ a means of authenticating data.

I plan to submit a subsequent PR to remove the `SaslAuthenticationDataSource`. This change is valuable by itself because it removes the reliance on `AuthenticationDataSource#authenticate`.

Note also that `SaslAuthenticationState#authenticate` is also deprecated in PIP 97. I want to first get this merged before moving to the async variant.

### Modifications

* Update `SaslAuthenticationDataSource` to remove unnecessary method declarations.
* Update constructor for `SaslAuthenticationState` to only take the `PulsarSaslServer` as a parameter.
* Update implementation of several methods in `SaslAuthenticationState` so that they no longer rely on the `SaslAuthenticationDataSource`.

### Verifying this change

This change is internal to the SASL provider itself. It is covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

- [x] `no-need-doc` 

This is a completely internal update, so no docs need updating.