### PR TITLE
[Authorization] Support CLEAR_BACKLOG namespace op after enable auth

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -533,6 +533,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                 break;
             case GET_TOPICS:
             case UNSUBSCRIBE:
+            case CLEAR_BACKLOG:
                 isAuthorizedFuture = allowConsumeOpsAsync(namespaceName, role, authData);
                 break;
             default:


### PR DESCRIPTION
### Motivation
This PR is similar to #12742 

### Documentation
- [x] `no-need-doc` 

