### PR TITLE
Fix handlePartitionResponse issue.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -577,7 +577,9 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse lookupResult) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Broker Partition response: {}", lookupResult.getPartitions());
+            log.debug("Received Broker Partition response: {}", ((lookupResult.getResponse() ==
+                    CommandPartitionedTopicMetadataResponse.LookupType.Success) ? lookupResult.getPartitions() :
+                    lookupResult.getError()));
         }
 
         long requestId = lookupResult.getRequestId();


### PR DESCRIPTION
### Motivation
When ClientCnx#handlePartitionResponse, the response `CommandLookupTopicResponse ` may have error, so we may meet the below log:
```
08:40:24.581 [pulsar-external-listener-3-1] WARN  org.apache.pulsar.client.impl.PulsarClientImpl - [topic: persistent://new_public/new_default/FWSRVdefault] Could not get connection while getPartitionedTopicMetadata -- Will try again in 5811 ms
08:40:24.582 [pulsar-client-io-1-1] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x1c493993, L:/127.0.0.1:15488 - R:localhost/127.0.0.1:6650]] Connected to server
08:40:24.586 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.ClientCnx - [localhost/127.0.0.1:6650] Got exception java.lang.IllegalStateException: Field 'partitions' is not set
	at org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadataResponse.getPartitions(CommandPartitionedTopicMetadataResponse.java:38)
	at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:569)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:129)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```

### Modifications

- Check the response if it is `success`

### Documentation
  
- [x] `no-need-doc` 
  


