### PR TITLE
[blog] Provide guide on fixing log4j cve without upgrading the chart

### DIFF
--- a/site2/website/blog/2021-12-11-Log4j-CVE.md
+++ b/site2/website/blog/2021-12-11-Log4j-CVE.md
@@ -24,8 +24,8 @@ Additionally, when running Pulsar Functions with Kubernetes runtime, you should 
 your Docker images, following the example described [here](https://github.com/lhotari/pulsar-docker-images-patch-CVE-2021-44228).
 
 If you are using the Pulsar Helm Chart for deploying in Kubernetes, a [new
-version of the chart](https://github.com/apache/pulsar-helm-chart/releases/tag/pulsar-2.7.6) is already available and it applies the above mentioned
-workaround.
+version of the chart](https://github.com/apache/pulsar-helm-chart/releases/tag/pulsar-2.7.6) is already available and it applies the above mentioned workaround.
+If upgrading is not an option, you may also mitigate by adding `-Dlog4j2.formatMsgNoLookups=true` to the `PUSLAR_EXTRA_OPTS` in the `configData` section for proxy, broker, bookkeeper, zookeeper, auto-recovery, and relative components in the helm values file.
 
 We are already preparing new patch releases, 2.7.4, 2.8.2 and 2.9.1. These
 releases will be ready in the next few days and will bundle the Log4j2 2.15.0,


### PR DESCRIPTION


### Motivation

Provide instructions to fix log4j cve when upgrade is not an option.

### Modifications

Update the blog post to provide instructions to fix log4j cve

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
 
  
- [x] `no-need-doc` 
  
  
- [ ] `doc` 



