### PR TITLE
[Cleanup] Evaluate the current protocol version once

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -129,6 +129,10 @@ public class Commands {
         }
     };
 
+    // Return the last ProtocolVersion enum value
+    private static final int CURRENT_PROTOCOL_VERSION =
+            ProtocolVersion.values()[ProtocolVersion.values().length - 1].getValue();
+
     private static BaseCommand localCmd(BaseCommand.Type type) {
         return LOCAL_BASE_COMMAND.get()
                 .clear()
@@ -1752,8 +1756,7 @@ public class Commands {
     }
 
     public static int getCurrentProtocolVersion() {
-        // Return the last ProtocolVersion enum value
-        return ProtocolVersion.values()[ProtocolVersion.values().length - 1].getValue();
+        return CURRENT_PROTOCOL_VERSION;
     }
 
     /**


### PR DESCRIPTION
### Motivation

- there's no need to dynamically evaluate it on every call
  - performance impact is minor
  - more about cleaning up the code and following a "no garbage" code style when it makes sense.

### Modifications

Make CURRENT_PROTOCOL_VERSION a constant instead of evaluating it on every call.