### PR TITLE
Add package management filesystem storage into the distribution lib

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -84,6 +84,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-package-filesystem-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-client-tools</artifactId>
       <version>${project.version}</version>
       <exclusions>


### PR DESCRIPTION
### Motivation
The package management filesystem storage jar is currently not included in the distribution package, when using this provider it will throws exception as below:
```
java.io.IOException: java.lang.ClassNotFoundException: org.apache.pulsar.packages.management.storage.filesystem.FileSystemPackagesStorageProvider
```

### Modifications

Add `pulsar-package-filesystem-storage.jar` to the distribution module.

### Documentation
  
- [x] `no-need-doc` 


