### PR TITLE
[broker] Reduce the time it takes for namespace bundle unloading to time out

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1125,6 +1125,9 @@ loadBalancerDirectMemoryResourceWeight=1.0
 # It only takes effect in the ThresholdShedder strategy.
 loadBalancerBundleUnloadMinThroughputThreshold=10
 
+# Time to wait for the unloading of a namespace bundle
+namespaceBundleUnloadingTimeoutMs=60000
+
 ### --- Replication --- ###
 
 # Enable replication metrics

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -815,6 +815,9 @@ loadBalancerDirectMemoryResourceWeight=1.0
 # It only takes effect in the ThresholdShedder strategy.
 loadBalancerBundleUnloadMinThroughputThreshold=10
 
+# Time to wait for the unloading of a namespace bundle
+namespaceBundleUnloadingTimeoutMs=60000
+
 ### --- Replication --- ###
 
 # Enable replication metrics

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1895,6 +1895,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Option to override the auto-detected network interfaces max speed"
     )
     private Double loadBalancerOverrideBrokerNicSpeedGbps;
+    @FieldContext(
+        category = CATEGORY_LOAD_BALANCER,
+        doc = "Time to wait for the unloading of a namespace bundle"
+    )
+    private long namespaceBundleUnloadingTimeoutMs = 60000;
 
     /**** --- Replication --- ****/
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -664,7 +664,7 @@ public class NamespaceService implements AutoCloseable {
 
     public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle) {
         // unload namespace bundle
-        return unloadNamespaceBundle(bundle, 5, TimeUnit.MINUTES);
+        return unloadNamespaceBundle(bundle, config.getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle, long timeout, TimeUnit timeoutUnit) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -845,7 +845,9 @@ public class BrokerService implements Closeable {
             serviceUnits.forEach(su -> {
                 if (su instanceof NamespaceBundle) {
                     try {
-                        pulsar.getNamespaceService().unloadNamespaceBundle(su, 1, TimeUnit.MINUTES).get();
+                        pulsar.getNamespaceService().unloadNamespaceBundle(su,
+                                pulsar.getConfiguration().getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS)
+                                .get();
                     } catch (Exception e) {
                         log.warn("Failed to unload namespace bundle {}", su, e);
                     }

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -643,6 +643,7 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 | loadBalancerMemoryResourceWeight | The heap memory usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |
 | loadBalancerDirectMemoryResourceWeight | The direct memory usage weight when calculating new resource usage. It only takes effect in the ThresholdShedder strategy. | 1.0 |
 | loadBalancerBundleUnloadMinThroughputThreshold | Bundle unload minimum throughput threshold. Avoid bundle unload frequently. It only takes effect in the ThresholdShedder strategy. | 10 |
+| namespaceBundleUnloadingTimeoutMs | Time to wait for the unloading of a namespace bundle in milliseconds. | 60000 |
 |replicationMetricsEnabled|   |true|
 |replicationConnectionsPerBroker|   |16|
 |replicationProducerQueueSize|    |1000|


### PR DESCRIPTION
### Motivation

When the bug that has been fixed in https://github.com/apache/pulsar/pull/12993 occurred, the topic was unavailable for 5 minutes until the namespace bundle unloading timed out.
```
2021-11-26T21:45:07,455+0900 [BookKeeperClientWorker-OrderedExecutor-4-0] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.OpAddEntry.addComplete(OpAddEntry.java:148) ~[managed-ledger.jar:2.10.0-SNAPSHOT]
        at org.apache.bookkeeper.client.AsyncCallback$AddCallback.addCompleteWithLatency(AsyncCallback.java:92) ~[bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.client.PendingAddOp.submitCallback(PendingAddOp.java:431) ~[bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.client.LedgerHandle.errorOutPendingAdds(LedgerHandle.java:1799) ~[bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.client.LedgerHandle$5.safeRun(LedgerHandle.java:574) ~[bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.14.3.jar:4.14.3]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_312]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_312]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.68.Final.jar:4.1.68.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_312]

...

2021-11-26T21:50:07,454+0900 [pulsar-io-18-9] WARN  org.apache.pulsar.broker.service.BrokerService - Unloading of public/default/0x00000000_0x40000000 has timed out
```

I think 5 minutes is too long, but this value is hard-coded and we can't change it.
https://github.com/apache/pulsar/blob/6afbee6d0e7a6d21eb0fca400a19e38cbbad102e/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L667

### Modifications

Make it possible to change the time to wait for unloading of a namespace bundle. The default value is 1 minute.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `doc`

