### PR TITLE
[Authorization] Optimize the logic of allowing namespace operation

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -521,27 +521,44 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                                                    String role,
                                                                    NamespaceOperation operation,
                                                                    AuthenticationDataSource authData) {
-        CompletableFuture<Boolean> isAuthorizedFuture;
-        switch (operation) {
-            case PACKAGES:
-                isAuthorizedFuture = allowTheSpecifiedActionOpsAsync(namespaceName, role, authData, AuthAction.packages);
-                break;
-            case GET_TOPICS:
-            case UNSUBSCRIBE:
-            case CLEAR_BACKLOG:
-                isAuthorizedFuture = allowTheSpecifiedActionOpsAsync(namespaceName, role, authData, AuthAction.consume);
-                break;
-            default:
-                isAuthorizedFuture = CompletableFuture.completedFuture(false);
+        if (log.isDebugEnabled()) {
+            log.debug("Check allowNamespaceOperationAsync [{}] on [{}].", operation.name(), namespaceName);
         }
-        CompletableFuture<Boolean> isTenantAdminFuture = validateTenantAdminAccess(namespaceName.getTenant(), role, authData);
-        return isTenantAdminFuture.thenCombine(isAuthorizedFuture, (isTenantAdmin, isAuthorized) -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Verify if role {} is allowed to {} to topic {}: isTenantAdmin={}, isAuthorized={}",
-                        role, operation, namespaceName, isTenantAdmin, isAuthorized);
-            }
-            return isTenantAdmin || isAuthorized;
-        });
+
+        return validateTenantAdminAccess(namespaceName.getTenant(), role, authData)
+                .thenCompose(isSuperUserOrAdmin -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Verify if role {} is allowed to {} to namespace {}: isSuperUserOrAdmin={}",
+                                role, operation, namespaceName, isSuperUserOrAdmin);
+                    }
+                    if (isSuperUserOrAdmin) {
+                        return CompletableFuture.completedFuture(true);
+                    } else {
+                        switch (operation) {
+                            case PACKAGES:
+                                return allowTheSpecifiedActionOpsAsync(
+                                        namespaceName, role, authData, AuthAction.packages);
+                            case GET_TOPIC:
+                            case GET_TOPICS:
+                            case UNSUBSCRIBE:
+                            case CLEAR_BACKLOG:
+                                return allowTheSpecifiedActionOpsAsync(
+                                        namespaceName, role, authData, AuthAction.consume);
+                            case CREATE_TOPIC:
+                            case DELETE_TOPIC:
+                            case ADD_BUNDLE:
+                            case GET_BUNDLE:
+                            case DELETE_BUNDLE:
+                            case GRANT_PERMISSION:
+                            case GET_PERMISSION:
+                            case REVOKE_PERMISSION:
+                                return CompletableFuture.completedFuture(false);
+                            default:
+                                return FutureUtil.failedFuture(new IllegalStateException(
+                                        "NamespaceOperation [" + operation.name() + "] is not supported."));
+                        }
+                    }
+                });
     }
 
     @Override
@@ -558,43 +575,8 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                                                String role,
                                                                TopicOperation operation,
                                                                AuthenticationDataSource authData) {
-        log.debug("Check allowTopicOperationAsync [" + operation.name() + "] on [" + topicName.toString() + "].");
-
-        CompletableFuture<Boolean> isAuthorizedFuture;
-
-        switch (operation) {
-            case LOOKUP:
-            case GET_STATS:
-            case GET_METADATA:
-                isAuthorizedFuture = canLookupAsync(topicName, role, authData);
-                break;
-            case PRODUCE:
-                isAuthorizedFuture = canProduceAsync(topicName, role, authData);
-                break;
-            case GET_SUBSCRIPTIONS:
-            case CONSUME:
-            case SUBSCRIBE:
-            case UNSUBSCRIBE:
-            case SKIP:
-            case EXPIRE_MESSAGES:
-            case PEEK_MESSAGES:
-            case RESET_CURSOR:
-            case GET_BACKLOG_SIZE:
-            case SET_REPLICATED_SUBSCRIPTION_STATUS:
-            case GET_REPLICATED_SUBSCRIPTION_STATUS:
-                isAuthorizedFuture = canConsumeAsync(topicName, role, authData, authData.getSubscription());
-                break;
-            case TERMINATE:
-            case COMPACT:
-            case OFFLOAD:
-            case UNLOAD:
-            case ADD_BUNDLE_RANGE:
-            case GET_BUNDLE_RANGE:
-            case DELETE_BUNDLE_RANGE:
-                return validateTenantAdminAccess(topicName.getTenant(), role, authData);
-            default:
-                return FutureUtil.failedFuture(
-                        new IllegalStateException("TopicOperation [" + operation.name() + "] is not supported."));
+        if (log.isDebugEnabled()) {
+            log.debug("Check allowTopicOperationAsync [{}] on [{}].", operation.name(), topicName);
         }
 
         return validateTenantAdminAccess(topicName.getTenant(), role, authData)
@@ -606,7 +588,37 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                     if (isSuperUserOrAdmin) {
                         return CompletableFuture.completedFuture(true);
                     } else {
-                        return isAuthorizedFuture;
+                        switch (operation) {
+                            case LOOKUP:
+                            case GET_STATS:
+                            case GET_METADATA:
+                                return canLookupAsync(topicName, role, authData);
+                            case PRODUCE:
+                                return canProduceAsync(topicName, role, authData);
+                            case GET_SUBSCRIPTIONS:
+                            case CONSUME:
+                            case SUBSCRIBE:
+                            case UNSUBSCRIBE:
+                            case SKIP:
+                            case EXPIRE_MESSAGES:
+                            case PEEK_MESSAGES:
+                            case RESET_CURSOR:
+                            case GET_BACKLOG_SIZE:
+                            case SET_REPLICATED_SUBSCRIPTION_STATUS:
+                            case GET_REPLICATED_SUBSCRIPTION_STATUS:
+                                return canConsumeAsync(topicName, role, authData, authData.getSubscription());
+                            case TERMINATE:
+                            case COMPACT:
+                            case OFFLOAD:
+                            case UNLOAD:
+                            case ADD_BUNDLE_RANGE:
+                            case GET_BUNDLE_RANGE:
+                            case DELETE_BUNDLE_RANGE:
+                                return CompletableFuture.completedFuture(false);
+                            default:
+                                return FutureUtil.failedFuture(new IllegalStateException(
+                                        "TopicOperation [" + operation.name() + "] is not supported."));
+                        }
                     }
                 });
     }


### PR DESCRIPTION
### Motivation
Currently, pulsar supports 13 `NamespaceOperation`, so there should not be more than 13 in method `PulsarAuthorizationProvider#allowNamespaceOperationAsync`. Otherwise, the undefined `NamespaceOperation` can also be passed by super-user or role with admin privileges.
https://github.com/apache/pulsar/blob/7adfffdecc2debacba2fa90c443cb992b826b0c0/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java#L525-L550

The purpose of this PR is to optimize the logic of `PulsarAuthorizationProvider#allowNamespaceOperationAsync` so that it only covers the `NamespaceOperation` supported by pulsar.

### Documentation
- [x] `no-need-doc`   

