### PR TITLE
[pulsar-package-management] Support to access a separated bookkeeper cluster

### DIFF
--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
@@ -82,8 +82,18 @@ public class BookKeeperPackagesStorage implements PackagesStorage {
     }
 
     private URI initializeDlogNamespace() throws IOException {
-        BKDLConfig bkdlConfig = new BKDLConfig(configuration.getZookeeperServers(),
-            configuration.getPackagesManagementLedgerRootPath());
+        String bookkeeperMetadataServiceUri = configuration.getProperty("bookkeeperMetadataServiceUri");
+        String ledgersRootPath;
+        String ledgersStoreServers;
+        if (bookkeeperMetadataServiceUri == null) {
+            ledgersRootPath = configuration.getPackagesManagementLedgerRootPath();
+            ledgersStoreServers = configuration.getZookeeperServers();
+        } else {
+            URI metadataServiceUri = URI.create(bookkeeperMetadataServiceUri);
+            ledgersStoreServers = metadataServiceUri.getAuthority().replace(";", ",");
+            ledgersRootPath = metadataServiceUri.getPath();
+        }
+        BKDLConfig bkdlConfig = new BKDLConfig(ledgersStoreServers, ledgersRootPath);
         DLMetadata dlMetadata = DLMetadata.create(bkdlConfig);
         URI dlogURI = URI.create(String.format("distributedlog://%s/pulsar/packages",
             configuration.getZookeeperServers()));

--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorage.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.DistributedLogConstants;
 import org.apache.distributedlog.api.DistributedLogManager;
@@ -85,13 +86,13 @@ public class BookKeeperPackagesStorage implements PackagesStorage {
         String bookkeeperMetadataServiceUri = configuration.getProperty("bookkeeperMetadataServiceUri");
         String ledgersRootPath;
         String ledgersStoreServers;
-        if (bookkeeperMetadataServiceUri == null) {
-            ledgersRootPath = configuration.getPackagesManagementLedgerRootPath();
-            ledgersStoreServers = configuration.getZookeeperServers();
-        } else {
+        if (StringUtils.isNotBlank(bookkeeperMetadataServiceUri)) {
             URI metadataServiceUri = URI.create(bookkeeperMetadataServiceUri);
             ledgersStoreServers = metadataServiceUri.getAuthority().replace(";", ",");
             ledgersRootPath = metadataServiceUri.getPath();
+        } else {
+            ledgersRootPath = configuration.getPackagesManagementLedgerRootPath();
+            ledgersStoreServers = configuration.getZookeeperServers();
         }
         BKDLConfig bkdlConfig = new BKDLConfig(ledgersStoreServers, ledgersRootPath);
         DLMetadata dlMetadata = DLMetadata.create(bkdlConfig);


### PR DESCRIPTION
### Motivation

Currently, the bookkeeper client used by can not be initialized correctly when using a separated bookkeeper cluster via `bookkeeperMetadataServiceUri` whose zookkeeper connection may be different with pulsar zookkeeper servers.  e.g.
```
17:08:07.661 [ForkJoinPool.commonPool-worker-43] WARN  org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl - Failed to find 1 bookies : excludeBookies [], allBookies [].
17:08:07.662 [ForkJoinPool.commonPool-worker-43] ERROR org.apache.bookkeeper.client.LedgerCreateOp - Not enough bookies to create ledger with ensembleSize=1, writeQuorumSize=1 and ackQuorumSize=1
17:08:07.662 [ForkJoinPool.commonPool-worker-43] ERROR org.apache.distributedlog.bk.SimpleLedgerAllocator - Error creating ledger for allocating /kobe/pulsar/packages/function/public/default/redis/v1.0/meta/<default>/allocation :
org.apache.bookkeeper.client.BKException$BKNotEnoughBookiesException: Not enough non-faulty bookies available
        at org.apache.bookkeeper.client.BKException.create(BKException.java:72) ~[org.apache.bookkeeper-bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.distributedlog.BookKeeperClient$1.createComplete(BookKeeperClient.java:223) ~[org.apache.distributedlog-distributedlog-core-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.client.LedgerCreateOp.createComplete(LedgerCreateOp.java:272) ~[org.apache.bookkeeper-bookkeeper-server-4.14.3.jar:4.14.3]
        at org.apache.bookkeeper.client.LedgerCreateOp.initiate(LedgerCreateOp.java:166) ~[org.apache.bookkeeper-bookkeeper-server-4.14.3.jar:4.14.3]
```
### Modifications

Use the correct `BKDLConfig` from property `bookkeeperMetadataServiceUri`.

### Documentation

- [x] `no-need-doc` 
