### PR TITLE
expose MaxAllowedEnsembleChange to limit the max number of ensemble change

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -902,6 +902,9 @@ bookkeeperExplicitLacIntervalInMills=0
 # Expose bookkeeper client managed ledger stats to prometheus. default is false
 # bookkeeperClientExposeStatsToPrometheus=false
 
+# Max number allowed for ensemble change, if exceeds this limit, ledger will be closed
+bookkeeperMaxNumEnsembleChanges=
+
 ### --- Managed Ledger --- ###
 
 # Number of bookies to use when creating a ledger

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -622,6 +622,9 @@ bookkeeperUseV2WireProtocol=true
 # Expose bookkeeper client managed ledger stats to prometheus. default is false
 # bookkeeperClientExposeStatsToPrometheus=false
 
+# Max number allowed for ensemble change, if exceeds this limit, ledger will be closed
+bookkeeperMaxNumEnsembleChanges=
+
 ### --- Managed Ledger --- ###
 
 # Number of bookies to use when creating a ledger

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1481,6 +1481,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int bookkeeperClientNumWorkerThreads = Runtime.getRuntime().availableProcessors();
 
+    @FieldContext(
+            category = CATEGORY_STORAGE_BK,
+            doc = "Max number allowed for ensemble change, if exceeds this limit, ledger will be closed. Default is Integer.MAX_VALUE"
+    )
+    private int bookkeeperMaxNumEnsembleChanges = Integer.MAX_VALUE;
 
     /**** --- Managed Ledger --- ****/
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -121,6 +121,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setStickyReadsEnabled(conf.isBookkeeperEnableStickyReads());
         bkConf.setNettyMaxFrameSizeBytes(conf.getMaxMessageSize() + Commands.MESSAGE_SIZE_FRAME_PADDING);
         bkConf.setDiskWeightBasedPlacementEnabled(conf.isBookkeeperDiskWeightBasedPlacementEnabled());
+        bkConf.setMaxAllowedEnsembleChanges(conf.getBookkeeperMaxNumEnsembleChanges());
 
         if (StringUtils.isNotBlank(conf.getBookkeeperMetadataServiceUri())) {
             bkConf.setMetadataServiceUri(conf.getBookkeeperMetadataServiceUri());


### PR DESCRIPTION
### Motivation
If we have a topic with write quorum > ack quorum,  when there are some entries that met the ack quorum but not the write quorum, then these entries will trigger an ensemble change when complete. 

```shell
14:32:50.001 [BookKeeperClientWorker-OrderedExecutor-34-0] INFO  org.apache.bookkeeper.client.LedgerHandle - New Ensemble: [11.181.55.191:3181, 9.146.211.202:3181, 11.181.55.252:3181] for ledger: 482146
14:32:50.004 [BookKeeperClientWorker-OrderedExecutor-34-0] INFO  org.apache.bookkeeper.client.LedgerHandle - New Ensemble: [11.181.55.191:3181, 9.146.211.234:3181, 11.181.55.252:3181] for ledger: 482146
14:32:50.008 [BookKeeperClientWorker-OrderedExecutor-34-0] INFO  org.apache.bookkeeper.client.LedgerHandle - New Ensemble: [11.181.55.191:3181, 11.181.55.210:3181, 11.181.55.252:3181] for ledger: 482146
```
The ensemble change happened many times, so, it's better we can add a limit for this behavior.
### Modifications

Add `bookkeeperMaxNumEnsembleChanges` in broker.conf to limit the max number of ensemble changes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


