### PR TITLE
[Transaction] Add a check for uninitialized PendingAck

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1233,5 +1233,13 @@ public class PersistentSubscription implements Subscription {
         }
     }
 
+    public boolean checkIfPendingAckStoreInit() {
+        if (this.pendingAckHandle instanceof PendingAckHandleImpl) {
+            return ((PendingAckHandleImpl) this.pendingAckHandle).checkIfPendingAckStoreInit();
+        } else {
+            return false;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentSubscription.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1235,7 +1235,7 @@ public class PersistentSubscription implements Subscription {
 
     public boolean checkIfPendingAckStoreInit() {
         if (this.pendingAckHandle instanceof PendingAckHandleImpl) {
-            return ((PendingAckHandleImpl) this.pendingAckHandle).checkIfPendingAckStoreInit();
+            return this.pendingAckHandle.checkIfPendingAckStoreInit();
         } else {
             return false;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1234,11 +1234,7 @@ public class PersistentSubscription implements Subscription {
     }
 
     public boolean checkIfPendingAckStoreInit() {
-        if (this.pendingAckHandle instanceof PendingAckHandleImpl) {
-            return this.pendingAckHandle.checkIfPendingAckStoreInit();
-        } else {
-            return false;
-        }
+        return this.pendingAckHandle.checkIfPendingAckStoreInit();
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentSubscription.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -64,7 +64,8 @@ public class TransactionAggregator {
                             topic.getSubscriptions().values().forEach(subscription -> {
                                 try {
                                     localManageLedgerStats.get().reset();
-                                    if (!checkTopicIsEventsNames(TopicName.get(subscription.getTopic().getName()))) {
+                                    if (!checkTopicIsEventsNames(TopicName.get(subscription.getTopic().getName()))
+                                            && ((PersistentSubscription) subscription).checkIfPendingAckStoreInit()) {
                                         ManagedLedger managedLedger =
                                                 ((PersistentSubscription) subscription)
                                                         .getPendingAckManageLedger().get();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -65,6 +65,7 @@ public class TransactionAggregator {
                                 try {
                                     localManageLedgerStats.get().reset();
                                     if (!checkTopicIsEventsNames(TopicName.get(subscription.getTopic().getName()))
+                                            && subscription instanceof  PersistentSubscription
                                             && ((PersistentSubscription) subscription).checkIfPendingAckStoreInit()) {
                                         ManagedLedger managedLedger =
                                                 ((PersistentSubscription) subscription)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -159,4 +159,9 @@ public interface PendingAckHandle {
      */
     CompletableFuture<Void> close();
 
+    /**
+     * Check if the PendingAckStore is init.
+     * @return if the PendingAckStore is init.
+     */
+    boolean checkIfPendingAckStoreInit();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -99,4 +99,9 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
     public CompletableFuture<Void> close() {
         return CompletableFuture.completedFuture(null);
     }
+
+    @Override
+    public boolean checkIfPendingAckStoreInit() {
+        return false;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -923,7 +923,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     public CompletableFuture<ManagedLedger> getStoreManageLedger() {
-        if (this.pendingAckStoreFuture.isDone()) {
+        if (this.pendingAckStoreFuture != null && this.pendingAckStoreFuture.isDone()) {
             return this.pendingAckStoreFuture.thenCompose(pendingAckStore -> {
                 if (pendingAckStore instanceof MLPendingAckStore) {
                     return ((MLPendingAckStore) pendingAckStore).getManagedLedger();
@@ -935,6 +935,10 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         } else {
             return FutureUtil.failedFuture(new ServiceUnitNotReadyException("Pending ack have not init success!"));
         }
+    }
+
+    public boolean checkIfPendingAckStoreInit() {
+        return pendingAckStoreFuture != null;
     }
 
     protected void handleCacheRequest() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -938,7 +938,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     public boolean checkIfPendingAckStoreInit() {
-        return pendingAckStoreFuture != null;
+        return this.pendingAckStoreFuture != null && this.pendingAckStoreFuture.isDone();
     }
 
     protected void handleCacheRequest() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -937,6 +937,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         }
     }
 
+    @Override
     public boolean checkIfPendingAckStoreInit() {
         return this.pendingAckStoreFuture != null && this.pendingAckStoreFuture.isDone();
     }


### PR DESCRIPTION
### Motivation 
We should not generate the statistics of a uninitialized PendingAck,and we should check if it is initialized when we get it by `getStoreManageLedger()`.
### Modifications
 Do not generate the statistics of a uninitialized PendingAck.
 Add check if it is initialized when we get it by `getStoreManageLedger()`.
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


