### PR TITLE
[Docker] Enable filesystem permission updates in derivative docker im…

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -63,8 +63,6 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 RUN echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security
 ADD target/python-client/ /pulsar/pulsar-client
 
-VOLUME  ["/pulsar/conf", "/pulsar/data"]
-
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 
 


### PR DESCRIPTION
…ages

Master Issue: https://github.com/apache/pulsar/issues/11269 and https://github.com/apache/pulsar/pull/8242

### Motivation

@roelrymenants points out in https://github.com/apache/pulsar/pull/8242:

> On OpenShift the user id in the container is random. In this case, the /pulsar folder has problematic permissions. The VOLUME statement even locks these into place for derivative images.

I realized today that because we removed the standalone docker image in https://github.com/apache/pulsar/pull/11657, we can now removed the `VOLUME` command in the dockerfile and make it easier for end users to extend the pulsar docker image. I describe moving the `VOLUME` command here https://github.com/apache/pulsar/pull/8796#issuecomment-774608357.

I think I should be able to make the pulsar docker images OpenShift compliant and non-root by default in early December. Until then, it is still valuable to update docker image to make it easier for end users to extend the image.

### Modifications

* Remove the `VOLUME` directive from the `pulsar` dockerfile.

### Verifying this change

Now that we removed the standalone docker image, there is no need for the `VOLUME` command.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
  
- [x] `no-need-doc` 
 
This is a minor feature that does not need documentation. I'll provide docs when I update the pulsar docker image to be non-root/OpenShift compliant.