### PR TITLE
[Authorization] Revert new AuthorizationProvider method

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -184,16 +184,6 @@ public interface AuthorizationProvider extends Closeable {
                                                  AuthenticationDataSource authenticationData);
 
     /**
-     * Allow consume operations with in this namespace
-     * @param namespaceName The namespace that the consume operations can be executed in
-     * @param role The role to check
-     * @param authenticationData authentication data related to the role
-     * @return a boolean to determine whether authorized or not
-     */
-    CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role,
-                                                 AuthenticationDataSource authenticationData);
-
-    /**
      *
      * Grant authorization-action permission on a namespace to the given client
      *

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -210,11 +210,6 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     }
 
     @Override
-    public CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role, AuthenticationDataSource authenticationData) {
-        return authorize(authenticationData, r -> super.allowConsumeOpsAsync(namespaceName, r, authenticationData));
-    }
-
-    @Override
     public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName,
                                                                 String role,
                                                                 TenantOperation operation,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -225,11 +225,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
         return allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData, AuthAction.sinks);
     }
 
-    @Override
-    public CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role, AuthenticationDataSource authenticationData) {
-        return allowTheSpecifiedActionOpsAsync(namespaceName, role, authenticationData, AuthAction.consume);
-    }
-
     private CompletableFuture<Boolean> allowTheSpecifiedActionOpsAsync(NamespaceName namespaceName, String role,
                                                                        AuthenticationDataSource authenticationData,
                                                                        AuthAction authAction) {
@@ -534,7 +529,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             case GET_TOPICS:
             case UNSUBSCRIBE:
             case CLEAR_BACKLOG:
-                isAuthorizedFuture = allowConsumeOpsAsync(namespaceName, role, authData);
+                isAuthorizedFuture = allowTheSpecifiedActionOpsAsync(namespaceName, role, authData, AuthAction.consume);
                 break;
             default:
                 isAuthorizedFuture = CompletableFuture.completedFuture(false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthorizationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthorizationProvider.java
@@ -97,12 +97,6 @@ public class MockAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role,
-                                                    AuthenticationDataSource authenticationData) {
-        return roleAuthorizedAsync(role);
-    }
-
-    @Override
     public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions, String role,
                                                         String authDataJson) {
         return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -650,11 +650,6 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role, AuthenticationDataSource authenticationData) {
-            return null;
-        }
-
-        @Override
         public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions,
                 String role, String authenticationData) {
             return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
@@ -297,11 +297,6 @@ public class PatternTopicsConsumerImplAuthTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> allowConsumeOpsAsync(NamespaceName namespaceName, String role, AuthenticationDataSource authenticationData) {
-            return null;
-        }
-
-        @Override
         public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions,
                                                             String role, String authenticationData) {
             return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
### Motivation

In PR https://github.com/apache/pulsar/pull/12600, we added a method to the `AuthorizationProvider` that is not used outside of implementations of the `AuthorizationProvider` itself. Since this interface is public, we should make sure that all methods are necessary. Further, since we cherry picked the commit for https://github.com/apache/pulsar/pull/12600 to `branch-2.9` and `branch-2.8`, we introduced a potentially breaking change for third party implementations of the `AuthorizationProvider` interface. While the commit itself isn't breaking, it does imply that the interface has a method that _could_ be used by the authorization service or some other part of Pulsar. Since third party implementations might not have this method implemented, they could break.

For added context, it is likely that this method was added because there are other similar methods in the interface. For example, the interface has the following methods: `allowSinkOpsAsync`, `allowSourceOpsAsync`, and `allowFunctionOpsAsync`. These methods are much older and are called by the `AuthenticationService`.

### Modifications

* Remove the `AuthorizationProvider#allowConsumeOpsAsync` method from the interface and from all implementations of the interface.

### Verifying this change

This is a trivial change. No underlying logic is changed by this commit.

### Does this pull request potentially affect one of the following parts:

This fix addresses a potentially breaking change.

### Documentation
- [x] `no-need-doc` 
