### PR TITLE
[admin-client] 'rebalance' command for functions worker

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Worker.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Worker.java
@@ -95,4 +95,16 @@ public interface Worker {
      * @return
      */
     CompletableFuture<Map<String, Collection<String>>> getAssignmentsAsync();
+
+    /**
+     * Triggers a rebalance of functions to workers.
+     * @throws PulsarAdminException
+     */
+    void rebalance() throws PulsarAdminException;
+
+    /**
+     * Triggers a rebalance of functions to workersasynchronously..
+     * @throws PulsarAdminException
+     */
+    CompletableFuture<Void> rebalanceAsync();
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -180,7 +182,8 @@ public class WorkerImpl extends BaseResource implements Worker {
                             future.completeExceptionally(new ClientErrorException(response));
                         } else {
                             future.complete(response.readEntity(
-                                    new GenericType<Map<String, Collection<String>>>() {}));
+                                    new GenericType<Map<String, Collection<String>>>() {
+                                    }));
                         }
                     }
 
@@ -190,5 +193,16 @@ public class WorkerImpl extends BaseResource implements Worker {
                     }
                 });
         return future;
+    }
+
+    @Override
+    public void rebalance() throws PulsarAdminException {
+        sync(this::rebalanceAsync);
+    }
+
+    @Override
+    public CompletableFuture<Void> rebalanceAsync() {
+        final WebTarget path = worker.path("rebalance");
+        return asyncPutRequest(path,  Entity.entity("", MediaType.APPLICATION_JSON));
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerImpl.java
@@ -182,8 +182,7 @@ public class WorkerImpl extends BaseResource implements Worker {
                             future.completeExceptionally(new ClientErrorException(response));
                         } else {
                             future.complete(response.readEntity(
-                                    new GenericType<Map<String, Collection<String>>>() {
-                                    }));
+                                    new GenericType<Map<String, Collection<String>>>() {}));
                         }
                     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
@@ -99,6 +99,7 @@ public class CmdFunctionWorker extends CmdBase {
         @Override
         void runCmd() throws Exception {
             getAdmin().worker().rebalance();
+            print("Rebalance command sent successfully");
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorker.java
@@ -93,6 +93,15 @@ public class CmdFunctionWorker extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Triggers a rebalance of functions to workers")
+    class Rebalance extends BaseCommand {
+
+        @Override
+        void runCmd() throws Exception {
+            getAdmin().worker().rebalance();
+        }
+    }
+
     public CmdFunctionWorker(Supplier<PulsarAdmin> admin) throws PulsarClientException {
         super("functions-worker", admin);
         jcommander.addCommand("function-stats", new FunctionsStats());
@@ -100,6 +109,7 @@ public class CmdFunctionWorker extends CmdBase {
         jcommander.addCommand("get-cluster", new GetCluster());
         jcommander.addCommand("get-cluster-leader", new GetClusterLeader());
         jcommander.addCommand("get-function-assignments", new GetFunctionAssignments());
+        jcommander.addCommand("rebalance", new Rebalance());
     }
 
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdFunctionWorker.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdFunctionWorker.java
@@ -23,7 +23,11 @@ import org.apache.pulsar.client.admin.Worker;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class TestCmdFunctionWorker {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdFunctionWorker.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdFunctionWorker.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.Worker;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestCmdFunctionWorker {
+
+    private PulsarAdmin pulsarAdmin;
+
+    private CmdFunctionWorker cmdFunctionWorker;
+
+    private Worker worker;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        pulsarAdmin = mock(PulsarAdmin.class);
+        worker = mock(Worker.class);
+        when(pulsarAdmin.worker()).thenReturn(worker);
+
+        cmdFunctionWorker = spy(new CmdFunctionWorker(() -> pulsarAdmin));
+    }
+
+    @Test
+    public void testCmdRebalance() throws Exception {
+        cmdFunctionWorker.run(new String[]{"rebalance"});
+        verify(pulsarAdmin.worker(), times(1)).rebalance();
+    }
+}


### PR DESCRIPTION
### Motivation

The `rebalance` feature is currently exposed only to the REST api. 
It can be useful to have this command in the Admin CLI because the rebalance work is performed only by leader of Functions workers so the client needs to eventually follow redirects and the user may not be aware.
The Admin CLI follow the redirect under the hood  

### Modifications

* Added a new command `bin/pulsar-admin functions-worker rebalance` (no parameters needed)
* Added a unit test to verify the REST api is triggered

Notes:
* the user doesn't need to specify the functions worker leader
* it works with and without enabling authentication

### Does this pull request potentially affect one of the following parts:

 - The admin cli options: (yes) -> new command

### Documentation

- [x] `no-need-doc`
 

