### PR TITLE
support limit message size produced by protocol handlers by maxMessag…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2289,8 +2289,14 @@ public class BrokerService implements Closeable {
         configRegisteredListeners.put(configKey, listener);
     }
 
-    public <T> void registerPublishBufferLimitListener(Consumer<PublishBufferEvent> listener) {
+    public void registerPublishBufferLimitListener(Consumer<PublishBufferEvent> listener) {
         publishBufferLimitListeners.add(listener);
+    }
+
+    public void unRegisterPublishBufferLimitListener(Consumer<PublishBufferEvent> listener) {
+        if (listener != null) {
+            publishBufferLimitListeners.remove(listener);
+        }
     }
 
     private void checkPulishBufferLimit() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2356,13 +2356,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     public void closeProducer(Producer producer) {
         // removes producer-connection from map and send close command to producer
+        service.unRegisterPublishBufferLimitListener(this::handlePulishBufferLimit);
         safelyRemoveProducer(producer);
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
             ctx.writeAndFlush(Commands.newCloseProducer(producer.getProducerId(), -1L));
         } else {
             close();
         }
-
     }
 
     @Override


### PR DESCRIPTION
### Motivation

See  #13170 .
Also, Protocols handlers like KOP should make changes to add and decrease pendingBytes from BrokerService.



### Modifications

Add a LongAdder `totalPendingBytes` in BrokerService to record total pending message size.



### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


