### PR TITLE
[Java Client] Improve consumer listener logic

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -85,7 +84,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected volatile long incomingMessagesSize = 0;
     protected volatile Timeout batchReceiveTimeout = null;
     protected final Lock reentrantLock = new ReentrantLock();
-    private final AtomicInteger executorQueueSize = new AtomicInteger(0);
+    private volatile boolean isListenerHandlingMessage = false;
 
     protected ConsumerBase(PulsarClientImpl client, String topic, ConsumerConfigurationData<T> conf,
                            int receiverQueueSize, ExecutorProvider executorProvider,
@@ -911,15 +910,16 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     }
 
     protected void triggerListener() {
-        // Trigger the notification on the message listener in a separate thread to avoid blocking the networking
-        // thread while the message processing happens
+        // Use internalPinnedExecutor to maintain message ordering
         internalPinnedExecutor.execute(() -> {
             try {
-                // Control executor to call MessageListener one by one.
-                if (executorQueueSize.get() < 1) {
+                // Listener should only have one pending/running executable to process a message
+                // See https://github.com/apache/pulsar/issues/11008 for context.
+                if (!isListenerHandlingMessage) {
                     final Message<T> msg = internalReceive(0, TimeUnit.MILLISECONDS);
                     if (msg != null) {
-                        executorQueueSize.incrementAndGet();
+                        // Trigger the notification on the message listener in a separate thread to avoid blocking the
+                        // internal pinned executor thread while the message processing happens
                         if (SubscriptionType.Key_Shared == conf.getSubscriptionType()) {
                             executorProvider.getExecutor(peekMessageKey(msg)).execute(() ->
                                     callMessageListener(msg));
@@ -928,6 +928,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                                 callMessageListener(msg);
                             });
                         }
+                        isListenerHandlingMessage = true;
                     }
                 }
             } catch (PulsarClientException e) {
@@ -952,7 +953,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             log.error("[{}][{}] Message listener error in processing message: {}", topic, subscription,
                     msg.getMessageId(), t);
         } finally {
-            executorQueueSize.decrementAndGet();
+            isListenerHandlingMessage = false;
             triggerListener();
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -918,6 +918,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                 if (!isListenerHandlingMessage) {
                     final Message<T> msg = internalReceive(0, TimeUnit.MILLISECONDS);
                     if (msg != null) {
+                        isListenerHandlingMessage = true;
                         // Trigger the notification on the message listener in a separate thread to avoid blocking the
                         // internal pinned executor thread while the message processing happens
                         if (SubscriptionType.Key_Shared == conf.getSubscriptionType()) {
@@ -928,7 +929,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                                 callMessageListener(msg);
                             });
                         }
-                        isListenerHandlingMessage = true;
                     }
                 }
             } catch (PulsarClientException e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1137,8 +1137,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             increaseAvailablePermits(cnx(), skippedMessages.get());
         }
 
-        internalPinnedExecutor.execute(()
-                -> tryTriggerListener());
+        tryTriggerListener();
     }
 
     void messageReceived(MessageIdData messageId, int redeliveryCount, List<Long> ackSet, ByteBuf headersAndPayload, ClientCnx cnx) {


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/13023, we updated the Java client's consumer listener logic to ensure correct ordering of messages received. We can simplify the logic for the variable named `executorQueueSize`. It can be `volatile` instead of `atomic` and it can be a boolean instead of an integer.

### Modifications

* Rename `executorQueueSize` to `isListenerHandlingMessage` in `ConsumerBase` and make it `volatile` instead of `Atomic`
* Remove unnecessary scheduling on `internalPinnedExecutor` in `ConsumerImpl`

### Verifying this change

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation
- [x] `no-need-doc` 
  
This is an internal change.



