### PR TITLE
[Issue 13004] Fix race condition in ResourceLockImpl#revalidate

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -44,6 +44,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     private long version;
     private final CompletableFuture<Void> expiredFuture;
     private boolean revalidateAfterReconnection = false;
+    private CompletableFuture<Void> revalidateFuture;
 
     private enum State {
         Init,
@@ -144,6 +145,9 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
 
     // Simple operation of acquiring the lock with no retries, or checking for the lock content
     private CompletableFuture<Void> acquireWithNoRevalidation(T newValue) {
+        if (log.isDebugEnabled()) {
+            log.debug("acquireWithNoRevalidation,newValue={},version={}", newValue, version);
+        }
         byte[] payload;
         try {
             payload = serde.serialize(path, newValue);
@@ -212,6 +216,30 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     }
 
     synchronized CompletableFuture<Void> revalidate(T newValue) {
+        if (revalidateFuture == null || revalidateFuture.isDone()) {
+            revalidateFuture = doRevalidate(newValue);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Previous revalidating is not finished while revalidate newValue={}, value={}, version={}",
+                        newValue, value, version);
+            }
+            CompletableFuture<Void> newFuture = new CompletableFuture<>();
+            revalidateFuture.whenComplete((unused, throwable) -> {
+                doRevalidate(newValue).thenRun(() -> newFuture.complete(null))
+                        .exceptionally(throwable1 -> {
+                            newFuture.completeExceptionally(throwable1);
+                            return null;
+                        });
+            });
+            revalidateFuture = newFuture;
+        }
+        return revalidateFuture;
+    }
+
+    private synchronized CompletableFuture<Void> doRevalidate(T newValue) {
+        if (log.isDebugEnabled()) {
+            log.debug("doRevalidate with newValue={}, version={}", newValue, version);
+        }
         return store.get(path)
                 .thenCompose(optGetResult -> {
                     if (!optGetResult.isPresent()) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes #13004


### Motivation

See #13004

### Modifications

Add a new field `revalidateFuture` to store the status of last revalidate. If it's not done, then current revalidate will be executed after last revalidateFuture is complete.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as LeaderElectionTest#leaderNodeIsDeletedExternally and other test cases in LockManagerTest and LeaderElectionTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
Bug fix.