### PR TITLE
cleanup code for ZkBookieRackAffinityMapping

### DIFF
--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMapping.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.zookeeper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
Descriptions of the changes in this PR:

### Motivation

Simple code cleanup

### Modifications

1. no use import  UnknownHostException for ZkBookieRackAffinityMapping 



