### PR TITLE
[broker] Optimize TopicPolicy#deduplicationEnabled with HierarchyTopicPolicies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import java.util.Arrays;
 import java.util.List;
@@ -150,6 +149,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected void updateTopicPolicy(TopicPolicies data) {
         topicPolicies.getMaxSubscriptionsPerTopic().updateTopicValue(data.getMaxSubscriptionsPerTopic());
         topicPolicies.getInactiveTopicPolicies().updateTopicValue(data.getInactiveTopicPolicies());
+        topicPolicies.getDeduplicationEnabled().updateTopicValue(data.getDeduplicationEnabled());
         Arrays.stream(BacklogQuota.BacklogQuotaType.values()).forEach(type ->
                 this.topicPolicies.getBackLogQuotaMap().get(type).updateTopicValue(
                         data.getBackLogQuotaMap() == null ? null : data.getBackLogQuotaMap().get(type.toString())));
@@ -165,6 +165,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
         topicPolicies.getMaxSubscriptionsPerTopic().updateNamespaceValue(namespacePolicies.max_subscriptions_per_topic);
         topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(namespacePolicies.inactive_topic_policies);
+        topicPolicies.getDeduplicationEnabled().updateNamespaceValue(namespacePolicies.deduplicationEnabled);
         Arrays.stream(BacklogQuota.BacklogQuotaType.values()).forEach(
                 type -> this.topicPolicies.getBackLogQuotaMap().get(type)
                         .updateNamespaceValue(MapUtils.getObject(namespacePolicies.backlog_quota_map, type)));
@@ -178,7 +179,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                 config.isBrokerDeleteInactiveTopicsEnabled()));
 
         topicPolicies.getMaxSubscriptionsPerTopic().updateBrokerValue(config.getMaxSubscriptionsPerTopic());
-
+        topicPolicies.getDeduplicationEnabled().updateBrokerValue(config.isBrokerDeduplicationEnabled());
         //init backlogQuota
         topicPolicies.getBackLogQuotaMap()
                 .get(BacklogQuota.BacklogQuotaType.destination_storage)
@@ -991,7 +992,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
     }
 
-    @VisibleForTesting
     public HierarchyTopicPolicies getHierarchyTopicPolicies() {
         return topicPolicies;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -29,12 +29,14 @@ import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
  */
 @Getter
 public class HierarchyTopicPolicies {
+    final PolicyHierarchyValue<Boolean> deduplicationEnabled;
     final PolicyHierarchyValue<InactiveTopicPolicies> inactiveTopicPolicies;
     final PolicyHierarchyValue<Integer> maxSubscriptionsPerTopic;
     final Map<BacklogQuotaType, PolicyHierarchyValue<BacklogQuota>> backLogQuotaMap;
     final PolicyHierarchyValue<Integer> topicMaxMessageSize;
 
     public HierarchyTopicPolicies() {
+        deduplicationEnabled = new PolicyHierarchyValue<>();
         inactiveTopicPolicies = new PolicyHierarchyValue<>();
         maxSubscriptionsPerTopic = new PolicyHierarchyValue<>();
         backLogQuotaMap = new ImmutableMap.Builder<BacklogQuotaType, PolicyHierarchyValue<BacklogQuota>>()


### PR DESCRIPTION
### Motivation

This is one of the serial topic policy optimization with `HierarchyTopicPolicies`. 

Update topic policy with HierarchyTopicPolicies comes with these benefits:
- All topic policy related settings will goes into AbstractTopic#topicPolicies, easier to understand, check, review, and modify.
- Unify policy update to AbstractTopic. And easier to find which policy is not applied to non-persistent topic yet. And we can easily add support for it.
- Unify policy value with 3 level settings (topic/namespace/broker), and priority with topic > namespace > broker.  And it's easier to find which level settings is missing.
- All values are updated at creation or by trigger. We can save some resource to update it or recalculate each time we use it. 
- etc.

### Modifications

Add new field deduplicationEnabled in org.apache.pulsar.broker.service.AbstractTopic#topicPolicies.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as org.apache.pulsar.broker.service.persistent.TopicDuplicationTest

Some checklist for updating topic policy with `HierarchyTopicPolicies`.

- [x] Broker level value set. And this configuration is not dynamic. (Not supported yet)
- [x] Namespace level value updated.
- [x] Topic level value updated. And it's only for persistent topic (Non-persistent topic support in #12830)
- [x] Pre-existing unit test covers this change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Code optimization.