### PR TITLE
Disable PulsarLedgerAuditorManagerTest when running on RocksDB backend

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerAuditorManagerTest.java
@@ -70,7 +70,7 @@ public class PulsarLedgerAuditorManagerTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
     public void testSimple(String provider, Supplier<String> urlSupplier) throws Exception {
-        if (provider.equals("Memory")) {
+        if (provider.equals("Memory") || provider.equals("RocksDB")) {
             // With memory provider there are not multiple sessions to test with
             return;
         }


### PR DESCRIPTION
### Motivation

Fix #13071

After independently merging changes for BK -> MetadataStore and RocksDb implementation of MetadataStore, there's a test failing PulsarLedgerAuditorManagerTest. We should disable this when running on RocksDB, since it's expecting to test with multiple client sessions.