### PR TITLE
[pulsar-package-management] Correct the invalid package domain in admin-api-packages doc

### DIFF
--- a/site2/docs/admin-api-packages.md
+++ b/site2/docs/admin-api-packages.md
@@ -79,7 +79,7 @@ You can upload a package to the package management service in the following ways
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 ```
 
 <!--REST API-->
@@ -104,7 +104,7 @@ You can download a package to the package management service in the following wa
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 ```
 
 <!--REST API-->
@@ -230,7 +230,7 @@ You can delete a specified package with its package name in the following ways.
 The following command example deletes a package of version 0.1.
 
 ```shell
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 ```
 
 <!--REST API-->

--- a/site2/website-next/docs/admin-api-packages.md
+++ b/site2/website-next/docs/admin-api-packages.md
@@ -90,7 +90,7 @@ You can upload a package to the package management service in the following ways
 
 ```shell
 
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 
 ```
 
@@ -132,7 +132,7 @@ You can download a package to the package management service in the following wa
 
 ```shell
 
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 
 ```
 
@@ -341,7 +341,7 @@ The following command example deletes a package of version 0.1.
 
 ```shell
 
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 
 ```
 

--- a/site2/website-next/versioned_docs/version-2.8.0/admin-api-packages.md
+++ b/site2/website-next/versioned_docs/version-2.8.0/admin-api-packages.md
@@ -81,7 +81,7 @@ You can upload a package to the package management service in the following ways
 
 ```shell
 
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 
 ```
 
@@ -123,7 +123,7 @@ You can download a package to the package management service in the following wa
 
 ```shell
 
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 
 ```
 
@@ -332,7 +332,7 @@ The following command example deletes a package of version 0.1.
 
 ```shell
 
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 
 ```
 

--- a/site2/website/versioned_docs/version-2.8.0/admin-api-packages.md
+++ b/site2/website/versioned_docs/version-2.8.0/admin-api-packages.md
@@ -70,7 +70,7 @@ You can upload a package to the package management service in the following ways
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 ```
 
 <!--REST API-->
@@ -95,7 +95,7 @@ You can download a package to the package management service in the following wa
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 ```
 
 <!--REST API-->
@@ -221,7 +221,7 @@ You can delete a specified package with its package name in the following ways.
 The following command example deletes a package of version 0.1.
 
 ```shell
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 ```
 
 <!--REST API-->

--- a/site2/website/versioned_docs/version-2.8.1/admin-api-packages.md
+++ b/site2/website/versioned_docs/version-2.8.1/admin-api-packages.md
@@ -70,7 +70,7 @@ You can upload a package to the package management service in the following ways
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 ```
 
 <!--REST API-->
@@ -95,7 +95,7 @@ You can download a package to the package management service in the following wa
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 ```
 
 <!--REST API-->
@@ -221,7 +221,7 @@ You can delete a specified package with its package name in the following ways.
 The following command example deletes a package of version 0.1.
 
 ```shell
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 ```
 
 <!--REST API-->

--- a/site2/website/versioned_docs/version-2.8.2/admin-api-packages.md
+++ b/site2/website/versioned_docs/version-2.8.2/admin-api-packages.md
@@ -80,7 +80,7 @@ You can upload a package to the package management service in the following ways
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages upload functions://public/default/example@v0.1 --path package-file --description package-description
+bin/pulsar-admin packages upload function://public/default/example@v0.1 --path package-file --description package-description
 ```
 
 <!--REST API-->
@@ -105,7 +105,7 @@ You can download a package to the package management service in the following wa
 <!--DOCUSAURUS_CODE_TABS-->
 <!--pulsar-admin-->
 ```shell
-bin/pulsar-admin packages download functions://public/default/example@v0.1 --path package-file
+bin/pulsar-admin packages download function://public/default/example@v0.1 --path package-file
 ```
 
 <!--REST API-->
@@ -231,7 +231,7 @@ You can delete a specified package with its package name in the following ways.
 The following command example deletes a package of version 0.1.
 
 ```shell
-bin/pulsar-admin packages delete functions://public/default/example@v0.1
+bin/pulsar-admin packages delete function://public/default/example@v0.1
 ```
 
 <!--REST API-->


### PR DESCRIPTION
### Motivation
Correct the invalid package domain `functions` which leads to:
```
Caused by: java.lang.IllegalArgumentException: Invalid package domain: 'functions'
```
### Modifications
Change `functions` to`function`.




