### PR TITLE
Add maven.restlet.org repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2339,6 +2339,14 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>maven.restlet.org</id>
+      <name>maven.restlet.org</name>
+      <url>http://maven.restlet.org</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2342,7 +2342,7 @@ flexible messaging model and an intuitive client API.</description>
     <repository>
       <id>maven.restlet.org</id>
       <name>maven.restlet.org</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/src/settings.xml
+++ b/src/settings.xml
@@ -47,13 +47,4 @@
       </properties>
     </profile>
   </profiles>
-
-  <mirrors>
-    <mirror>
-      <id>restlet-http-unblocker</id>
-      <mirrorOf>central</mirrorOf>
-      <name>restlet-http-unblocker</name>
-      <url>http://maven.restlet.org</url>
-    </mirror>
-  </mirrors>
 </settings>

--- a/src/settings.xml
+++ b/src/settings.xml
@@ -47,4 +47,13 @@
       </properties>
     </profile>
   </profiles>
+
+  <mirrors>
+    <mirror>
+      <id>restlet-http-unblocker</id>
+      <mirrorOf>central</mirrorOf>
+      <name>restlet-http-unblocker</name>
+      <url>http://maven.restlet.org</url>
+    </mirror>
+  </mirrors>
 </settings>


### PR DESCRIPTION
### Motivation

Fix the build issue if no maven cache

```
[ERROR] Failed to execute goal on project pulsar-io-solr: Could not resolve dependencies for project org.apache.pulsar:pulsar-io-solr:jar:2.7.4-SNAPSHOT: Failed to collect dependencies at org.apache.solr:solr-core:jar:8.6.3 -> org.restlet.jee:org.restlet:jar:2.4.3: Failed to read artifact descriptor for org.restlet.jee:org.restlet:jar:2.4.3: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.4.3 from/to maven-restlet (https://maven.restlet.com): Transfer failed for https://maven.restlet.com/org/restlet/jee/org.restlet/2.4.3/org.restlet-2.4.3.pom: sun.security.validator.ValidatorException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed: NotAfter: Sun Dec 12 06:28:29 CST 2021 -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :pulsar-io-solr
```

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


