### PR TITLE
Fix schedule task memory leak in ManagedLedgerFactoryImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -352,6 +352,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                         // Managed ledger is in unusable state. Recreate it.
                         log.warn("[{}] Attempted to open ledger in {} state. Removing from the map to recreate it",
                                 name, l.getState());
+                        l.close();
                         ledgers.remove(name, existingFuture);
                     }
                 } catch (Exception e) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -352,8 +352,18 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                         // Managed ledger is in unusable state. Recreate it.
                         log.warn("[{}] Attempted to open ledger in {} state. Removing from the map to recreate it",
                                 name, l.getState());
-                        l.close();
                         ledgers.remove(name, existingFuture);
+                        l.asyncClose(new CloseCallback() {
+                            @Override
+                            public void closeComplete(Object ctx) {
+                                log.info("[{}] [{}] closed", name, l.getName());
+                            }
+
+                            @Override
+                            public void closeFailed(ManagedLedgerException exception, Object ctx) {
+                                log.warn("[{}] [{}] Failed to close: {}", name, l.getName(), exception.getMessage());
+                            }
+                        }, null);
                     }
                 } catch (Exception e) {
                     // Unable to get the future

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1192,6 +1192,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     @Override
     public synchronized void asyncTerminate(TerminateCallback callback, Object ctx) {
         if (state == State.Fenced) {
+            cancelScheduledTasks();
             callback.terminateFailed(new ManagedLedgerFencedException(), ctx);
             return;
         } else if (state == State.Terminated) {


### PR DESCRIPTION
### Motivation
The memory is leak due to the ManagerLedgerImpl can't be garbage collected.

### Modifications

Before remove the `managedLedgerImpl` from map, call  `close()` to cacel the schdule job first.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
 Fix a memory leak bug


