### PR TITLE
[Security] Upgrade OkHttp3 to address CVE-2021-0341

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -446,12 +446,18 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-1.27.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
- * Apache Thrifth - org.apache.thrift-libthrift-0.14.2.jar
+ * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3
-     - com.squareup.okhttp3-logging-interceptor-3.14.9.jar
-     - com.squareup.okhttp3-okhttp-3.14.9.jar
- * Okio - com.squareup.okio-okio-1.17.2.jar
+     - com.squareup.okhttp3-logging-interceptor-4.9.3.jar
+     - com.squareup.okhttp3-okhttp-4.9.3.jar
+ * Okio - com.squareup.okio-okio-2.8.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
+ * Kotlin Standard Lib
+     - org.jetbrains.kotlin-kotlin-stdlib-1.4.32.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-common-1.4.32.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.4.32.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.4.32.jar
+     - org.jetbrains-annotations-13.0.jar
  * gRPC
     - io.grpc-grpc-all-1.33.0.jar
     - io.grpc-grpc-auth-1.33.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,11 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jna.version>4.2.0</jna.version>
     <kubernetesclient.version>12.0.1</kubernetesclient.version>
-    <okhttp3.version>3.14.9</okhttp3.version>
+    <okhttp3.version>4.9.3</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
-    <okio.version>1.17.2</okio.version>
+    <okio.version>2.8.0</okio.version>
+    <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
+    <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.3</cron-utils.version>
     <spring-context.version>5.3.1</spring-context.version>
@@ -1188,10 +1190,33 @@ flexible messaging model and an intuitive client API.</description>
         <version>${okhttp3.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
         <version>${okio.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin-stdlib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin-stdlib.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin-stdlib.version}</version>
+      </dependency>
+
 
     </dependencies>
   </dependencyManagement>

--- a/pulsar-sql/pom.xml
+++ b/pulsar-sql/pom.xml
@@ -37,6 +37,13 @@
         <module>presto-distribution</module>
     </modules>
 
+    <properties>
+        <!-- keep using okhttp3 3.x for Presto -->
+        <okhttp3.version>3.14.9</okhttp3.version>
+        <!-- use okio version that matches the okhttp3 version -->
+        <okio.version>1.17.2</okio.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -103,6 +110,28 @@
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+
+            <!-- keep using okhttp3 3.x for Presto -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-urlconnection</artifactId>
+                <version>${okhttp3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>logging-interceptor</artifactId>
+                <version>${okhttp3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Motivation

Current OkHttp3 version - 3.14.9 - has an open CVE (https://nvd.nist.gov/vuln/detail/CVE-2021-0341) with a score of 7.5.
OkHttp3 is used by Java Kubernetes Client (currently only used by Pulsar Function Worker in "kubernetes" mode)

I upgraded to the latest stable release (4.9.3) where a fix for the CVE has been [committed](https://github.com/square/okhttp/pull/6741). The OkHttp3 team [claims](https://square.github.io/okhttp/upgrading_to_okhttp_4/) that 3.x and 4.x are fully compatibles (at least the java library)

> OkHttp 4.x is both binary- and Java source-compatible with OkHttp 3.x. You can use an OkHttp 4.x .jar file with applications or libraries built for OkHttp 3.x.

Upgrading OkHttp3 and Okio, there is a new transitive dependency - Kotlin Standard Lib (licensed under Apache 2.0)

```
io.kubernetes:client-java:jar:12.0.1:compile
[INFO] |  |     +- io.kubernetes:client-java-api:jar:12.0.1:compile
[INFO] |  |     |  +- com.squareup.okhttp3:okhttp:jar:4.9.3:compile
[INFO] |  |     |  |  +- com.squareup.okio:okio:jar:2.8.0:compile
[INFO] |  |     |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.4.32:compile
[INFO] |  |     |  |  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.4.32:compile
[INFO] |  |     |  |     \- org.jetbrains:annotations:jar:13.0:compile
[INFO] |  |     |  +- com.squareup.okhttp3:logging-interceptor:jar:4.9.3:compile
[INFO] |  |     |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.4.32:compile
[INFO] |  |     |  |     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.4.32:compile

``` 

Unfortunately, the `kotlin-stdlib` version used by Okio and OkHttp3 has, in turn, a CVE open (https://nvd.nist.gov/vuln/detail/CVE-2020-29582); in order to not introduce another vulnerability, I've overridden the version with latest stable one (1.4.32) 

### Modifications

* Upgrade OkHttp3 from 3.14.9 to 4.9.3
* Upgrade Okio to the same version of OkHttp3 4.9.3
* Override Okio transitive dependency - Kotlin stdlib - to 1.4.32 in order to address CVE-2020-29582


### Verifying this change

The change must be verified deploying and testing a Pulsar Function with `runtime` set to `kubernetes`. (I already performed this kind of test)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
 
- [x] `no-need-doc` 
