### PR TITLE
Fix running pulsar-perf in docker image after #11285 changes

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -33,7 +33,7 @@ COPY scripts/pulsar-zookeeper-ruok.sh /pulsar/bin
 COPY scripts/watch-znode.py /pulsar/bin
 COPY scripts/install-pulsar-client.sh /pulsar/bin
 
-RUN mkdir /pulsar/data
+RUN mkdir /pulsar/data /pulsar/logs
 
 ### Create 2nd stage from Ubuntu image
 ### and add OpenJDK and Python dependencies (for Pulsar functions)


### PR DESCRIPTION
### Motivation

Running `pulsar-perf` in docker fails with this error:
```
root@3b36a0ea475b:/pulsar# ./bin/pulsar-perf produce 
[0.000s][error][logging] Error opening log file 'logs/pulsar_gc_14.log': No such file or directory
[0.000s][error][logging] Initialization of output 'file=logs/pulsar_gc_%p.log' using options 'filecount=10,filesize=20M' failed.
Invalid -Xlog option '-Xlog:gc*:logs/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

### Modifications

- create /pulsar/logs directory since it's now required for running `pulsar-perf` after #11285 changes