### PR TITLE
When the Replicator is enabled and updateLocalTopicOnly=true,the numb…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -425,7 +425,8 @@ public class PersistentTopicsBase extends AdminResource {
             }
             try {
                 tryCreatePartitionsAsync(numPartitions).get(DEFAULT_OPERATION_TIMEOUT_SEC, TimeUnit.SECONDS);
-                createSubscriptions(topicName, numPartitions).get(DEFAULT_OPERATION_TIMEOUT_SEC, TimeUnit.SECONDS);
+                updatePartitionedTopic(topicName, numPartitions, force).get(DEFAULT_OPERATION_TIMEOUT_SEC,
+                        TimeUnit.SECONDS);
             } catch (Exception e) {
                 if (e.getCause() instanceof RestException) {
                     throw (RestException) e.getCause();


### PR DESCRIPTION
### Motivation

When the Replicator is enabled and updateLocalTopicOnly=true,the number of partitions in `/admin/partitioned-topics` is not  updated

### Modifications

### Documentation

- [x] `no-need-doc` 
  
  
