### PR TITLE
[pulsar-admin] Check the size options in cmd for topic and namespace

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -82,25 +82,34 @@ abstract class CliCommand {
     static long validateSizeString(String s) {
         char last = s.charAt(s.length() - 1);
         String subStr = s.substring(0, s.length() - 1);
+        long size;
+        try {
+            size = sizeUint.contains(last)
+                    ? Long.parseLong(subStr)
+                    : Long.parseLong(s);
+        } catch (IllegalArgumentException e) {
+            throw new ParameterException(String.format("Invalid size '%s'. Valid formats are: %s",
+                    s, "(4096, 100K, 10M, 16G, 2T)"));
+        }
         switch (last) {
         case 'k':
         case 'K':
-            return Long.parseLong(subStr) * 1024;
+            return size * 1024;
 
         case 'm':
         case 'M':
-            return Long.parseLong(subStr) * 1024 * 1024;
+            return size * 1024 * 1024;
 
         case 'g':
         case 'G':
-            return Long.parseLong(subStr) * 1024 * 1024 * 1024;
+            return size * 1024 * 1024 * 1024;
 
         case 't':
         case 'T':
-            return Long.parseLong(subStr) * 1024 * 1024 * 1024 * 1024;
+            return size * 1024 * 1024 * 1024 * 1024;
 
         default:
-            return Long.parseLong(s);
+            return size;
         }
     }
 
@@ -208,6 +217,7 @@ abstract class CliCommand {
 
     private static ObjectMapper mapper = ObjectMapperFactory.create();
     private static ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+    private static Set<Character> sizeUint = Sets.newHashSet('k', 'K', 'm', 'M', 'g', 'G', 't', 'T');
 
     abstract void run() throws Exception;
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -719,8 +719,14 @@ public class CmdNamespaces extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            long sizeLimit = validateSizeString(limitStr);
+            long sizeLimit;
             long retentionTimeInSec;
+            try {
+                sizeLimit = validateSizeString(limitStr);
+            } catch (IllegalArgumentException e) {
+                throw new ParameterException(String.format("Invalid retention size limit '%s'. Valid formats are: %s",
+                        limitStr, "(4096, 100K, 10M, 16G, 2T)"));
+            }
             try {
                 retentionTimeInSec = RelativeTimeUtil.parseRelativeTimeInSeconds(retentionTimeStr);
             } catch (IllegalArgumentException exception) {
@@ -1194,7 +1200,7 @@ public class CmdNamespaces extends CmdBase {
             try {
                 limit = validateSizeString(limitStr);
             } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid retention policy type '%s'. Valid formats are: %s",
+                throw new ParameterException(String.format("Invalid size limit '%s'. Valid formats are: %s",
                         limitStr, "(4096, 100K, 10M, 16G, 2T)"));
             }
 
@@ -1808,12 +1814,19 @@ public class CmdNamespaces extends CmdBase {
                    description = "Maximum number of bytes in a topic backlog before compaction is triggered "
                                  + "(eg: 10M, 16G, 3T). 0 disables automatic compaction",
                    required = true)
-        private String threshold = "0";
+        private String thresholdStr = "0";
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setCompactionThreshold(namespace, validateSizeString(threshold));
+            long threshold;
+            try {
+                threshold = validateSizeString(thresholdStr);
+            } catch (IllegalArgumentException e) {
+                throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
+                        thresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
+            }
+            getAdmin().namespaces().setCompactionThreshold(namespace, threshold);
         }
     }
 
@@ -1841,12 +1854,19 @@ public class CmdNamespaces extends CmdBase {
                                  + " Negative values disable automatic offload."
                                  + " 0 triggers offloading as soon as possible.",
                    required = true)
-        private String threshold = "-1";
+        private String thresholdStr = "-1";
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setOffloadThreshold(namespace, validateSizeString(threshold));
+            long threshold;
+            try {
+                threshold = validateSizeString(thresholdStr);
+            } catch (IllegalArgumentException e) {
+                throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
+                        thresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
+            }
+            getAdmin().namespaces().setOffloadThreshold(namespace, threshold);
         }
     }
 
@@ -2201,7 +2221,13 @@ public class CmdNamespaces extends CmdBase {
 
             int maxBlockSizeInBytes = OffloadPoliciesImpl.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
             if (StringUtils.isNotEmpty(maxBlockSizeStr)) {
-                long maxBlockSize = validateSizeString(maxBlockSizeStr);
+                long maxBlockSize;
+                try {
+                    maxBlockSize = validateSizeString(maxBlockSizeStr);
+                } catch (IllegalArgumentException e) {
+                    throw new ParameterException(String.format("Invalid max block size '%s'. Valid formats are: %s",
+                            maxBlockSizeStr, "(4096, 100K, 10M, 16G, 2T)"));
+                }
                 if (positiveCheck("MaxBlockSize", maxBlockSize)
                         && maxValueCheck("MaxBlockSize", maxBlockSize, Integer.MAX_VALUE)) {
                     maxBlockSizeInBytes = new Long(maxBlockSize).intValue();
@@ -2210,7 +2236,13 @@ public class CmdNamespaces extends CmdBase {
 
             int readBufferSizeInBytes = OffloadPoliciesImpl.DEFAULT_READ_BUFFER_SIZE_IN_BYTES;
             if (StringUtils.isNotEmpty(readBufferSizeStr) ) {
-                long readBufferSize = validateSizeString(readBufferSizeStr);
+                long readBufferSize;
+                try {
+                    readBufferSize = validateSizeString(readBufferSizeStr);
+                } catch (IllegalArgumentException e) {
+                    throw new ParameterException(String.format("Invalid read buffer size '%s'. Valid formats are: %s",
+                            readBufferSizeStr, "(4096, 100K, 10M, 16G, 2T)"));
+                }
                 if (positiveCheck("ReadBufferSize", readBufferSize)
                         && maxValueCheck("ReadBufferSize", readBufferSize, Integer.MAX_VALUE)) {
                     readBufferSizeInBytes = new Long(readBufferSize).intValue();
@@ -2234,7 +2266,13 @@ public class CmdNamespaces extends CmdBase {
 
             Long offloadAfterThresholdInBytes = OffloadPoliciesImpl.DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES;
             if (StringUtils.isNotEmpty(offloadAfterThresholdStr)) {
-                long offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
+                long offloadAfterThreshold ;
+                try {
+                    offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
+                } catch (IllegalArgumentException e) {
+                    throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
+                            offloadAfterThresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
+                }
                 if (positiveCheck("OffloadAfterThreshold", offloadAfterThreshold)
                         && maxValueCheck("OffloadAfterThreshold", offloadAfterThreshold, Long.MAX_VALUE)) {
                     offloadAfterThresholdInBytes = offloadAfterThreshold;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -719,14 +719,8 @@ public class CmdNamespaces extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            long sizeLimit;
+            long sizeLimit = validateSizeString(limitStr);
             long retentionTimeInSec;
-            try {
-                sizeLimit = validateSizeString(limitStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid retention size limit '%s'. Valid formats are: %s",
-                        limitStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
             try {
                 retentionTimeInSec = RelativeTimeUtil.parseRelativeTimeInSeconds(retentionTimeStr);
             } catch (IllegalArgumentException exception) {
@@ -1187,7 +1181,7 @@ public class CmdNamespaces extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             BacklogQuota.RetentionPolicy policy;
-            long limit;
+            long limit = validateSizeString(limitStr);
             BacklogQuota.BacklogQuotaType backlogQuotaType;
 
             try {
@@ -1195,13 +1189,6 @@ public class CmdNamespaces extends CmdBase {
             } catch (IllegalArgumentException e) {
                 throw new ParameterException(String.format("Invalid retention policy type '%s'. Valid options are: %s",
                         policyStr, Arrays.toString(BacklogQuota.RetentionPolicy.values())));
-            }
-
-            try {
-                limit = validateSizeString(limitStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid size limit '%s'. Valid formats are: %s",
-                        limitStr, "(4096, 100K, 10M, 16G, 2T)"));
             }
 
             try {
@@ -1819,13 +1806,7 @@ public class CmdNamespaces extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            long threshold;
-            try {
-                threshold = validateSizeString(thresholdStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
-                        thresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
+            long threshold = validateSizeString(thresholdStr);
             getAdmin().namespaces().setCompactionThreshold(namespace, threshold);
         }
     }
@@ -1859,13 +1840,7 @@ public class CmdNamespaces extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            long threshold;
-            try {
-                threshold = validateSizeString(thresholdStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
-                        thresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
+            long threshold = validateSizeString(thresholdStr);
             getAdmin().namespaces().setOffloadThreshold(namespace, threshold);
         }
     }
@@ -2221,13 +2196,7 @@ public class CmdNamespaces extends CmdBase {
 
             int maxBlockSizeInBytes = OffloadPoliciesImpl.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
             if (StringUtils.isNotEmpty(maxBlockSizeStr)) {
-                long maxBlockSize;
-                try {
-                    maxBlockSize = validateSizeString(maxBlockSizeStr);
-                } catch (IllegalArgumentException e) {
-                    throw new ParameterException(String.format("Invalid max block size '%s'. Valid formats are: %s",
-                            maxBlockSizeStr, "(4096, 100K, 10M, 16G, 2T)"));
-                }
+                long maxBlockSize = validateSizeString(maxBlockSizeStr);
                 if (positiveCheck("MaxBlockSize", maxBlockSize)
                         && maxValueCheck("MaxBlockSize", maxBlockSize, Integer.MAX_VALUE)) {
                     maxBlockSizeInBytes = new Long(maxBlockSize).intValue();
@@ -2236,13 +2205,7 @@ public class CmdNamespaces extends CmdBase {
 
             int readBufferSizeInBytes = OffloadPoliciesImpl.DEFAULT_READ_BUFFER_SIZE_IN_BYTES;
             if (StringUtils.isNotEmpty(readBufferSizeStr) ) {
-                long readBufferSize;
-                try {
-                    readBufferSize = validateSizeString(readBufferSizeStr);
-                } catch (IllegalArgumentException e) {
-                    throw new ParameterException(String.format("Invalid read buffer size '%s'. Valid formats are: %s",
-                            readBufferSizeStr, "(4096, 100K, 10M, 16G, 2T)"));
-                }
+                long readBufferSize = validateSizeString(readBufferSizeStr);
                 if (positiveCheck("ReadBufferSize", readBufferSize)
                         && maxValueCheck("ReadBufferSize", readBufferSize, Integer.MAX_VALUE)) {
                     readBufferSizeInBytes = new Long(readBufferSize).intValue();
@@ -2266,13 +2229,7 @@ public class CmdNamespaces extends CmdBase {
 
             Long offloadAfterThresholdInBytes = OffloadPoliciesImpl.DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES;
             if (StringUtils.isNotEmpty(offloadAfterThresholdStr)) {
-                long offloadAfterThreshold ;
-                try {
-                    offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
-                } catch (IllegalArgumentException e) {
-                    throw new ParameterException(String.format("Invalid threshold size '%s'. Valid formats are: %s",
-                            offloadAfterThresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
-                }
+                long offloadAfterThreshold = validateSizeString(offloadAfterThresholdStr);
                 if (positiveCheck("OffloadAfterThreshold", offloadAfterThreshold)
                         && maxValueCheck("OffloadAfterThreshold", offloadAfterThreshold, Long.MAX_VALUE)) {
                     offloadAfterThresholdInBytes = offloadAfterThreshold;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1142,14 +1142,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-
-            long sizeThreshold;
-            try {
-                sizeThreshold = validateSizeString(sizeThresholdStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid size threshold '%s'. Valid formats are: %s",
-                        sizeThresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
+            long sizeThreshold = validateSizeString(sizeThresholdStr);
 
             PersistentTopicInternalStats stats = getTopics().getInternalStats(persistentTopic, false);
             if (stats.ledgers.size() < 1) {
@@ -1270,12 +1263,7 @@ public class CmdTopics extends CmdBase {
                         policyStr, Arrays.toString(BacklogQuota.RetentionPolicy.values())));
             }
 
-            try {
-                limit = validateSizeString(limitStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid size limit '%s'. Valid formats are: %s",
-                        limitStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
+            limit = validateSizeString(limitStr);
 
             try {
                 backlogQuotaType = BacklogQuota.BacklogQuotaType.valueOf(backlogQuotaTypeStr);
@@ -1542,14 +1530,8 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            long sizeLimit;
+            long sizeLimit = validateSizeString(limitStr);
             long retentionTimeInSec;
-            try {
-                sizeLimit = validateSizeString(limitStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid retention size limit '%s'. Valid formats are: %s",
-                        limitStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
             try {
                 retentionTimeInSec = RelativeTimeUtil.parseRelativeTimeInSeconds(retentionTimeStr);
             } catch (IllegalArgumentException exception) {
@@ -2040,13 +2022,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            long threshold;
-            try {
-                threshold = validateSizeString(thresholdStr);
-            } catch (IllegalArgumentException e) {
-                throw new ParameterException(String.format("Invalid threshold '%s'. Valid formats are: %s",
-                        thresholdStr, "(4096, 100K, 10M, 16G, 2T)"));
-            }
+            long threshold = validateSizeString(thresholdStr);
             getTopics().setCompactionThreshold(persistentTopic, threshold);
         }
     }


### PR DESCRIPTION
### Motivation
We should check the parameters releted to `size` and throw `ParameterException` when there is an exception, which can avoid displaying stack information on the client.
Currently, the lack of verification about `size` will directly display the exception, as below:
```
bin/pulsar-admin topics set-backlog-quota --limit 70z --policy producer_exception public/default/test
java.lang.NumberFormatException: For input string: "70z"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.parseLong(Long.java:631)
	at org.apache.pulsar.admin.cli.CliCommand.validateSizeString(CliCommand.java:102)
	at org.apache.pulsar.admin.cli.CmdTopics$SetBacklogQuota.run(CmdTopics.java:1148)
	at org.apache.pulsar.admin.cli.CmdBase.run(CmdBase.java:86)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.run(PulsarAdminTool.java:282)
	at org.apache.pulsar.admin.cli.PulsarAdminTool.main(PulsarAdminTool.java:330)
```

### Documentation
- [x] `no-need-doc`
