### PR TITLE
Fix race condition in FaultInjectionMetadataStore#programmedFailure

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -192,13 +192,16 @@ public class FaultInjectionMetadataStore implements MetadataStoreExtended {
         if (ex != null) {
             return Optional.of(ex);
         }
-        Optional<Failure> failure = failures.stream()
-                .filter(f -> f.predicate.test(op, path))
-                .findFirst();
-        if (failure.isPresent()) {
-            failures.remove(failure.get());
+        while (true) {
+            Optional<Failure> failure = failures.stream().filter(f -> f.predicate.test(op, path)).findFirst();
+            if (failure.isPresent()) {
+                if (failures.remove(failure.get())) {
+                    return failure.map(Failure::getException);
+                }
+                // failure is taken by other threads. Retry.
+            } else {
+                return Optional.empty();
+            }
         }
-
-        return failure.map(Failure::getException);
     }
 }


### PR DESCRIPTION

### Motivation
`org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore#programmedFailure` is not thread safe. 
Multi threads can get the same failure at the same time (At Line 195), resulting one failure returned multiply times, which I believe is not the design purpose.

### Modifications

Only return failure when remove is success. (`failures` is a thread safe list.)

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as ManagedLedgerErrorsTest

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
Bug fix