### PR TITLE
[pulsar-broker] Support roll-over ledgers for inactive topics

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -988,6 +988,10 @@ managedLedgerMinLedgerRolloverTimeMinutes=10
 # Maximum time before forcing a ledger rollover for a topic
 managedLedgerMaxLedgerRolloverTimeMinutes=240
 
+# Time to rollover ledger for inactive topic (duration without any publish on that topic)
+# Disable rollover with value 0 (Default value 0)
+managedLedgerInactiveLedgerRolloverTimeSeconds=0
+
 # Maximum ledger size before triggering a rollover for a topic (MB)
 managedLedgerMaxSizePerLedgerMbytes=2048
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -649,4 +649,10 @@ public interface ManagedLedger {
      * @return the future of managed ledger internal stats
      */
     CompletableFuture<ManagedLedgerInternalStats> getManagedLedgerInternalStats(boolean includeLedgerMetadata);
+
+    /**
+     * Check current inactive ledger (based on {@link ManagedLedgerConfig#getInactiveLedgerRollOverTimeMs()} and
+     * roll over that ledger if inactive.
+     */
+    void checkInactiveLedgerAndRollOver();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -74,6 +74,7 @@ public class ManagedLedgerConfig {
     private Clock clock = Clock.systemUTC();
     private ManagedLedgerInterceptor managedLedgerInterceptor;
     private Map<String, String> properties;
+    private int inactiveLedgerRollOverTimeMs = 0;
 
     public boolean isCreateIfMissing() {
         return createIfMissing;
@@ -653,4 +654,19 @@ public class ManagedLedgerConfig {
     public void setManagedLedgerInterceptor(ManagedLedgerInterceptor managedLedgerInterceptor) {
         this.managedLedgerInterceptor = managedLedgerInterceptor;
     }
+
+    public int getInactiveLedgerRollOverTimeMs() {
+        return inactiveLedgerRollOverTimeMs;
+    }
+
+    /**
+     * Set rollOver time for inactive ledgers.
+     *
+     * @param inactiveLedgerRollOverTimeMs
+     * @param unit
+     */
+    public void setInactiveLedgerRollOverTime(int inactiveLedgerRollOverTimeMs, TimeUnit unit) {
+        this.inactiveLedgerRollOverTimeMs = (int) unit.toMillis(inactiveLedgerRollOverTimeMs);
+    }
+
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -225,6 +225,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private ManagedLedgerInterceptor managedLedgerInterceptor;
 
+    private volatile long lastAddEntryTimeMs = 0;
+    private long inactiveLedgerRollOverTimeMs = 0;
+
     protected static final int DEFAULT_LEDGER_DELETE_RETRIES = 3;
     protected static final int DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC = 60;
 
@@ -323,6 +326,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.maximumRolloverTimeMs = getMaximumRolloverTimeMs(config);
         this.mlOwnershipChecker = mlOwnershipChecker;
         this.propertiesMap = Maps.newHashMap();
+        if (config.getManagedLedgerInterceptor() != null) {
+            this.managedLedgerInterceptor = config.getManagedLedgerInterceptor();
+        }
+        this.inactiveLedgerRollOverTimeMs = config.getInactiveLedgerRollOverTimeMs();
     }
 
     synchronized void initialize(final ManagedLedgerInitializeLedgerCallback callback, final Object ctx) {
@@ -797,6 +804,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             }
             addOperation.initiate();
         }
+        // mark add entry activity
+        lastAddEntryTimeMs = System.currentTimeMillis();
     }
 
     private boolean beforeAddEntry(OpAddEntry addOperation) {
@@ -4073,6 +4082,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         if (this.checkLedgerRollTask != null) {
             this.checkLedgerRollTask.cancel(false);
+        }
+    }
+
+    @Override
+    public void checkInactiveLedgerAndRollOver() {
+        long currentTimeMs = System.currentTimeMillis();
+        if (inactiveLedgerRollOverTimeMs > 0 && currentTimeMs > (lastAddEntryTimeMs + inactiveLedgerRollOverTimeMs)) {
+            log.info("[{}] Closing inactive ledger, last-add entry {}", name, lastAddEntryTimeMs);
+            ledgerClosed(currentLedger);
         }
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2402,6 +2402,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int managedLedgerOffloadPrefetchRounds = 1;
 
+    @FieldContext(
+        dynamic = true,
+        category = CATEGORY_STORAGE_ML,
+        doc = "Time to rollover ledger for inactive topic (duration without any publish on that topic). "
+                + "Disable rollover with value 0 (Default value 0)"
+        )
+    private int managedLedgerInactiveLedgerRolloverTimeSeconds = 0;
+
     /**** --- Transaction config variables. --- ****/
     @FieldContext(
             category = CATEGORY_TRANSACTION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1539,6 +1539,8 @@ public class BrokerService implements Closeable {
                     managedLedgerConfig.setRetentionSizeInMB(retentionPolicies.getRetentionSizeInMB());
                     managedLedgerConfig.setAutoSkipNonRecoverableData(serviceConfig.isAutoSkipNonRecoverableData());
                     managedLedgerConfig.setLazyCursorRecovery(serviceConfig.isLazyCursorRecovery());
+                    managedLedgerConfig.setInactiveLedgerRollOverTime(
+                            serviceConfig.getManagedLedgerInactiveLedgerRolloverTimeSeconds(), TimeUnit.SECONDS);
 
                     OffloadPoliciesImpl nsLevelOffloadPolicies =
                             (OffloadPoliciesImpl) policies.map(p -> p.offload_policies).orElse(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -139,6 +139,8 @@ public class PulsarStats implements Closeable {
                                 // this task: helps to activate inactive-backlog-cursors which have caught up and
                                 // connected, also deactivate active-backlog-cursors which has backlog
                                 topic.checkBackloggedCursors();
+                                // check if topic is inactive and require ledger rollover
+                                ((PersistentTopic) topic).checkInactiveLedgers();
                             } else if (topic instanceof NonPersistentTopic) {
                                 tempNonPersistentTopics.add((NonPersistentTopic) topic);
                             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2337,6 +2337,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
     }
 
+    public void checkInactiveLedgers() {
+        ledger.checkInactiveLedgerAndRollOver();
+    }
+
     @Override
     public void checkDeduplicationSnapshot() {
         messageDeduplication.takeSnapshot();

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -294,6 +294,7 @@ brokerServiceCompactionThresholdInBytes|If the estimated backlog size is greater
 |managedLedgerMaxEntriesPerLedger| The max number of entries to append to a ledger before triggering a rollover. A ledger rollover is triggered after the min rollover time has passed and one of the following conditions is true: <ul><li>The max rollover time has been reached</li><li>The max entries have been written to the ledger</li><li>The max ledger size has been written to the ledger</li></ul>|50000|
 |managedLedgerMinLedgerRolloverTimeMinutes| Minimum time between ledger rollover for a topic  |10|
 |managedLedgerMaxLedgerRolloverTimeMinutes| Maximum time before forcing a ledger rollover for a topic |240|
+|managedLedgerInactiveLedgerRolloverTimeSeconds| Time to rollover ledger for inactive topic |0|
 |managedLedgerCursorMaxEntriesPerLedger|  Max number of entries to append to a cursor ledger  |50000|
 |managedLedgerCursorRolloverTimeInSeconds|  Max time before triggering a rollover on a cursor ledger  |14400|
 |managedLedgerMaxUnackedRangesToPersist|  Max number of “acknowledgment holes” that are going to be persistently stored. When acknowledging out of order, a consumer will leave holes that are supposed to be quickly filled by acking all the messages. The information of which messages are acknowledged is persisted by compressing in “ranges” of messages that were acknowledged. After the max number of ranges is reached, the information will only be tracked in memory and messages will be redelivered in case of crashes.  |1000|

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -356,4 +356,9 @@ public class MockManagedLedger implements ManagedLedger {
     public CompletableFuture<ManagedLedgerInternalStats> getManagedLedgerInternalStats(boolean includeLedgerMetadata) {
         return null;
     }
+
+    @Override
+    public void checkInactiveLedgerAndRollOver() {
+
+    }
 }


### PR DESCRIPTION
### Motivation
we need the support of ledger roll-over for inactive topics to prevent data-loss. It happens when Inactive topics that do not have publish for a long time and the current ledger segment ensemble bookies are replaced by replicator when ensemble bookies went into maintenance mode. In this scenario, there is a chance of data loss and rolling over such ledgers prevents data loss.
For example:
1. In the beginning topic is writing to ledger `1000` with bookie `b1` and `b2`
```
get /ledgers/00/0000/L1000
BookieMetadataFormatVersion	2
quorumSize: 2
ensembleSize: 2
length: 0
lastEntryId: -1
state: OPEN
segment {
  ensembleMember: "b1:3181" -> prod5-bookie7.messaging.gq1.yahoo.com
  ensembleMember: "b2:3181" -> prod5-bookie3.messaging.gq1.yahoo.com
  firstEntryId: 0
} 
```

2. Then both bookie b1 and b2 went down and replicator replaced them with bookie b3 and b4
```
get /ledgers/00/0000/L1000
quorumSize: 2
ensembleSize: 2
length: 104
lastEntryId: 1
state: CLOSED
segment {
  ensembleMember: "b3:3181"
  ensembleMember: "b4:3181"
  firstEntryId: 0
}
segment {
  ensembleMember: "b5:3181"
  ensembleMember: "b6:3181"
  firstEntryId: 1
}
```
3. after that bookie b1 and b2 came back again and topic received a publish. broker was able to reconnect to bookie b1, and b2 and continued to write to bookie b1 and b2
```
Broker-DEBUG log:
22:45:24.000 [bookkeeper-ml-workers-OrderedExecutor-6-0] DEBUG org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [prop/us-west1/test/persistent/t1] Write into current ledger lh=291607 entries=14
# broker successfully connected to b1 and b2 and wrote new entry to b1 and b2

22:36:38.949 [bookie-io-1-6] INFO  o.a.b.proto.BookieRequestHandler     - Channel connected  [id: 0x43c62e1c, L:/10.10.10.10:3181 - R:/b1:60908]
22:36:38.950 [bookie-io-1-5] INFO  o.a.b.proto.BookieRequestHandler     - Channel connected  [id: 0x43c62e1c, L:/10.10.10.10:3181 - R:/b2:60908]
```
4. So, according to zk ledger `1000` has one entry but the broker is kept writing to b1 and b2 bookies which can cause the data loss.

[Bookie PR#2616](https://github.com/apache/bookkeeper/pull/2616) can be helpful in this scenario but rolling over inactive ledger helps to user who are doing bookie replacement/maintenance more frequent to avoid kind of data loss.

### Modification
- added config `managedLedgerInActiveLedgerRolloverTimeMinutes` to enable rollover of inactive ledgers (by default it will be 0)

### Result
this feature helps in case of inactive topics which write to replaced bookies during any maintenance and helps to avoid data-loss in that situation. 
