### PR TITLE
[Broker] Consider topics in pulsar/system namespace as system topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.events.EventsTopicNames;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 
 /**
@@ -189,6 +190,10 @@ public interface SystemTopicClient<T> {
     }
 
     static boolean isSystemTopic(TopicName topicName) {
+        if (topicName.getNamespaceObject().equals(NamespaceName.SYSTEM_NAMESPACE)) {
+            return true;
+        }
+
         TopicName nonePartitionedTopicName = TopicName.get(topicName.getPartitionedTopicName());
 
         // event topic

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/SystemTopicClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/SystemTopicClientTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.systopic;
 
+import static org.apache.pulsar.common.naming.TopicName.TRANSACTION_COORDINATOR_ASSIGN;
+import static org.apache.pulsar.common.naming.TopicName.TRANSACTION_COORDINATOR_LOG;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.apache.pulsar.common.naming.TopicName;
@@ -43,5 +45,7 @@ public class SystemTopicClientTest {
         assertTrue(SystemTopicClient.isSystemTopic(
                 TopicName.get("topicxxx-multiTopicsReader-f433329d68__transaction_pending_ack")));
 
+        assertTrue(SystemTopicClient.isSystemTopic(TRANSACTION_COORDINATOR_ASSIGN));
+        assertTrue(SystemTopicClient.isSystemTopic(TRANSACTION_COORDINATOR_LOG));
     }
 }


### PR DESCRIPTION
### Motivation

The current system topic concept doesn't seem to be consistent. It would be expected that topics in the "pulsar/system" namespace are considered as system topics.

### Modifications

Change SystemTopicClient.isSystemTopic to consider all topics in pulsar/system namespace to be system topics.