### PR TITLE
[Broker] Add removeMaxConsumersPerSubscription method for v1 namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -1094,7 +1094,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Get maxConsumersPerSubscription config on a namespace.")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist")})
-    public int getMaxConsumersPerSubscription(@PathParam("property") String property,
+    public Integer getMaxConsumersPerSubscription(@PathParam("property") String property,
                                               @PathParam("cluster") String cluster,
                                               @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
@@ -1114,6 +1114,20 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace, int maxConsumersPerSubscription) {
         validateNamespaceName(property, cluster, namespace);
         internalSetMaxConsumersPerSubscription(maxConsumersPerSubscription);
+    }
+
+    @DELETE
+    @Path("/{property}/{cluster}/{namespace}/maxConsumersPerSubscription")
+    @ApiOperation(value = "Remove maxConsumersPerSubscription configuration on a namespace.")
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 409, message = "Concurrent modification")})
+    public void removeMaxConsumersPerSubscription(
+            @PathParam("property") String property,
+            @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace) {
+        validateNamespaceName(property, cluster, namespace);
+        internalSetMaxConsumersPerSubscription(null);
     }
 
     @GET

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -99,6 +99,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
     private final String myNamespace = testTenant + "/" + testNamespace;
 
+    private final String myNamespaceV1 = testTenant + "/test/" + testNamespace;
+
     private final String testTopic = "persistent://" + myNamespace + "/test-set-backlog-quota";
 
     private final String persistenceTopic = "persistent://" + myNamespace + "/test-set-persistence";
@@ -119,6 +121,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Sets.newHashSet("test"));
+        admin.namespaces().createNamespace(myNamespaceV1);
         admin.topics().createPartitionedTopic(testTopic, testTopicPartitions);
         Producer producer = pulsarClient.newProducer().topic(testTopic).create();
         producer.close();
@@ -1498,6 +1501,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         Awaitility.await()
                 .untilAsserted(() -> Assert.assertNull(admin.topicPolicies().getMaxConsumersPerSubscription(testTopic)));
+
+        admin.namespaces().setMaxConsumersPerSubscription(myNamespaceV1, 20);
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(admin.namespaces().getMaxConsumersPerSubscription(myNamespaceV1).intValue(), 20));
+        admin.namespaces().removeMaxConsumersPerSubscription(myNamespaceV1);
+        Awaitility.await().untilAsserted(() ->
+                assertNull(admin.namespaces().getMaxConsumersPerSubscription(myNamespaceV1)));
 
         admin.topics().deletePartitionedTopic(testTopic, true);
     }


### PR DESCRIPTION
### Motivation
Currently, the CLI supports `set`/`get`/`remove` operation to the `maxConsumersPerSubscription` of `v1/namespace` and `v2/namespace`, and the server provides corresponding processing interfaces, including:
1. v1/namespace
- setMaxConsumersPerSubscription
- getMaxConsumersPerSubscription
- ~~removeMaxConsumersPerSubscription~~
2. v2/namespace
- setMaxConsumersPerSubscription
- getMaxConsumersPerSubscription
- removeMaxConsumersPerSubscription

However, the remove interface is missing for v1/namespace, so the purpose of this PR is to supplement this processing interface.

### Documentation
- [x] `no-need-doc` 

