### PR TITLE
[branch-2.7] Upgrade Zookeeper version to 3.5.9

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -511,7 +511,7 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-core-3.5.3.jar
     - io.vertx-vertx-web-3.5.3.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-jute-3.5.7.jar
+    - org.apache.zookeeper-zookeeper-jute-3.5.9.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.21</commons-compress.version>
 
     <bookkeeper.version>4.12.0</bookkeeper.version>
-    <zookeeper.version>3.5.7</zookeeper.version>
+    <zookeeper.version>3.5.9</zookeeper.version>
     <netty.version>4.1.60.Final</netty.version>
     <netty-tc-native.version>2.0.36.Final</netty-tc-native.version>
     <jetty.version>9.4.42.v20210604</jetty.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -455,8 +455,8 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
   * Apache Zookeeper
-    - zookeeper-3.5.7.jar
-    - zookeeper-jute-3.5.7.jar
+    - zookeeper-3.5.9.jar
+    - zookeeper-jute-3.5.9.jar
   * Apache Yetus Audience Annotations
     - audience-annotations-0.5.0.jar
   * Swagger


### PR DESCRIPTION
### Motivation

- Main motivation is to get fix for [ZOOKEEPER-2164](https://issues.apache.org/jira/browse/ZOOKEEPER-2164)
  - Fixes issue where Zookeeper sessions are expired and all brokers restart after a rolling restart of Zookeeper servers. 

### Modifications

Upgrade Zookeeper from 3.5.7 to 3.5.9
