### PR TITLE
Failed split bundle base on throughput

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
@@ -124,7 +124,7 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
         return bundleRange;
     }
 
-    public static String getKey(NamespaceName nsname, Range<Long> keyRange) {
+    private static String getKey(NamespaceName nsname, Range<Long> keyRange) {
         return String.format("%s/0x%08x_0x%08x", nsname, keyRange.lowerEndpoint(), keyRange.upperEndpoint());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
@@ -124,7 +124,7 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
         return bundleRange;
     }
 
-    private static String getKey(NamespaceName nsname, Range<Long> keyRange) {
+    public static String getKey(NamespaceName nsname, Range<Long> keyRange) {
         return String.format("%s/0x%08x_0x%08x", nsname, keyRange.lowerEndpoint(), keyRange.upperEndpoint());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -218,7 +218,7 @@ public class NamespaceBundleFactory {
                 int maxCount = 0;
                 for (String topic : topics) {
                     NamespaceBundle bundle = bundles.findBundle(TopicName.get(topic));
-                    String bundleRange = bundles.findBundle(TopicName.get(topic)).getBundleRange();
+                    String bundleRange = bundle.getBundleRange();
                     int count = countMap.getOrDefault(bundleRange, 0) + 1;
                     countMap.put(bundleRange, count);
                     if (count > maxCount) {
@@ -236,16 +236,18 @@ public class NamespaceBundleFactory {
         if (loadManager instanceof ModularLoadManagerWrapper) {
             NamespaceBundles bundles = getBundles(nsName);
             double maxMsgThroughput = -1;
-            NamespaceBundle bundleWithHighestThroughpit = null;
+            NamespaceBundle bundleWithHighestThroughput = null;
             for (NamespaceBundle bundle : bundles.getBundles()) {
-                BundleData budnleData = ((ModularLoadManagerWrapper) loadManager).getLoadManager()
-                        .getBundleDataOrDefault(bundle.getBundleRange());
-                if (budnleData.getLongTermData().totalMsgThroughput() > maxMsgThroughput) {
-                    maxMsgThroughput = budnleData.getLongTermData().totalMsgThroughput();
-                    bundleWithHighestThroughpit = bundle;
+                BundleData bundleData = ((ModularLoadManagerWrapper) loadManager).getLoadManager()
+                        .getBundleDataOrDefault(NamespaceBundle.getKey(bundle.getNamespaceObject(),
+                                bundle.getKeyRange()));
+                if (bundleData.getTopics() > 0
+                        && bundleData.getLongTermData().totalMsgThroughput() > maxMsgThroughput) {
+                    maxMsgThroughput = bundleData.getLongTermData().totalMsgThroughput();
+                    bundleWithHighestThroughput = bundle;
                 }
             }
-            return bundleWithHighestThroughpit;
+            return bundleWithHighestThroughput;
         }
         return getBundleWithHighestTopics(nsName);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -239,8 +239,7 @@ public class NamespaceBundleFactory {
             NamespaceBundle bundleWithHighestThroughput = null;
             for (NamespaceBundle bundle : bundles.getBundles()) {
                 BundleData bundleData = ((ModularLoadManagerWrapper) loadManager).getLoadManager()
-                        .getBundleDataOrDefault(NamespaceBundle.getKey(bundle.getNamespaceObject(),
-                                bundle.getKeyRange()));
+                        .getBundleDataOrDefault(bundle.toString());
                 if (bundleData.getTopics() > 0
                         && bundleData.getLongTermData().totalMsgThroughput() > maxMsgThroughput) {
                     maxMsgThroughput = bundleData.getLongTermData().totalMsgThroughput();


### PR DESCRIPTION

### Motivation

Pr  #12378 Provided an option to split bundle based on load, there are 2 problems:
1、Method `getBundleWithHighestThroughput` returned a bundle which not owned by any broker, split would be failed.

```
11:46:23.080 [AsyncHttpClient-7-1] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:8080/admin/v2/namespaces/public/default/HOT/split?unload=false] Failed to perform http put request: javax.ws.rs.ClientErrorException: HTTP 412 Precondition Failed
Failed to find ownership for ServiceUnit:public/default/0x00000000_0x10000000

Reason: Failed to find ownership for ServiceUnit:public/default/0x00000000_0x10000000
```
2、incorrect  bundle-data path.
### Modifications

correct the above errors



### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


