### PR TITLE
[Zookeeper] Enable TCP keepAlive flag on the sockets

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -310,7 +310,7 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 OPTS="$OPTS -Dpulsar.functions.log.conf=${FUNCTIONS_LOG_CONF}"
 
-ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true"
+ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true"
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"
 

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -310,7 +310,7 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 OPTS="$OPTS -Dpulsar.functions.log.conf=${FUNCTIONS_LOG_CONF}"
 
-ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true"
+ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true"
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"
 


### PR DESCRIPTION
### Motivation

- Enable TCP keepAlive flag on the sockets used by quorum members to perform elections
  - see https://issues.apache.org/jira/browse/ZOOKEEPER-1748 for details
    - "Setting this to true sets the TCP keepAlive flag on the sockets used by
       quorum members to perform elections. This will allow for connections between
       quorum members to remain up when there is network infrastructure that may
       otherwise break them.
       Some NATs and firewalls may terminate or lose state for long running
       or idle connections."
- Enable TCP keepAlive flag on the sockets used for client connections
  - see https://issues.apache.org/jira/browse/ZOOKEEPER-3712 for details
    - "Some broken network infrastructure may lose the FIN packet that is sent from closing client.
        These never closed client sockets cause OS resource leak. Enabling this option terminates
        these zombie sockets by idle check. ... Currently this option is only available
        when default NIOServerCnxnFactory is used."

### Modifications

Specify `-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true`
 in default options for Zookeeper (`ZK_OPTS` in `bin/pulsar`)

### Documentation

- [x] `no-need-doc` 