### PR TITLE
[Metadata] Log thread dump when Zookeeper session expires to help detect possible deadlocks

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -136,6 +136,7 @@ import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.protocol.schema.SchemaStorage;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.ThreadDumpUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.compaction.TwoPhaseCompactor;
@@ -838,7 +839,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         LOG.info("Received metadata service session event: {}", e);
         if (e == SessionEvent.SessionLost
                 && config.getZookeeperSessionExpiredPolicy() == MetadataSessionExpiredPolicy.shutdown) {
-            LOG.warn("The session with metadata service was lost. Shutting down.");
+            LOG.warn("The session with metadata service was lost. Shutting down.\n{}\n",
+                    ThreadDumpUtil.buildThreadDiagnosticString());
             shutdownNow();
         }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ThreadDumpUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ThreadDumpUtil.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.tests;
+package org.apache.pulsar.common.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -72,7 +72,7 @@ public class ThreadDumpUtil {
         for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
             Thread thread = e.getKey();
             dump.append('\n');
-            dump.append(String.format("\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s", thread.getName(),
+            dump.append(String.format("\"%s\" %s prio=%d tid=%d %s%njava.lang.Thread.State: %s", thread.getName(),
                     (thread.isDaemon() ? "daemon" : ""), thread.getPriority(), thread.getId(),
                     Thread.State.WAITING.equals(thread.getState()) ? "in Object.wait()" : thread.getState().name(),
                     Thread.State.WAITING.equals(thread.getState()) ? "WAITING (on object monitor)"


### PR DESCRIPTION
### Motivation

Some Zookeeper session expiration issues might be caused by deadlocks in Pulsar broker's Zookeeper client threads. In the past there have been such issues such as #3566 . This change is  inspired by @massakam 's comment https://github.com/apache/pulsar/issues/3566#issuecomment-462756998

### Modifications

- Add ThreadDumpUtil to pulsar-common module
- When a Zookeeper session expires, create a thread dump and log it. 