### PR TITLE
[Java Client] Fix producer data race to get cnx

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
@@ -151,11 +151,11 @@ public class PulsarTestClient extends PulsarClientImpl {
             }
 
             @Override
-            protected boolean shouldWriteOpSendMsg() {
+            protected ClientCnx getCnxIfReady() {
                 if (dropOpSendMessages) {
-                    return false;
+                    return null;
                 } else {
-                    return super.shouldWriteOpSendMsg();
+                    return super.getCnxIfReady();
                 }
             }
         };


### PR DESCRIPTION
### Motivation

I observed `testProducerReconnect` failing with an NPE. It is the same NPE that was fixed here https://github.com/apache/pulsar/pull/4427. The current code has a data race that can allow the producer to get a null cnx, which will cause an NPE. Here are the logs from the test.

```
2021-12-07T12:12:13,308-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0xbb674320, L:/127.0.0.1:64666 - R:localhost/127.0.0.1:64501]] Connected to server
2021-12-07T12:12:13,311-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - Starting Pulsar producer perf with config: {"topicName":"persistent://prop/use/ns/t1","producerName":null,"sendTimeoutMs":30000,"blockIfQueueFull":false,"maxPendingMessages":1000,"maxPendingMessagesAcrossPartitions":50000,"messageRoutingMode":"RoundRobinPartition","hashingScheme":"JavaStringHash","cryptoFailureAction":"FAIL","batchingMaxPublishDelayMicros":1000,"batchingPartitionSwitchFrequencyByPublishDelay":10,"batchingMaxMessages":1000,"batchingMaxBytes":131072,"batchingEnabled":true,"chunkingEnabled":false,"compressionType":"NONE","initialSequenceId":null,"autoUpdatePartitions":true,"autoUpdatePartitionsIntervalSeconds":60,"multiSchema":true,"accessMode":"Shared","lazyStartPartitionedProducers":false,"properties":{}}
2021-12-07T12:12:13,312-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - Pulsar client config: {"serviceUrl":"pulsar://localhost:64501","authPluginClassName":null,"authParams":null,"authParamMap":null,"operationTimeoutMs":30000,"lookupTimeoutMs":30000,"statsIntervalSeconds":60,"numIoThreads":1,"numListenerThreads":1,"connectionsPerBroker":1,"useTcpNoDelay":true,"useTls":false,"tlsTrustCertsFilePath":"","tlsAllowInsecureConnection":false,"tlsHostnameVerificationEnable":false,"concurrentLookupRequest":5000,"maxLookupRequest":50000,"maxLookupRedirects":20,"maxNumberOfRejectedRequestPerConnection":50,"keepAliveIntervalSeconds":30,"connectionTimeoutMs":10000,"requestTimeoutMs":60000,"initialBackoffIntervalNanos":100000000,"maxBackoffIntervalNanos":60000000000,"enableBusyWait":false,"listenerName":null,"useKeyStoreTls":false,"sslProvider":null,"tlsTrustStoreType":"JKS","tlsTrustStorePath":null,"tlsTrustStorePassword":null,"tlsCiphers":[],"tlsProtocols":[],"memoryLimitBytes":0,"proxyServiceUrl":null,"proxyProtocol":null,"enableTransaction":false,"socks5ProxyAddress":null,"socks5ProxyUsername":null,"socks5ProxyPassword":null}
2021-12-07T12:12:13,312-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ProducerImpl - [persistent://prop/use/ns/t1] [null] Creating producer on cnx [id: 0xbb674320, L:/127.0.0.1:64666 - R:localhost/127.0.0.1:64501]
2021-12-07T12:12:13,313-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ProducerImpl - [persistent://prop/use/ns/t1] [default-producer] Created producer on cnx [id: 0xbb674320, L:/127.0.0.1:64666 - R:localhost/127.0.0.1:64501]
2021-12-07T12:12:13,313-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ClientCnx - [id: 0xbb674320, L:/127.0.0.1:64666 ! R:localhost/127.0.0.1:64501] Disconnected
2021-12-07T12:12:13,313-0600 [pulsar-client-io-132-1] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://prop/use/ns/t1] [default-producer] Closed connection [id: 0xbb674320, L:/127.0.0.1:64666 ! R:localhost/127.0.0.1:64501] -- Will try again in 0.1 s
2021-12-07T12:12:13,313-0600 [main] WARN  org.apache.pulsar.client.impl.ProducerImpl - [persistent://prop/use/ns/t1] [default-producer] error while closing out batch -- java.lang.NullPointerException
2021-12-07T12:12:13,313-0600 [main] INFO  org.apache.pulsar.client.impl.PulsarClientImpl - Client closing. URL: pulsar://localhost:64501
2021-12-07T12:12:13,314-0600 [main] INFO  org.apache.pulsar.client.impl.ProducerStatsRecorderImpl - [persistent://prop/use/ns/t1] [default-producer] Pending messages: 1 --- Publish throughput: 0.00 msg/s --- 0.00 Mbit/s --- Latency: med: 0.000 ms - 95pct: 0.000 ms - 99pct: 0.000 ms - 99.9pct: 0.000 ms - max: -∞ ms --- Ack received rate: 0.00 ack/s --- Failed messages: 1
2021-12-07T12:12:13,314-0600 [main] INFO  org.apache.pulsar.client.impl.ProducerImpl - [persistent://prop/use/ns/t1] [default-producer] Closed Producer (not connected)
2021-12-07T12:12:13,414-0600 [pulsar-timer-135-1] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://prop/use/ns/t1] [default-producer] Reconnecting after timeout
2021-12-07T12:12:13,414-0600 [pulsar-timer-135-1] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [persistent://prop/use/ns/t1] [default-producer] Ignoring reconnection request (state: Closed)

org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.ExecutionException: org.apache.pulsar.client.api.PulsarClientException: java.lang.NullPointerException

	at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:1074)
	at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.send(TypedMessageBuilderImpl.java:90)
	at org.apache.pulsar.client.impl.ProducerBase.send(ProducerBase.java:63)
	at org.apache.pulsar.client.api.ClientErrorsTest.testProducerReconnect(ClientErrorsTest.java:747)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
Caused by: java.util.concurrent.ExecutionException: org.apache.pulsar.client.api.PulsarClientException: java.lang.NullPointerException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.send(TypedMessageBuilderImpl.java:88)
	... 29 more
Caused by: org.apache.pulsar.client.api.PulsarClientException: java.lang.NullPointerException
	at org.apache.pulsar.client.impl.ProducerImpl.processOpSendMsg(ProducerImpl.java:1855)
	at org.apache.pulsar.client.impl.ProducerImpl.batchMessageAndSend(ProducerImpl.java:1811)
	at org.apache.pulsar.client.impl.ProducerImpl.triggerFlush(ProducerImpl.java:1790)
	at org.apache.pulsar.client.impl.TypedMessageBuilderImpl.send(TypedMessageBuilderImpl.java:85)
	... 29 more
Caused by: java.lang.NullPointerException
	at org.apache.pulsar.client.impl.ProducerImpl.processOpSendMsg(ProducerImpl.java:1844)
	... 32 more
```

### Modifications

* Replace `shouldWriteOpSendMsg()` with `getCnxIfReady()` to ensure that we only get the `cnx` once. This is an optimization that maintains all current functionality. 

### Verifying this change

This change is covered by existing tests (I found it by observing a failing test).

### Does this pull request potentially affect one of the following parts:

No breaking changes.

### Documentation
  
- [x] `no-need-doc` 

This is an internal bug fix for an NPE.

