### PR TITLE
[Issue 12812] Introduce ZKBatchedMetadataStore.

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
@@ -49,7 +49,7 @@ public class MetadataStoreFactoryImpl {
         if (metadataURL.startsWith("memory://")) {
             return new LocalMemoryMetadataStore(metadataURL, metadataStoreConfig);
         } else {
-            return new ZKMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);
+            return new ZKBatchedMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);
         }
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStore.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl;
+
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.impl.batch.BatchWorker;
+import org.apache.pulsar.metadata.impl.batch.MetadataOp;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
+
+@Slf4j
+public class ZKBatchedMetadataStore extends ZKMetadataStore implements AsyncCallback.MultiCallback {
+
+    protected final boolean metadataStoreBatchingEnable = true;
+    protected final int metadataStoreBatchingMaxDelayMillis = 5;
+    protected final int metadataStoreBatchingMaxOperations = 100;
+    protected final int metadataStoreBatchingMaxSizeKb = 128;
+
+    private final BatchWorker batchReadWorker;
+
+    public ZKBatchedMetadataStore(String metadataURL, MetadataStoreConfig metadataStoreConfig,
+                                  boolean enableSessionWatcher) throws MetadataStoreException {
+        super(metadataURL, metadataStoreConfig, enableSessionWatcher);
+        batchReadWorker = new BatchWorker("reader",
+                metadataStoreBatchingMaxDelayMillis, metadataStoreBatchingMaxOperations, this::executeBatchReadOps);
+    }
+
+    public void executeBatchReadOps(List<MetadataOp<?>> batch) {
+        if (batch == null || batch.isEmpty()) {
+            return;
+        }
+        if (batch.size() == 1) {
+            fallbackToSingleOps(batch);
+            return;
+        }
+        List<Op> zkOpList = batch.stream().map(MetadataOp::toZkOp).collect(Collectors.toList());
+        zkc.multi(zkOpList, this, batch);
+    }
+
+    @Override
+    public CompletableFuture<Optional<GetResult>> storeGet(String path) {
+        if (!metadataStoreBatchingEnable) {
+            return super.storeGet(path);
+        }
+        MetadataOp.OpGetData op = MetadataOp.getData(path);
+        if (!batchReadWorker.add(op)) {
+            // Add op to queue failed. fallback to non-batch mode.
+            return super.storeGet(path);
+        }
+        return op.getFuture();
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getChildrenFromStore(String path) {
+        if (!metadataStoreBatchingEnable) {
+            return super.getChildrenFromStore(path);
+        }
+        MetadataOp.OpGetChildren op = MetadataOp.getChildren(path);
+        if (!batchReadWorker.add(op)) {
+            // Add op to queue failed. fallback to non-batch mode.
+            return super.getChildrenFromStore(path);
+        }
+        return op.getFuture();
+    }
+
+    @Override
+    public void processResult(int rc, String path, Object ctx, List<OpResult> opResults) {
+        if (log.isDebugEnabled()) {
+            log.debug("processResult, rc={}, path={}, ctx={}, opResult.size={}", rc, path, ctx,
+                    CollectionUtils.size(opResults));
+        }
+        List<MetadataOp<?>> batch = (List<MetadataOp<?>>) ctx;
+        Code code = Code.get(rc);
+        if (opResults == null || opResults.size() != batch.size()
+                || code == Code.BADARGUMENTS || code == Code.CONNECTIONLOSS) {
+            log.warn("fallback batch operations. rc={},path={},batch.size={},opResult.size={}",
+                    rc, path, batch.size(), opResults == null ? null : opResults.size());
+            fallbackToSingleOps(batch);
+            return;
+        }
+
+        for (int i = 0; i < batch.size(); i++) {
+            MetadataOp<?> metadataOp = batch.get(i);
+            OpResult opResult = opResults.get(i);
+            switch (opResult.getType()) {
+                case ZooDefs.OpCode.getData:
+                    OpResult.GetDataResult getResult = (OpResult.GetDataResult) opResult;
+                    super.processGetResult(Code.OK.intValue(), metadataOp.getPath(),
+                            metadataOp, getResult.getData(), getResult.getStat());
+                    break;
+                case ZooDefs.OpCode.getChildren:
+                    OpResult.GetChildrenResult getChildrenResult = (OpResult.GetChildrenResult) opResult;
+                    super.processGetChildrenResult(Code.OK.intValue(),
+                            metadataOp.getPath(), metadataOp, getChildrenResult.getChildren());
+                    break;
+                case ZooDefs.OpCode.error:
+                    OpResult.ErrorResult errorResult = (OpResult.ErrorResult) opResult;
+                    if (metadataOp.getType() == MetadataOp.TYPE_GET_DATA) {
+                        super.processGetResult(errorResult.getErr(), metadataOp.getPath(),
+                                metadataOp.getFuture(), null, null);
+                    } else if (metadataOp.getType() == MetadataOp.TYPE_GET_CHILDREN) {
+                        super.processGetChildrenResult(errorResult.getErr(), metadataOp.getPath(),
+                                metadataOp.getFuture(), null);
+                    } else {
+                        log.error("Error Op type error, code:{}, op.type={}", errorResult.getErr(),
+                                metadataOp.getType());
+                    }
+                    break;
+                default:
+                    log.error("unknown opResult type:{}", opResult.getType());
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        batchReadWorker.close();
+        super.close();
+    }
+
+    public void fallbackToSingleOps(List<MetadataOp<?>> batch) {
+        for (MetadataOp<?> op : batch) {
+            switch (op.getType()) {
+                case MetadataOp.TYPE_GET_DATA:
+                    super.storeGet(op.getPath()).whenComplete((result, throwable) -> {
+                        CompletableFuture<Optional<GetResult>> future =
+                                (CompletableFuture<Optional<GetResult>>) op.getFuture();
+                        if (throwable != null) {
+                            future.completeExceptionally(throwable);
+                        } else {
+                            future.complete(result);
+                        }
+                    });
+                    break;
+                case MetadataOp.TYPE_GET_CHILDREN:
+                    super.getChildrenFromStore(op.getPath()).whenComplete((result, throwable) -> {
+                        CompletableFuture<List<String>> future = (CompletableFuture<List<String>>) op.getFuture();
+                        if (throwable != null) {
+                            future.completeExceptionally(throwable);
+                        } else {
+                            future.complete(result);
+                        }
+                    });
+                    break;
+                default:
+                    log.error("Unknown metadata op type:{}, path={}", op.getType(), op.getPath());
+                    op.getFuture().completeExceptionally(
+                            new MetadataStoreException("Unknown metadata op type in fallbackToNonBatchOps."));
+            }
+        }
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStore.java
@@ -126,10 +126,10 @@ public class ZKBatchedMetadataStore extends ZKMetadataStore implements AsyncCall
                     OpResult.ErrorResult errorResult = (OpResult.ErrorResult) opResult;
                     if (metadataOp.getType() == MetadataOp.TYPE_GET_DATA) {
                         super.processGetResult(errorResult.getErr(), metadataOp.getPath(),
-                                metadataOp.getFuture(), null, null);
+                                metadataOp, null, null);
                     } else if (metadataOp.getType() == MetadataOp.TYPE_GET_CHILDREN) {
                         super.processGetChildrenResult(errorResult.getErr(), metadataOp.getPath(),
-                                metadataOp.getFuture(), null);
+                                metadataOp, null);
                     } else {
                         log.error("Error Op type error, code:{}, op.type={}", errorResult.getErr(),
                                 metadataOp.getType());

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batch/BatchWorker.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batch/BatchWorker.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl.batch;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+
+public class BatchWorker {
+    private final Consumer<List<MetadataOp<?>>> batchHandler;
+    private volatile long lastBatchOpsExecuteTime;
+    protected final int maxDelayMillis;
+    protected final int maxOpsPerBatch;
+    protected Queue<MetadataOp<?>> opQueue;
+    private final ScheduledExecutorService scheduler;
+    private volatile boolean running;
+
+    public BatchWorker(String name,
+                       int maxDelayMillis, int maxOpsPerBatch,
+                       Consumer<List<MetadataOp<?>>> batchHandler) {
+        this.maxDelayMillis = maxDelayMillis;
+        this.maxOpsPerBatch = maxOpsPerBatch;
+        this.opQueue = new ConcurrentLinkedQueue<>();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                new DefaultThreadFactory("metadata-store-batch-worker-" + name));
+        scheduler.scheduleWithFixedDelay(this::doBatch, maxDelayMillis, maxDelayMillis, TimeUnit.MILLISECONDS);
+        this.batchHandler = batchHandler;
+        this.running = true;
+    }
+
+    private boolean isBatchReady() {
+        if (!running) {
+            return false;
+        }
+        return opQueue.size() > maxOpsPerBatch
+                || (System.currentTimeMillis() - lastBatchOpsExecuteTime) > maxDelayMillis;
+    }
+
+    private void triggerBatch() {
+        if (isBatchReady()) {
+            scheduler.execute(this::doBatch);
+        }
+    }
+
+    private void doBatch() {
+        while (running && isBatchReady()) {
+            lastBatchOpsExecuteTime = System.currentTimeMillis();
+            List<MetadataOp<?>> singleBatch = new ArrayList<>();
+            while (singleBatch.size() < maxOpsPerBatch) {
+                if (!opQueue.isEmpty()) {
+                    singleBatch.add(opQueue.poll());
+                } else {
+                    break;
+                }
+            }
+            if (singleBatch.isEmpty()) {
+                break;
+            }
+            batchHandler.accept(singleBatch);
+        }
+    }
+
+    public boolean add(MetadataOp<?> op) {
+        if (!running) {
+            return false;
+        }
+        if (opQueue.offer(op)) {
+            triggerBatch();
+            return true;
+        }
+        return false;
+    }
+
+    public void close() {
+        synchronized (this) {
+            if (!running) {
+                return;
+            }
+            running = false;
+        }
+        while (!opQueue.isEmpty()) {
+            MetadataOp<?> op = opQueue.poll();
+            op.getFuture().completeExceptionally(
+                    new MetadataStoreException.AlreadyClosedException("Metadata store already closed."));
+        }
+        scheduler.shutdown();
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batch/MetadataOp.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batch/MetadataOp.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl.batch;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.zookeeper.Op;
+
+@Data
+@AllArgsConstructor
+public abstract class MetadataOp<T> {
+
+    public static final int TYPE_GET_DATA = 1;
+    public static final int TYPE_GET_CHILDREN = 2;
+
+
+    final int type;
+    final String path;
+    final CompletableFuture<T> future;
+    public abstract Op toZkOp();
+
+    public static class OpGetData extends MetadataOp<Optional<GetResult>> {
+
+        OpGetData(String path) {
+            super(TYPE_GET_DATA, path, new CompletableFuture<>());
+        }
+
+        @Override
+        public Op toZkOp() {
+            return Op.getData(path);
+        }
+    }
+
+    public static class OpGetChildren extends MetadataOp<List<String>> {
+
+        OpGetChildren(String path) {
+            super(TYPE_GET_CHILDREN, path, new CompletableFuture<>());
+        }
+
+        @Override
+        public Op toZkOp() {
+            return Op.getChildren(path);
+        }
+    }
+
+    public static OpGetData getData(String path) {
+        return new OpGetData(path);
+    }
+
+    public static OpGetChildren getChildren(String path) {
+        return new OpGetChildren(path);
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -195,9 +195,12 @@ public class LockManagerTest extends BaseMetadataStoreTest {
 
         store.delete("/my/path/1", Optional.empty()).join();
 
-        lock.updateValue("value-2").join();
-        assertEquals(lock.getValue(), "value-2");
-        assertEquals(cache.get("/my/path/1").join().get(), "value-2");
+        Awaitility.await().untilAsserted(()->{
+            //There is a race condition between re-acquire the lock by Node delete notification and this updateValue.
+            lock.updateValue("value-2").join();
+            assertEquals(lock.getValue(), "value-2");
+            assertEquals(cache.get("/my/path/1").join().get(), "value-2");
+        });
     }
 
     @Test(dataProvider = "impl")

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/ZKBatchedMetadataStoreTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.impl;
+
+import static org.apache.zookeeper.client.ZKClientConfig.CLIENT_MAX_PACKET_LENGTH_DEFAULT;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.metadata.BaseMetadataStoreTest;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.impl.batch.MetadataOp;
+import org.assertj.core.util.Lists;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class ZKBatchedMetadataStoreTest extends BaseMetadataStoreTest {
+
+    @Test
+    public void testBatchRead() throws Exception {
+        ZKBatchedMetadataStore batchedStore = new ZKBatchedMetadataStore(zks.getConnectionString(),
+                MetadataStoreConfig.builder().build(), false);
+
+        batchedStore.put("/testBatchRead/a", "data1".getBytes(StandardCharsets.UTF_8), Optional.of(-1L)).get();
+        batchedStore.put("/testBatchRead/b", "data2".getBytes(StandardCharsets.UTF_8), Optional.of(-1L)).get();
+
+        MetadataOp.OpGetData getData1 = MetadataOp.getData("/testBatchRead/a");
+        MetadataOp.OpGetData getData2 = MetadataOp.getData("/testBatchRead/b");
+        MetadataOp.OpGetChildren getChildren = MetadataOp.getChildren("/testBatchRead");
+
+        batchedStore.executeBatchReadOps(Lists.newArrayList(getData1, getData2, getChildren));
+
+        Assert.assertEquals(getData1.getFuture().get().get().getValue(), "data1".getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(getData2.getFuture().get().get().getValue(), "data2".getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(getChildren.getFuture().get(), Lists.newArrayList("a", "b"));
+    }
+
+    @Test
+    public void testFallbackToSingleOps() throws Exception {
+        ZKBatchedMetadataStore batchedStore = new ZKBatchedMetadataStore(zks.getConnectionString(),
+                MetadataStoreConfig.builder().build(), false);
+
+        batchedStore.put("/testFallback/a", "data1".getBytes(StandardCharsets.UTF_8), Optional.of(-1L)).get();
+        batchedStore.put("/testFallback/b", "data2".getBytes(StandardCharsets.UTF_8), Optional.of(-1L)).get();
+
+        MetadataOp.OpGetData getData1 = MetadataOp.getData("/testFallback/a");
+        MetadataOp.OpGetData getData2 = MetadataOp.getData("/testFallback/b");
+        MetadataOp.OpGetChildren getChildren = MetadataOp.getChildren("/testFallback");
+
+        batchedStore.fallbackToSingleOps(Lists.newArrayList(getData1, getData2, getChildren));
+
+        Assert.assertEquals(getData1.getFuture().get().get().getValue(), "data1".getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(getData2.getFuture().get().get().getValue(), "data2".getBytes(StandardCharsets.UTF_8));
+        Assert.assertEquals(getChildren.getFuture().get(), Lists.list("a", "b"));
+    }
+
+    @Test
+    public void testAutoFallbackWithResultSizeOutOfRange() throws Exception {
+        int dataSize = CLIENT_MAX_PACKET_LENGTH_DEFAULT / 2;
+        ZKBatchedMetadataStore batchedStore = new ZKBatchedMetadataStore(zks.getConnectionString(),
+                MetadataStoreConfig.builder().build(), false);
+        byte[] data = new byte[dataSize];
+        batchedStore.put("/testAutoFallbackWithResultSizeOutOfRange/a", data, Optional.of(-1L)).get();
+        batchedStore.put("/testAutoFallbackWithResultSizeOutOfRange/b", data, Optional.of(-1L)).get();
+        MetadataOp.OpGetData getData1 = MetadataOp.getData("/testAutoFallbackWithResultSizeOutOfRange/a");
+        MetadataOp.OpGetData getData2 = MetadataOp.getData("/testAutoFallbackWithResultSizeOutOfRange/b");
+        //
+        batchedStore.executeBatchReadOps(Lists.newArrayList(getData1, getData2));
+
+        Assert.assertEquals(getData1.getFuture().get().get().getValue().length, dataSize);
+        Assert.assertEquals(getData2.getFuture().get().get().getValue().length, dataSize);
+    }
+}


### PR DESCRIPTION
Fixes #12812


### Motivation


See #12812

### Modifications

Add class `ZKBatchedMetadataStore` extends `ZKMetadataStore` and overrides `storeGet` and `getChildrenFromStore`.
Put these two kinds of read operations into `org.apache.pulsar.metadata.impl.batch.BatchWorker#opQueue`,  which contains a background thread that will send batch ops once it reaches target op number (set as 100) or waited long enough (5ms).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, all test cases in pulsar-metadata.

This change added tests and can be verified as follows:
  - ZKBatchedMetadataStoreTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Pref optimization.
