### PR TITLE
[ Java Client ] fix parseProtobufSchema method will be called two times.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericProtobufNativeReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericProtobufNativeReader.java
@@ -48,7 +48,11 @@ public class MultiVersionGenericProtobufNativeReader
         super(new GenericProtobufNativeReader(parseProtobufSchema(schemaInfo)));
         this.useProvidedSchemaAsReaderSchema = useProvidedSchemaAsReaderSchema;
         this.schemaInfo = schemaInfo;
-        this.descriptor = parseProtobufSchema(schemaInfo);
+        this.descriptor = (Descriptors.Descriptor) providerSchemaReader.getNativeSchema()
+                .orElseThrow(()->{
+                    log.error("No protobuf native reader found.");
+                    return new IllegalArgumentException("No protobuf native reader found.");
+                });
     }
 
     @Override


### PR DESCRIPTION
- fix ``MultiVersionGenericProtobufNativeReader.parseProtobufSchema``  method will be called two times.


- [x] `no-need-doc`