### PR TITLE
[pulsar-broker] Support of TopicLifecyclePolicies REST handler.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -69,6 +69,7 @@ import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrat
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
+import org.apache.pulsar.common.policies.data.TopicLifecyclePolicies;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -896,6 +897,21 @@ public class Namespaces extends NamespacesBase {
             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         return internalGetPersistence();
+    }
+
+    @POST
+    @Path("/{tenant}/{namespace}/topicLifecycle")
+    @ApiOperation(value = "Set the topic lifecycle configuration for all the topics on a namespace.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace does not exist"),
+            @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 400, message = "Invalid persistence policies") })
+    public void setTopicsLifeCycle(
+            @Suspended final AsyncResponse asyncResponse,
+            @PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
+            TopicLifecyclePolicies lifecyclePolicies) {
+        validateNamespaceName(tenant, namespace);
+        internalSetTopicLifecycle(asyncResponse, lifecyclePolicies);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
@@ -173,7 +174,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
         topicPolicies.getMaxSubscriptionsPerTopic().updateNamespaceValue(namespacePolicies.max_subscriptions_per_topic);
         topicPolicies.getMaxProducersPerTopic().updateNamespaceValue(namespacePolicies.max_producers_per_topic);
-        topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(namespacePolicies.inactive_topic_policies);
+        if (namespacePolicies.topicLifecycle != null) {
+            // reset new inactiveTopicPolicies with topicLifecycle info if it exists
+            topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(
+                    new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                            0, namespacePolicies.topicLifecycle.isAutoDeleteTopics()));
+        } else {
+            topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(namespacePolicies.inactive_topic_policies);
+        }
         topicPolicies.getDeduplicationEnabled().updateNamespaceValue(namespacePolicies.deduplicationEnabled);
         topicPolicies.getSubscriptionTypesEnabled().updateNamespaceValue(
                 subTypeStringsToEnumSet(namespacePolicies.subscription_types_enabled));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -130,6 +130,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
+import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
@@ -329,6 +330,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
 
                     schemaValidationEnforced = policies.schema_validation_enforced;
+
+                    if (policies.inactive_topic_policies != null) {
+                        inactiveTopicPolicies = policies.inactive_topic_policies;
+                    }
+
+                    if (policies.topicLifecycle != null) {
+                        inactiveTopicPolicies = new InactiveTopicPolicies(
+                                InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                                0, policies.topicLifecycle.isAutoDeleteTopics());
+                    }
 
                     updateUnackedMessagesAppliedOnSubscription(policies);
                     updateUnackedMessagesExceededOnConsumer(policies);
@@ -2484,6 +2495,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         //If the topic-level policy already exists, the namespace-level policy cannot override the topic-level policy.
         Optional<TopicPolicies> topicPolicies = getTopicPolicies();
+
+        if (data.topicLifecycle != null) {
+            this.inactiveTopicPolicies = new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                    0, data.topicLifecycle.isAutoDeleteTopics());
+        }
 
         initializeRateLimiterIfNeeded(Optional.ofNullable(data));
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -331,14 +331,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                     schemaValidationEnforced = policies.schema_validation_enforced;
 
-                    if (policies.inactive_topic_policies != null) {
-                        inactiveTopicPolicies = policies.inactive_topic_policies;
-                    }
-
                     if (policies.topicLifecycle != null) {
-                        inactiveTopicPolicies = new InactiveTopicPolicies(
-                                InactiveTopicDeleteMode.delete_when_no_subscriptions,
-                                0, policies.topicLifecycle.isAutoDeleteTopics());
+                        // reset new inactiveTopicPolicies with topicLifecycle info if one exists
+                        this.topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(
+                                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                                        0, policies.topicLifecycle.isAutoDeleteTopics()));
                     }
 
                     updateUnackedMessagesAppliedOnSubscription(policies);
@@ -2497,8 +2494,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         Optional<TopicPolicies> topicPolicies = getTopicPolicies();
 
         if (data.topicLifecycle != null) {
-            this.inactiveTopicPolicies = new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
-                    0, data.topicLifecycle.isAutoDeleteTopics());
+            // reset new inactiveTopicPolicies with topicLifecycle info if one exists
+            this.topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(
+                    new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
+                            0, data.topicLifecycle.isAutoDeleteTopics()));
         }
 
         initializeRateLimiterIfNeeded(Optional.ofNullable(data));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -331,13 +331,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                     schemaValidationEnforced = policies.schema_validation_enforced;
 
-                    if (policies.topicLifecycle != null) {
-                        // reset new inactiveTopicPolicies with topicLifecycle info if one exists
-                        this.topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(
-                                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
-                                        0, policies.topicLifecycle.isAutoDeleteTopics()));
-                    }
-
                     updateUnackedMessagesAppliedOnSubscription(policies);
                     updateUnackedMessagesExceededOnConsumer(policies);
                 }).exceptionally(ex -> {
@@ -2492,13 +2485,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         //If the topic-level policy already exists, the namespace-level policy cannot override the topic-level policy.
         Optional<TopicPolicies> topicPolicies = getTopicPolicies();
-
-        if (data.topicLifecycle != null) {
-            // reset new inactiveTopicPolicies with topicLifecycle info if one exists
-            this.topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(
-                    new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions,
-                            0, data.topicLifecycle.isAutoDeleteTopics()));
-        }
 
         initializeRateLimiterIfNeeded(Optional.ofNullable(data));
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -74,6 +74,8 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public InactiveTopicPolicies inactive_topic_policies = null;
     @SuppressWarnings("checkstyle:MemberName")
+    public TopicLifecyclePolicies topicLifecycle = null;
+    @SuppressWarnings("checkstyle:MemberName")
     public SubscriptionAuthMode subscription_auth_mode = SubscriptionAuthMode.None;
 
     @SuppressWarnings("checkstyle:MemberName")

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicLifecyclePolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicLifecyclePolicies.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Topic life-cycle policies.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TopicLifecyclePolicies {
+
+    /**
+     * Whether topics should be automatically created when producers/consumers connect, or rather explicitly created
+     * through admin API.
+     */
+    private boolean autoCreateTopics;
+
+    /**
+     * Whether topics should be automatically deleted when inactive, or rather explicitly deleted through admin API.
+     */
+    private boolean autoDeleteTopics;
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>
-->

Originally authored by @merlimat, fixed for compatibility with 2.10 branch. (Note that with the first commit only, it would adapt to 2.9 branch)

### Motivation

*Support of TopicLifecyclePolicies REST handler.*

### Modifications
The added endpoint `TopicLifecycle` can be used during tenant creation time.
Both `InactiveTopicPolicies` and `TopicLifecycle` are fields declared in `Policies`. The `InactiveTopicPolicies` has a boolean value `deleteWhileInactive` which determines whether topics should be automatically deleted when inactive. We ask it to be same as that defined in `TopicLifecycle`, while `TopicLifecycle` additionally defines whether topics should be automatically created when there exists producer/consumer connection (which is oppose to being created explicitly with API).

Specifically, our changes include:
- defined TopicLifecyclePolicies class
- declared in Policies
- reset new inactiveTopicPolicies with topicLifecycle info if one exists while initializing and updating PersistentTopic
- added setter methods in broker-admin Namespaces.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `no-need-doc` 
 

