### PR TITLE
[Metadata] Attempt to fix flakiness in ZKSessionTest and quarantine the test

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -43,7 +43,10 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     @Override
     public final void cleanup() throws Exception {
         markCurrentSetupNumberCleaned();
-        zks.close();
+        if (zks != null) {
+            zks.close();
+            zks = null;
+        }
     }
 
     private static String createTempFolder() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,7 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
+@Test(groups = "quarantine")
 public class ZKSessionTest extends BaseMetadataStoreTest {
 
     @Test
@@ -70,7 +72,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         @Cleanup
         MetadataStoreExtended store = MetadataStoreExtended.create(zks.getConnectionString(),
                 MetadataStoreConfig.builder()
-                        .sessionTimeoutMillis(10_000)
+                        .sessionTimeoutMillis(5_000)
                         .build());
 
         BlockingQueue<SessionEvent> sessionEvents = new LinkedBlockingQueue<>();
@@ -166,13 +168,13 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionLost);
         // --- test  le1 can be leader
-        Awaitility.await()
+        Awaitility.await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(()-> assertEquals(le1.getState(),LeaderElectionState.Leading)); // reacquire leadership
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.Reconnected);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
-        Awaitility.await()
+        Awaitility.await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(()-> assertEquals(le1.getState(),LeaderElectionState.Leading));
         assertTrue(store.get(path).join().isPresent());
     }


### PR DESCRIPTION
### Motivation

ZKSessionTest is very flaky. See #13008.

### Modifications

- quarantine the test until the flakiness is fully fixed.
- improvements in this PR as an attempt to fix flakiness:
  - improve clean up of TestZKServer which left uncleaned resources running.
    - The session tracker thread was duplicated after stop/start
  - Reduce tick time used in TestZKServer
  - Reduce session expiration timeout in tests
  - Increase timeout for polling in tests