### PR TITLE
fix:remove the loadbalance/bundle-data node

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -303,7 +303,24 @@ public class NamespaceResources extends BaseResources<Policies> {
         final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, ns.toString());
         CompletableFuture<Void> future = new CompletableFuture<Void>();
         deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
+            if (ex != null && ex.getCause() instanceof KeeperException.NoNodeException) {
+                future.complete(null);
+            } else if (ex != null) {
+                future.completeExceptionally(ex);
+            } else {
+                future.complete(null);
+            }
+        });
+
+        return future;
+    }
+
+    // clear resource of `/loadbalance/bundle-data/{tenant}/` for zk-node
+    public CompletableFuture<Void> deleteBundleDataTenantAsync(String tenant) {
+        final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, tenant);
+        CompletableFuture<Void> future = new CompletableFuture<Void>();
+        deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
+            if (ex != null && ex.getCause() instanceof KeeperException.NoNodeException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -303,7 +304,7 @@ public class NamespaceResources extends BaseResources<Policies> {
         final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, ns.toString());
         CompletableFuture<Void> future = new CompletableFuture<Void>();
         deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause() instanceof KeeperException.NoNodeException) {
+            if (ex != null && ExceptionUtils.getRootCause(ex) instanceof KeeperException.NoNodeException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);
@@ -317,10 +318,10 @@ public class NamespaceResources extends BaseResources<Policies> {
 
     // clear resource of `/loadbalance/bundle-data/{tenant}/` for zk-node
     public CompletableFuture<Void> deleteBundleDataTenantAsync(String tenant) {
-        final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, tenant);
+        final String tenantBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, tenant);
         CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause() instanceof KeeperException.NoNodeException) {
+        deleteRecursiveAsync(this, tenantBundlePath).whenComplete((ignore, ex) -> {
+            if (ex != null && ExceptionUtils.getRootCause(ex) instanceof KeeperException.NoNodeException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -54,6 +54,7 @@ public class NamespaceResources extends BaseResources<Policies> {
 
     private static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
     private static final String NAMESPACE_BASE_PATH = "/namespace";
+    private static final String BUNDLE_DATA_BASE_PATH = "/loadbalance/bundle-data";
 
     public NamespaceResources(MetadataStore localStore, MetadataStore configurationStore, int operationTimeoutSec) {
         super(configurationStore, Policies.class, operationTimeoutSec);
@@ -296,4 +297,22 @@ public class NamespaceResources extends BaseResources<Policies> {
             return future;
         }
     }
+
+    // clear resource of `/loadbalance/bundle-data/{tenant}/{namespace}/` for zk-node
+    public CompletableFuture<Void> deleteBundleDataAsync(NamespaceName ns) {
+        final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, ns.toString());
+        CompletableFuture<Void> future = new CompletableFuture<Void>();
+        deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
+            if (ex != null && ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
+                future.complete(null);
+            } else if (ex != null) {
+                future.completeExceptionally(ex);
+            } else {
+                future.complete(null);
+            }
+        });
+
+        return future;
+    }
+
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -304,7 +303,7 @@ public class NamespaceResources extends BaseResources<Policies> {
         final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, ns.toString());
         CompletableFuture<Void> future = new CompletableFuture<Void>();
         deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ExceptionUtils.getRootCause(ex) instanceof KeeperException.NoNodeException) {
+            if (ex instanceof MetadataStoreException.NotFoundException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);
@@ -321,7 +320,7 @@ public class NamespaceResources extends BaseResources<Policies> {
         final String tenantBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, tenant);
         CompletableFuture<Void> future = new CompletableFuture<Void>();
         deleteRecursiveAsync(this, tenantBundlePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ExceptionUtils.getRootCause(ex) instanceof KeeperException.NoNodeException) {
+            if (ex instanceof MetadataStoreException.NotFoundException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -320,6 +320,8 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(ignore -> namespaceResources().deletePoliciesAsync(namespaceName))
                 // clear z-node of local policies
                 .thenCompose(ignore -> getLocalPolicies().deleteLocalPoliciesAsync(namespaceName))
+                // clear /loadbalance/bundle-data
+                .thenCompose(ignore -> namespaceResources().deleteBundleDataAsync(namespaceName))
                 .whenComplete((ignore, ex) -> {
                     if (ex != null) {
                         log.warn("[{}] Failed to remove namespace or managed-ledger for {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -269,6 +269,8 @@ public class TenantsBase extends PulsarWebResource {
                             .getPartitionedTopicResources().clearPartitionedTopicTenantAsync(tenant))
                     .thenCompose(ignore -> pulsar().getPulsarResources().getLocalPolicies()
                             .deleteLocalPoliciesTenantAsync(tenant))
+                    .thenCompose(ignore -> pulsar().getPulsarResources().getNamespaceResources()
+                            .deleteBundleDataTenantAsync(tenant))
                     .whenComplete((ignore, ex) -> {
                         if (ex != null) {
                             log.error("[{}] Failed to delete tenant {}", clientAppId(), tenant, ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1357,6 +1357,11 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
         final String managedLedgersPath = "/managed-ledgers/" + namespace;
         assertFalse(pulsar.getLocalMetadataStore().exists(managedLedgersPath).join());
+
+
+        final String bundleDataPath = "/loadbalance/bundle-data/" + namespace;
+
+        assertFalse(pulsar.getLocalMetadataStore().exists(bundleDataPath).join());
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1311,9 +1311,11 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         final String managedLedgersPath = "/managed-ledgers/" + tenant;
         final String partitionedTopicPath = "/admin/partitioned-topics/" + tenant;
         final String localPoliciesPath = "/admin/local-policies/" + tenant;
+        final String bundleDataPath = "/loadbalance/bundle-data/" + tenant;
         assertFalse(pulsar.getLocalMetadataStore().exists(managedLedgersPath).join());
         assertFalse(pulsar.getLocalMetadataStore().exists(partitionedTopicPath).join());
         assertFalse(pulsar.getLocalMetadataStore().exists(localPoliciesPath).join());
+        assertFalse(pulsar.getLocalMetadataStore().exists(bundleDataPath).join());
     }
 
     @Test
@@ -1360,7 +1362,6 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
 
         final String bundleDataPath = "/loadbalance/bundle-data/" + namespace;
-
         assertFalse(pulsar.getLocalMetadataStore().exists(bundleDataPath).join());
     }
 


### PR DESCRIPTION
Fixes #13162


### Motivation


fix: remove the loadbalance/bundle-data node, when deleting namespace. it will cause zk node leak, fix #13162

### Modifications

remove the bundle-data Recursively


### Verifying this change

*Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


