### PR TITLE
[Client] Fix memory leak when message payload processor is configured

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagePayloadContextImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessagePayloadContextImpl.java
@@ -88,6 +88,7 @@ public class MessagePayloadContextImpl implements MessagePayloadContext {
             ackBitSet.recycle();
             ackBitSet = null;
         }
+        recyclerHandle.recycle(this);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

When `MessagePayloadProcessor` is configured, there will be a memory leak caused by unused `MessagePayloadContextImpl#recyclerHandle`.

### Modifications

Call `recycle()` to recycle the `MessagePayloadContextImpl` object in `recycle()` method.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.