### PR TITLE
Fix initialisation of autorecovery pod

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -183,6 +183,9 @@ fi
 
 BOOKIE_LOG_DIR=${BOOKIE_LOG_DIR:-"$BK_HOME/logs"}
 BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"bookkeeper-server.log"}
+if [ ! -d "$BOOKIE_LOG_DIR" ]; then
+  mkdir -p "$BOOKIE_LOG_DIR"
+fi
 
 #Configure log configuration system properties
 OPTS="$OPTS -Dpulsar.log.appender=$BOOKIE_LOG_APPENDER"


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

#11285 prevents the autorecovery pod from initialising successfully. The pod would throw the error:

```
[conf/bookkeeper.conf] Applying config zkServers = pulsar-zookeeper-ca:2181
[0.001s][error][logging] Error opening log file 'logs/pulsar_bookie_gc_1.log': No such file or directory
[0.001s][error][logging] Initialization of output 'file=logs/pulsar_bookie_gc_%p.log' using options 'filecount=10,filesize=20M' failed.
Invalid -Xlog option '-Xlog:gc*:logs/pulsar_bookie_gc_%p.log:time,uptime,level,tags:filecount=10,filesize=20M', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

As a result the helm deployment would not complete. The error can be reproduced by deploying pulsar, using the [datastax helmchart](https://github.com/datastax/pulsar-helm-chart):

`helm install pulsar -n pulsar -f "pulsar-values.yaml" --wait datastax-pulsar/pulsar`

```
# pulsar-values.yaml
enableAntiAffinity: no
initialize: true  # ASF Helm Chart
restartOnConfigMapChange:
  enabled: yes
image:
  zookeeper:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  bookie:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  bookkeeper:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  autorecovery:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  broker:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  proxy:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  functions:
    repository: <pulsar_master>/pulsar-all
    tag: latest
  function:
    repository: <pulsar_master>/pulsar-all
    tag: latest
extra:
  function: yes
  burnell: yes
  burnellLogCollector: yes
  pulsarHeartbeat: yes
  pulsarAdminConsole: yes
  autoRecovery: yes
  functionsAsPods: yes
default_storage:
  existingStorageClassName: server-storage
volumes:
  data: #ASF Helm Chart
    storageClassName: existent-storage-class
zookeeper:
  replicaCount: 3
bookkeeper:
  replicaCount: 3
broker:
  component: broker
  replicaCount: 2
  ledger:
    defaultEnsembleSize: 1
    defaultAckQuorum:  1
    defaultWriteQuorum: 1
function:
  replicaCount: 1
  functionReplicaCount: 1
  runtime: "kubernetes"
proxy:
  replicaCount: 2
  autoPortAssign:
    enablePlainTextWithTLS: yes
  service:
    type: ClusterIP
    autoPortAssign:
      enabled: yes
grafanaDashboards:
  enabled: yes
pulsarAdminConsole:
  replicaCount: 0
  service:
    type: ClusterIP
grafana: #ASF Helm Chart
  service:
    type: ClusterIP
pulsar_manager:
  service: #ASF Helm Chart
    type: ClusterIP
kube-prometheus-stack: # Luna Streaming Helm Chart
  enabled: no
  prometheusOperator:
    enabled: no
  grafana:
    enabled: no
    service:
      type: ClusterIP
pulsarSQL:
  service:
    type: ClusterIP
enableTls: yes
cert-manager:
  enabled: true
createCertificates:
  selfSigned:
    enabled: true
enableTokenAuth: yes
autoRecovery:
  enableProvisionContainer: yes
```

### Modifications

- adding instruction to create `/pulsar/logs/`, if it does not exist

> The change is equivalent to https://github.com/apache/pulsar/pull/11285/files#diff-89618c73d511b2015766c1fb0cd4bd16aa7f949dfdfa02d1995b586b8ed57d7aR291-R292 in #11285.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment: **yes**

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 


