### PR TITLE
[Proxy] Fix issue when Proxy fails to start and logs about an uncaught exception

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.client.ProtocolHandlers;
 import org.eclipse.jetty.client.RedirectProtocolHandler;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.util.HttpCookieStore;
@@ -209,12 +210,14 @@ class AdminProxyHandler extends ProxyServlet {
     }
 
     private static class JettyHttpClient extends HttpClient {
+        private static final int NUMBER_OF_SELECTOR_THREADS = 1;
+
         public JettyHttpClient() {
-            super();
+            super(new HttpClientTransportOverHTTP(NUMBER_OF_SELECTOR_THREADS), null);
         }
 
         public JettyHttpClient(SslContextFactory sslContextFactory) {
-            super(sslContextFactory);
+            super(new HttpClientTransportOverHTTP(NUMBER_OF_SELECTOR_THREADS), sslContextFactory);
         }
 
         /**

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -108,6 +108,7 @@ public class ProxyServiceStarter {
                 FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
             Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
                 System.out.println(String.format("%s [%s] error Uncaught exception in thread %s: %s", dateFormat.format(new Date()), thread.getContextClassLoader(), thread.getName(), exception.getMessage()));
+                exception.printStackTrace(System.out);
             });
 
             JCommander jcommander = new JCommander();


### PR DESCRIPTION
### Motivation

The Pulsar proxy fails to start when deploying the master branch version of Pulsar with the Apache Pulsar Helm chart.
The proxy logs an obscure error message:
```
2021-12-07T12:27:16,052Z [jdk.internal.loader.ClassLoaders$AppClassLoader@5ffd2b27] error Uncaught exception in thread main: Failed to start HTTP server on ports [8080]
```
The reason why this happens is that the thread pool doesn't have sufficient amount of threads. Jetty reserves the threads from the main executor. The number of threads in the main executor can be configured with the `httpNumThreads` configuration parameter. (The workaround for the issue is to increase the `httpNumThreads` value until the proxy can start.)

### Modifications

- add logging of the stack traces for uncaught exceptions in the proxy
- limit the number of selector threads to 1 for the Proxy http client since it will consume a lot of threads from the main executor (50% of number of CPU cores).