### PR TITLE
[testclient] Multiple calls to printAggregatedStats result in inaccur…

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -270,7 +270,6 @@ public class ManagedLedgerWriter {
                             if (arguments.testTime > 0) {
                                 if (System.nanoTime() > testEndTime) {
                                     log.info("------------- DONE (reached the maximum duration: [{} seconds] of production) --------------", arguments.testTime);
-                                    printAggregatedStats();
                                     isDone.set(true);
                                     Thread.sleep(5000);
                                     PerfClientUtils.exit(0);
@@ -280,7 +279,6 @@ public class ManagedLedgerWriter {
                             if (numMessagesForThisThread > 0) {
                                 if (totalSent++ >= numMessagesForThisThread) {
                                     log.info("------------- DONE (reached the maximum number: [{}] of production) --------------", numMessagesForThisThread);
-                                    printAggregatedStats();
                                     isDone.set(true);
                                     Thread.sleep(5000);
                                     PerfClientUtils.exit(0);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -372,7 +372,6 @@ public class PerformanceConsumer {
                 if (arguments.testTime > 0) {
                     if (System.nanoTime() > testEndTime) {
                         log.info("------------------- DONE -----------------------");
-                        printAggregatedStats();
                         PerfClientUtils.exit(0);
                         thread.interrupt();
                     }
@@ -380,7 +379,6 @@ public class PerformanceConsumer {
                 if (arguments.totalNumTxn > 0) {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
-                        printAggregatedStats();
                         PerfClientUtils.exit(0);
                         thread.interrupt();
                     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -668,7 +668,6 @@ public class PerformanceProducer {
                     if (arguments.testTime > 0) {
                         if (System.nanoTime() > testEndTime) {
                             log.info("------------- DONE (reached the maximum duration: [{} seconds] of production) --------------", arguments.testTime);
-                            printAggregatedStats();
                             doneLatch.countDown();
                             Thread.sleep(5000);
                             PerfClientUtils.exit(0);
@@ -678,7 +677,6 @@ public class PerformanceProducer {
                     if (numMessages > 0) {
                         if (totalSent++ >= numMessages) {
                             log.info("------------- DONE (reached the maximum number: {} of production) --------------", numMessages);
-                            printAggregatedStats();
                             doneLatch.countDown();
                             Thread.sleep(5000);
                             PerfClientUtils.exit(0);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -231,7 +231,6 @@ public class PerformanceReader {
             }
             if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
                 log.info("------------- DONE (reached the maximum number: [{}] of consumption) --------------", arguments.numMessages);
-                printAggregatedStats();
                 PerfClientUtils.exit(0);
             }
             messagesReceived.increment();


### PR DESCRIPTION

Fixes [#ISSUE-13250](https://github.com/streamnative/pulsar/issues/3409)

### Motivation

We repeatedly call `#printAggregatedStats` in those places, which ultimately calls `Record#getIntervalHistogram`. The `startTimestamp` and `endTimestamp` will be reset, which may result in inconsistent results of multiple access. 

We should only call printAggregatedStats once inside `ShutdownHook`, like `PerformanceClient`.

```
Runtime.getRuntime().addShutdownHook(new Thread(() -> {
    printAggregatedThroughput(start);
    printAggregatedStats();
}));
```

### Modifications

Remove redundant calls to `#printAggregatedStats`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
- [ ] `doc-required` 
- [x] `no-need-doc` 
- [ ] `doc` 
 


