### PR TITLE
Suggest to use tlsPort instead of deprecated TlsEnable

### DIFF
--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -120,7 +120,8 @@ To configure a Pulsar [broker](reference-terminology.md#broker) to use TLS trans
 Add these values to the configuration file (substituting the appropriate certificate paths where necessary):
 
 ```properties
-tlsEnabled=true
+brokerServicePortTls=6651
+webServicePortTls=8081
 tlsRequireTrustedClientCertOnConnect=true
 tlsCertificateFilePath=/path/to/broker.cert.pem
 tlsKeyFilePath=/path/to/broker.key-pk8.pem

--- a/site2/website-next/docs/security-tls-transport.md
+++ b/site2/website-next/docs/security-tls-transport.md
@@ -134,8 +134,8 @@ To configure a Pulsar [broker](reference-terminology.md#broker) to use TLS trans
 Add these values to the configuration file (substituting the appropriate certificate paths where necessary):
 
 ```properties
-
-tlsEnabled=true
+brokerServicePortTls=6651
+webServicePortTls=8081
 tlsRequireTrustedClientCertOnConnect=true
 tlsCertificateFilePath=/path/to/broker.cert.pem
 tlsKeyFilePath=/path/to/broker.key-pk8.pem


### PR DESCRIPTION
### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `doc` 
  
Suggest to use tlsPort instead of deprecated TlsEnable


