### PR TITLE
[Java Client] Send CloseProducer on timeout

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1476,6 +1476,16 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         cnx.channel().close();
                         return null;
                     }
+
+                    if (cause instanceof TimeoutException) {
+                        // Creating the producer has timed out. We need to ensure the broker closes the producer
+                        // in case it was indeed created, otherwise it might prevent new create producer operation,
+                        // since we are not necessarily closing the connection.
+                        long closeRequestId = client.newRequestId();
+                        ByteBuf cmd = Commands.newCloseProducer(producerId, closeRequestId);
+                        cnx.sendRequestWithId(cmd, closeRequestId);
+                    }
+
                     if (cause instanceof PulsarClientException.ProducerFencedException) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] [{}] Failed to create producer: {}",
@@ -1484,7 +1494,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     } else {
                         log.error("[{}] [{}] Failed to create producer: {}", topic, producerName, cause.getMessage());
                     }
-                    // Close the producer since topic does not exists.
+                    // Close the producer since topic does not exist.
                     if (cause instanceof PulsarClientException.TopicDoesNotExistException) {
                         closeAsync().whenComplete((v, ex) -> {
                             if (ex != null) {


### PR DESCRIPTION
### Motivation

When producer creation times out, send the `CloseProducer` before sending a command to recreate the `Producer`. This ensures a better time to recovery.

This issue was discussed on the mailing list here, https://lists.apache.org/thread/tko0z4jg0oq0yf931rbow2zf9fq8wjt1. The protocol spec has already been updated to indicate that this is the correct client behavior https://github.com/apache/pulsar/pull/12948.

### Modifications

* Update the java client to send `CloseProducer` when the producer creation times out.
* Add tests.
* Clean up some comments and unnecessary calls to `close()` in the modified test file.

### Verifying this change

I added tests to verify this change.

### Does this pull request potentially affect one of the following parts:

There are no breaking changes. This is an improvement to the protocol. The previous implementation was valid, but not ideal.

### Documentation

- [x] `no-need-doc` 
Docs were added here: https://github.com/apache/pulsar/pull/12948