### PR TITLE
[Producer] Change the time units from ns to ms

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -39,7 +39,6 @@ import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -90,6 +89,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.RelativeTimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1228,9 +1228,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     String errMsg = String.format(
                         "%s : createdAt %s ns ago, firstSentAt %s ns ago, lastSentAt %s ns ago, retryCount %s",
                         te.getMessage(),
-                        nsToSeconds(ns - this.createdAt),
-                        nsToSeconds(this.firstSentAt <= 0 ? ns - this.lastSentAt : ns - this.firstSentAt),
-                        nsToSeconds(ns - this.lastSentAt),
+                        RelativeTimeUtil.nsToSeconds(ns - this.createdAt),
+                        RelativeTimeUtil.nsToSeconds(this.firstSentAt <= 0 ? ns - this.lastSentAt : ns - this.firstSentAt),
+                        RelativeTimeUtil.nsToSeconds(ns - this.lastSentAt),
                         retryCount
                     );
 
@@ -1293,11 +1293,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         };
     }
 
-    private static double nsToSeconds(long ns) {
-        double seconds = (double) ns / 1_000_000_000;
-        BigDecimal bd = new BigDecimal(seconds);
-        return bd.setScale(3, BigDecimal.ROUND_HALF_UP).doubleValue();
-    }
 
     /**
      * Queue implementation that is used as the pending messages queue.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -39,6 +39,7 @@ import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -1227,9 +1228,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     String errMsg = String.format(
                         "%s : createdAt %s ns ago, firstSentAt %s ns ago, lastSentAt %s ns ago, retryCount %s",
                         te.getMessage(),
-                        ns - this.createdAt,
-                        this.firstSentAt <= 0 ? ns - this.lastSentAt : ns - this.firstSentAt,
-                        ns - this.lastSentAt,
+                        nsToSeconds(ns - this.createdAt),
+                        nsToSeconds(this.firstSentAt <= 0 ? ns - this.lastSentAt : ns - this.firstSentAt),
+                        nsToSeconds(ns - this.lastSentAt),
                         retryCount
                     );
 
@@ -1290,6 +1291,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 return new OpSendMsg(handle);
             }
         };
+    }
+
+    private static double nsToSeconds(long ns) {
+        double seconds = (double) ns / 1_000_000_000;
+        BigDecimal bd = new BigDecimal(seconds);
+        return bd.setScale(3, BigDecimal.ROUND_HALF_UP).doubleValue();
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/RelativeTimeUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/RelativeTimeUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.util;
 
+import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 import lombok.experimental.UtilityClass;
 
@@ -62,5 +63,16 @@ public class RelativeTimeUtil {
         default:
             throw new IllegalArgumentException("Invalid time unit '" + lastChar + "'");
         }
+    }
+
+    /**
+     * Convert nanoseconds to seconds and keep three decimal places.
+     * @param ns
+     * @return seconds
+     */
+    public static double nsToSeconds(long ns) {
+        double seconds = (double) ns / 1_000_000_000;
+        BigDecimal bd = new BigDecimal(seconds);
+        return bd.setScale(3, BigDecimal.ROUND_HALF_UP).doubleValue();
     }
 }


### PR DESCRIPTION

### Motivation

*The time unit in this exception message is ns, which is not very readable. We can change it from ns to ms.*
```
org.apache.pulsar.client.api.PulsarClientException$TimeoutException:
The producer xxx can not send message to the topic xxx within given timeout : createdAt 461913074 ns ago, firstSentAt 29545553038276935 ns ago, lastSentAt 29545553038276935 ns ago, retryCount 0 at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:916)
at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.send(TypedMessageBuilderImpl.java:93)
at org.apache.pulsar.client.impl.ProducerBase.send(ProducerBase.java:63)
at com.yum.boh.oh.service.impl.StoreOrderPostServiceImpl.generalProcessing(StoreOrderPostServiceImpl.java:272)
at com.yum.boh.oh.service.impl.StoreOrderPostServiceImpl.saveThirdOrder(StoreOrderPostServiceImpl.java:72)
at com.yum.boh.oh.controller.StoreOrderController.postOrderInfo$original$T8425mfx(StoreOrderController.java:39)
at com.yum.boh.oh.controller.StoreOrderController.postOrderInfo$original$T8425mfx$accessor$vJljNzML(StoreOrderController.java)
at com.yum.boh.oh.controller.StoreOrderController$auxiliary$nysalhgy.call(Unknown Source)
at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:86)
...
```

### Modifications

*Change the time units from ns to ms for ProducerImpl#OpSendMsg.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
- [ ] `doc-required` 
- [x] `no-need-doc` 
- [ ] `doc` 

