### PR TITLE
[ Client ] Support string topic names.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Utils for loading configuration data.
@@ -58,6 +60,12 @@ public final class ConfigurationDataUtils {
                                  Class<T> dataCls) {
         ObjectMapper mapper = getThreadLocal();
         try {
+            Object topicNames = config.get("topicNames");
+            if (topicNames instanceof String) {
+                String[] split = ((String) topicNames).split(",");
+                Set<String> topicNamesSet = Sets.newHashSet(split);
+                config.put("topicNames", topicNamesSet);
+            }
             String existingConfigJson = mapper.writeValueAsString(existingData);
             Map<String, Object> existingConfig = mapper.readValue(existingConfigJson, Map.class);
             Map<String, Object> newConfig = Maps.newHashMap();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.collections4.CollectionUtils;
 import org.testng.Assert;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -228,5 +229,25 @@ public class ConfigurationDataUtilsTest {
             assertTrue(ex.getMessage().contains("Invalid config [socks5Proxy.address]"));
         }
         System.clearProperty("socks5Proxy.address");
+    }
+
+    @Test
+    public void testLoadStringTopicNames() {
+        String topic1 = "persistent://public/default/test-string1";
+        String topic2 = "persistent://public/default/test-string2";
+        ConsumerConfigurationData confData = new ConsumerConfigurationData();
+        Map<String, Object> config = new HashMap<>();
+        config.put("topicNames", String.format("%s,%s", topic1, topic2));
+
+        confData = ConfigurationDataUtils.loadData(config, confData, ConsumerConfigurationData.class);
+        assertTrue(confData.getTopicNames().contains(topic1));
+        assertTrue(confData.getTopicNames().contains(topic2));
+    }
+    @Test
+    public void testLoadEmptyTopicNames() {
+        ConsumerConfigurationData confData = new ConsumerConfigurationData();
+        Map<String, Object> config = new HashMap<>();
+        confData = ConfigurationDataUtils.loadData(config, confData, ConsumerConfigurationData.class);
+        assertTrue(CollectionUtils.isEmpty(confData.getTopicNames()));
     }
 }


### PR DESCRIPTION
Fixes #13016

Master Issue: #13016

### Motivation

 see #13016

### Modifications

- support string topic names in ConfigurationDataUtils;

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: (yes)

### Documentation

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  


