### PR TITLE
fixtypo: Correct sizeUint to sizeUnit

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -85,7 +85,7 @@ abstract class CliCommand {
         String subStr = s.substring(0, s.length() - 1);
         long size;
         try {
-            size = sizeUint.contains(last)
+            size = sizeUnit.contains(last)
                     ? Long.parseLong(subStr)
                     : Long.parseLong(s);
         } catch (IllegalArgumentException e) {
@@ -218,7 +218,7 @@ abstract class CliCommand {
 
     private static ObjectMapper mapper = ObjectMapperFactory.create();
     private static ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
-    private static Set<Character> sizeUint = Sets.newHashSet('k', 'K', 'm', 'M', 'g', 'G', 't', 'T');
+    private static Set<Character> sizeUnit = Sets.newHashSet('k', 'K', 'm', 'M', 'g', 'G', 't', 'T');
 
     abstract void run() throws Exception;
 }


### PR DESCRIPTION
### Motivation
Correct `sizeUint` to `sizeUnit`
https://github.com/apache/pulsar/blob/bebfc772456e689b14f6d10a6231165993e8ab14/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java#L221

### Documentation  
- [x] `no-need-doc` 


