### PR TITLE
Allow to config Sasl configs in Kafka source

### DIFF
--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -21,11 +21,15 @@ package org.apache.pulsar.io.kafka;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -83,6 +87,27 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
             props.putAll(kafkaSourceConfig.getConsumerConfigProperties());
         }
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaSourceConfig.getBootstrapServers());
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSecurityProtocol())) {
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, kafkaSourceConfig.getSecurityProtocol());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSaslMechanism())) {
+            props.put(SaslConfigs.SASL_MECHANISM, kafkaSourceConfig.getSaslMechanism());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSaslJaasConfig())) {
+            props.put(SaslConfigs.SASL_JAAS_CONFIG, kafkaSourceConfig.getSaslJaasConfig());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSslEnabledProtocols())) {
+            props.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, kafkaSourceConfig.getSslEnabledProtocols());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSslEndpointIdentificationAlgorithm())) {
+            props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, kafkaSourceConfig.getSslEndpointIdentificationAlgorithm());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSslTruststoreLocation())) {
+            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, kafkaSourceConfig.getSslTruststoreLocation());
+        }
+        if (StringUtils.isNotEmpty(kafkaSourceConfig.getSslTruststorePassword())) {
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, kafkaSourceConfig.getSslTruststorePassword());
+        }
         props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaSourceConfig.getGroupId());
         props.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, String.valueOf(kafkaSourceConfig.getFetchMinBytes()));
         props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(kafkaSourceConfig.getAutoCommitIntervalMs()));

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
@@ -47,13 +47,13 @@ public class KafkaSinkConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "",
-            help = "Protocol used to communicate with kafka brokers.")
+            help = "Protocol used to communicate with Kafka brokers.")
     private String securityProtocol;
 
     @FieldDoc(
             required = false,
             defaultValue = "",
-            help = "SASL mechanism used for kafka client connections.")
+            help = "SASL mechanism used for Kafka client connections.")
     private String saslMechanism;
 
     @FieldDoc(

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -47,13 +47,13 @@ public class KafkaSourceConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "",
-            help = "Protocol used to communicate with kafka brokers.")
+            help = "Protocol used to communicate with Kafka brokers.")
     private String securityProtocol;
 
     @FieldDoc(
             required = false,
             defaultValue = "",
-            help = "SASL mechanism used for kafka client connections.")
+            help = "SASL mechanism used for Kafka client connections.")
     private String saslMechanism;
 
     @FieldDoc(

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -43,6 +43,49 @@ public class KafkaSourceConfig implements Serializable {
             "A comma-separated list of host and port pairs that are the addresses of "
           + "the Kafka brokers that a Kafka client connects to initially bootstrap itself")
     private String bootstrapServers;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "Protocol used to communicate with kafka brokers.")
+    private String securityProtocol;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "SASL mechanism used for kafka client connections.")
+    private String saslMechanism;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "JAAS login context parameters for SASL connections in the format used by JAAS configuration files.")
+    private String saslJaasConfig;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "The list of protocols enabled for SSL connections.")
+    private String sslEnabledProtocols;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "The endpoint identification algorithm to validate server hostname using server certificate.")
+    private String sslEndpointIdentificationAlgorithm;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "The location of the trust store file.")
+    private String sslTruststoreLocation;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "",
+            help = "The password for the trust store file.")
+    private String sslTruststorePassword;
+
     @FieldDoc(
         required = true,
         defaultValue = "",

--- a/pulsar-io/kafka/src/test/resources/kafkaSourceConfigSasl.yaml
+++ b/pulsar-io/kafka/src/test/resources/kafkaSourceConfigSasl.yaml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"bootstrapServers": "localhost:6667"
+"groupId": "test-pulsar-io"
+"topic": "test"
+"securityProtocol": "SASL_PLAINTEXT"
+"saslMechanism" : "PLAIN"
+"saslJaasConfig" : "org.apache.kafka.common.security.plain.PlainLoginModule required \nusername=\"alice\" \npassword=\"pwd\";"
+"sslEnabledProtocols" : "TLSv1.2"
+"sslEndpointIdentificationAlgorithm" : ""
+"sslTruststoreLocation" : "/etc/cert.pem"
+"sslTruststorePassword" : "cert_pwd"
+


### PR DESCRIPTION
related to #11422

### Motivation
Allow pulsar io to consume messages to sasl kafka cluster.

### Modifications

Add several kafka sasl configs, make them configable.


### Documentation

Check the box below and label this PR (if you have committer privilege).
  
- [x] `no-need-doc` 
  
 **Pulsar-io** can automatically generate the doc for added fields. So we don't need add any docs.