### PR TITLE
[Transaction] Fix transaction sequenceId generate error.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -53,7 +53,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.commons.collections.map.SingletonMap;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
@@ -65,7 +64,6 @@ import org.apache.pulsar.broker.transaction.pendingack.PendingAckStore;
 import org.apache.pulsar.broker.transaction.buffer.matadata.TransactionBufferSnapshot;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStore;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
-import org.apache.pulsar.broker.transaction.timeout.TransactionTimeoutTrackerImpl;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -572,7 +570,8 @@ public class TransactionTest extends TransactionTestBase {
                     null);
             return null;
         }).when(managedCursor).asyncReadEntries(anyInt(), any(), any(), any());
-
+        MLTransactionLogInterceptor mlTransactionLogInterceptor = new MLTransactionLogInterceptor();
+        persistentTopic.getManagedLedger().getConfig().setManagedLedgerInterceptor(mlTransactionLogInterceptor);
         MLTransactionLogImpl mlTransactionLog =
                 new MLTransactionLogImpl(new TransactionCoordinatorID(1), null,
                         persistentTopic.getManagedLedger().getConfig());
@@ -591,7 +590,8 @@ public class TransactionTest extends TransactionTestBase {
         doNothing().when(timeoutTracker).start();
         MLTransactionMetadataStore metadataStore1 =
                 new MLTransactionMetadataStore(new TransactionCoordinatorID(1),
-                        mlTransactionLog, timeoutTracker, transactionRecoverTracker);
+                        mlTransactionLog, timeoutTracker, transactionRecoverTracker,
+                        mlTransactionLogInterceptor.getSequenceId());
 
         Awaitility.await().untilAsserted(() ->
                 assertEquals(metadataStore1.getCoordinatorStats().state, "Ready"));
@@ -604,7 +604,8 @@ public class TransactionTest extends TransactionTestBase {
 
         MLTransactionMetadataStore metadataStore2 =
                 new MLTransactionMetadataStore(new TransactionCoordinatorID(1),
-                        mlTransactionLog, timeoutTracker, transactionRecoverTracker);
+                        mlTransactionLog, timeoutTracker, transactionRecoverTracker,
+                        mlTransactionLogInterceptor.getSequenceId());
         Awaitility.await().untilAsserted(() ->
                 assertEquals(metadataStore2.getCoordinatorStats().state, "Ready"));
     }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImpl.java
@@ -68,15 +68,11 @@ public class MLTransactionLogImpl implements TransactionLog {
 
     private final TopicName topicName;
 
-    private final MLTransactionLogInterceptor mlTransactionLogInterceptor;
-
     public MLTransactionLogImpl(TransactionCoordinatorID tcID,
                                 ManagedLedgerFactory managedLedgerFactory,
                                 ManagedLedgerConfig managedLedgerConfig) {
         this.topicName = getMLTransactionLogName(tcID);
         this.tcId = tcID.getId();
-        this.mlTransactionLogInterceptor = new MLTransactionLogInterceptor();
-        managedLedgerConfig.setManagedLedgerInterceptor(this.mlTransactionLogInterceptor);
         this.managedLedgerFactory = managedLedgerFactory;
         this.managedLedgerConfig = managedLedgerConfig;
         this.entryQueue = new SpscArrayQueue<>(2000);
@@ -161,7 +157,6 @@ public class MLTransactionLogImpl implements TransactionLog {
             @Override
             public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                 buf.release();
-                mlTransactionLogInterceptor.setMaxLocalTxnId(transactionMetadataEntry.getMaxLocalTxnId());
                 completableFuture.complete(position);
             }
 
@@ -240,42 +235,6 @@ public class MLTransactionLogImpl implements TransactionLog {
             }
             transactionLogReplayCallback.replayComplete();
         }
-    }
-
-    public CompletableFuture<Long> getMaxLocalTxnId() {
-
-        CompletableFuture<Long> completableFuture = new CompletableFuture<>();
-        PositionImpl position = (PositionImpl) managedLedger.getLastConfirmedEntry();
-
-        if (position != null && position.getEntryId() != -1
-                && ((ManagedLedgerImpl) managedLedger).ledgerExists(position.getLedgerId())) {
-            ((ManagedLedgerImpl) this.managedLedger).asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
-                @Override
-                public void readEntryComplete(Entry entry, Object ctx) {
-                    TransactionMetadataEntry lastConfirmEntry = new TransactionMetadataEntry();
-                    ByteBuf buffer = entry.getDataBuffer();
-                    lastConfirmEntry.parseFrom(buffer, buffer.readableBytes());
-                    completableFuture.complete(lastConfirmEntry.getMaxLocalTxnId());
-                }
-
-                @Override
-                public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                    log.error("[{}] MLTransactionLog recover MaxLocalTxnId fail!", topicName, exception);
-                    completableFuture.completeExceptionally(exception);
-                }
-            }, null);
-        } else if (managedLedger.getProperties()
-                .get(MLTransactionLogInterceptor.MAX_LOCAL_TXN_ID) != null) {
-            completableFuture.complete(Long.parseLong(managedLedger.getProperties()
-                    .get(MLTransactionLogInterceptor.MAX_LOCAL_TXN_ID)));
-        } else {
-            log.error("[{}] MLTransactionLog recover MaxLocalTxnId fail! "
-                    + "not found MaxLocalTxnId in managedLedger and properties", topicName);
-            completableFuture.completeExceptionally(new ManagedLedgerException(topicName
-                    + "MLTransactionLog recover MaxLocalTxnId fail! "
-                    + "not found MaxLocalTxnId in managedLedger and properties"));
-        }
-        return completableFuture;
     }
 
     class FillEntryQueueCallback implements AsyncCallbacks.ReadEntriesCallback {

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogInterceptor.java
@@ -18,14 +18,18 @@
  */
 package org.apache.pulsar.transaction.coordinator.impl;
 
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
+import org.apache.pulsar.transaction.coordinator.proto.TransactionMetadataEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Store max sequenceID in ManagedLedger properties, in order to recover transaction log.
@@ -33,31 +37,68 @@ import java.util.concurrent.CompletableFuture;
 public class MLTransactionLogInterceptor implements ManagedLedgerInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(MLTransactionLogInterceptor.class);
+    private static final long TC_ID_NOT_USED = -1L;
     public static final String MAX_LOCAL_TXN_ID = "max_local_txn_id";
-
-    private volatile long maxLocalTxnId = -1;
+    @Getter
+    private final AtomicLong sequenceId = new AtomicLong(TC_ID_NOT_USED);
 
     @Override
     public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
-        return null;
+        return op;
     }
 
+    // When all of ledger have been deleted, we will generate sequenceId from managedLedger properties
     @Override
     public void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap) {
+        if (propertiesMap == null || propertiesMap.size() == 0) {
+            return;
+        }
 
+        if (propertiesMap.containsKey(MAX_LOCAL_TXN_ID)) {
+            sequenceId.set(Long.parseLong(propertiesMap.get(MAX_LOCAL_TXN_ID)));
+        }
     }
 
+    // When we don't roll over ledger, we can init sequenceId from the getLastAddConfirmed transaction metadata entry
     @Override
-    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle) {
-        return CompletableFuture.completedFuture(null);
+    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle lh) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        if (lh.getLastAddConfirmed() >= 0) {
+            lh.readAsync(lh.getLastAddConfirmed(), lh.getLastAddConfirmed()).whenComplete((entries, ex) -> {
+                if (ex != null) {
+                    log.error("[{}] Read last entry error.", name, ex);
+                    promise.completeExceptionally(ex);
+                } else {
+                    if (entries != null) {
+                        try {
+                            LedgerEntry ledgerEntry = entries.getEntry(lh.getLastAddConfirmed());
+                            if (ledgerEntry != null) {
+                                TransactionMetadataEntry lastConfirmEntry = new TransactionMetadataEntry();
+                                ByteBuf buffer = ledgerEntry.getEntryBuffer();
+                                lastConfirmEntry.parseFrom(buffer, buffer.readableBytes());
+                                this.sequenceId.set(lastConfirmEntry.getMaxLocalTxnId());
+                            }
+                            entries.close();
+                            promise.complete(null);
+                        } catch (Exception e) {
+                            log.error("[{}] Failed to recover the tc sequenceId from the last add confirmed entry.",
+                                    name, e);
+                            promise.completeExceptionally(e);
+                        }
+                    } else {
+                        promise.complete(null);
+                    }
+                }
+            });
+        } else {
+            promise.complete(null);
+        }
+        return promise;
     }
 
+    // roll over ledger will update sequenceId to managedLedger properties
     @Override
     public void onUpdateManagedLedgerInfo(Map<String, String> propertiesMap) {
-        propertiesMap.put(MAX_LOCAL_TXN_ID, maxLocalTxnId + "");
-    }
-
-    protected void setMaxLocalTxnId(long maxLocalTxnId) {
-        this.maxLocalTxnId = maxLocalTxnId;
+        propertiesMap.put(MAX_LOCAL_TXN_ID, sequenceId.get() + "");
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
@@ -42,10 +42,14 @@ public class MLTransactionMetadataStoreProvider implements TransactionMetadataSt
                                                                  ManagedLedgerConfig managedLedgerConfig,
                                                                  TransactionTimeoutTracker timeoutTracker,
                                                                  TransactionRecoverTracker recoverTracker) {
+        MLTransactionLogInterceptor mlTransactionLogInterceptor = new MLTransactionLogInterceptor();
+        managedLedgerConfig.setManagedLedgerInterceptor(new MLTransactionLogInterceptor());
         MLTransactionLogImpl txnLog = new MLTransactionLogImpl(transactionCoordinatorId,
                 managedLedgerFactory, managedLedgerConfig);
 
+        // mlTransactionLogInterceptor.getSequenceId() MLTransactionLogInterceptor will init sequenceId
         return txnLog.initialize().thenApply(__ ->
-                new MLTransactionMetadataStore(transactionCoordinatorId, txnLog, timeoutTracker, recoverTracker));
+                new MLTransactionMetadataStore(transactionCoordinatorId, txnLog, timeoutTracker,
+                        recoverTracker, mlTransactionLogInterceptor.getSequenceId()));
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStoreProvider.java
@@ -47,7 +47,7 @@ public class MLTransactionMetadataStoreProvider implements TransactionMetadataSt
         MLTransactionLogImpl txnLog = new MLTransactionLogImpl(transactionCoordinatorId,
                 managedLedgerFactory, managedLedgerConfig);
 
-        // mlTransactionLogInterceptor.getSequenceId() MLTransactionLogInterceptor will init sequenceId
+        // MLTransactionLogInterceptor will init sequenceId and update the sequenceId to managedLedger properties.
         return txnLog.initialize().thenApply(__ ->
                 new MLTransactionMetadataStore(transactionCoordinatorId, txnLog, timeoutTracker,
                         recoverTracker, mlTransactionLogInterceptor.getSequenceId()));


### PR DESCRIPTION
## Motivation
now, we recover transaction sequenceId from lastConfirmEntry or managedLedger properties. But update managedLedger properties is not a Synchronize op, so it will recover error sequenceId. 

### Modifications
use ManagedLedgerInterceptor will fix this problem.
1. use interceptor.onUpdateManagedLedgerInfo, when ledger roll over, it will update current sequenceId to managedLedger properties.
2. use interceptor.onManagedLedgerPropertiesInitialize, first we will recover sequenceId from managedLedger properties.
3. use interceptor.onManagedLedgerLastLedgerInitialize, when tc recover and has a effective lastConfirmEntry, we will change the sequenceID after interceptor.onManagedLedgerPropertiesInitialize
4. If a new TC, it can't recover from interceptor.onManagedLedgerPropertiesInitialize and interceptor.onManagedLedgerLastLedgerInitialize, it will use the initial sequenceId -1
### Verifying this change
Add the tests for it

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: (no)
The admin cli options: (no)
Anything that affects deployment: (no)

