### PR TITLE
[broker] Optimize TopicPolicies#messageTTLInSeconds with HierarchyTopicPolicies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -162,6 +162,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                 this.topicPolicies.getBackLogQuotaMap().get(type).updateTopicValue(
                         data.getBackLogQuotaMap() == null ? null : data.getBackLogQuotaMap().get(type.toString())));
         topicPolicies.getTopicMaxMessageSize().updateTopicValue(data.getMaxMessageSize());
+        topicPolicies.getMessageTTLInSeconds().updateTopicValue(data.getMessageTTLInSeconds());
     }
 
     protected void updateTopicPolicyByNamespacePolicy(Policies namespacePolicies) {
@@ -171,6 +172,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         if (namespacePolicies.deleted) {
             return;
         }
+        topicPolicies.getMessageTTLInSeconds().updateNamespaceValue(namespacePolicies.message_ttl_in_seconds);
         topicPolicies.getMaxSubscriptionsPerTopic().updateNamespaceValue(namespacePolicies.max_subscriptions_per_topic);
         topicPolicies.getMaxProducersPerTopic().updateNamespaceValue(namespacePolicies.max_producers_per_topic);
         topicPolicies.getInactiveTopicPolicies().updateNamespaceValue(namespacePolicies.inactive_topic_policies);
@@ -202,6 +204,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                 .updateBrokerValue(brokerService.getBacklogQuotaManager().getDefaultQuota());
 
         topicPolicies.getTopicMaxMessageSize().updateBrokerValue(config.getMaxMessageSize());
+        topicPolicies.getMessageTTLInSeconds().updateBrokerValue(config.getTtlDurationDefaultInSeconds());
     }
 
     private EnumSet<SubType> subTypeStringsToEnumSet(Set<String> getSubscriptionTypesEnabled) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1379,12 +1379,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         CompletableFuture<List<String>> replicationClustersFuture = getReplicationClusters(name);
 
-        CompletableFuture<Integer> ttlFuture = getMessageTTL();
-
-        return CompletableFuture.allOf(replicationClustersFuture, ttlFuture)
+        return CompletableFuture.allOf(replicationClustersFuture)
                 .thenCompose(__ -> {
                     List<String> configuredClusters = replicationClustersFuture.join();
-                    int newMessageTTLinSeconds = ttlFuture.join();
+                    int newMessageTTLinSeconds = topicPolicies.getMessageTTLInSeconds().get();
 
                     String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
 
@@ -1454,15 +1452,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public void checkMessageExpiry() {
-        getMessageTTL().thenAccept(messageTtlInSeconds -> {
-            //If topic level policy or message ttl is not set, fall back to namespace level config.
-
-            if (messageTtlInSeconds != 0) {
-                subscriptions.forEach((__, sub) -> sub.expireMessages(messageTtlInSeconds));
-                replicators.forEach((__, replicator)
-                        -> ((PersistentReplicator) replicator).expireMessages(messageTtlInSeconds));
-            }
-        });
+        int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
+        if (messageTtlInSeconds != 0) {
+            subscriptions.forEach((__, sub) -> sub.expireMessages(messageTtlInSeconds));
+            replicators.forEach((__, replicator)
+                    -> ((PersistentReplicator) replicator).expireMessages(messageTtlInSeconds));
+        }
     }
 
     @Override
@@ -2880,31 +2875,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return OffloadProcessStatus.forError(e.getMessage());
             }
         }
-    }
-
-    /**
-     * Get message TTL for this topic.
-     * @return Message TTL in second.
-     */
-    private CompletableFuture<Integer> getMessageTTL() {
-        //Return Topic level message TTL if exist. If topic level policy or message ttl is not set,
-        //fall back to namespace level message ttl then message ttl set for current broker.
-        Optional<Integer> messageTtl = getTopicPolicies().map(TopicPolicies::getMessageTTLInSeconds);
-        if (messageTtl.isPresent()) {
-            return CompletableFuture.completedFuture(messageTtl.get());
-        }
-
-        return brokerService.pulsar().getPulsarResources().getNamespaceResources()
-                .getPoliciesAsync(TopicName.get(topic).getNamespaceObject())
-                .thenApply(optPolicies -> {
-                    if (optPolicies.isPresent()) {
-                        if (optPolicies.get().message_ttl_in_seconds != null) {
-                            return optPolicies.get().message_ttl_in_seconds;
-                        }
-                    }
-
-                    return brokerService.getPulsar().getConfiguration().getTtlDurationDefaultInSeconds();
-                });
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentTopic.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -277,6 +277,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         for (String topic : topicList) {
             PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
             persistentTopic.getBrokerService().getPulsar().getConfiguration().setTtlDurationDefaultInSeconds(-1);
+            persistentTopic.getHierarchyTopicPolicies().getMessageTTLInSeconds().updateBrokerValue(-1);
         }
         pulsar.getBrokerService().forEachTopic(Topic::checkMessageExpiry);
         //wait for checkMessageExpiry

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -38,6 +38,7 @@ public class HierarchyTopicPolicies {
     final PolicyHierarchyValue<Integer> maxProducersPerTopic;
     final Map<BacklogQuotaType, PolicyHierarchyValue<BacklogQuota>> backLogQuotaMap;
     final PolicyHierarchyValue<Integer> topicMaxMessageSize;
+    final PolicyHierarchyValue<Integer> messageTTLInSeconds;
 
     public HierarchyTopicPolicies() {
         deduplicationEnabled = new PolicyHierarchyValue<>();
@@ -50,5 +51,6 @@ public class HierarchyTopicPolicies {
                 .put(BacklogQuotaType.message_age, new PolicyHierarchyValue<>())
                 .build();
         topicMaxMessageSize = new PolicyHierarchyValue<>();
+        messageTTLInSeconds = new PolicyHierarchyValue<>();
     }
 }


### PR DESCRIPTION
### Motivation

This is one of the serial topic policy optimization with `HierarchyTopicPolicies`. 

Update topic policy with HierarchyTopicPolicies comes with these benefits:
- All topic policy related settings will goes into AbstractTopic#topicPolicies, easier to understand, check, review, and modify.
- Unify policy update to AbstractTopic. And easier to find which policy is not applied to non-persistent topic yet. And we can easily add support for it.
- Unify policy value with 3 level settings (topic/namespace/broker), and priority with topic > namespace > broker.  And it's easier to find which level settings is missing.
- All values are updated at creation or by trigger. We can save some resource to update it or recalculate each time we use it. 
- etc.

### Modifications

Add new field `messageTTLInSeconds` in org.apache.pulsar.broker.service.AbstractTopic#topicPolicies.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as 
- class org.apache.pulsar.broker.admin.TopicMessageTTLTest
- org.apache.pulsar.client.api.KeySharedSubscriptionTest#testContinueDispatchMessagesWhenMessageTTL
- org.apache.pulsar.broker.stats.PrometheusMetricsTest#testPerTopicExpiredStat
- org.apache.pulsar.client.impl.TopicsConsumerImplTest#testDefaultBacklogTTL

Some checklist for updating topic policy with `HierarchyTopicPolicies`.

- [x] Broker level value set. And if it's dynamic (no).
- [x] Namespace level value updated. 
- [x] Topic level value updated.
- [x] Pre-existing unit test covers this change and updated to verify this change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 

Code optimization.