### PR TITLE
Make sure the client can get response when encounter producer busy exception.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1322,10 +1322,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     remoteAddress, topicName, producerId, ex.getMessage());
 
             producer.closeNow(true);
-            if (producerFuture.completeExceptionally(ex)) {
-                commandSender.sendErrorResponse(requestId,
-                        BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
-            }
+            producerFuture.completeExceptionally(ex);
+            commandSender.sendErrorResponse(requestId,
+                    BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
             return null;
         });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -893,6 +893,11 @@ public class ServerCnxTest {
                 producerName, Collections.emptyMap(), false);
         channel.writeInbound(createProducer3);
 
+        // 1nd producer will fail
+        response = getResponse();
+        assertEquals(response.getClass(), CommandError.class);
+        assertEquals(((CommandError) response).getRequestId(), 1);
+
         // 3nd producer will fail
         response = getResponse();
         assertEquals(response.getClass(), CommandError.class);


### PR DESCRIPTION
When the producer with the same producer ID and same connection,
Of course, this usually doesn't happen. When cherry-picking #12846,
the test using the same producer ID https://github.com/apache/pulsar/pull/12846/files#diff-b73845cd7706e03b89122a21b3e60c36c95ce6a0c7dd4574f8eda3fc67dd02b1R867-R876
And after we apply the change https://github.com/apache/pulsar/pull/8685/files#diff-1e0e8195fb5ec5a6d79acbc7d859c025a9b711f94e6ab37c94439e99b3202e84R1161
Only one request can get a response when encountering exceptions.

The fix is to make sure the broker doesn't miss the response to the client,
we should make sure one request can get one response, otherwise the client
side might get blocked.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


