### PR TITLE
[Modernizer] Apply modernizer plugin to pulsar-client modules.

### DIFF
--- a/pulsar-client-1x-base/pulsar-client-1x/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-1x/pom.xml
@@ -54,6 +54,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.client.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -94,7 +94,7 @@ public class ConsumerConfiguration implements Serializable {
      *            the subscription type value
      */
     public ConsumerConfiguration setSubscriptionType(SubscriptionType subscriptionType) {
-        checkNotNull(subscriptionType);
+        Objects.requireNonNull(subscriptionType);
         conf.setSubscriptionType(subscriptionType);
         return this;
     }
@@ -116,7 +116,7 @@ public class ConsumerConfiguration implements Serializable {
      *            the listener object
      */
     public ConsumerConfiguration setMessageListener(MessageListener<byte[]> messageListener) {
-        checkNotNull(messageListener);
+        Objects.requireNonNull(messageListener);
         this.messageListener = messageListener;
         conf.setMessageListener(new org.apache.pulsar.shade.client.api.v2.MessageListener<byte[]>() {
 
@@ -158,7 +158,7 @@ public class ConsumerConfiguration implements Serializable {
      * @since 2.0
      */
     public ConsumerConfiguration setConsumerEventListener(ConsumerEventListener listener) {
-        checkNotNull(listener);
+        Objects.requireNonNull(listener);
         conf.setConsumerEventListener(listener);
         return this;
     }
@@ -204,7 +204,7 @@ public class ConsumerConfiguration implements Serializable {
      *            CryptoKeyReader object
      */
     public ConsumerConfiguration setCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
-        checkNotNull(cryptoKeyReader);
+        Objects.requireNonNull(cryptoKeyReader);
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.client.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -188,7 +188,7 @@ public class ProducerConfiguration implements Serializable {
      * @see MessageRoutingMode
      */
     public ProducerConfiguration setMessageRoutingMode(MessageRoutingMode messageRouteMode) {
-        checkNotNull(messageRouteMode);
+        Objects.requireNonNull(messageRouteMode);
         conf.setMessageRoutingMode(
                 org.apache.pulsar.client.api.MessageRoutingMode.valueOf(messageRouteMode.toString()));
         return this;
@@ -239,7 +239,7 @@ public class ProducerConfiguration implements Serializable {
      * @param messageRouter
      */
     public ProducerConfiguration setMessageRouter(MessageRouter messageRouter) {
-        checkNotNull(messageRouter);
+        Objects.requireNonNull(messageRouter);
         setMessageRoutingMode(MessageRoutingMode.CustomPartition);
         conf.setCustomMessageRouter(messageRouter);
         return this;
@@ -313,7 +313,7 @@ public class ProducerConfiguration implements Serializable {
      *            CryptoKeyReader object
      */
     public ProducerConfiguration setCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
-        checkNotNull(cryptoKeyReader);
+        Objects.requireNonNull(cryptoKeyReader);
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ReaderConfiguration.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/api/ReaderConfiguration.java
@@ -21,9 +21,9 @@ package org.apache.pulsar.client.api;
 import org.apache.commons.lang3.StringUtils;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.client.impl.v1.ReaderV1Impl;
@@ -56,7 +56,7 @@ public class ReaderConfiguration implements Serializable {
      *            the listener object
      */
     public ReaderConfiguration setReaderListener(ReaderListener<byte[]> readerListener) {
-        checkNotNull(readerListener);
+        Objects.requireNonNull(readerListener);
         this.readerListener = readerListener;
         conf.setReaderListener(new org.apache.pulsar.shade.client.api.v2.ReaderListener<byte[]>() {
 
@@ -94,7 +94,7 @@ public class ReaderConfiguration implements Serializable {
      *            CryptoKeyReader object
      */
     public ReaderConfiguration setCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
-        checkNotNull(cryptoKeyReader);
+        Objects.requireNonNull(cryptoKeyReader);
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }

--- a/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client-1x-base/pulsar-client-1x/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -20,11 +20,10 @@ package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Preconditions;
-
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
@@ -101,7 +100,7 @@ public class MessageBuilderImpl implements MessageBuilder {
 
     @Override
     public MessageBuilder setReplicationClusters(List<String> clusters) {
-        Preconditions.checkNotNull(clusters);
+        Objects.requireNonNull(clusters);
         msgMetadataBuilder.clearReplicateTo();
         msgMetadataBuilder.addAllReplicateTos(clusters);
         return this;

--- a/pulsar-client-admin-api/pom.xml
+++ b/pulsar-client-admin-api/pom.xml
@@ -48,6 +48,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>8</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -117,6 +117,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -19,8 +19,6 @@
 package org.apache.pulsar.client.admin.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.InputStream;
@@ -31,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -1145,7 +1144,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
         checkArgument(numMessages > 0);
         CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
-        peekMessagesAsync(topic, subName, numMessages, Lists.newArrayList(), future, 1);
+        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, 1);
         return future;
     }
 
@@ -1615,7 +1614,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             byte[] data = new byte[stream.available()];
             stream.read(data);
 
-            Map<String, String> properties = Maps.newTreeMap();
+            Map<String, String> properties = new TreeMap<>();
             MultivaluedMap<String, Object> headers = response.getHeaders();
             Object tmp = headers.getFirst(PUBLISH_TIME);
             if (tmp != null) {

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -52,6 +52,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <failOnViolations>true</failOnViolations>
+                    <javaVersion>8</javaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>modernizer</id>
+                        <goals>
+                            <goal>modernizer</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -66,6 +66,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -30,7 +30,6 @@ import static org.testng.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.io.File;
@@ -40,6 +39,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -1513,7 +1513,7 @@ public class PulsarAdminToolTest {
 
         Properties properties = new Properties();
         properties.put("authPlugin", AuthenticationTls.class.getName());
-        Map<String, String> paramMap = Maps.newHashMap();
+        Map<String, String> paramMap = new HashMap<>();
         final String certFilePath = "/my-file:role=name.cert";
         final String keyFilePath = "/my-file:role=name.key";
         paramMap.put("tlsCertFile", certFilePath);

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -100,6 +100,23 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- this task is used for copy all python files together to provide a instance directory
            for running python instance -->
       <plugin>

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
@@ -36,7 +37,6 @@ import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 
 abstract class CliCommand {
 
@@ -167,7 +167,7 @@ abstract class CliCommand {
     }
 
     static Set<AuthAction> getAuthActions(List<String> actions) {
-        Set<AuthAction> res = Sets.newTreeSet();
+        Set<AuthAction> res = new TreeSet<>();
         AuthAction authAction;
         for (String action : actions) {
             try {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2204,7 +2204,7 @@ public class CmdNamespaces extends CmdBase {
                 long maxBlockSize = validateSizeString(maxBlockSizeStr);
                 if (positiveCheck("MaxBlockSize", maxBlockSize)
                         && maxValueCheck("MaxBlockSize", maxBlockSize, Integer.MAX_VALUE)) {
-                    maxBlockSizeInBytes = new Long(maxBlockSize).intValue();
+                    maxBlockSizeInBytes = Long.valueOf(maxBlockSize).intValue();
                 }
             }
 
@@ -2213,7 +2213,7 @@ public class CmdNamespaces extends CmdBase {
                 long readBufferSize = validateSizeString(readBufferSizeStr);
                 if (positiveCheck("ReadBufferSize", readBufferSize)
                         && maxValueCheck("ReadBufferSize", readBufferSize, Integer.MAX_VALUE)) {
-                    readBufferSizeInBytes = new Long(readBufferSize).intValue();
+                    readBufferSizeInBytes = Long.valueOf(readBufferSize).intValue();
                 }
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -25,7 +25,6 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.JsonParseException;
 
@@ -91,11 +90,11 @@ public class CmdProduce {
     @Parameter(names = { "-m", "--messages" },
                description = "Messages to send, either -m or -f must be specified. The default separator is comma",
                splitter = NoSplitter.class)
-    private List<String> messages = Lists.newArrayList();
+    private List<String> messages = new ArrayList<>();
 
     @Parameter(names = { "-f", "--files" },
                description = "Comma separated file paths to send, either -m or -f must be specified.")
-    private List<String> messageFileNames = Lists.newArrayList();
+    private List<String> messageFileNames = new ArrayList<>();
 
     @Parameter(names = { "-n", "--num-produce" },
                description = "Number of times to send message(s), the count of messages/files * num-produce " +
@@ -120,7 +119,7 @@ public class CmdProduce {
 
     @Parameter(names = { "-p", "--properties"}, description = "Properties to add, Comma separated "
             + "key=value string, like k1=v1,k2=v2.")
-    private List<String> properties = Lists.newArrayList();
+    private List<String> properties = new ArrayList<>();
 
     @Parameter(names = { "-k", "--key"}, description = "message key to add ")
     private String key;

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -196,6 +196,23 @@
     <!-- Generate protobuf for testing purposes -->
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.collect.Lists;
-
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,7 +51,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     private long lowestSequenceId = -1L;
     private long highestSequenceId = -1L;
     private ByteBuf batchedMessageMetadataAndPayload;
-    private List<MessageImpl<?>> messages = Lists.newArrayList();
+    private List<MessageImpl<?>> messages = new ArrayList<>();
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
@@ -147,7 +146,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public void clear() {
-        messages = Lists.newArrayList();
+        messages = new ArrayList<>();
         firstCallback = null;
         previousCallback = null;
         messageMetadata.clear();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Lists;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
@@ -191,7 +190,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         // sequence id for this batch which will be persisted as a single entry by broker
         private long sequenceId = -1;
         private ByteBuf batchedMessageMetadataAndPayload;
-        private List<MessageImpl<?>> messages = Lists.newArrayList();
+        private List<MessageImpl<?>> messages = new ArrayList<>();
         private SendCallback previousCallback = null;
         private CompressionType compressionType;
         private CompressionCodec compressor;
@@ -249,7 +248,7 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         }
 
         public void clear() {
-            messages = Lists.newArrayList();
+            messages = new ArrayList<>();
             firstCallback = null;
             previousCallback = null;
             messageMetadata.clear();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -20,12 +20,11 @@ package org.apache.pulsar.client.impl;
 
 import static java.lang.String.format;
 
-import com.google.common.collect.Lists;
-
 import io.netty.buffer.ByteBuf;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -280,7 +279,7 @@ public class BinaryProtoLookupService implements LookupService {
                     }
 
                     // do not keep partition part of topic name
-                    List<String> result = Lists.newArrayList();
+                    List<String> result = new ArrayList<>();
                     r.forEach(topic -> {
                         String filtered = TopicName.get(topic).getPartitionedTopicName();
                         if (!result.contains(filtered)) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerId.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerId.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
+
+import java.util.Objects;
 
 public class ConsumerId implements Comparable<ConsumerId> {
     private final String topic;
@@ -40,14 +41,14 @@ public class ConsumerId implements Comparable<ConsumerId> {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(topic, subscription);
+        return Objects.hash(topic, subscription);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof ConsumerId) {
             ConsumerId other = (ConsumerId) obj;
-            return Objects.equal(this.topic, other.topic) && Objects.equal(this.subscription, other.subscription);
+            return Objects.equals(this.topic, other.topic) && Objects.equals(this.subscription, other.subscription);
         }
 
         return false;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.collect.Lists;
-
 import io.netty.channel.EventLoopGroup;
 
 import java.io.IOException;
@@ -27,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -133,7 +132,7 @@ public class HttpLookupService implements LookupService {
         httpClient
             .get(String.format(format, namespace, mode.toString()), String[].class)
             .thenAccept(topics -> {
-                List<String> result = Lists.newArrayList();
+                List<String> result = new ArrayList<>();
                 // do not keep partition part of topic name
                 Arrays.asList(topics).forEach(topic -> {
                     String filtered = TopicName.get(topic).getPartitionedTopicName();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ComparisonChain;
 
 import io.netty.buffer.ByteBuf;
@@ -27,6 +25,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.concurrent.FastThreadLocal;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.MessageIdData;
@@ -103,7 +102,7 @@ public class MessageIdImpl implements MessageId {
     };
 
     public static MessageId fromByteArray(byte[] data) throws IOException {
-        checkNotNull(data);
+        Objects.requireNonNull(data);
 
         MessageIdData idData = LOCAL_MESSAGE_ID.get();
         try {
@@ -144,7 +143,7 @@ public class MessageIdImpl implements MessageId {
     }
 
     public static MessageId fromByteArrayWithTopic(byte[] data, TopicName topicName) throws IOException {
-        checkNotNull(data);
+        Objects.requireNonNull(data);
         MessageIdData idData = LOCAL_MESSAGE_ID.get();
         try {
             idData.parseFrom(Unpooled.wrappedBuffer(data, 0, data.length), data.length);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.impl;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -36,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -189,7 +189,7 @@ public class MessageImpl<T> implements Message<T> {
         
         if (singleMessageMetadata != null) {
             if (singleMessageMetadata.getPropertiesCount() > 0) {
-                Map<String, String> properties = Maps.newTreeMap();
+                Map<String, String> properties = new TreeMap<>();
                 for (KeyValue entry : singleMessageMetadata.getPropertiesList()) {
                     properties.put(entry.getKey(), entry.getValue());
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.netty.util.Timeout;
@@ -28,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -111,7 +111,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
         switch (messageRouteMode) {
             case CustomPartition:
-                messageRouter = checkNotNull(conf.getCustomMessageRouter());
+                messageRouter = Objects.requireNonNull(conf.getCustomMessageRouter());
                 break;
             case SinglePartition:
                 messageRouter = new SinglePartitionMessageRouterImpl(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -24,6 +24,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -92,7 +94,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
             }
 
             List<String> newTopics = PulsarClientImpl.topicsPatternFilter(topics, topicsPattern);
-            List<String> oldTopics = Lists.newArrayList();
+            List<String> oldTopics = new ArrayList<>();
             oldTopics.addAll(getPartitionedTopics());
             getPartitions().forEach(p -> {
                 TopicName t = TopicName.get(p);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Lists;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -673,7 +672,7 @@ public class PulsarClientImpl implements PulsarClient {
         }
 
         final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-        List<CompletableFuture<Void>> futures = Lists.newArrayList();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
 
         producers.forEach(p -> futures.add(p.closeAsync()));
         consumers.forEach(c -> futures.add(c.closeAsync()));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -21,12 +21,11 @@ package org.apache.pulsar.client.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.client.util.TypeCheckUtil.checkType;
 
-import com.google.common.base.Preconditions;
-
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -215,7 +214,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     @Override
     public TypedMessageBuilder<T> replicationClusters(List<String> clusters) {
-        Preconditions.checkNotNull(clusters);
+        Objects.requireNonNull(clusters);
         msgMetadata.clearReplicateTo();
         msgMetadata.addAllReplicateTos(clusters);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 import io.netty.buffer.ByteBuf;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -151,8 +151,8 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
     }
 
     private void triggerZeroQueueSizeListener(final Message<T> message) {
-        checkNotNull(listener, "listener can't be null");
-        checkNotNull(message, "unqueued message can't be null");
+        Objects.requireNonNull(listener, "listener can't be null");
+        Objects.requireNonNull(message, "unqueued message can't be null");
 
         externalPinnedExecutor.execute(() -> {
             stats.updateNumMsgsReceived(message);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationToken.java
@@ -19,11 +19,10 @@
 
 package org.apache.pulsar.client.impl.auth;
 
-import com.google.common.base.Charsets;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -113,7 +112,7 @@ public class AuthenticationToken implements Authentication, EncodedAuthenticatio
         @Override
         public String get() {
             try {
-                return new String(Files.readAllBytes(Paths.get(uri)), Charsets.UTF_8).trim();
+                return new String(Files.readAllBytes(Paths.get(uri)), StandardCharsets.UTF_8).trim();
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read token from file", e);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Sets;
 
 import io.swagger.annotations.ApiModelProperty;
 import java.net.InetSocketAddress;
@@ -38,6 +37,7 @@ import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.util.Secret;
 
@@ -260,13 +260,13 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             name = "tlsCiphers",
             value = "Set of TLS Ciphers."
     )
-    private Set<String> tlsCiphers = Sets.newTreeSet();
+    private Set<String> tlsCiphers = new TreeSet<>();
 
     @ApiModelProperty(
             name = "tlsProtocols",
             value = "Protocols of TLS."
     )
-    private Set<String> tlsProtocols = Sets.newTreeSet();
+    private Set<String> tlsProtocols = new TreeSet<>();
 
     @ApiModelProperty(
             name = "memoryLimitBytes",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -21,9 +21,9 @@ package org.apache.pulsar.client.impl.conf;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Maps;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -60,7 +60,7 @@ public final class ConfigurationDataUtils {
         try {
             String existingConfigJson = mapper.writeValueAsString(existingData);
             Map<String, Object> existingConfig = mapper.readValue(existingConfigJson, Map.class);
-            Map<String, Object> newConfig = Maps.newHashMap();
+            Map<String, Object> newConfig = new HashMap<>();
             newConfig.putAll(existingConfig);
             newConfig.putAll(config);
             String configJson = mapper.writeValueAsString(newConfig);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.impl.conf;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.io.Serializable;
@@ -29,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -56,7 +56,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
-    private Set<String> topicNames = Sets.newTreeSet();
+    private Set<String> topicNames = new TreeSet<>();
 
     private Pattern topicsPattern;
 
@@ -176,7 +176,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
             @SuppressWarnings("unchecked")
             ConsumerConfigurationData<T> c = (ConsumerConfigurationData<T>) super.clone();
             c.topicNames = Sets.newTreeSet(this.topicNames);
-            c.properties = Maps.newTreeMap(this.properties);
+            c.properties = new TreeMap<>(this.properties);
             return c;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Failed to clone ConsumerConfigurationData");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -39,7 +39,6 @@ import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import lombok.Data;
@@ -120,7 +119,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
         try {
             ProducerConfigurationData c = (ProducerConfigurationData) super.clone();
             c.encryptionKeys = Sets.newTreeSet(this.encryptionKeys);
-            c.properties = Maps.newTreeMap(this.properties);
+            c.properties = new TreeMap<>(this.properties);
             return c;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Failed to clone ProducerConfigurationData", e);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.impl.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.avro.Schema.Type.RECORD;
-import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.pulsar.client.api.Schema;
@@ -38,6 +37,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
@@ -58,7 +58,7 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     private SchemaInfoProvider schemaInfoProvider;
 
     private ConcurrentMap<SchemaVersion, Schema<?>> initSchemaMap() {
-        ConcurrentMap<SchemaVersion, Schema<?>> schemaMap = Maps.newConcurrentMap();
+        ConcurrentMap<SchemaVersion, Schema<?>> schemaMap = new ConcurrentHashMap<>();
         // The Schema.BYTES will not be uploaded to the broker and store in the schema storage,
         // if the schema version in the message metadata is empty byte[], it means its schema is Schema.BYTES.
         schemaMap.put(BytesSchemaVersion.of(new byte[0]), Schema.BYTES);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
@@ -18,14 +18,15 @@
  */
 package org.apache.pulsar.client.util;
 
-import com.google.common.collect.Lists;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class ExecutorProvider {
@@ -62,8 +62,8 @@ public class ExecutorProvider {
     public ExecutorProvider(int numThreads, String poolName) {
         checkArgument(numThreads > 0);
         this.numThreads = numThreads;
-        checkNotNull(poolName);
-        executors = Lists.newArrayListWithCapacity(numThreads);
+        Objects.requireNonNull(poolName);
+        executors = new ArrayList<>(numThreads);
         for (int i = 0; i < numThreads; i++) {
             ExtendedThreadFactory threadFactory = new ExtendedThreadFactory(
                     poolName, Thread.currentThread().isDaemon());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerIdTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerIdTest.java
@@ -23,9 +23,9 @@ import static org.testng.Assert.assertNotEquals;
 
 import org.testng.annotations.Test;
 
-import com.google.common.base.Objects;
-
 import org.apache.pulsar.client.impl.ConsumerId;
+
+import java.util.Objects;
 
 public class ConsumerIdTest {
     private static final String TOPIC_TEST = "my-topic-1";
@@ -47,7 +47,7 @@ public class ConsumerIdTest {
     @Test
     public void hashCodeTest() {
         ConsumerId testConsumerId = new ConsumerId(TOPIC_TEST, SUBSCRIPTION_TEST);
-        assertEquals(Objects.hashCode(TOPIC_TEST, SUBSCRIPTION_TEST), testConsumerId.hashCode());
+        assertEquals(Objects.hash(TOPIC_TEST, SUBSCRIPTION_TEST), testConsumerId.hashCode());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -23,8 +23,8 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import com.google.common.collect.Maps;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.client.api.MessageId;
 import org.testng.annotations.Test;
@@ -235,8 +235,8 @@ public class MessageIdCompareToTest  {
         assertNotEquals(item4, item3);
 
         // 2 items
-        Map<String, MessageId> map1 = Maps.newHashMap();
-        Map<String, MessageId> map2 = Maps.newHashMap();
+        Map<String, MessageId> map1 = new HashMap<>();
+        Map<String, MessageId> map2 = new HashMap<>();
         map1.put(topic1, messageIdImpl1);
         map1.put(topic2, messageIdImpl2);
         map2.put(topic2, messageIdImpl2);
@@ -341,8 +341,8 @@ public class MessageIdCompareToTest  {
         }
 
         // 2 items
-        Map<String, MessageId> map1 = Maps.newHashMap();
-        Map<String, MessageId> map2 = Maps.newHashMap();
+        Map<String, MessageId> map1 = new HashMap<>();
+        Map<String, MessageId> map2 = new HashMap<>();
         map1.put(topic1, messageIdImpl1);
         map1.put(topic2, messageIdImpl2);
         map2.put(topic2, messageIdImpl2);
@@ -394,7 +394,7 @@ public class MessageIdCompareToTest  {
         assertTrue(item7.compareTo(item5) > 0);
         assertTrue(item5.compareTo(item7) < 0);
 
-        Map<String, MessageId> map3 = Maps.newHashMap();
+        Map<String, MessageId> map3 = new HashMap<>();
         map3.put(topic1, messageIdImpl3);
         map3.put(topic2, messageIdImpl3);
         MultiMessageIdImpl item8 = new MultiMessageIdImpl(map3);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -23,9 +23,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import com.google.common.base.Charsets;
-
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.function.Supplier;
 
@@ -101,7 +100,7 @@ public class AuthenticationTokenTest {
     public void testAuthTokenConfigFromFile() throws Exception {
         File tokenFile = File.createTempFile("pulsar-test-token", ".key");
         tokenFile.deleteOnExit();
-        FileUtils.write(tokenFile, "my-test-token-string", Charsets.UTF_8);
+        FileUtils.write(tokenFile, "my-test-token-string", StandardCharsets.UTF_8);
 
         AuthenticationToken authToken = new AuthenticationToken();
         authToken.configure(getTokenFileUri(tokenFile));
@@ -112,7 +111,7 @@ public class AuthenticationTokenTest {
         assertEquals(authData.getCommandData(), "my-test-token-string");
 
         // Ensure if the file content changes, the token will get refreshed as well
-        FileUtils.write(tokenFile, "other-token", Charsets.UTF_8);
+        FileUtils.write(tokenFile, "other-token", StandardCharsets.UTF_8);
 
         AuthenticationDataProvider authData2 = authToken.getAuthData();
         assertTrue(authData2.hasDataFromCommand());
@@ -129,7 +128,7 @@ public class AuthenticationTokenTest {
     public void testAuthTokenConfigFromFileWithNewline() throws Exception {
         File tokenFile = File.createTempFile("pulsar-test-token", ".key");
         tokenFile.deleteOnExit();
-        FileUtils.write(tokenFile, "  my-test-token-string  \r\n", Charsets.UTF_8);
+        FileUtils.write(tokenFile, "  my-test-token-string  \r\n", StandardCharsets.UTF_8);
 
         AuthenticationToken authToken = new AuthenticationToken();
         authToken.configure(getTokenFileUri(tokenFile));
@@ -140,7 +139,7 @@ public class AuthenticationTokenTest {
         assertEquals(authData.getCommandData(), "my-test-token-string");
 
         // Ensure if the file content changes, the token will get refreshed as well
-        FileUtils.write(tokenFile, "other-token", Charsets.UTF_8);
+        FileUtils.write(tokenFile, "other-token", StandardCharsets.UTF_8);
 
         AuthenticationDataProvider authData2 = authToken.getAuthData();
         assertTrue(authData2.hasDataFromCommand());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.impl.schema;
 
 import static org.testng.Assert.assertEquals;
 
-import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -35,7 +34,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-
+import java.util.TreeMap;
 
 @Slf4j
 public class KeyValueSchemaTest {
@@ -67,11 +66,11 @@ public class KeyValueSchemaTest {
 
     @Test
     public void testFillParametersToSchemainfo() {
-        Map<String, String> keyProperties = Maps.newTreeMap();
+        Map<String, String> keyProperties = new TreeMap<>();
         keyProperties.put("foo.key1", "value");
         keyProperties.put("foo.key2", "value");
 
-        Map<String, String> valueProperties = Maps.newTreeMap();
+        Map<String, String> valueProperties = new TreeMap<>();
         valueProperties.put("bar.key", "key");
 
         AvroSchema<Foo> fooSchema = AvroSchema.of(

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -298,12 +298,12 @@ public class SchemaInfoTest {
             assertEquals(schemaInfo.getSchema(), new byte[0]);
             assertEquals(schemaInfo.getType(), SchemaType.STRING);
             assertEquals(schemaInfo.getName(), "string");
-            assertEquals(schemaInfo.getProperties(), Maps.newHashMap());
+            assertEquals(schemaInfo.getProperties(), new HashMap<>());
         }
 
         @Test
         public void testSetProperties() {
-            final Map<String, String> map = Maps.newHashMap();
+            final Map<String, String> map = new HashMap<>();
             map.put("test", "value");
             final SchemaInfo schemaInfo = SchemaInfo.builder()
                     .type(SchemaType.STRING)
@@ -315,7 +315,7 @@ public class SchemaInfoTest {
             assertEquals(schemaInfo.getSchema(), new byte[0]);
             assertEquals(schemaInfo.getType(), SchemaType.STRING);
             assertEquals(schemaInfo.getName(), "string");
-            assertEquals(schemaInfo.getProperties(), Maps.newHashMap(map));
+            assertEquals(schemaInfo.getProperties(), new HashMap<>(map));
         }
 
         @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.tutorial;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -26,8 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
-
-import com.google.common.collect.Lists;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,7 +38,7 @@ public class SampleAsyncProducer {
         Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-tenant/my-ns/my-topic")
                 .sendTimeout(3, TimeUnit.SECONDS).create();
 
-        List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
             final String content = "my-message-" + i;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducerWithSchema.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducerWithSchema.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.client.tutorial;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
+
 @Slf4j
 public class SampleAsyncProducerWithSchema {
 
@@ -38,7 +39,7 @@ public class SampleAsyncProducerWithSchema {
         Producer<JsonPojo> producer = pulsarClient.newProducer(JSONSchema.of(SchemaDefinition.<JsonPojo>builder().withPojo(JsonPojo.class).build())).topic("persistent://my-property/use/my-ns/my-topic")
                 .sendTimeout(3, TimeUnit.SECONDS).create();
 
-        List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
             final String content = "my-message-" + i;


### PR DESCRIPTION
Master Issue: #12271

### Motivation

Apply Maven Modernizer plugin to enforce we move away from legacy APIs for pulsar-client modeules.
### Modifications

Add Maven Modernizer plugin in pom and fix violation.

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


