### PR TITLE
[CI] Fix Tune Runner VM memory.swappiness no such file or directory

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -33,8 +33,10 @@ runs:
             # Set vm.swappiness=1 to avoid swapping and allow high RAM usage
             echo 1 | sudo tee /proc/sys/vm/swappiness
             # Set swappiness to 1 for all cgroups and sub-groups
-            for swappiness_file in /sys/fs/cgroup/memory/*/memory.swappiness /sys/fs/cgroup/memory/*/*/memory.swappiness; do
-              echo 1 | sudo tee $swappiness_file > /dev/null
+            for swappiness_dir in /sys/fs/cgroup/memory/*/ /sys/fs/cgroup/memory/*/*/; do
+              if [ -d "swappiness_dir" ]; then
+                echo 1 | sudo tee $(swappiness_dir)memory.swappiness > /dev/null
+              fi
             done
 
             # use "madvise" Linux Transparent HugePages (THP) setting


### PR DESCRIPTION
Failed CI: https://github.com/apache/pulsar/runs/4501006108?check_suite_focus=true#step:3:1

### Motivation

The Tune Runner VM is flaky.

Sometimes, the parent directory of `memory.swappiness` can't find, we should check it first.

```shell
Run if [[ "$OSTYPE" == "linux-gnu"* ]]; then
10.1.0.235	fv-az198-145.gjkxsqtjg41etoza45cw35jkyb.bx.internal.cloudapp.net fv-az198-145
1
tee: /sys/fs/cgroup/memory/system.slice/snap-snapd-13640.mount/memory.swappiness: No such file or directory
Error: Process completed with exit code 1.
```

### Modifications

Add a check of the parent directory of `memory.swappiness`

### Documentation

- [x] `no-need-doc` 

