### PR TITLE
[Broker] Never delete system topic because of inactivity

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -41,6 +41,11 @@ public class SystemTopic extends PersistentTopic {
     }
 
     @Override
+    public boolean isDeleteWhileInactive() {
+        return false;
+    }
+
+    @Override
     public boolean isSystemTopic() {
         return true;
     }


### PR DESCRIPTION
### Motivation

System topics shouldn't be deleted because of inactivity.

### Modifications

Override `isDeleteWhileInactive` method in `SystemTopic` class and return `false`.