### PR TITLE
Enable CheckStyle Plugin in Pulsar metadata

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -89,6 +89,19 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStore.java
@@ -20,12 +20,10 @@ package org.apache.pulsar.metadata.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.Beta;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -47,25 +47,25 @@ public class MetadataStoreConfig {
     private final String configFilePath = null;
 
     /**
-     * Whether we should enable metadata operations batching
+     * Whether we should enable metadata operations batching.
      */
     @Builder.Default
     private final boolean batchingEnabled = true;
 
     /**
-     * Maximum delay to impose on batching grouping
+     * Maximum delay to impose on batching grouping.
      */
     @Builder.Default
     private final int batchingMaxDelayMillis = 5;
 
     /**
-     * Maximum number of operations to include in a singular batch
+     * Maximum number of operations to include in a singular batch.
      */
     @Builder.Default
     private final int batchingMaxOperations = 1_000;
 
     /**
-     * Maximum size of a batch
+     * Maximum size of a batch.
      */
     @Builder.Default
     private final int batchingMaxSizeKb = 128;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -40,7 +40,7 @@ public class MetadataStoreException extends IOException {
     }
 
     /**
-     * Implementation is invalid
+     * Implementation is invalid.
      */
     public static class InvalidImplementationException extends MetadataStoreException {
         public InvalidImplementationException() {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreFactory.java
@@ -19,9 +19,7 @@
 package org.apache.pulsar.metadata.api;
 
 import java.io.IOException;
-
 import lombok.experimental.UtilityClass;
-
 import org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl;
 
 /**

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Notification.java
@@ -28,7 +28,7 @@ public final class Notification {
     private final NotificationType type;
 
     /**
-     * Path of the kev/value pair interested by the notification
+     * Path of the kev/value pair interested by the notification.
      */
     private final String path;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
@@ -27,7 +27,7 @@ import lombok.Data;
 public class Stat {
 
     /**
-     * The path of the value
+     * The path of the value.
      */
     final String path;
 
@@ -47,12 +47,12 @@ public class Stat {
     final long modificationTimestamp;
 
     /**
-     * Whether the key-value pair is ephemeral or persistent
+     * Whether the key-value pair is ephemeral or persistent.
      */
     final boolean ephemeral;
 
     /**
-     * Whether the key-value pair had been created within the current "session"
+     * Whether the key-value pair had been created within the current "session".
      */
     final boolean createdBySelf;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LeaderElection.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LeaderElection.java
@@ -35,13 +35,12 @@ public interface LeaderElection<T> extends AutoCloseable {
      * @param proposedValue
      *            the value to set for the leader, in the case this instance succeeds in becoming leader
      * @return a future that will track the completion of the operation
-     * @throws MetadataStoreException
      *             if there's a failure in the leader election
      */
     CompletableFuture<LeaderElectionState> elect(T proposedValue);
 
     /**
-     * Get the current leader election state
+     * Get the current leader election state.
      */
     LeaderElectionState getState();
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LeaderElectionState.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LeaderElectionState.java
@@ -23,17 +23,17 @@ package org.apache.pulsar.metadata.api.coordination;
  */
 public enum LeaderElectionState {
     /**
-     * No leader has been elected yet
+     * No leader has been elected yet.
      */
     NoLeader,
 
     /**
-     * We are currently the leader
+     * We are currently the leader.
      */
     Leading,
 
     /**
-     * Follower state
+     * Follower state.
      */
     Following
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LockManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LockManager.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.metadata.api.coordination;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
@@ -41,8 +40,6 @@ public interface LockManager<T> extends AutoCloseable {
      *
      * @param path
      *            the path of the resource on which to acquire the lock
-     * @param content
-     *            the payload of the lock
      * @return a future that will track the completion of the operation
      * @throws NotFoundException
      *             if the lock is not taken

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.api.coordination;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/CreateOption.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/CreateOption.java
@@ -19,16 +19,16 @@
 package org.apache.pulsar.metadata.api.extended;
 
 /**
- * Options to use when creating key-value pairs on the {@link MetadataStoreExtended}
+ * Options to use when creating key-value pairs on the {@link MetadataStoreExtended}.
  */
 public enum CreateOption {
     /**
-     * The key-value pair will automatically expires when the session is terminated
+     * The key-value pair will automatically expires when the session is terminated.
      */
     Ephemeral,
 
     /**
-     * Create a sequential unique key
+     * Create a sequential unique key.
      */
     Sequential
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/MetadataStoreExtended.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/MetadataStoreExtended.java
@@ -22,7 +22,6 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/SessionEvent.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/SessionEvent.java
@@ -19,17 +19,17 @@
 package org.apache.pulsar.metadata.api.extended;
 
 /**
- * An event regarding a session of MetadataStore
+ * An event regarding a session of MetadataStore.
  */
 public enum SessionEvent {
 
     /**
-     * The client is temporarily disconnected, although the session is still valid
+     * The client is temporarily disconnected, although the session is still valid.
      */
     ConnectionLost,
 
     /**
-     * The client was able to successfully reconnect
+     * The client was able to successfully reconnect.
      */
     Reconnected,
 
@@ -40,7 +40,7 @@ public enum SessionEvent {
     SessionLost,
 
     /**
-     * The session was established
+     * The session was established.
      */
     SessionReestablished;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.api.extended;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.api;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractHierarchicalLedgerManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractHierarchicalLedgerManager.java
@@ -190,7 +190,8 @@ abstract class AbstractHierarchicalLedgerManager {
             final int successRc, final int failureRc) {
         store.getChildren(path)
                 .thenAccept(ledgerNodes -> {
-                    Set<Long> activeLedgers = HierarchicalLedgerUtils.ledgerListToSet(ledgerNodes, ledgerRootPath, path);
+                    Set<Long> activeLedgers = HierarchicalLedgerUtils.ledgerListToSet(ledgerNodes,
+                            ledgerRootPath, path);
                     if (log.isDebugEnabled()) {
                         log.debug("Processing ledgers: {}", activeLedgers);
                     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import lombok.Cleanup;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.bookie.Bookie;
@@ -303,10 +302,10 @@ public class BKCluster implements AutoCloseable {
     private static String getLoopbackInterfaceName() {
         try {
             Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
-            Iterator var1 = Collections.list(nifs).iterator();
+            Iterator<NetworkInterface> var1 = Collections.list(nifs).iterator();
 
-            while(var1.hasNext()) {
-                NetworkInterface nif = (NetworkInterface)var1.next();
+            while (var1.hasNext()) {
+                NetworkInterface nif = var1.next();
                 if (nif.isLoopback()) {
                     return nif.getName();
                 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BookieServiceInfoSerde.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.proto.DataFormats.BookieServiceInfoFormat;
-import org.apache.bookkeeper.server.service.BookieService;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManagerFactory.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerManagerFactory.java
@@ -96,7 +96,7 @@ public class PulsarLedgerManagerFactory implements LedgerManagerFactory {
     @Override
     public void format(AbstractConfiguration<?> abstractConfiguration, LayoutManager layoutManager)
             throws InterruptedException, IOException {
-        // TODO: XXX
+        // TODO: format
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -56,7 +56,6 @@ import org.apache.bookkeeper.replication.ReplicationEnableCb;
 import org.apache.bookkeeper.replication.ReplicationException;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.pulsar.metadata.api.GetResult;
-import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.bookkeeper;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/JSONMetadataSerdeTypeRef.java
@@ -19,9 +19,7 @@
 package org.apache.pulsar.metadata.cache.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import java.io.IOException;
-
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.cache.impl;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImpl.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.metadata.coordination.impl;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
-
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -28,13 +27,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.SafeRunnable;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyClosedException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
@@ -46,7 +44,6 @@ import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
-import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 class LeaderElectionImpl<T> implements LeaderElection<T> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -137,7 +137,7 @@ class LockManagerImpl<T> implements LockManager<T> {
 
             try {
                 FutureUtil.waitForAll(futures).get();
-            } catch (ExecutionException|InterruptedException e) {
+            } catch (ExecutionException | InterruptedException e) {
                 log.warn("Failure when processing session event", e);
             }
         }));

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -21,17 +21,16 @@ package org.apache.pulsar.metadata.coordination.impl;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.apache.pulsar.metadata.api.MetadataSerde;
 
 @Slf4j
 public class ResourceLockImpl<T> implements ResourceLock<T> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.coordination.impl;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -313,7 +312,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     }
 
     /**
-     * Run the task in the executor thread and fail the future if the executor is shutting down
+     * Run the task in the executor thread and fail the future if the executor is shutting down.
      */
     protected void execute(Runnable task, CompletableFuture<?> future) {
         try {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImpl.java
@@ -48,7 +48,8 @@ public class MetadataStoreFactoryImpl {
 
         if (metadataURL.startsWith("memory://")) {
             return new LocalMemoryMetadataStore(metadataURL, metadataStoreConfig);
-        } if (metadataURL.startsWith("rocksdb://")) {
+        }
+        if (metadataURL.startsWith("rocksdb://")) {
             return new RocksdbMetadataStore(metadataURL, metadataStoreConfig);
         } else {
             return new ZKMetadataStore(metadataURL, metadataStoreConfig, enableSessionWatcher);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -1440,9 +1439,11 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
             elapsedTimeMs = MathUtils.elapsedMSec(startTimeNanos);
             if (!ZooWorker.isRecoverableException(rc)) {
                 if (KeeperException.Code.OK.intValue() == rc) {
-                    statsLogger.registerSuccessfulEvent(MathUtils.elapsedMicroSec(startTimeNanos), TimeUnit.MICROSECONDS);
+                    statsLogger.registerSuccessfulEvent(MathUtils.elapsedMicroSec(startTimeNanos),
+                            TimeUnit.MICROSECONDS);
                 } else {
-                    statsLogger.registerFailedEvent(MathUtils.elapsedMicroSec(startTimeNanos), TimeUnit.MICROSECONDS);
+                    statsLogger.registerFailedEvent(MathUtils.elapsedMicroSec(startTimeNanos),
+                            TimeUnit.MICROSECONDS);
                 }
                 return false;
             }
@@ -1526,7 +1527,8 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                     }
                     result = proc.call();
                     isDone = true;
-                    statsLogger.registerSuccessfulEvent(MathUtils.elapsedMicroSec(startTimeNanos), TimeUnit.MICROSECONDS);
+                    statsLogger.registerSuccessfulEvent(MathUtils.elapsedMicroSec(startTimeNanos),
+                            TimeUnit.MICROSECONDS);
                 } catch (KeeperException e) {
                     ++attempts;
                     boolean rethrow = true;
@@ -1536,7 +1538,8 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                         rethrow = false;
                     }
                     if (rethrow) {
-                        statsLogger.registerFailedEvent(MathUtils.elapsedMicroSec(startTimeNanos), TimeUnit.MICROSECONDS);
+                        statsLogger.registerFailedEvent(MathUtils.elapsedMicroSec(startTimeNanos),
+                                TimeUnit.MICROSECONDS);
                         log.debug("Stopped executing {} after {} attempts.", proc, attempts);
                         throw e;
                     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -487,8 +487,8 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
                 byte[] oldValueData = transaction.getForUpdate(optionDontCache, pathBytes, false);
                 MetaValue metaValue = MetaValue.parse(oldValueData);
                 if (expectedVersion.isPresent()) {
-                    if (metaValue == null && expectedVersion.get() != -1 ||
-                            metaValue != null && !expectedVersion.get().equals(metaValue.getVersion())) {
+                    if (metaValue == null && expectedVersion.get() != -1
+                            || metaValue != null && !expectedVersion.get().equals(metaValue.getVersion())) {
                         throw new MetadataStoreException.BadVersionException(
                                 String.format("Version mismatch, actual=%s, expect=%s",
                                         metaValue == null ? null : metaValue.getVersion(), expectedVersion.get()));

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -66,7 +65,8 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 
 @Slf4j
-public class ZKMetadataStore extends AbstractBatchedMetadataStore implements MetadataStoreExtended, MetadataStoreLifecycle {
+public class ZKMetadataStore extends AbstractBatchedMetadataStore
+        implements MetadataStoreExtended, MetadataStoreLifecycle {
 
     private final String metadataURL;
     private final MetadataStoreConfig metadataStoreConfig;
@@ -127,7 +127,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore implements Met
                         } else {
                             log.error("Failed to recreate persistent watch on ZooKeeper: {}", Code.get(rc));
                             sessionWatcher.ifPresent(ZKSessionWatcher::setSessionInvalid);
-                            // On the reconnectable client, mark the session as expired to trigger a new reconnect and 
+                            // On the reconnectable client, mark the session as expired to trigger a new reconnect and
                             // we will have the chance to set the watch again.
                             if (zkc instanceof PulsarZooKeeperClient) {
                                 ((PulsarZooKeeperClient) zkc).process(
@@ -146,7 +146,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore implements Met
     protected void batchOperation(List<MetadataOp> ops) {
         try {
             zkc.multi(ops.stream().map(this::convertOp).collect(Collectors.toList()), (rc, path, ctx, results) -> {
-                if (results == null ) {
+                if (results == null) {
                     Code code = Code.get(rc);
                     if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.metadata.impl;
 
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import io.netty.util.concurrent.DefaultThreadFactory;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -29,9 +28,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 import org.apache.zookeeper.AsyncCallback.StatCallback;
 import org.apache.zookeeper.KeeperException;
@@ -40,7 +37,7 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 
 /**
- * Monitor the ZK session state every few seconds and send notifications
+ * Monitor the ZK session state every few seconds and send notifications.
  */
 @Slf4j
 public class ZKSessionWatcher implements AutoCloseable, Watcher {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/package-info.java
@@ -17,26 +17,3 @@
  * under the License.
  */
 package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/package-info.java
@@ -16,27 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.metadata.impl.batching;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OpGetChildren implements MetadataOp {
-
-    private final String path;
-    private final CompletableFuture<List<String>> future = new CompletableFuture<>();
-
-    @Override
-    public Type getType() {
-        return Type.GET_CHILDREN;
-    }
-
-    @Override
-    public int size() {
-        return path.length();
-    }
-}
+package org.apache.pulsar.metadata.impl;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
@@ -20,35 +20,26 @@ package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
-import org.apache.pulsar.metadata.api.Notification;
-import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.assertj.core.util.Lists;
 import org.testng.annotations.Test;
 
 public class MetadataStoreBatchingTest extends BaseMetadataStoreTest {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -36,8 +36,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
@@ -37,7 +37,6 @@ import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
 import org.apache.pulsar.metadata.BaseMetadataStoreTest;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;


### PR DESCRIPTION
### Motivation
currently, the `pulsar-metadata` module is not protected by the `checkstyle-plugin`.

### Modifications
- Enable CheckStyle Plugin
- Fix checkstyle violations

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
java checkstyle changes, no need doc.


