### PR TITLE
Update cursor last active timestamp when reseting cursor 

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1103,7 +1103,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     }
                 }
                 callback.resetComplete(newPosition);
-
+                updateLastActive();
             }
 
             @Override


### PR DESCRIPTION
Resolves #13165 

### Modifications
1. trigger last active time update after resetting cursor
2. add related test case

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
  
Just a little function supplement, no need to update the document