### PR TITLE
[pulsar-client]Add getNumPartitions method into PartitionedProducerImpl

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -194,4 +194,9 @@ public interface Producer<T> extends Closeable {
      * @return The last disconnected timestamp of the producer
      */
     long getLastDisconnectedTimestamp();
+
+    /**
+     * @return the number of partitions per topic.
+     */
+    int getNumOfPartitions();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -438,4 +438,13 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         return partitionsAutoUpdateTimeout;
     }
 
+    /**
+     * Return the number of partitions per topic.
+     *
+     * @return the number of partitions per topic.
+     */
+    public int getNumOfPartitions() {
+        return topicMetadata.numPartitions();
+    }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -438,11 +438,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         return partitionsAutoUpdateTimeout;
     }
 
-    /**
-     * Return the number of partitions per topic.
-     *
-     * @return the number of partitions per topic.
-     */
+    @Override
     public int getNumOfPartitions() {
         return topicMetadata.numPartitions();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -493,6 +493,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
     }
 
+    @Override
+    public int getNumOfPartitions() {
+        return 0;
+    }
+
     private void serializeAndSendMessage(MessageImpl<?> msg, ByteBuf payload,
             long sequenceId, String uuid, int chunkId, int totalChunks, int readStartIndex, int chunkMaxSizeInBytes, ByteBuf compressedPayload,
             boolean compressed, int compressedPayloadSize,

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -235,4 +235,27 @@ public class PartitionedProducerImplTest {
         assertEquals(stats.getTotalSendFailed(), 1);
     }
 
+    @Test
+    public void testGetNumOfPartitions() throws Exception {
+        String topicName = "test-get-num-of-partitions";
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        conf.setStatsIntervalSeconds(100);
+
+        ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), false, threadFactory);
+
+        PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
+
+        ProducerConfigurationData producerConfData = new ProducerConfigurationData();
+        producerConfData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
+        producerConfData.setCustomMessageRouter(new CustomMessageRouter());
+
+        PartitionedProducerImpl impl = new PartitionedProducerImpl(
+                clientImpl, topicName, producerConfData,
+                1, null, null, null);
+
+        assertEquals(impl.getNumOfPartitions(), 1);
+    }
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -251,11 +251,16 @@ public class PartitionedProducerImplTest {
         producerConfData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
         producerConfData.setCustomMessageRouter(new CustomMessageRouter());
 
-        PartitionedProducerImpl impl = new PartitionedProducerImpl(
-                clientImpl, topicName, producerConfData,
-                1, null, null, null);
+        PartitionedProducerImpl partitionedProducerImpl = new PartitionedProducerImpl(
+                clientImpl, topicName, producerConfData, 1, null, null, null);
 
-        assertEquals(impl.getNumOfPartitions(), 1);
+        assertEquals(partitionedProducerImpl.getNumOfPartitions(), 1);
+
+        String nonPartitionedTopicName = "test-get-num-of-partitions-for-non-partitioned-topic";
+        ProducerConfigurationData producerConfDataNonPartitioned = new ProducerConfigurationData();
+        ProducerImpl producerImpl = new ProducerImpl(clientImpl, nonPartitionedTopicName, producerConfDataNonPartitioned,
+                null, 0, null, null);
+        assertEquals(producerImpl.getNumOfPartitions(), 0);
     }
 
 }


### PR DESCRIPTION
### Motivation
`PartitionedProducerImpl` should public the number partitions of its topic. Although we can get the number partitions of a topic by calling the pulsar client's RPC, this will consume one RPC request which is time consuming.
- A topic partitions may change. calling the pulsar client's RPC is necessary if you need to know the latest number partitions of the topic in real time.
- `PartitionedProducerImpl` can always know the latest number partitions of its topic because of `TopicsPartitionChangedListener`. 

Therefore, Producer can get the latest number partitions of a topic in its `topicMetadata` cache. It can reduce RPC request and improve performance when you want to know the number partitions of a topic by `PartitionedProducerImpl`.

This was indeed used when I designed and implemented MQ on Pulsar, which improved the performance of Proxy and increased throughput.


### Modifications
public a getNumPartitions API in `PartitionedProducerImpl`

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (yes)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs?
- [x]  `doc`
(The function has its own java doc.)
Enhancement