### PR TITLE
Fix incorrect format for filesystem offload docs

### DIFF
--- a/site2/docs/tiered-storage-filesystem.md
+++ b/site2/docs/tiered-storage-filesystem.md
@@ -38,7 +38,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -59,7 +59,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -67,7 +67,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -77,11 +77,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -89,14 +88,20 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below. 
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -104,6 +109,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -127,7 +134,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -155,7 +162,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -198,7 +205,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -207,7 +214,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website-next/docs/tiered-storage-filesystem.md
+++ b/site2/website-next/docs/tiered-storage-filesystem.md
@@ -93,13 +93,13 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<Tabs
+  defaultValue="HDFS"
+  values={[{"label":"HDFS","value":"HDFS"},{"label":"NFS","value":"NFS"}]}>
+
+<TabItem value="HDFS">
+
 - **Required** configurations are as below.
-
-  <Tabs 
-    defaultValue="HDFS"
-    values={[{"label":"HDFS","value":"HDFS"},{"label":"NFS","value":"NFS"}]}>    
-
-  <TabItem value="HDFS">
 
   Parameter | Description | Example value
   |---|---|---
@@ -107,17 +107,22 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
   `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-  </TabItem>
-  <TabItem value="NFS">
+- **Optional** configurations are as below.
 
+  Parameter| Description | Example value
+  |---|---|---
+  `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
+  `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+</TabItem>
+<TabItem value="NFS">
+
+- **Required** configurations are as below.
+  
   Parameter | Description | Example value
   |---|---|---
   `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
   `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-  </TabItem>
-
-  </Tabs>
 
 - **Optional** configurations are as below.
 
@@ -125,6 +130,10 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
   |---|---|---
   `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br /><br />**Note**: it is not recommended to set this parameter in the production environment.|2
   `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br /><br />**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+</TabItem>
+
+</Tabs>
 
 ### Run filesystem offloader automatically
 

--- a/site2/website/package.json
+++ b/site2/website/package.json
@@ -33,5 +33,6 @@
     "jquery": "^3.1.1",
     "jquery.scrollto": "^2.1.2",
     "node-static": "^0.7.9"
-  }
+  },
+  "version": "0.0.0"
 }

--- a/site2/website/package.json
+++ b/site2/website/package.json
@@ -33,6 +33,5 @@
     "jquery": "^3.1.1",
     "jquery.scrollto": "^2.1.2",
     "node-static": "^0.7.9"
-  },
-  "version": "0.0.0"
+  }
 }

--- a/site2/website/versioned_docs/version-2.7.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.0/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.7.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.1/tiered-storage-filesystem.md
@@ -38,7 +38,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -59,7 +59,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -67,7 +67,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -77,11 +77,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -89,14 +88,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -104,6 +110,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -127,7 +135,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -155,7 +163,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -198,7 +206,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -207,7 +215,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.7.2/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.2/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.7.3/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.7.3/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.8.0/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.0/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.8.1/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.1/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.

--- a/site2/website/versioned_docs/version-2.8.2/tiered-storage-filesystem.md
+++ b/site2/website/versioned_docs/version-2.8.2/tiered-storage-filesystem.md
@@ -39,7 +39,7 @@ This example uses Pulsar 2.5.1.
     tar xvfz apache-pulsar-offloaders-2.5.1-bin.tar.gz
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that the `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -60,7 +60,7 @@ This example uses Pulsar 2.5.1.
     tiered-storage-jcloud-2.5.1.nar
     ```
 
-    > #### Note
+    > **Note**
     >
     > * If you run Pulsar in a bare metal cluster, ensure that `offloaders` tarball is unzipped in every broker's Pulsar directory.
     > 
@@ -68,7 +68,7 @@ This example uses Pulsar 2.5.1.
 
 ## Configuration
 
-> #### Note
+> **Note**
 > 
 > Before offloading data from BookKeeper to filesystem, you need to configure some properties of the filesystem offloader driver. 
 
@@ -78,11 +78,10 @@ Besides, you can also configure the filesystem offloader to run it automatically
 
 You can configure the filesystem offloader driver in the `broker.conf` or `standalone.conf` configuration file.
 
+<!--DOCUSAURUS_CODE_TABS-->
+<!--HDFS-->
+
 - **Required** configurations are as below.
-
-    <!--DOCUSAURUS_CODE_TABS-->
-
-    <!--HDFS-->
 
     Parameter | Description | Example value
     |---|---|---
@@ -90,14 +89,21 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
 
-    <!--NFS-->
-  
+- **Optional** configurations are as below.
+
+    Parameter| Description | Example value
+    |---|---|---
+    `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
+    `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--NFS-->
+
+- **Required** configurations are as below.
+    
     Parameter | Description | Example value
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory. The configuration file is stored in the offloader directory. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
-
-    <!--END_DOCUSAURUS_CODE_TABS-->
 
 - **Optional** configurations are as below.
 
@@ -105,6 +111,8 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerMinLedgerRolloverTimeMinutes`|Minimum time between ledger rollover for a topic. <br><br>**Note**: it is not recommended to set this parameter in the production environment.|2
     `managedLedgerMaxEntriesPerLedger`|Maximum number of entries to append to a ledger before triggering a rollover.<br><br>**Note**: it is not recommended to set this parameter in the production environment.|5000
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Run filesystem offloader automatically
 
@@ -128,7 +136,7 @@ This example sets the filesystem offloader threshold to 10 MB using pulsar-admin
 pulsar-admin namespaces set-offload-threshold --size 10M my-tenant/my-namespace
 ```
 
-> #### Tip
+> **Tip**
 >
 > For more information about the `pulsar-admin namespaces set-offload-threshold options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#set-offload-threshold). 
 
@@ -156,7 +164,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Offload triggered for persistent://my-tenant/my-namespace/topic1 for messages before 2:0:-1
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload). 
 
@@ -199,7 +207,7 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
     Reason: Error offloading: org.apache.bookkeeper.mledger.ManagedLedgerException: java.util.concurrent.CompletionException: com.amazonaws.services.s3.model.AmazonS3Exception: Anonymous users cannot initiate multipart uploads.  Please authenticate. (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 798758DE3F1776DF; S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=), S3 Extended Request ID: dhBFz/lZm1oiG/oBEepeNlhrtsDlzoOhocuYMpKihQGXe6EG8puRGOkK6UwqzVrMXTWBxxHcS+g=
     ```
 
-    > #### Tip
+    > **Tip**
     >
     > For more information about the `pulsar-admin topics offload-status options` command, including flags, descriptions, default values, and shorthands, see [here](reference-pulsar-admin.md#offload-status). 
 
@@ -208,7 +216,6 @@ To manually trigger the filesystem offloader via CLI tools, you need to specify 
 This section provides step-by-step instructions on how to use the filesystem offloader to move data from Pulsar to Hadoop Distributed File System (HDFS) or Network File system (NFS).
 
 <!--DOCUSAURUS_CODE_TABS-->
-
 <!--HDFS-->
 
 To move data from Pulsar to HDFS, follow these steps.


### PR DESCRIPTION
Fix #13038 
- Affected releases: Pulsar 2.7.0 - master, next-website
The preview of docs looks good.
![image](https://user-images.githubusercontent.com/48120384/144207077-3644ffd2-c3ac-4ef3-b973-16ec6ae8242f.png)

- [ x ] `doc` 
  
  (If this PR contains doc changes)


