### PR TITLE
[C++] Fix in macOS CMake might find error boost-python libs path

### DIFF
--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -72,11 +72,18 @@ set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY}
                         ${Boost_PYTHON39_LIBRARY})
 
 if (APPLE)
-    set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS}
-                            ${Boost_PYTHON27-MT_LIBRARY_RELEASE}
-                            ${Boost_PYTHON37-MT_LIBRARY_RELEASE}
-                            ${Boost_PYTHON38-MT_LIBRARY_RELEASE}
-                            ${Boost_PYTHON39-MT_LIBRARY_RELEASE})
+    if (Boost_PYTHON27-MT_LIBRARY_RELEASE)
+        set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON27-MT_LIBRARY_RELEASE})
+    endif ()
+    if (Boost_PYTHON37-MT_LIBRARY_RELEASE)
+        set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON37-MT_LIBRARY_RELEASE})
+    endif ()
+    if (Boost_PYTHON38-MT_LIBRARY_RELEASE)
+        set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON38-MT_LIBRARY_RELEASE})
+    endif ()
+    if (Boost_PYTHON39-MT_LIBRARY_RELEASE)
+        set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS} ${Boost_PYTHON39-MT_LIBRARY_RELEASE})
+    endif ()
 endif()
 
 message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")


### PR DESCRIPTION
Fixes #11747


### Motivation
In macOS, when CMake sets a variable like `Boost_PYTHON37-MT_LIBRARY_RELEASE`, we need to check this value exists, otherwise might get a `Boost_PYTHON37-MT_LIBRARY_RELEASE-NOTFOUND`.

### Modifications
Check the value is exists before we used it.



### Documentation
Need to update docs? 

- [x] `no-need-doc` 
 



