### PR TITLE
[C] Add missing includes in reader_configuration.h

### DIFF
--- a/pulsar-client-cpp/include/pulsar/c/reader_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/reader_configuration.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <pulsar/defines.h>
+#include <pulsar/c/message.h>
+#include <pulsar/c/reader.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Motivation

I'm adding some bindings for Haskell (via the FFI), and I cannot include it in standalone.

### Modifications

I've added the missing includes in `reader_configuration.h`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
I've only added an include.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


