### PR TITLE
[es-sink] Use topic name as the index name if indexName is not configured

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
@@ -258,7 +258,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            IndexRequest indexRequest = Requests.indexRequest(config.getIndexName());
+            IndexRequest indexRequest = Requests.indexRequest(indexName(record.getTopicName()));
             if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
                 indexRequest.id(idAndDoc.getLeft());
             indexRequest.type(config.getTypeName());
@@ -284,7 +284,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            IndexRequest indexRequest = Requests.indexRequest(config.getIndexName());
+            IndexRequest indexRequest = Requests.indexRequest(indexName(record.getTopicName()));
             if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
                 indexRequest.id(idAndDoc.getLeft());
             indexRequest.type(config.getTypeName());
@@ -309,7 +309,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            DeleteRequest deleteRequest = Requests.deleteRequest(config.getIndexName());
+            DeleteRequest deleteRequest = Requests.deleteRequest(indexName(record.getTopicName()));
             deleteRequest.id(id);
             deleteRequest.type(config.getTypeName());
 
@@ -333,7 +333,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            DeleteRequest deleteRequest = Requests.deleteRequest(config.getIndexName());
+            DeleteRequest deleteRequest = Requests.deleteRequest(indexName(record.getTopicName()));
             deleteRequest.id(id);
             deleteRequest.type(config.getTypeName());
             DeleteResponse deleteResponse = client.delete(deleteRequest, RequestOptions.DEFAULT);

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClient.java
@@ -254,16 +254,27 @@ public class ElasticSearchClient implements AutoCloseable {
         }
     }
 
+    IndexRequest makeIndexRequest(Record<GenericObject> record, Pair<String, String> idAndDoc) throws IOException {
+        IndexRequest indexRequest = Requests.indexRequest(indexName(record.getTopicName()));
+        if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
+            indexRequest.id(idAndDoc.getLeft());
+        indexRequest.type(config.getTypeName());
+        indexRequest.source(idAndDoc.getRight(), XContentType.JSON);
+        return indexRequest;
+    }
+
+    DeleteRequest makeDeleteRequest(Record<GenericObject> record, String id) throws IOException {
+        DeleteRequest deleteRequest = Requests.deleteRequest(indexName(record.getTopicName()));
+        deleteRequest.id(id);
+        deleteRequest.type(config.getTypeName());
+        return deleteRequest;
+    }
+
     public void bulkIndex(Record record, Pair<String, String> idAndDoc) throws Exception {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            IndexRequest indexRequest = Requests.indexRequest(indexName(record.getTopicName()));
-            if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
-                indexRequest.id(idAndDoc.getLeft());
-            indexRequest.type(config.getTypeName());
-            indexRequest.source(idAndDoc.getRight(), XContentType.JSON);
-
+            IndexRequest indexRequest = makeIndexRequest(record, idAndDoc);
             records.put(indexRequest, record);
             bulkProcessor.add(indexRequest);
         } catch(Exception e) {
@@ -284,12 +295,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            IndexRequest indexRequest = Requests.indexRequest(indexName(record.getTopicName()));
-            if (!Strings.isNullOrEmpty(idAndDoc.getLeft()))
-                indexRequest.id(idAndDoc.getLeft());
-            indexRequest.type(config.getTypeName());
-            indexRequest.source(idAndDoc.getRight(), XContentType.JSON);
-            IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
+            IndexResponse indexResponse = client.index(makeIndexRequest(record, idAndDoc), RequestOptions.DEFAULT);
             if (indexResponse.getResult().equals(DocWriteResponse.Result.CREATED) ||
                     indexResponse.getResult().equals(DocWriteResponse.Result.UPDATED)) {
                 record.ack();
@@ -309,10 +315,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            DeleteRequest deleteRequest = Requests.deleteRequest(indexName(record.getTopicName()));
-            deleteRequest.id(id);
-            deleteRequest.type(config.getTypeName());
-
+            DeleteRequest deleteRequest = makeDeleteRequest(record, id);
             records.put(deleteRequest, record);
             bulkProcessor.add(deleteRequest);
         } catch(Exception e) {
@@ -333,10 +336,7 @@ public class ElasticSearchClient implements AutoCloseable {
         try {
             checkNotFailed();
             checkIndexExists(record.getTopicName());
-            DeleteRequest deleteRequest = Requests.deleteRequest(indexName(record.getTopicName()));
-            deleteRequest.id(id);
-            deleteRequest.type(config.getTypeName());
-            DeleteResponse deleteResponse = client.delete(deleteRequest, RequestOptions.DEFAULT);
+            DeleteResponse deleteResponse = client.delete(makeDeleteRequest(record, id), RequestOptions.DEFAULT);
             log.debug("delete result=" + deleteResponse.getResult());
             if (deleteResponse.getResult().equals(DocWriteResponse.Result.DELETED) ||
                     deleteResponse.getResult().equals(DocWriteResponse.Result.NOT_FOUND)) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

According to the [document](https://github.com/apache/pulsar/blob/master/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java#L53), the default index name should be the topic name, but the code still uses `indexName` only when generating write requests which makes it a required config in practice.

### Modifications

- Use the method `indexName()` for the index name of write requests which will be the topic name if `indexName` is not configured.
- Extract methods `makeIndexRequest` and `makeDeleteRequest` for better code reuse and testability.
- Add unit tests to check the index name of generated index/delete requests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Unit tests to check the index name of generated index/delete requests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


