### PR TITLE
[Broker] Skip response when producerFuture is already complete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1161,9 +1161,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 } catch (Exception ise) {
                                     log.error("[{}] Failed to add producer to topic {}: {}", remoteAddress, topicName,
                                         ise.getMessage());
-                                    commandSender.sendErrorResponse(requestId,
-                                            BrokerServiceException.getClientErrorCode(ise), ise.getMessage());
-                                    producerFuture.completeExceptionally(ise);
+                                    if (producerFuture.completeExceptionally(ise)) {
+                                        commandSender.sendErrorResponse(requestId,
+                                                BrokerServiceException.getClientErrorCode(ise), ise.getMessage());
+                                    }
                                 }
 
                                 producers.remove(producerId, producerFuture);


### PR DESCRIPTION
### Motivation

This PR fixes an issue introduced in branch-2.7 by one of my commits. @codelipenghui has some context in this PR https://github.com/apache/pulsar/pull/13245 and proposes the opposite solution.

The behavior here aligns with https://github.com/apache/pulsar/commit/d12486b9b012fc8264fa0d4cb7f4e3e148c30187. Because `branch-2.7` does not have this commit, one of my tests in the cherry picked commits is failing.

I think we need to update `branch-2.7` to be like `master` and to only respond if the future is completed by this exception. From my perspective, the contract in the class is that if a thread completes the future, it should also send (or intentionally not send) a response. In the failing test case, the producer future is completed by a `CloseProducer` command.

Alternatively, we could update the test if we don't want to change this client behavior.

### Modifications

* If the producer fails to get created, only send a response to the client if the `producerFuture` is not already completed.

### Verifying this change

I verified this test by running the `ServerCnxTest` locally with the proposed change. It passed. This change is also already i master.

### Does this pull request potentially affect one of the following parts:

This change affects the binary protocol because it skips sending a response to the client. However, it only skips it when the future is already completed, and the completion implies that the `ServerCnx` has already handled the request.

### Documentation
- [x] `no-need-doc` 
 