### PR TITLE
[Issue 13232]Remote code injection in Log4j: Avoid a remote code execution vulnerability via the ldap JNDI parser.

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -301,6 +301,8 @@ OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
 # Configure log4j2 to disable servlet webapp detection so that Garbage free logging can be used
 OPTS="$OPTS -Dlog4j2.is.webapp=false"
+# Remote code injection in Log4j: Avoid a remote code execution vulnerability via the ldap JNDI parser.
+OPTS="$OPTS -Dlog4j2.formatMsgNoLookups=true"
 
 # Functions related logging
 OPTS="$OPTS -Dpulsar.functions.process.container.log.dir=$PULSAR_LOG_DIR"


### PR DESCRIPTION
Fixes #13232 
### Motivation
Remote code injection in Log4j: Avoid a remote code execution vulnerability via the ldap JNDI parser.
See #13232 

### Modifications
Add JVM options in pulsar daemon script: `-Dlog4j2.formatMsgNoLookups=true`

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs?
- [x]  `no-need-doc`

Bug fix