### PR TITLE
Function: add possibility to pass additional JVM arguments to the function JVM (additionalJavaRuntimeArguments)

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -126,6 +126,10 @@ functionRuntimeFactoryConfigs:
     # change the extra dependencies location:
     extraFunctionDependenciesDir:
 
+#### Additional JVM tuning (only process and Kubernetes runtime) ####
+#   This arguments will be added to the command line execution of 'java'
+#additionalJavaRuntimeArguments: ['-XX:+ExitOnOutOfMemoryError']
+
 #### Thread Runtime ####
 # Pulsar function instances are run as threads
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -23,6 +23,9 @@ import lombok.Getter;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * This is the config passed to the Java Instance. Contains all the information
  * passed to run functions.
@@ -44,6 +47,7 @@ public class InstanceConfig {
     @Getter
     private boolean exposePulsarAdminClientEnabled = false;
     private int metricsPort;
+    private List<String> additionalJavaRuntimeArguments = Collections.emptyList();
 
     /**
      * Get the string representation of {@link #getInstanceId()}.

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -320,6 +320,10 @@ public class RuntimeUtils {
 
             args.add("-Dio.netty.tryReflectionSetAccessible=true");
 
+            if (instanceConfig.getAdditionalJavaRuntimeArguments() != null) {
+                args.addAll(instanceConfig.getAdditionalJavaRuntimeArguments());
+            }
+
             if (!isEmpty(instanceConfig.getFunctionDetails().getRuntimeFlags())) {
                 for (String runtimeFlagArg : splitRuntimeArgs(instanceConfig.getFunctionDetails().getRuntimeFlags())) {
                     args.add(runtimeFlagArg);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -33,6 +33,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -538,6 +539,11 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         doc = "Whether to forward the source message properties to the output message"
     )
     private boolean forwardSourceMessageProperty = true;
+
+    @FieldContext(
+            doc = "Additional arguments to pass to the Java command line for Java functions"
+    )
+    private List<String> additionalJavaRuntimeArguments = new ArrayList<>();
 
     public String getFunctionMetadataTopic() {
         return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionMetadataTopicName);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -33,6 +33,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -205,7 +205,7 @@ public class RuntimeUtilsTest {
                 null,
                 "narExtractionDirectory",
                 "functionInstanceClassPath",
-                "",
+                false,
                 "");
 
         log.info("cmd {}", cmd);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -196,17 +196,17 @@ public class RuntimeUtilsTest {
                 AuthenticationConfig.builder().build(),
                 "shardId",
                 23,
-                 1234L,
+                1234L,
                 "logConfigFile",
                 "secretsProviderClassName",
                 "secretsProviderConfig",
                 false,
                 null,
                 null,
-        1234,
-        "narExtractionDirectory",
-        "functionInstanceClassPath",
-        "");
+                "narExtractionDirectory",
+                "functionInstanceClassPath",
+                "",
+                "");
 
         log.info("cmd {}", cmd);
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -206,7 +206,7 @@ public class RuntimeUtilsTest {
         1234,
         "narExtractionDirectory",
         "functionInstanceClassPath",
-        false);
+        "");
 
         log.info("cmd {}", cmd);
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.functions.runtime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.functions.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.jose4j.json.internal.json_simple.JSONObject;
@@ -28,9 +30,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.testng.AssertJUnit.assertTrue;
+
+@Slf4j
 public class RuntimeUtilsTest {
 
     @Test
@@ -166,5 +172,51 @@ public class RuntimeUtilsTest {
                         false
                 }
         };
+    }
+
+    @Test(dataProvider = "k8sRuntime")
+    public void getAdditionalJavaRuntimeArguments(boolean k8sRuntime) throws Exception {
+
+        InstanceConfig instanceConfig = new InstanceConfig();
+        instanceConfig.setClusterName("kluster");
+        instanceConfig.setInstanceId(3000);
+        instanceConfig.setFunctionId("func-7734");
+        instanceConfig.setFunctionVersion("1.0.0");
+        instanceConfig.setMaxBufferedTuples(5);
+        instanceConfig.setPort(1337);
+        instanceConfig.setFunctionDetails(Function.FunctionDetails.newBuilder().build());
+        instanceConfig.setAdditionalJavaRuntimeArguments(Arrays.asList("-XX:+ExitOnOutOfMemoryError"));
+
+        List<String> cmd = RuntimeUtils.getCmd(instanceConfig, "instanceFile",
+                "extraDependenciesDir", /* extra dependencies for running instances */
+                "logDirectory",
+                "originalCodeFileName",
+                "pulsarServiceUrl",
+                "stateStorageServiceUrl",
+                AuthenticationConfig.builder().build(),
+                "shardId",
+                23,
+                 1234L,
+                "logConfigFile",
+                "secretsProviderClassName",
+                "secretsProviderConfig",
+                false,
+                null,
+                null,
+        1234,
+        "narExtractionDirectory",
+        "functionInstanceClassPath",
+        false);
+
+        log.info("cmd {}", cmd);
+
+        assertTrue(cmd.contains("-XX:+ExitOnOutOfMemoryError"));
+
+        // verify that the additional runtime arguments are passed before the Java class
+        int indexJavaClass = cmd.indexOf("org.apache.pulsar.functions.instance.JavaInstanceMain");
+        int indexAdditionalArguments = cmd.indexOf("-XX:+ExitOnOutOfMemoryError");
+        assertTrue(indexJavaClass > 0);
+        assertTrue(indexAdditionalArguments > 0);
+        assertTrue(indexAdditionalArguments < indexJavaClass);
     }
 }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.functions.runtime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.common.functions.AuthenticationConfig;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.jose4j.json.internal.json_simple.JSONObject;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -189,6 +189,9 @@ public class FunctionActioner {
         instanceConfig.setFunctionAuthenticationSpec(functionAuthSpec);
         instanceConfig.setMaxPendingAsyncRequests(workerConfig.getMaxPendingAsyncRequests());
         instanceConfig.setExposePulsarAdminClientEnabled(workerConfig.isExposeAdminClientEnabled());
+        if (workerConfig.getAdditionalJavaRuntimeArguments() != null) {
+            instanceConfig.setAdditionalJavaRuntimeArguments(workerConfig.getAdditionalJavaRuntimeArguments());
+        }
         return instanceConfig;
     }
 


### PR DESCRIPTION
### Motivation

Sometimes it would be useful to be able to tune the JVM of the functions by passing additional command line arguments, 
like "-XX:+ExitOnOutOfMemoryError" or "-Dlog4j2.formatMsgNoLookups".

Those settings are not per-function, but they are to be applied to every function process.

### Modifications

Add a new configuration parameter additionalJavaRuntimeArguments in functions_worker.conf.
This is a list of strings to be added to the command line of the Java process. 


### Verifying this change

This change added tests.

### Documentation

- [x] `doc-required` 
This patch adds a feature and it deserves docs. I will follow up with a guide to configure such feature, like how to add -XX:+ExitOnOutOfMemoryError

