### PR TITLE
[Build] Fix modernizer-maven-plugin integration to Pulsar's build

### DIFF
--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -89,6 +89,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-client-1x-base/pulsar-client-1x/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-1x/pom.xml
@@ -63,6 +63,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-client-admin-api/pom.xml
+++ b/pulsar-client-admin-api/pom.xml
@@ -57,6 +57,7 @@
                 <executions>
                     <execution>
                         <id>modernizer</id>
+                        <phase>verify</phase>
                         <goals>
                             <goal>modernizer</goal>
                         </goals>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -126,6 +126,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -61,6 +61,7 @@
                 <executions>
                     <execution>
                         <id>modernizer</id>
+                        <phase>verify</phase>
                         <goals>
                             <goal>modernizer</goal>
                         </goals>

--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -75,6 +75,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -110,6 +110,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -205,6 +205,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -206,6 +206,7 @@
       <executions>
         <execution>
           <id>modernizer</id>
+          <phase>verify</phase>
           <goals>
             <goal>modernizer</goal>
           </goals>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -191,6 +191,7 @@
         <executions>
           <execution>
             <id>modernizer</id>
+            <phase>verify</phase>
             <goals>
               <goal>modernizer</goal>
             </goals>


### PR DESCRIPTION
### Motivation

The current modernizer-maven-plugin integration to Pulsar's build is invalid. modernizer-maven-plugin will analyse outdated class files and this leads to obscure error messages.

### Modifications

- the phase must be set to verify
  - unless this is specified, modernizer-maven-plugin will analyse outdated class files

### Additional context

- The [modernizer-maven-plugin documentation recommends using verify phase](https://github.com/gaul/modernizer-maven-plugin#configuration).