### PR TITLE
Fix deserialize a message id without partition topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageIdSerializationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageIdSerializationTest.java
@@ -48,9 +48,9 @@ public class MessageIdSerializationTest {
     public void testProtobufSerializationWithTopic() throws Exception {
         MessageId id = new MessageIdImpl(1, 2, -1);
         byte[] serializedId = id.toByteArray();
-        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId,"topic-1");
-        if (actualMessageId == null || actualMessageId instanceof TopicMessageIdImpl) {
-            fail("actualMessageId should be TopicMessageIdImpl type");
+        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId, "topic-1");
+        if (!(actualMessageId instanceof TopicMessageIdImpl)) {
+            fail("actualMessageId should be " + TopicMessageIdImpl.class);
         }
         assertEquals(actualMessageId, id);
     }
@@ -59,9 +59,9 @@ public class MessageIdSerializationTest {
     public void testProtobufSerializationWithPartitionTopic() throws Exception {
         MessageId id = new MessageIdImpl(1, 2, -1);
         byte[] serializedId = id.toByteArray();
-        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId,"topic-partition-1");
-        if (actualMessageId == null || actualMessageId instanceof TopicMessageIdImpl) {
-            fail("actualMessageId should be TopicMessageIdImpl type");
+        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId, "topic-partition-1");
+        if (!(actualMessageId instanceof TopicMessageIdImpl)) {
+            fail("actualMessageId should be " + TopicMessageIdImpl.class);
         }
         assertEquals(actualMessageId, id);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageIdSerializationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageIdSerializationTest.java
@@ -19,9 +19,12 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import java.io.IOException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
@@ -39,6 +42,28 @@ public class MessageIdSerializationTest {
         MessageId id = new MessageIdImpl(1, 2, -1);
         byte[] serializedId = id.toByteArray();
         assertEquals(MessageId.fromByteArray(serializedId), id);
+    }
+
+    @Test
+    public void testProtobufSerializationWithTopic() throws Exception {
+        MessageId id = new MessageIdImpl(1, 2, -1);
+        byte[] serializedId = id.toByteArray();
+        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId,"topic-1");
+        if (actualMessageId == null || actualMessageId instanceof TopicMessageIdImpl) {
+            fail("actualMessageId should be TopicMessageIdImpl type");
+        }
+        assertEquals(actualMessageId, id);
+    }
+
+    @Test
+    public void testProtobufSerializationWithPartitionTopic() throws Exception {
+        MessageId id = new MessageIdImpl(1, 2, -1);
+        byte[] serializedId = id.toByteArray();
+        MessageId actualMessageId = MessageId.fromByteArrayWithTopic(serializedId,"topic-partition-1");
+        if (actualMessageId == null || actualMessageId instanceof TopicMessageIdImpl) {
+            fail("actualMessageId should be TopicMessageIdImpl type");
+        }
+        assertEquals(actualMessageId, id);
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -159,7 +159,7 @@ public class MessageIdImpl implements MessageId {
         } else {
             messageId = new MessageIdImpl(idData.getLedgerId(), idData.getEntryId(), idData.getPartition());
         }
-        if (idData.getPartition() > -1 && topicName != null) {
+        if (topicName != null) {
             messageId = new TopicMessageIdImpl(
                     topicName.getPartition(idData.getPartition()).toString(), topicName.toString(), messageId);
         }


### PR DESCRIPTION
### Motivation

The `MessageId.fromByteArrayWithTopic` ignores deserialize a message id without partition topic, it is behavior incorrectly, we should be support deserialize message id with any type topic.

### Modification

- Remove check partition topic in fromByteArrayWithTopic

### Documentation

- [x] `no-need-doc`

It is fix.

Signed-off-by: Zixuan Liu <nodeces@gmail.com>
