### PR TITLE
[C] Add pulsar_client_subscribe_multi_topics and pulsar_client_subscribe_pattern

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/client.h
+++ b/pulsar-client-cpp/include/pulsar/c/client.h
@@ -90,6 +90,18 @@ PULSAR_PUBLIC void pulsar_client_subscribe_async(pulsar_client_t *client, const 
                                                  const pulsar_consumer_configuration_t *conf,
                                                  pulsar_subscribe_callback callback, void *ctx);
 
+/**
+ * Create a consumer to multiple topics under the same namespace with default configuration
+ *
+ * @see subscribe(const std::vector<std::string>&, const std::string&, Consumer& consumer)
+ *
+ * @param topics a list of topic names to subscribe to
+ * @param topicsCount the number of topics
+ * @param subscriptionName the subscription name
+ * @param consumer a non-const reference where the new consumer will be copied
+ * @return ResultOk if the consumer has been successfully created
+ * @return ResultError if there was an error
+ */
 PULSAR_PUBLIC pulsar_result pulsar_client_subscribe_multi_topics(pulsar_client_t *client, const char **topics,
                                                                  int topicsCount,
                                                                  const char *subscriptionName,
@@ -101,6 +113,17 @@ PULSAR_PUBLIC void pulsar_client_subscribe_multi_topics_async(pulsar_client_t *c
                                                               const pulsar_consumer_configuration_t *conf,
                                                               pulsar_subscribe_callback callback, void *ctx);
 
+/**
+ * Create a consumer to multiple (which match given topicPattern) with default configuration
+ *
+ * @see subscribeWithRegex(const std::string&, const std::string&, Consumer& consumer)
+ *
+ * @param topicPattern topic regex topics should match to subscribe to
+ * @param subscriptionName the subscription name
+ * @param consumer a non-const reference where the new consumer will be copied
+ * @return ResultOk if the consumer has been successfully created
+ * @return ResultError if there was an error
+ */
 PULSAR_PUBLIC pulsar_result pulsar_client_subscribe_pattern(pulsar_client_t *client, const char *topicPattern,
                                                             const char *subscriptionName,
                                                             const pulsar_consumer_configuration_t *conf,

--- a/pulsar-client-cpp/include/pulsar/c/client.h
+++ b/pulsar-client-cpp/include/pulsar/c/client.h
@@ -90,10 +90,21 @@ PULSAR_PUBLIC void pulsar_client_subscribe_async(pulsar_client_t *client, const 
                                                  const pulsar_consumer_configuration_t *conf,
                                                  pulsar_subscribe_callback callback, void *ctx);
 
+PULSAR_PUBLIC pulsar_result pulsar_client_subscribe_multi_topics(pulsar_client_t *client, const char **topics,
+                                                                 int topicsCount,
+                                                                 const char *subscriptionName,
+                                                                 const pulsar_consumer_configuration_t *conf,
+                                                                 pulsar_consumer_t **consumer);
+
 PULSAR_PUBLIC void pulsar_client_subscribe_multi_topics_async(pulsar_client_t *client, const char **topics,
                                                               int topicsCount, const char *subscriptionName,
                                                               const pulsar_consumer_configuration_t *conf,
                                                               pulsar_subscribe_callback callback, void *ctx);
+
+PULSAR_PUBLIC pulsar_result pulsar_client_subscribe_pattern(pulsar_client_t *client, const char *topicPattern,
+                                                            const char *subscriptionName,
+                                                            const pulsar_consumer_configuration_t *conf,
+                                                            pulsar_consumer_t **consumer);
 
 PULSAR_PUBLIC void pulsar_client_subscribe_pattern_async(pulsar_client_t *client, const char *topicPattern,
                                                          const char *subscriptionName,

--- a/pulsar-client-cpp/lib/c/c_Client.cc
+++ b/pulsar-client-cpp/lib/c/c_Client.cc
@@ -98,6 +98,27 @@ void pulsar_client_subscribe_async(pulsar_client_t *client, const char *topic, c
         std::bind(&handle_subscribe_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
 }
 
+pulsar_result pulsar_client_subscribe_multi_topics(pulsar_client_t *client, const char **topics,
+                                                   int topicsCount, const char *subscriptionName,
+                                                   const pulsar_consumer_configuration_t *conf,
+                                                   pulsar_consumer_t **c_consumer) {
+    pulsar::Consumer consumer;
+    std::vector<std::string> topicsList;
+    for (int i = 0; i < topicsCount; i++) {
+        topicsList.push_back(topics[i]);
+    }
+
+    pulsar::Result res =
+        client->client->subscribe(topicsList, subscriptionName, conf->consumerConfiguration, consumer);
+    if (res == pulsar::ResultOk) {
+        (*c_consumer) = new pulsar_consumer_t;
+        (*c_consumer)->consumer = consumer;
+        return pulsar_result_Ok;
+    } else {
+        return (pulsar_result)res;
+    }
+}
+
 void pulsar_client_subscribe_multi_topics_async(pulsar_client_t *client, const char **topics, int topicsCount,
                                                 const char *subscriptionName,
                                                 const pulsar_consumer_configuration_t *conf,
@@ -110,6 +131,22 @@ void pulsar_client_subscribe_multi_topics_async(pulsar_client_t *client, const c
     client->client->subscribeAsync(
         topicsList, subscriptionName, conf->consumerConfiguration,
         std::bind(&handle_subscribe_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
+}
+
+pulsar_result pulsar_client_subscribe_pattern(pulsar_client_t *client, const char *topicPattern,
+                                              const char *subscriptionName,
+                                              const pulsar_consumer_configuration_t *conf,
+                                              pulsar_consumer_t **c_consumer) {
+    pulsar::Consumer consumer;
+    pulsar::Result res = client->client->subscribeWithRegex(topicPattern, subscriptionName,
+                                                            conf->consumerConfiguration, consumer);
+    if (res == pulsar::ResultOk) {
+        (*c_consumer) = new pulsar_consumer_t;
+        (*c_consumer)->consumer = consumer;
+        return pulsar_result_Ok;
+    } else {
+        return (pulsar_result)res;
+    }
 }
 
 void pulsar_client_subscribe_pattern_async(pulsar_client_t *client, const char *topicPattern,


### PR DESCRIPTION
### Motivation

I'm adding some bindings for Haskell (via the FFI), and I'm not at ease dealing with callbacks, I prefer synchronous versions which are not exposed.

### Modifications

I've added the synchyronous of `pulsar_client_subscribe_multi_topics` and `pulsar_client_subscribe_pattern_async`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

=> I'll have a look, but I have no example

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `doc-required` 
  
I need help
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


