### PR TITLE
[broker] Replace BaseResources#deleteRecursiveAsync with MetadataStore#deleteRecursive

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -261,25 +261,7 @@ public class NamespaceResources extends BaseResources<Policies> {
 
         public CompletableFuture<Void> clearPartitionedTopicMetadataAsync(NamespaceName namespaceName) {
             final String globalPartitionedPath = joinPath(PARTITIONED_TOPIC_PATH, namespaceName.toString());
-
-            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-
-            deleteRecursiveAsync(this, globalPartitionedPath)
-                    .thenAccept(ignore -> {
-                        log.info("Clear partitioned topic metadata [{}] success.", namespaceName);
-                        completableFuture.complete(null);
-                    }).exceptionally(ex -> {
-                if (ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
-                    completableFuture.complete(null);
-                } else {
-                    log.error("Clear partitioned topic metadata failed.");
-                    completableFuture.completeExceptionally(ex.getCause());
-                    return null;
-                }
-                return null;
-            });
-
-            return completableFuture;
+            return getStore().deleteRecursive(globalPartitionedPath);
         }
 
         public CompletableFuture<Void> clearPartitionedTopicTenantAsync(String tenant) {
@@ -298,38 +280,16 @@ public class NamespaceResources extends BaseResources<Policies> {
         }
     }
 
-    // clear resource of `/loadbalance/bundle-data/{tenant}/{namespace}/` for zk-node
+    // clear resource of `/loadbalance/bundle-data/{tenant}/{namespace}/` in metadata-store
     public CompletableFuture<Void> deleteBundleDataAsync(NamespaceName ns) {
         final String namespaceBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, ns.toString());
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteRecursiveAsync(this, namespaceBundlePath).whenComplete((ignore, ex) -> {
-            if (ex instanceof MetadataStoreException.NotFoundException) {
-                future.complete(null);
-            } else if (ex != null) {
-                future.completeExceptionally(ex);
-            } else {
-                future.complete(null);
-            }
-        });
-
-        return future;
+        return getStore().deleteRecursive(namespaceBundlePath);
     }
 
-    // clear resource of `/loadbalance/bundle-data/{tenant}/` for zk-node
+    // clear resource of `/loadbalance/bundle-data/{tenant}/` in metadata-store
     public CompletableFuture<Void> deleteBundleDataTenantAsync(String tenant) {
         final String tenantBundlePath = joinPath(BUNDLE_DATA_BASE_PATH, tenant);
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteRecursiveAsync(this, tenantBundlePath).whenComplete((ignore, ex) -> {
-            if (ex instanceof MetadataStoreException.NotFoundException) {
-                future.complete(null);
-            } else if (ex != null) {
-                future.completeExceptionally(ex);
-            } else {
-                future.complete(null);
-            }
-        });
-
-        return future;
+        return getStore().deleteRecursive(tenantBundlePath);
     }
 
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

MetadataStore#deleteRecursive is introduced in #11867. 
So we can replace BaseResources#deleteRecursiveAsync with MetadataStore#deleteRecursive, to make the code cleaner.

### Modifications

Replace BaseResources#deleteRecursiveAsync with MetadataStore#deleteRecursive

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as org.apache.pulsar.broker.admin.AdminApiTest2

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Code optimization.


