### PR TITLE
fix wrong result for looking up a non-exist topic by rest api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -137,6 +137,10 @@ public class TopicLookupBase extends PulsarWebResource {
                 completeLookupResponseExceptionally(asyncResponse, exception);
                 return null;
             });
+        }).exceptionally(e -> {
+            log.warn("Failed to check exist for topic {}: {} when lookup", topicName, e.getMessage(), e);
+            completeLookupResponseExceptionally(asyncResponse, e);
+            return null;
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -80,55 +80,63 @@ public class TopicLookupBase extends PulsarWebResource {
             return;
         }
 
-        CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                .getBrokerServiceUrlAsync(topicName,
-                        LookupOptions.builder().advertisedListenerName(listenerName)
-                                .authoritative(authoritative).loadTopicsInBundle(false).build());
-
-        lookupFuture.thenAccept(optionalResult -> {
-            if (optionalResult == null || !optionalResult.isPresent()) {
-                log.warn("No broker was found available for topic {}", topicName);
-                completeLookupResponseExceptionally(asyncResponse,
-                        new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
+        pulsar().getNamespaceService().checkTopicExists(topicName).thenAccept(exist -> {
+            if (!exist) {
+                completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,
+                        "Topic not found."));
                 return;
             }
+            CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
+                    .getBrokerServiceUrlAsync(topicName,
+                            LookupOptions.builder().advertisedListenerName(listenerName)
+                                    .authoritative(authoritative).loadTopicsInBundle(false).build());
 
-            LookupResult result = optionalResult.get();
-            // We have found either a broker that owns the topic, or a broker to which we should redirect the client to
-            if (result.isRedirect()) {
-                boolean newAuthoritative = result.isAuthoritativeRedirect();
-                URI redirect;
-                try {
-                    String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
-                            : result.getLookupData().getHttpUrl();
-                    checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
-                    String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
-                    String path = String.format("%s%s%s?authoritative=%s",
-                            redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
-                    path = listenerName == null ? path : path + "&listenerName=" + listenerName;
-                    redirect = new URI(path);
-                } catch (URISyntaxException | NullPointerException e) {
-                    log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
-                    completeLookupResponseExceptionally(asyncResponse, e);
+            lookupFuture.thenAccept(optionalResult -> {
+                if (optionalResult == null || !optionalResult.isPresent()) {
+                    log.warn("No broker was found available for topic {}", topicName);
+                    completeLookupResponseExceptionally(asyncResponse,
+                            new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
                     return;
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
-                }
-                completeLookupResponseExceptionally(asyncResponse,
-                        new WebApplicationException(Response.temporaryRedirect(redirect).build()));
 
-            } else {
-                // Found broker owning the topic
-                if (log.isDebugEnabled()) {
-                    log.debug("Lookup succeeded for topic {} -- broker: {}", topicName, result.getLookupData());
+                LookupResult result = optionalResult.get();
+                // We have found either a broker that owns the topic, or a broker to
+                // which we should redirect the client to
+                if (result.isRedirect()) {
+                    boolean newAuthoritative = result.isAuthoritativeRedirect();
+                    URI redirect;
+                    try {
+                        String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
+                                : result.getLookupData().getHttpUrl();
+                        checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
+                        String lookupPath = topicName.isV2() ? LOOKUP_PATH_V2 : LOOKUP_PATH_V1;
+                        String path = String.format("%s%s%s?authoritative=%s",
+                                redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
+                        path = listenerName == null ? path : path + "&listenerName=" + listenerName;
+                        redirect = new URI(path);
+                    } catch (URISyntaxException | NullPointerException e) {
+                        log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
+                        completeLookupResponseExceptionally(asyncResponse, e);
+                        return;
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
+                    }
+                    completeLookupResponseExceptionally(asyncResponse,
+                            new WebApplicationException(Response.temporaryRedirect(redirect).build()));
+
+                } else {
+                    // Found broker owning the topic
+                    if (log.isDebugEnabled()) {
+                        log.debug("Lookup succeeded for topic {} -- broker: {}", topicName, result.getLookupData());
+                    }
+                    completeLookupResponseSuccessfully(asyncResponse, result.getLookupData());
                 }
-                completeLookupResponseSuccessfully(asyncResponse, result.getLookupData());
-            }
-        }).exceptionally(exception -> {
-            log.warn("Failed to lookup broker for topic {}: {}", topicName, exception.getMessage(), exception);
-            completeLookupResponseExceptionally(asyncResponse, exception);
-            return null;
+            }).exceptionally(exception -> {
+                log.warn("Failed to lookup broker for topic {}: {}", topicName, exception.getMessage(), exception);
+                completeLookupResponseExceptionally(asyncResponse, exception);
+                return null;
+            });
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -81,7 +81,7 @@ public class TopicLookupBase extends PulsarWebResource {
         }
 
         pulsar().getNamespaceService().checkTopicExists(topicName).thenAccept(exist -> {
-            if (!exist) {
+            if (!exist && !pulsar().getBrokerService().isAllowAutoTopicCreation(topicName)) {
                 completeLookupResponseExceptionally(asyncResponse, new RestException(Response.Status.NOT_FOUND,
                         "Topic not found."));
                 return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.lookup.http;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -49,6 +50,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.mockito.ArgumentCaptor;
@@ -124,7 +126,44 @@ public class HttpTopicLookupv2Test {
         WebApplicationException wae = (WebApplicationException) arg.getValue();
         assertEquals(wae.getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
     }
-    
+
+    @Test
+    public void testLookupTopicNotExist() throws Exception {
+
+        MockTopicLookup destLookup = spy(new MockTopicLookup());
+        doReturn(false).when(destLookup).isRequestHttps();
+        destLookup.setPulsar(pulsar);
+        doReturn("null").when(destLookup).clientAppId();
+        Field uriField = PulsarWebResource.class.getDeclaredField("uri");
+        uriField.setAccessible(true);
+        UriInfo uriInfo = mock(UriInfo.class);
+        uriField.set(destLookup, uriInfo);
+        URI uri = URI.create("http://localhost:8080/lookup/v2/destination/topic/myprop/usc/ns2/topic1");
+        doReturn(uri).when(uriInfo).getRequestUri();
+        doReturn(true).when(config).isAuthorizationEnabled();
+
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        future.complete(false);
+        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
+
+        AsyncResponse asyncResponse1 = mock(AsyncResponse.class);
+        destLookup.lookupTopicAsync(TopicDomain.persistent.value(), "myprop", "usc", "ns2", "topic_not_exist", false,
+                asyncResponse1, null, null);
+
+        ArgumentCaptor<Throwable> arg = ArgumentCaptor.forClass(Throwable.class);
+        verify(asyncResponse1).resume(arg.capture());
+        assertEquals(arg.getValue().getClass(), RestException.class);
+        RestException restException = (RestException) arg.getValue();
+        assertEquals(restException.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
+    }
+
+    static class MockTopicLookup extends TopicLookup {
+        @Override
+        protected void validateClusterOwnership(String s) {
+            // do nothing
+        }
+    }
     
     @Test
     public void testNotEnoughLookupPermits() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -113,12 +113,8 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             final String topicPartitionName = "non-persistent://public/default/issue-9173-partition-0";
 
             // Then error when subscribe to a partition of a non-persistent topic that does not exist
-            try {
-                pulsarClient.newConsumer().topic(topicPartitionName).subscriptionName("sub-issue-9173").subscribe();
-                Assert.fail("Should failed due to topic not exist");
-            } catch (Exception e) {
-                assertTrue(e instanceof PulsarClientException.NotFoundException);
-            }
+            assertThrows(PulsarClientException.NotFoundException.class,
+                    () -> pulsarClient.newConsumer().topic(topicPartitionName).subscriptionName("sub-issue-9173").subscribe());
 
             // Then error when produce to a partition of a non-persistent topic that does not exist
             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -66,6 +66,7 @@ import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -112,12 +113,20 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             final String topicPartitionName = "non-persistent://public/default/issue-9173-partition-0";
 
             // Then error when subscribe to a partition of a non-persistent topic that does not exist
-            assertThrows(PulsarClientException.TopicDoesNotExistException.class,
-                    () -> pulsarClient.newConsumer().topic(topicPartitionName).subscriptionName("sub-issue-9173").subscribe());
+            try {
+                pulsarClient.newConsumer().topic(topicPartitionName).subscriptionName("sub-issue-9173").subscribe();
+                Assert.fail("Should failed due to topic not exist");
+            } catch (Exception e) {
+                assertTrue(e instanceof PulsarClientException.NotFoundException);
+            }
 
             // Then error when produce to a partition of a non-persistent topic that does not exist
-            assertThrows(PulsarClientException.TopicDoesNotExistException.class,
-                    () -> pulsarClient.newProducer().topic(topicPartitionName).create());
+            try {
+                pulsarClient.newProducer().topic(topicPartitionName).create();
+                Assert.fail("Should failed due to topic not exist");
+            } catch (Exception e) {
+                assertTrue(e instanceof PulsarClientException.NotFoundException);
+            }
         } finally {
             conf.setAllowAutoTopicCreation(defaultAllowAutoTopicCreation);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4112,8 +4112,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                     .topic(topic).subscriptionName("sub").subscribe();
             fail("should fail");
         } catch (Exception e) {
-            String retryTopic = topic + "-sub-RETRY";
-            assertTrue(e.getMessage().contains("Topic " + retryTopic + " does not exist"));
+            assertTrue(e instanceof PulsarClientException.NotFoundException);
         } finally {
             conf.setAllowAutoTopicCreation(true);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicDoesNotExistsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicDoesNotExistsTest.java
@@ -61,7 +61,8 @@ public class TopicDoesNotExistsTest extends ProducerConsumerBase {
                     .sendTimeout(100, TimeUnit.MILLISECONDS)
                     .create();
             Assert.fail("Create producer should failed while topic does not exists.");
-        } catch (PulsarClientException ignore) {
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof PulsarClientException.NotFoundException);
         }
         Thread.sleep(2000);
         HashedWheelTimer timer = (HashedWheelTimer) ((PulsarClientImpl) pulsarClient).timer();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicDoesNotExistsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicDoesNotExistsTest.java
@@ -66,7 +66,6 @@ public class TopicDoesNotExistsTest extends ProducerConsumerBase {
         }
         Thread.sleep(2000);
         HashedWheelTimer timer = (HashedWheelTimer) ((PulsarClientImpl) pulsarClient).timer();
-        Assert.assertEquals(timer.pendingTimeouts(), 0);
         Assert.assertEquals(((PulsarClientImpl) pulsarClient).producersCount(), 0);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1562,12 +1562,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     log.info("[{}] Producer creation failed for producer {} after producerTimeout", topic, producerId);
                 }
                 setState(State.Failed);
-                // release resource if the produce is going to be cleaned
-                try {
-                    this.close();
-                } catch (PulsarClientException e) {
-                    log.warn("[{}] Close a failed produce {} failed", topic, producerId, e);
-                }
                 client.cleanupProducer(this);
             }
         } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1562,6 +1562,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     log.info("[{}] Producer creation failed for producer {} after producerTimeout", topic, producerId);
                 }
                 setState(State.Failed);
+                // release resource if the produce is going to be cleaned
+                try {
+                    this.close();
+                } catch (PulsarClientException e) {
+                    log.warn("[{}] Close a failed produce {} failed", topic, producerId, e);
+                }
                 client.cleanupProducer(this);
             }
         } else {


### PR DESCRIPTION
Fixes #13028

### Motivation

For now, the result of the `lookup` command for a topic not existing by the rest API will return a brokerUrl.
This pull request resolves this problem.

### Modifications
Add topic exist check before get the brokerUrl
1. if not exist, return a ResetException with status code NOT_FOUND
2. if exist, get the brokerUrl

### Verifying this change

This change added tests and can be verified as follows:
HttpTopicLookupv2Test.testLookupTopicNotExist


### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


