### PR TITLE
When the traffic to be unloaded is too small, it means that maxThroug…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -129,8 +129,7 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
 
             if(msgThroughtputRequiredFromUnloadedBundles.getValue() < minThroughputThreshold){
                 if (log.isDebugEnabled()) {
-                    log.debug("Planning to shed throughput {} MByte/s less than "
-                                    + "minimumThroughputThreshold {} MByte/s, stop unload.",
+                    log.debug("Planning to shed throughput {} MByte/s less than minimumThroughputThreshold {} MByte/s, stop unload.",
                             msgThroughtputRequiredFromUnloadedBundles.getValue() / MB, minThroughputThreshold / MB);
                 }
                 return selectedBundlesCache;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -127,9 +127,10 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                     (int) ((maxThroughputRate.getValue() - minThroughputgRate.getValue()) / 2));
             LocalBrokerData overloadedBrokerData = brokersData.get(overloadedBroker.getValue()).getLocalData();
 
-            if(msgThroughtputRequiredFromUnloadedBundles.getValue() < minThroughputThreshold){
+            if (msgThroughtputRequiredFromUnloadedBundles.getValue() < minThroughputThreshold) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Planning to shed throughput {} MByte/s less than minimumThroughputThreshold {} MByte/s, stop unload.",
+                    log.debug("Planning to shed throughput {} MByte/s less than "
+                                    + "minimumThroughputThreshold {} MByte/s, stop unload.",
                             msgThroughtputRequiredFromUnloadedBundles.getValue() / MB, minThroughputThreshold / MB);
                 }
                 return selectedBundlesCache;


### PR DESCRIPTION
### Motivation
When the traffic to be unloaded is too small, it means that maxThroughputRate is very small, and there is no need to unload at this time to avoid unnecessary unload.

Need to update docs? 

- [x] `no-need-doc` 
  


