### PR TITLE
[website] Modify admin-api-topic.md document

### DIFF
--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -945,7 +945,7 @@ admin.topics().getLastMessage(topic);
 
 ### Get backlog size
 
-You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
+You can get the backlog size of a single partition topic or a non-partitioned topic with a given message ID (in bytes).
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -943,6 +943,30 @@ admin.topics().getLastMessage(topic);
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
+### Get backlog size
+
+You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--pulsar-admin-->
+```shell
+$ pulsar-admin topics get-backlog-size \
+  -m 1:1 \
+  persistent://test-tenant/ns1/tp1-partition-0 \
+```
+
+<!--REST API-->
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=[[pulsar:version_number]]}
+
+<!--Java-->
+```java
+String topic = "persistent://my-tenant/my-namespace/my-topic";
+MessageId messageId = MessageId.earliest;
+admin.topics().getBacklogSizeByMessageId(topic, messageId);
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ## Manage non-partitioned topics
 You can use Pulsar [admin API](admin-api-overview.md) to create, delete and check status of non-partitioned topics.
 
@@ -1210,11 +1234,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -1224,7 +1248,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -1368,29 +1392,6 @@ admin.topics().getInternalStats(topic);
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-### Get backlog size
-
-You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--pulsar-admin-->
-```shell
-$ pulsar-admin topics get-backlog-size \
-  -m 1:1 \
-  persistent://test-tenant/ns1/tp1-partition-0 \
-```
-
-<!--REST API-->
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=[[pulsar:version_number]]}
-
-<!--Java-->
-```java
-String topic = "persistent://my-tenant/my-namespace/my-topic";
-MessageId messageId = MessageId.earliest;
-admin.topics().getBacklogSizeByMessageId(topic, messageId);
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Publish to partitioned topics
 

--- a/site2/website-next/docs/admin-api-topics.md
+++ b/site2/website-next/docs/admin-api-topics.md
@@ -1175,7 +1175,7 @@ admin.topics().getLastMessage(topic);
 
 ### Get backlog size
 
-You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
+You can get the backlog size of a single partition topic or a non-partitioned topic with a given message ID (in bytes).
 
 <Tabs
 defaultValue="pulsar-admin"

--- a/site2/website-next/docs/admin-api-topics.md
+++ b/site2/website-next/docs/admin-api-topics.md
@@ -1173,6 +1173,43 @@ admin.topics().getLastMessage(topic);
 
 </Tabs>
 
+### Get backlog size
+
+You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
+
+<Tabs
+defaultValue="pulsar-admin"
+values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
+<TabItem value="pulsar-admin">
+
+```shell
+
+$ pulsar-admin topics get-backlog-size \
+  -m 1:1 \
+  persistent://test-tenant/ns1/tp1-partition-0 \
+
+```
+
+</TabItem>
+<TabItem value="REST API">
+
+{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=@pulsar:version_number@}
+
+</TabItem>
+<TabItem value="Java">
+
+```java
+
+String topic = "persistent://my-tenant/my-namespace/my-topic";
+MessageId messageId = MessageId.earliest;
+admin.topics().getBacklogSizeByMessageId(topic, messageId);
+
+```
+
+</TabItem>
+
+</Tabs>
+
 ## Manage non-partitioned topics
 You can use Pulsar [admin API](admin-api-overview) to create, delete and check status of non-partitioned topics.
 
@@ -1568,7 +1605,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
@@ -1576,7 +1613,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin list-partitioned-topics list tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1592,7 +1629,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 
@@ -1769,42 +1806,6 @@ admin.topics().getInternalStats(topic);
 
 </Tabs>
 
-### Get backlog size
-
-You can get backlog size of a single topic partition or a nonpartitioned topic given a message ID (in bytes).
-
-<Tabs 
-  defaultValue="pulsar-admin"
-  values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
-<TabItem value="pulsar-admin">
-
-```shell
-
-$ pulsar-admin topics get-backlog-size \
-  -m 1:1 \
-  persistent://test-tenant/ns1/tp1-partition-0 \
-
-```
-
-</TabItem>
-<TabItem value="REST API">
-
-{@inject: endpoint|PUT|/admin/v2/:schema/:tenant/:namespace/:topic/backlogSize|operation/getBacklogSizeByMessageId?version=@pulsar:version_number@}
-
-</TabItem>
-<TabItem value="Java">
-
-```java
-
-String topic = "persistent://my-tenant/my-namespace/my-topic";
-MessageId messageId = MessageId.earliest;
-admin.topics().getBacklogSizeByMessageId(topic, messageId);
-
-```
-
-</TabItem>
-
-</Tabs>
 
 ## Publish to partitioned topics
 

--- a/site2/website-next/versioned_docs/version-2.7.0/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.7.0/admin-api-topics.md
@@ -1698,7 +1698,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[
@@ -1719,7 +1719,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1735,7 +1735,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.7.1/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.7.1/admin-api-topics.md
@@ -1310,7 +1310,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
@@ -1318,7 +1318,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1334,7 +1334,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.7.2/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.7.2/admin-api-topics.md
@@ -1310,7 +1310,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
@@ -1318,7 +1318,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1334,7 +1334,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.7.3/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.7.3/admin-api-topics.md
@@ -1310,7 +1310,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
@@ -1318,7 +1318,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1334,7 +1334,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.8.0/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/admin-api-topics.md
@@ -1340,7 +1340,7 @@ admin.topics().delete(topic);
 </Tabs>
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <Tabs 
   defaultValue="pulsar-admin"
   values={[{"label":"pulsar-admin","value":"pulsar-admin"},{"label":"REST API","value":"REST API"},{"label":"Java","value":"Java"}]}>
@@ -1348,7 +1348,7 @@ You can get the list of topics under a given namespace in the following ways.
 
 ```shell
 
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 
@@ -1364,7 +1364,7 @@ persistent://tenant/namespace/topic2
 
 ```java
 
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 
 ```
 

--- a/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.0/admin-api-topics.md
@@ -943,11 +943,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -957,7 +957,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.7.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.1/admin-api-topics.md
@@ -943,11 +943,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -957,7 +957,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.7.2/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.2/admin-api-topics.md
@@ -943,11 +943,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -957,7 +957,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.7.3/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.7.3/admin-api-topics.md
@@ -943,11 +943,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -957,7 +957,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.8.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.0/admin-api-topics.md
@@ -973,11 +973,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -987,7 +987,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.8.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.1/admin-api-topics.md
@@ -973,11 +973,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -987,7 +987,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/site2/website/versioned_docs/version-2.8.2/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.8.2/admin-api-topics.md
@@ -983,11 +983,11 @@ admin.topics().delete(topic);
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### List
-You can get the list of topics under a given namespace in the following ways.  
+You can get the list of partitioned topics under a given namespace in the following ways.  
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-$ pulsar-admin topics list tenant/namespace
+$ pulsar-admin topics list-partitioned-topics tenant/namespace
 persistent://tenant/namespace/topic1
 persistent://tenant/namespace/topic2
 ```
@@ -997,7 +997,7 @@ persistent://tenant/namespace/topic2
 
 <!--Java-->
 ```java
-admin.topics().getList(namespace);
+admin.topics().getPartitionedTopicList(namespace);
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
### Motivation
There are two parts need to adjust in [admin-api-topic.md](https://pulsar.apache.org/docs/en/next/admin-api-topics/)
1. List partitioned topics should use `list-partitioned-topics` rather than `list` in [manage-partitioned-topics/List](https://pulsar.apache.org/docs/en/next/admin-api-topics/#list-1). It involves `all versions` that support the command.
2. [Get backlog size](https://pulsar.apache.org/docs/en/next/admin-api-topics/#get-backlog-size) should not be placed in part [Manage partitioned topics](https://pulsar.apache.org/docs/en/next/admin-api-topics/#manage-partitioned-topics), because this command applies to  all topics included `no-partitioned-topics` and `partitioned-topics`, so it should be placed in [Manage topic resources](https://pulsar.apache.org/docs/en/next/admin-api-topics/#manage-topic-resources). It only involves `master` branch.

### Documentation
- [x] `doc` 



