### PR TITLE
Correct the packagepath variable define in Sink/SourceApiV3ResourceTest

### DIFF
--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SinkApiV3ResourceTest.java
@@ -1320,7 +1320,7 @@ public class SinkApiV3ResourceTest {
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 
-        String packagePath = String.format("http://foo.com/connector.jar", Utils.BUILTIN);
+        String packagePath = "http://foo.com/connector.jar";
         when(mockedManager.getFunctionMetaData(eq(tenant), eq(namespace), eq(sink)))
                 .thenReturn(FunctionMetaData.newBuilder().setPackageLocation(
                         Function.PackageLocationMetaData.newBuilder().setPackagePath(packagePath).build()).build());
@@ -1339,7 +1339,7 @@ public class SinkApiV3ResourceTest {
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(sink))).thenReturn(true);
 
-        String packagePath = String.format("file://foo/connector.jar", Utils.BUILTIN);
+        String packagePath = "file://foo/connector.jar";
         when(mockedManager.getFunctionMetaData(eq(tenant), eq(namespace), eq(sink)))
                 .thenReturn(FunctionMetaData.newBuilder().setPackageLocation(
                         Function.PackageLocationMetaData.newBuilder().setPackagePath(packagePath).build()).build());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -1351,7 +1351,7 @@ public class SourceApiV3ResourceTest {
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 
-        String packagePath = String.format("http://foo.com/connector.jar", Utils.BUILTIN);
+        String packagePath = "http://foo.com/connector.jar";
         when(mockedManager.getFunctionMetaData(eq(tenant), eq(namespace), eq(source)))
                 .thenReturn(FunctionMetaData.newBuilder().setPackageLocation(
                         PackageLocationMetaData.newBuilder().setPackagePath(packagePath).build()).build());
@@ -1370,7 +1370,7 @@ public class SourceApiV3ResourceTest {
 
         when(mockedManager.containsFunction(eq(tenant), eq(namespace), eq(source))).thenReturn(true);
 
-        String packagePath = String.format("file://foo/connector.jar", Utils.BUILTIN);
+        String packagePath = "file://foo/connector.jar";
         when(mockedManager.getFunctionMetaData(eq(tenant), eq(namespace), eq(source)))
                 .thenReturn(FunctionMetaData.newBuilder().setPackageLocation(
                         PackageLocationMetaData.newBuilder().setPackagePath(packagePath).build()).build());


### PR DESCRIPTION
### Motivation
Correct the packagepath variable define.

### Modifications

Remove the unused `builtin` string format.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
simple changes, no need doc


