### PR TITLE
[Broker] Fix LeaderElectionService.getCurrentLeader and add support for empheralOwner in MockZooKeeper

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
+    protected List<PulsarService> additionalBrokers;
+    protected List<PulsarAdmin> additionalBrokerAdmins;
+    protected List<PulsarClient> additionalBrokerClients;
+
+    protected int numberOfAdditionalBrokers() {
+        return 2;
+    }
+
+    @BeforeClass
+    @Override
+    public final void setup() throws Exception {
+        super.internalSetup();
+        additionalBrokersSetup();
+        admin.tenants().createTenant("public", createDefaultTenantInfo());
+        admin.namespaces().createNamespace("public/default", getPulsar().getConfiguration().getDefaultNumberOfNamespaceBundles());
+    }
+
+    protected void additionalBrokersSetup() throws Exception {
+        int numberOfAdditionalBrokers = numberOfAdditionalBrokers();
+        additionalBrokers = new ArrayList<>(numberOfAdditionalBrokers);
+        additionalBrokerAdmins = new ArrayList<>(numberOfAdditionalBrokers);
+        additionalBrokerClients = new ArrayList<>(numberOfAdditionalBrokers);
+        for (int i = 0; i < numberOfAdditionalBrokers; i++) {
+            PulsarService pulsarService = createAdditionalBroker(i);
+            additionalBrokers.add(i, pulsarService);
+            PulsarAdminBuilder pulsarAdminBuilder =
+                    PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress() != null
+                            ? pulsarService.getWebServiceAddress()
+                            : pulsarService.getWebServiceAddressTls());
+            customizeNewPulsarAdminBuilder(pulsarAdminBuilder);
+            additionalBrokerAdmins.add(i, pulsarAdminBuilder.build());
+            additionalBrokerClients.add(i, newPulsarClient(pulsarService.getBrokerServiceUrl(), 0));
+        }
+    }
+
+    protected ServiceConfiguration createConfForAdditionalBroker(int additionalBrokerIndex) {
+        return getDefaultConf();
+    }
+
+    protected PulsarService createAdditionalBroker(int additionalBrokerIndex) throws Exception {
+        return startBroker(createConfForAdditionalBroker(additionalBrokerIndex));
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public final void cleanup() throws Exception {
+        additionalBrokersCleanup();
+        super.internalCleanup();
+    }
+
+    protected void additionalBrokersCleanup() {
+        if (additionalBrokerAdmins != null) {
+            for (PulsarAdmin additionalBrokerAdmin : additionalBrokerAdmins) {
+                additionalBrokerAdmin.close();
+            }
+            additionalBrokerAdmins = null;
+        }
+        if (additionalBrokerClients != null) {
+            for (PulsarClient additionalBrokerClient : additionalBrokerClients) {
+                try {
+                    additionalBrokerClient.close();
+                } catch (PulsarClientException e) {
+                    // ignore
+                }
+            }
+            additionalBrokerClients = null;
+        }
+        if (additionalBrokers != null) {
+            for (PulsarService pulsarService : additionalBrokers) {
+                try {
+                    pulsarService.close();
+                } catch (PulsarServerException e) {
+                    // ignore
+                }
+            }
+            additionalBrokers = null;
+        }
+    }
+
+    public final List<PulsarService> getAllBrokers() {
+        List<PulsarService> brokers = new ArrayList<>(numberOfAdditionalBrokers() + 1);
+        brokers.add(getPulsar());
+        brokers.addAll(additionalBrokers);
+        return Collections.unmodifiableList(brokers);
+    }
+
+    public final List<PulsarAdmin> getAllAdmins() {
+        List<PulsarAdmin> admins = new ArrayList<>(numberOfAdditionalBrokers() + 1);
+        admins.add(admin);
+        admins.addAll(additionalBrokerAdmins);
+        return Collections.unmodifiableList(admins);
+    }
+
+    public final List<PulsarClient> getAllClients() {
+        List<PulsarClient> clients = new ArrayList<>(numberOfAdditionalBrokers() + 1);
+        clients.add(pulsarClient);
+        clients.addAll(additionalBrokerClients);
+        return Collections.unmodifiableList(clients);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -45,8 +46,13 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
     public final void setup() throws Exception {
         super.internalSetup();
         additionalBrokersSetup();
+        pulsarResourcesSetup();
+    }
+
+    protected void pulsarResourcesSetup() throws PulsarAdminException {
         admin.tenants().createTenant("public", createDefaultTenantInfo());
-        admin.namespaces().createNamespace("public/default", getPulsar().getConfiguration().getDefaultNumberOfNamespaceBundles());
+        admin.namespaces()
+                .createNamespace("public/default", getPulsar().getConfiguration().getDefaultNumberOfNamespaceBundles());
     }
 
     protected void additionalBrokersSetup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -110,7 +110,7 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         if (additionalBrokerClients != null) {
             for (PulsarClient additionalBrokerClient : additionalBrokerClients) {
                 try {
-                    additionalBrokerClient.close();
+                    additionalBrokerClient.shutdown();
                 } catch (PulsarClientException e) {
                     // ignore
                 }
@@ -120,6 +120,7 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         if (additionalBrokers != null) {
             for (PulsarService pulsarService : additionalBrokers) {
                 try {
+                    pulsarService.getConfiguration().setBrokerShutdownTimeoutMs(0L);
                     pulsarService.close();
                 } catch (PulsarServerException e) {
                     // ignore

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -41,7 +41,7 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         return 2;
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     public final void setup() throws Exception {
         super.internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -26,6 +26,8 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -71,6 +73,18 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
 
     protected PulsarService createAdditionalBroker(int additionalBrokerIndex) throws Exception {
         return startBroker(createConfForAdditionalBroker(additionalBrokerIndex));
+    }
+
+    @Override
+    protected ZKMetadataStore createLocalMetadataStore() {
+        // use MockZooKeeperSession to provide a unique session id for each instance
+        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeper));
+    }
+
+    @Override
+    protected ZKMetadataStore createConfigurationMetadataStore() {
+        // use MockZooKeeperSession to provide a unique session id for each instance
+        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeperGlobal));
     }
 
     @AfterClass(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -317,8 +318,10 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
         // Override default providers with mocked ones
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-        doReturn(new ZKMetadataStore(mockZooKeeperGlobal)).when(pulsar).createConfigurationMetadataStore();
+        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore();
+        MockZooKeeperSession mockZooKeeperSessionGlobal = MockZooKeeperSession.newInstance(mockZooKeeperGlobal);
+        doReturn(new ZKMetadataStore(mockZooKeeperSessionGlobal)).when(pulsar).createConfigurationMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -67,7 +67,6 @@ import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
-import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -318,10 +317,8 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
         // Override default providers with mocked ones
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
-        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore();
-        MockZooKeeperSession mockZooKeeperSessionGlobal = MockZooKeeperSession.newInstance(mockZooKeeperGlobal);
-        doReturn(new ZKMetadataStore(mockZooKeeperSessionGlobal)).when(pulsar).createConfigurationMetadataStore();
+        doReturn(createLocalMetadataStore()).when(pulsar).createLocalMetadataStore();
+        doReturn(createConfigurationMetadataStore()).when(pulsar).createConfigurationMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
@@ -333,6 +330,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         if (enableBrokerInterceptor) {
             mockConfigBrokerInterceptors(pulsar);
         }
+    }
+
+    protected ZKMetadataStore createLocalMetadataStore() {
+        return new ZKMetadataStore(mockZooKeeper);
+    }
+
+    protected ZKMetadataStore createConfigurationMetadataStore() {
+        return new ZKMetadataStore(mockZooKeeperGlobal);
     }
 
     private void mockConfigBrokerInterceptors(PulsarService pulsarService) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
@@ -19,8 +19,11 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.Optional;
 import org.apache.pulsar.broker.MultiBrokerBaseTest;
 import org.apache.pulsar.broker.PulsarService;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
@@ -35,5 +38,15 @@ public class MultiBrokerLeaderElectionTest extends MultiBrokerBaseTest {
             }
         }
         assertEquals(leaders, 1);
+    }
+
+    @Test
+    public void shouldAllBrokersKnowTheLeader() {
+        Awaitility.await().untilAsserted(() -> {
+            for (PulsarService broker : getAllBrokers()) {
+                Optional<LeaderBroker> currentLeader = broker.getLeaderElectionService().getCurrentLeader();
+                assertTrue(currentLeader.isPresent(), "Leader wasn't known on broker " + broker.getBrokerServiceUrl());
+            }
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import static org.testng.Assert.assertEquals;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.PulsarService;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class MultiBrokerLeaderElectionTest extends MultiBrokerBaseTest {
+
+    @Test
+    public void shouldElectOneLeader() {
+        int leaders = 0;
+        for (PulsarService broker : getAllBrokers()) {
+            if (broker.getLeaderElectionService().isLeader()) {
+                leaders++;
+            }
+        }
+        assertEquals(leaders, 1);
+    }
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
@@ -105,7 +105,10 @@ class LeaderElectionImpl<T> implements LeaderElection<T> {
             } else {
                 return tryToBecomeLeader();
             }
-        });
+        }).thenCompose(leaderElectionState ->
+                // make sure that the cache contains the current leader
+                // so that getLeaderValueIfPresent works on all brokers
+                cache.get(path).thenApply(__ -> leaderElectionState));
     }
 
     private synchronized CompletableFuture<LeaderElectionState> handleExistingLeaderValue(GetResult res) {

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -375,7 +375,8 @@ public class MockZooKeeper extends ZooKeeper {
                                     parent)));
                     cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
                 } else {
-                    tree.put(name, MockZNode.of(data, 0, createMode.isEphemeral() ? getEphemeralOwner() : -1L));
+                    tree.put(name, MockZNode.of(data, 0,
+                            createMode != null && createMode.isEphemeral() ? getEphemeralOwner() : -1L));
                     watchers.removeAll(name);
                     unlockIfLocked();
                     cb.processResult(0, path, ctx, name);

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -602,11 +602,11 @@ public class MockZooKeeper extends ZooKeeper {
         }
     }
 
-    private Stat createStatForZNode(MockZNode zNode) {
+    private static Stat createStatForZNode(MockZNode zNode) {
         return applyToStat(zNode, new Stat());
     }
 
-    private Stat applyToStat(MockZNode zNode, Stat stat) {
+    private static Stat applyToStat(MockZNode zNode, Stat stat) {
         stat.setVersion(zNode.getVersion());
         if (zNode.getEphemeralOwner() != -1L) {
             stat.setEphemeralOwner(zNode.getEphemeralOwner());

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -44,7 +44,7 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     private static final Objenesis objenesis = new ObjenesisStd();
 
-    private static final AtomicInteger sessionIdGenerator = new AtomicInteger(0);
+    private static final AtomicInteger sessionIdGenerator = new AtomicInteger(1000);
 
     public static MockZooKeeperSession newInstance(MockZooKeeper mockZooKeeper) {
         ObjectInstantiator<MockZooKeeperSession> instantiator = objenesis.getInstantiatorOf(MockZooKeeperSession.class);
@@ -80,13 +80,23 @@ public class MockZooKeeperSession extends ZooKeeper {
     @Override
     public String create(String path, byte[] data, List<ACL> acl, CreateMode createMode)
             throws KeeperException, InterruptedException {
-        return mockZooKeeper.create(path, data, acl, createMode);
+        try {
+            mockZooKeeper.overrideEpheralOwner(getSessionId());
+            return mockZooKeeper.create(path, data, acl, createMode);
+        } finally {
+            mockZooKeeper.removeEpheralOwnerOverride();
+        }
     }
 
     @Override
     public void create(final String path, final byte[] data, final List<ACL> acl, CreateMode createMode,
                        final AsyncCallback.StringCallback cb, final Object ctx) {
-        mockZooKeeper.create(path, data, acl, createMode, cb, ctx);
+        try {
+            mockZooKeeper.overrideEpheralOwner(getSessionId());
+            mockZooKeeper.create(path, data, acl, createMode, cb, ctx);
+        } finally {
+            mockZooKeeper.removeEpheralOwnerOverride();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

`LeaderElectionService.getCurrentLeader()` always returned `Optional.empty()` on all other than the leader broker.
This has several severe consequences in the Pulsar Broker code base.

When a lookup is made to a topic that isn't currently loaded, the decision will be made in a distributed fashion on the follower brokers since the information about the leader broker is missing (because `LeaderElectionService.getCurrentLeader()` always returned `Optional.empty()`). This leads to races when assigning the topic ownership to a broker since the decision isn't made centrally on the leader broker.
I'll provide a separate PR for improving and fixing the topic ownership assignment. That PR is #13069 and it contains a failing test case for the topic ownership assignment / lookup problem.

### Modifications

- Add support for empheralOwner in MockZooKeeper
- Add MultiBrokerBaseTest base test class for writing tests that involve multiple brokers
- Add test case that fails without the fix
- Make the fix to LeaderElectionImpl