### PR TITLE
[Test] Use shorter timeout in ClientErrorsTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -327,7 +327,8 @@ public class ClientErrorsTest {
 
     private void subscribeFailWithoutRetry(String topic) throws Exception {
         @Cleanup
-        PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress()).build();
+        PulsarClient client = PulsarClient.builder().serviceUrl(mockBrokerService.getBrokerAddress())
+                .operationTimeout(1, TimeUnit.SECONDS).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleSubscribe((ctx, subscribe) -> {


### PR DESCRIPTION
### Motivation

Tests `testSubscribeFailWithoutRetry` and `testPartitionedSubscribeFailWithoutRetry` each take about 50 seconds right now. By setting a better operation timeout, the two tests take about 5 seconds total instead of 100 seconds.

### Modifications

* Configure an operation timeout for two timeout tests in `ClientErrorsTest` 
 
### Verifying this change

This is a trivial change

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
- [x] `no-need-doc` 
This is a minor optimization for a test. No docs need to be updated.

