### PR TITLE
[Issue 12844][pulsar-client-cpp] Excessive locking cause significant performance degradation

### DIFF
--- a/pulsar-client-cpp/lib/stats/AsyncCallbackLock.h
+++ b/pulsar-client-cpp/lib/stats/AsyncCallbackLock.h
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef ASYNC_CALLBACK_LOCK_H_
+#define ASYNC_CALLBACK_LOCK_H_
+
+#include <mutex>
+
+namespace pulsar {
+namespace stats {
+
+struct AsyncCallbackLock {
+    std::mutex mutex;
+    bool enabled = true;
+};
+
+} /* namespace stats */
+} /* namespace pulsar */
+
+#endif /* ASYNC_CALLBACK_LOCK_H_ */

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -337,9 +337,9 @@ TEST(BatchMessageTest, testSmallReceiverQueueSize) {
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalAckedMsgMap()), numOfMessages);
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getReceivedMsgMap()), numOfMessages);
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalReceivedMsgMap()), numOfMessages);
-    ASSERT_EQ(consumerStatsImplPtr->getTotalNumBytesRecieved(), consumerStatsImplPtr->getNumBytesRecieved());
+    ASSERT_EQ(consumerStatsImplPtr->getTotalNumBytesRecieved(), consumerStatsImplPtr->getNumBytesReceived());
     std::this_thread::sleep_for(std::chrono::seconds(20));
-    ASSERT_NE(consumerStatsImplPtr->getTotalNumBytesRecieved(), consumerStatsImplPtr->getNumBytesRecieved());
+    ASSERT_NE(consumerStatsImplPtr->getTotalNumBytesRecieved(), consumerStatsImplPtr->getNumBytesReceived());
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalAckedMsgMap()), numOfMessages);
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getTotalReceivedMsgMap()), numOfMessages);
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getAckedMsgMap()), 0);
@@ -580,7 +580,7 @@ TEST(BatchMessageTest, testCumulativeAck) {
     ASSERT_EQ(consumerStatsImplPtr->getReceivedMsgMap().at(ResultOk), i);
     ASSERT_EQ(consumerStatsImplPtr->getReceivedMsgMap().at(ResultTimeout), 1);
     ASSERT_EQ(PulsarFriend::sum(consumerStatsImplPtr->getAckedMsgMap()), 1);
-    ASSERT_EQ(producerStatsImplPtr->getNumBytesSent(), consumerStatsImplPtr->getNumBytesRecieved());
+    ASSERT_EQ(producerStatsImplPtr->getNumBytesSent(), consumerStatsImplPtr->getNumBytesReceived());
     unsigned long t = consumerStatsImplPtr->getAckedMsgMap().at(
         std::make_pair<Result, proto::CommandAck_AckType>(ResultOk, proto::CommandAck_AckType_Cumulative));
     ASSERT_EQ(t, 1);


### PR DESCRIPTION
Fixes #12844


### Motivation

1.  ProducerStatsImpl (and ConsumerStatsImpl) classes use a single shared lock to protect access to internal data. This cause signficant contention on high load.
2. Data races between timer and object destructor

### Modifications

1. Use separate lock for updating send and receive statistics. 
2. Add shared lock to prevent data races.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: ( no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no )

### Documentation

- [x ] `no-need-doc` 
  

