### PR TITLE
fix flaky test for BrokerServiceLookupTest.testModularLoadManagerSplitBundle

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -654,14 +654,17 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
             conf2.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
             conf2.setZookeeperServers("localhost:2181");
             conf2.setConfigurationStoreServers("localhost:3181");
-
-            @Cleanup
-            PulsarService pulsar2 = startBroker(conf2);
+            conf2.setLoadBalancerAutoBundleSplitEnabled(true);
+            conf2.setLoadBalancerAutoUnloadSplitBundlesEnabled(true);
+            conf2.setLoadBalancerNamespaceBundleMaxTopics(1);
 
             // configure broker-1 with ModularLoadManager
             stopBroker();
             conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
             startBroker();
+
+            @Cleanup
+            PulsarService pulsar2 = startBroker(conf2);
 
             pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
             pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
@@ -732,9 +735,6 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
                     .getLoadManager().get()).getLoadManager();
 
             updateAllMethod.invoke(loadManager);
-            conf2.setLoadBalancerAutoBundleSplitEnabled(true);
-            conf2.setLoadBalancerAutoUnloadSplitBundlesEnabled(true);
-            conf2.setLoadBalancerNamespaceBundleMaxTopics(1);
             loadManager.checkNamespaceBundleSplit();
 
             // (6) Broker-2 should get the watch and update bundle cache


### PR DESCRIPTION
Fixed #13102 

It is invalid to set the `loadBalancerNamespaceBundleMaxTopics=1` after the initialization is completed, and the condition of `stats.topics = 2 > maxBundleTopics = 1000(default)` can not be established, so the operation of bundle-split can not be triggered after the leader transfer.

### Documentation
  
- [x] `no-need-doc` 

no doc is required to update.