### PR TITLE
Broker: brokerDeduplicationSnapshotFrequencyInSeconds default should be 10

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -576,7 +576,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_POLICIES,
         doc = "How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)"
     )
-    private int brokerDeduplicationSnapshotFrequencyInSeconds = 120;
+    private int brokerDeduplicationSnapshotFrequencyInSeconds = 10;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "If this time interval is exceeded, a snapshot will be taken."


### PR DESCRIPTION
### Motivation
In the default configuration file `conf/broker.conf` the entry `brokerDeduplicationSnapshotFrequencyInSeconds` is 10, 
but in the Java code the default is 120.
So if you comment out or you remove that line in broker.conf the behaviour of the broker changes.

### Modifications
Change the default value from 120 to 10. 

An alternative could be to change broker.conf, but doing so if you upgrade the Pulsar docker image you would see an unexpected behaviour change, so it is better to change the Java value.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
