### PR TITLE
Align configurations defaults between default file and Java object (broker.conf, proxy.conf, websocket.conf)

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -232,7 +232,7 @@ brokerDeduplicationEnabled=false
 brokerDeduplicationMaxNumberOfProducers=10000
 
 # How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)
-brokerDeduplicationSnapshotFrequencyInSeconds=10
+brokerDeduplicationSnapshotFrequencyInSeconds=120
 # If this time interval is exceeded, a snapshot will be taken.
 # It will run simultaneously with `brokerDeduplicationEntriesInterval`
 brokerDeduplicationSnapshotIntervalSeconds=120
@@ -426,7 +426,7 @@ maxConcurrentTopicLoadRequest=5000
 maxConcurrentNonPersistentMessagePerConnection=1000
 
 # Number of worker threads to serve non-persistent topic
-numWorkerThreadsForNonPersistentTopic=8
+numWorkerThreadsForNonPersistentTopic=
 
 # Enable broker to load persistent topics
 enablePersistentTopics=true
@@ -926,10 +926,10 @@ managedLedgerStatsPeriodSeconds=60
 managedLedgerDigestType=CRC32C
 
 # Number of threads to be used for managed ledger tasks dispatching
-managedLedgerNumWorkerThreads=8
+managedLedgerNumWorkerThreads=
 
 # Number of threads to be used for managed ledger scheduled tasks
-managedLedgerNumSchedulerThreads=8
+managedLedgerNumSchedulerThreads=
 
 # Amount of memory to use for caching data payload in managed ledger. This memory
 # is allocated from JVM direct memory and it's shared across all the topics
@@ -1195,10 +1195,10 @@ bootstrapNamespaces=
 webSocketServiceEnabled=false
 
 # Number of IO threads in Pulsar Client used in WebSocket proxy
-webSocketNumIoThreads=8
+webSocketNumIoThreads=
 
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
-webSocketConnectionsPerBroker=8
+webSocketConnectionsPerBroker=
 
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -49,13 +49,13 @@ bindAddress=0.0.0.0
 clusterName=
 
 # Number of IO threads in Pulsar Client used in WebSocket proxy
-webSocketNumIoThreads=8
+webSocketNumIoThreads=
 
 # Number of threads to use in HTTP server. Default is Runtime.getRuntime().availableProcessors()
 numHttpServerThreads=
 
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
-webSocketConnectionsPerBroker=8
+webSocketConnectionsPerBroker=
 
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -576,7 +576,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_POLICIES,
         doc = "How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)"
     )
-    private int brokerDeduplicationSnapshotFrequencyInSeconds = 10;
+    private int brokerDeduplicationSnapshotFrequencyInSeconds = 120;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "If this time interval is exceeded, a snapshot will be taken."
@@ -933,7 +933,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Number of worker threads to serve non-persistent topic")
-    private int numWorkerThreadsForNonPersistentTopic = 8;
+    private int numWorkerThreadsForNonPersistentTopic = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -1636,12 +1636,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_STORAGE_ML,
         doc = "Number of threads to be used for managed ledger tasks dispatching"
     )
-    private int managedLedgerNumWorkerThreads = 8;
+    private int managedLedgerNumWorkerThreads = Runtime.getRuntime().availableProcessors();
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "Number of threads to be used for managed ledger scheduled tasks"
     )
-    private int managedLedgerNumSchedulerThreads = 8;
+    private int managedLedgerNumSchedulerThreads = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
@@ -2136,12 +2136,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_WEBSOCKET,
         doc = "Number of IO threads in Pulsar Client used in WebSocket proxy"
     )
-    private int webSocketNumIoThreads = 8;
+    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Number of connections per Broker in Pulsar Client used in WebSocket proxy"
     )
-    private int webSocketConnectionsPerBroker = 8;
+    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Time in milliseconds that idle WebSocket session times out"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -576,7 +576,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_POLICIES,
         doc = "How often is the thread pool scheduled to check whether a snapshot needs to be taken.(disable with value 0)"
     )
-    private int brokerDeduplicationSnapshotFrequencyInSeconds = 120;
+    private int brokerDeduplicationSnapshotFrequencyInSeconds = 10;
     @FieldContext(
         category = CATEGORY_POLICIES,
         doc = "If this time interval is exceeded, a snapshot will be taken."
@@ -699,7 +699,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "Reducing to lower value can give more accuracy while throttling publish but "
                     + "it uses more CPU to perform frequent check. (Disable publish throttling with value 0)"
         )
-    private int topicPublisherThrottlingTickTimeMillis = 5;
+    private int topicPublisherThrottlingTickTimeMillis = 10;
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Enable precise rate limit for topic publish"
@@ -815,7 +815,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Default dispatch-throttling is disabled for consumers which already caught-up with"
             + " published messages and don't have backlog. This enables dispatch-throttling for "
             + " non-backlog consumers as well.")
-    private boolean dispatchThrottlingOnNonBacklogConsumerEnabled = false;
+    private boolean dispatchThrottlingOnNonBacklogConsumerEnabled = true;
 
     @FieldContext(
             category = CATEGORY_POLICIES,
@@ -933,7 +933,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Number of worker threads to serve non-persistent topic")
-    private int numWorkerThreadsForNonPersistentTopic = Runtime.getRuntime().availableProcessors();
+    private int numWorkerThreadsForNonPersistentTopic = 8;
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -1590,7 +1590,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_STORAGE_ML,
         doc = "Threshold to which bring down the cache level when eviction is triggered"
     )
-    private double managedLedgerCacheEvictionWatermark = 0.9f;
+    private double managedLedgerCacheEvictionWatermark = 0.9;
     @FieldContext(category = CATEGORY_STORAGE_ML,
             doc = "Configure the cache eviction frequency for the managed ledger cache. Default is 100/s")
     private double managedLedgerCacheEvictionFrequency = 100.0;
@@ -1636,12 +1636,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_STORAGE_ML,
         doc = "Number of threads to be used for managed ledger tasks dispatching"
     )
-    private int managedLedgerNumWorkerThreads = Runtime.getRuntime().availableProcessors();
+    private int managedLedgerNumWorkerThreads = 8;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "Number of threads to be used for managed ledger scheduled tasks"
     )
-    private int managedLedgerNumSchedulerThreads = Runtime.getRuntime().availableProcessors();
+    private int managedLedgerNumSchedulerThreads = 8;
 
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
@@ -1999,7 +1999,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_REPLICATION,
         doc = "Enable replication metrics"
     )
-    private boolean replicationMetricsEnabled = false;
+    private boolean replicationMetricsEnabled = true;
     @FieldContext(
         category = CATEGORY_REPLICATION,
         doc = "Max number of connections to open for each broker in a remote cluster.\n\n"
@@ -2136,12 +2136,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_WEBSOCKET,
         doc = "Number of IO threads in Pulsar Client used in WebSocket proxy"
     )
-    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
+    private int webSocketNumIoThreads = 8;
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Number of connections per Broker in Pulsar Client used in WebSocket proxy"
     )
-    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
+    private int webSocketConnectionsPerBroker = 8;
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Time in milliseconds that idle WebSocket session times out"

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
@@ -123,7 +123,7 @@ public class PulsarBrokerStarterTest {
         assertTrue(serviceConfig.isBacklogQuotaCheckEnabled());
         assertEquals(serviceConfig.getManagedLedgerDefaultMarkDeleteRateLimit(), 5.0);
         assertEquals(serviceConfig.getReplicationProducerQueueSize(), 50);
-        assertFalse(serviceConfig.isReplicationMetricsEnabled());
+        assertTrue(serviceConfig.isReplicationMetricsEnabled());
         assertTrue(serviceConfig.isBookkeeperClientHealthCheckEnabled());
         assertEquals(serviceConfig.getBookkeeperClientHealthCheckErrorThresholdPerInterval(), 5);
         assertTrue(serviceConfig.isBookkeeperClientRackawarePolicyEnabled());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -23,12 +23,19 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import lombok.Cleanup;
@@ -209,5 +216,28 @@ public class ServiceConfigurationTest {
         assertEquals(conf.getBookkeeperMetadataStoreUrl(), "xx:other-system");
         assertTrue(conf.isConfigurationStoreSeparated());
         assertTrue(conf.isBookkeeperMetadataStoreSeparated());
+    }
+
+    @Test
+    public void testConfigFileDefaults() throws Exception {
+        try (FileInputStream stream = new FileInputStream("../conf/broker.conf")) {
+            final ServiceConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), ServiceConfiguration.class);
+            final ServiceConfiguration fileConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+            List<String> toSkip = Arrays.asList("properties", "class");
+            int counter = 0;
+            for (PropertyDescriptor pd : Introspector.getBeanInfo(ServiceConfiguration.class).getPropertyDescriptors()) {
+                if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
+                    continue;
+                }
+                final String key = pd.getName();
+                final Object javaValue = pd.getReadMethod().invoke(javaConfig);
+                final Object fileValue = pd.getReadMethod().invoke(fileConfig);
+                assertTrue(Objects.equals(javaValue, fileValue), "property '"
+                        + key + "' conf/broker.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
+                counter++;
+            }
+            assertEquals(377, counter);
+        }
+
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -236,7 +236,7 @@ public class ServiceConfigurationTest {
                         + key + "' conf/broker.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
                 counter++;
             }
-            assertEquals(377, counter);
+            assertEquals(counter, 378);
         }
 
     }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+@Test(groups = "broker")
 public class ProxyConfigurationTest {
 
     @Test

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -1,0 +1,43 @@
+package org.apache.pulsar.proxy.server;
+
+
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.testng.annotations.Test;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class ProxyConfigurationTest {
+
+    @Test
+    public void testConfigFileDefaults() throws Exception {
+        try (FileInputStream stream = new FileInputStream("../conf/proxy.conf")) {
+            final ProxyConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), ProxyConfiguration.class);
+            final ProxyConfiguration fileConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
+            List<String> toSkip = Arrays.asList("properties", "class");
+            int counter = 0;
+            for (PropertyDescriptor pd : Introspector.getBeanInfo(ProxyConfiguration.class).getPropertyDescriptors()) {
+                if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
+                    continue;
+                }
+                final String key = pd.getName();
+                final Object javaValue = pd.getReadMethod().invoke(javaConfig);
+                final Object fileValue = pd.getReadMethod().invoke(fileConfig);
+                assertTrue(Objects.equals(javaValue, fileValue), "property '"
+                        + key + "' conf/proxy.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
+                counter++;
+            }
+            assertEquals(79, counter);
+        }
+    }
+
+
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.proxy.server;
 
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -84,7 +84,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private Optional<Integer> webServicePortTls = Optional.empty();
 
     @FieldContext(doc = "Hostname or IP address the service binds on, default is 0.0.0.0.")
-    private String bindAddress;
+    private String bindAddress = "0.0.0.0";
 
     @FieldContext(doc = "Maximum size of a text message during parsing in WebSocket proxy")
     private int webSocketMaxTextFrameSize = 1024 * 1024;
@@ -120,13 +120,13 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String brokerClientTrustCertsFilePath = "";
 
     @FieldContext(doc = "Number of IO threads in Pulsar client used in WebSocket proxy")
-    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
+    private int webSocketNumIoThreads = 8;
 
     @FieldContext(doc = "Number of threads to used in HTTP server")
     private int numHttpServerThreads = Math.max(6, Runtime.getRuntime().availableProcessors());
 
     @FieldContext(doc = "Number of connections per broker in Pulsar client used in WebSocket proxy")
-    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
+    private int webSocketConnectionsPerBroker = 8;
 
     @FieldContext(doc = "Timeout of idling WebSocket session (in milliseconds)")
     private int webSocketSessionIdleTimeoutMillis = 300000;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -120,13 +120,13 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String brokerClientTrustCertsFilePath = "";
 
     @FieldContext(doc = "Number of IO threads in Pulsar client used in WebSocket proxy")
-    private int webSocketNumIoThreads = 8;
+    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(doc = "Number of threads to used in HTTP server")
     private int numHttpServerThreads = Math.max(6, Runtime.getRuntime().availableProcessors());
 
     @FieldContext(doc = "Number of connections per broker in Pulsar client used in WebSocket proxy")
-    private int webSocketConnectionsPerBroker = 8;
+    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(doc = "Timeout of idling WebSocket session (in milliseconds)")
     private int webSocketSessionIdleTimeoutMillis = 300000;

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
@@ -1,0 +1,42 @@
+package org.apache.pulsar.websocket.service;
+
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.testng.annotations.Test;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class WebSocketProxyConfigurationTest {
+
+    @Test
+    public void testConfigFileDefaults() throws Exception {
+        try (FileInputStream stream = new FileInputStream("../conf/websocket.conf")) {
+            final WebSocketProxyConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), WebSocketProxyConfiguration.class);
+            final WebSocketProxyConfiguration fileConfig = PulsarConfigurationLoader.create(stream, WebSocketProxyConfiguration.class);
+            List<String> toSkip = Arrays.asList("properties", "class");
+            int counter = 0;
+            for (PropertyDescriptor pd : Introspector.getBeanInfo(WebSocketProxyConfiguration.class).getPropertyDescriptors()) {
+                if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
+                    continue;
+                }
+                final String key = pd.getName();
+                final Object javaValue = pd.getReadMethod().invoke(javaConfig);
+                final Object fileValue = pd.getReadMethod().invoke(fileConfig);
+                assertTrue(Objects.equals(javaValue, fileValue), "property '"
+                        + key + "' conf/websocket.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
+                counter++;
+            }
+            assertEquals(36, counter);
+        }
+    }
+
+}

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.websocket.service;
 
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-
+@Test(groups = "broker")
 public class WebSocketProxyConfigurationTest {
 
     @Test

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -168,6 +168,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerDeduplicationMaxNumberOfProducers| The maximum number of producers for which information will be stored for deduplication purposes.  |10000|
 |brokerDeduplicationEntriesInterval|  The number of entries after which a deduplication informational snapshot is taken. A larger interval will lead to fewer snapshots being taken, though this would also lengthen the topic recovery time (the time required for entries published after the snapshot to be replayed). |1000|
 |brokerDeduplicationProducerInactivityTimeoutMinutes| The time of inactivity (in minutes) after which the broker will discard deduplication information related to a disconnected producer. |360|
+|brokerDeduplicationSnapshotFrequencyInSeconds| How often is the thread pool scheduled to check whether a snapshot needs to be taken. The value of `0` means it is disabled. |10| 
 |dispatchThrottlingRatePerReplicatorInMsg| The default messages per second dispatch throttling-limit for every replicator in replication. The value of `0` means disabling replication message dispatch-throttling| 0 |
 |dispatchThrottlingRatePerReplicatorInByte| The default bytes per second dispatch throttling-limit for every replicator in replication. The value of `0` means disabling replication message-byte dispatch-throttling| 0 | 
 |zooKeeperSessionTimeoutMillis| Zookeeper session timeout in milliseconds |30000|

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -153,8 +153,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |webServicePort|  Port to use to server HTTP request  |8080|
 |webServicePortTls| Port to use to server HTTPS request |8443|
 |webSocketServiceEnabled| Enable the WebSocket API service in broker  |false|
-|webSocketNumIoThreads|The number of IO threads in Pulsar Client used in WebSocket proxy.|8|
-|webSocketConnectionsPerBroker|The number of connections per Broker in Pulsar Client used in WebSocket proxy.|8|
+|webSocketNumIoThreads|The number of IO threads in Pulsar Client used in WebSocket proxy.|Runtime.getRuntime().availableProcessors()|
+|webSocketConnectionsPerBroker|The number of connections per Broker in Pulsar Client used in WebSocket proxy.|Runtime.getRuntime().availableProcessors()|
 |webSocketSessionIdleTimeoutMillis|Time in milliseconds that idle WebSocket session times out.|300000|
 |webSocketMaxTextFrameSize|The maximum size of a text message during parsing in WebSocket proxy.|1048576|
 |exposeTopicLevelMetricsInPrometheus|Whether to enable topic level metrics.|true|
@@ -168,7 +168,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerDeduplicationMaxNumberOfProducers| The maximum number of producers for which information will be stored for deduplication purposes.  |10000|
 |brokerDeduplicationEntriesInterval|  The number of entries after which a deduplication informational snapshot is taken. A larger interval will lead to fewer snapshots being taken, though this would also lengthen the topic recovery time (the time required for entries published after the snapshot to be replayed). |1000|
 |brokerDeduplicationProducerInactivityTimeoutMinutes| The time of inactivity (in minutes) after which the broker will discard deduplication information related to a disconnected producer. |360|
-|brokerDeduplicationSnapshotFrequencyInSeconds| How often is the thread pool scheduled to check whether a snapshot needs to be taken. The value of `0` means it is disabled. |10| 
+|brokerDeduplicationSnapshotFrequencyInSeconds| How often is the thread pool scheduled to check whether a snapshot needs to be taken. The value of `0` means it is disabled. |120| 
 |dispatchThrottlingRatePerReplicatorInMsg| The default messages per second dispatch throttling-limit for every replicator in replication. The value of `0` means disabling replication message dispatch-throttling| 0 |
 |dispatchThrottlingRatePerReplicatorInByte| The default bytes per second dispatch throttling-limit for every replicator in replication. The value of `0` means disabling replication message-byte dispatch-throttling| 0 | 
 |zooKeeperSessionTimeoutMillis| Zookeeper session timeout in milliseconds |30000|
@@ -591,8 +591,8 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |managedLedgerDefaultWriteQuorum|   |1|
 |managedLedgerDefaultAckQuorum|   |1|
 | managedLedgerDigestType | Default type of checksum to use when writing to BookKeeper. | CRC32C |
-| managedLedgerNumWorkerThreads | Number of threads to be used for managed ledger tasks dispatching. | 8 |
-| managedLedgerNumSchedulerThreads | Number of threads to be used for managed ledger scheduled tasks. | 8 |
+| managedLedgerNumWorkerThreads | Number of threads to be used for managed ledger tasks dispatching. | Runtime.getRuntime().availableProcessors() |
+| managedLedgerNumSchedulerThreads | Number of threads to be used for managed ledger scheduled tasks. | Runtime.getRuntime().availableProcessors() |
 |managedLedgerCacheSizeMB|    |N/A|
 |managedLedgerCacheCopyEntries| Whether to copy the entry payloads when inserting in cache.| false|
 |managedLedgerCacheEvictionWatermark|   |0.9|


### PR DESCRIPTION
Based on #13268 
### Motivation

In the default configuration files `conf/broker.conf`, `conf/proxy.conf` and `conf/websocket.conf` some entries are set with a value which differs from the Java one.

So if you comment out or you remove that line in the configuration file, the behavior changes.

### Modifications

* Aligned some Java properties to the file's value. Likely the user will not comment out the config lines so the expected behavior is that the config file contains the default values.
* Added tests to avoid future regressions 

#### Broker

| Property | broker.conf | Java | New value |
| --------- | ----------- | ----- | ---------- |
|  brokerDeduplicationSnapshotFrequencyInSeconds | 10s | 120s | 120s |  
|  numWorkerThreadsForNonPersistentTopic | 8 | availableProcessors | availableProcessors |  
|  managedLedgerNumWorkerThreads | 8 | availableProcessors | availableProcessors |  
|  webSocketNumIoThreads | 8 | availableProcessors | availableProcessors |  
|  webSocketConnectionsPerBroker | 8 | availableProcessors | availableProcessors |  
|  topicPublisherThrottlingTickTimeMillis | 10 | 5 | 10 |
|  dispatchThrottlingOnNonBacklogConsumerEnabled | true | false | true (see #1654) |
|  replicationMetricsEnabled | true | false | true |  


#### WebSocket
| Property | websocket.conf | Java | New value |
| --------- | ---------------- | ----- | ---------- |  
|  bindAddress | 0.0.0.0 | null | 0.0.0.0 |  
|  webSocketNumIoThreads | 8 | availableProcessors | availableProcessors |  
|  webSocketConnectionsPerBroker | 8 | availableProcessors | availableProcessors |  


### Does this pull request potentially affect one of the following parts:

 - The default values of configurations: yes
 
### Documentation

- [x] `doc` 
 

