### PR TITLE
Adapt grpc plugin compile requirement with apple m1 silicon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2284,6 +2284,18 @@ flexible messaging model and an intuitive client API.</description>
         </plugins>
       </reporting>
     </profile>
+    <profile>
+      <id>mac-apple-silicon</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <os.detected.classifier>osx-x86_64</os.detected.classifier>
+      </properties>
+    </profile>
   </profiles>
 
   <repositories>


### PR DESCRIPTION
### Motivation
Let people who has mac with `apple m1 silicon` can easily compile. Otherwise the grpc plugin will error.

### Verifying this change

Compile on my `m1` and `intel` computer.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
 compile xml changes


