### PR TITLE
[Functions] Enable poolMessages of functions by default

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/ConsumerConfig.java
@@ -45,7 +45,8 @@ public class ConsumerConfig {
     private Map<String, String> consumerProperties = new HashMap<>();
     private Integer receiverQueueSize;
     private CryptoConfig cryptoConfig;
-    private boolean poolMessages;
+    @Builder.Default
+    private boolean poolMessages = true;
 
     public ConsumerConfig(String schemaType) {
         this.schemaType = schemaType;

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -585,19 +585,19 @@ public class FunctionConfigUtilsTest {
     public void testPoolMessages() {
         FunctionConfig functionConfig = createFunctionConfig();
         Function.FunctionDetails functionDetails = FunctionConfigUtils.convert(functionConfig, null);
-        assertFalse(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+        assertTrue(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
         FunctionConfig convertedConfig = FunctionConfigUtils.convertFromDetails(functionDetails);
-        assertFalse(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
+        assertTrue(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
 
         Map<String, ConsumerConfig> inputSpecs = new HashMap<>();
         inputSpecs.put("test-input", ConsumerConfig.builder()
-                .poolMessages(true).build());
+                .poolMessages(false).build());
         functionConfig.setInputSpecs(inputSpecs);
 
         functionDetails = FunctionConfigUtils.convert(functionConfig, null);
-        assertTrue(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
+        assertFalse(functionDetails.getSource().getInputSpecsMap().get("test-input").getPoolMessages());
 
         convertedConfig = FunctionConfigUtils.convertFromDetails(functionDetails);
-        assertTrue(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
+        assertFalse(convertedConfig.getInputSpecs().get("test-input").isPoolMessages());
     }
 }


### PR DESCRIPTION
### Motivation

We have introduced poolMessages for consumer by PIP-83, and add configuration for functions by #11618
The default value of poolMessage is false if user did not config it in `FunctionConfig`.

It's better to enable poolMessage for function instance to avoid high work load of JVM GC. And user do not need to call release API for each messages, we have already did that in function instance side.
For those user developing functions, they do not need to known the detail of memory usage with poolMessage and whether they need to enable poolMessage when create functions. 

### Modifications
Enable poolMessages of functions by default

### Verifying this change

This change is already covered by existing tests, such as testPoolMessages()

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
  
  Only change default value

