### PR TITLE
[fix][client] Fix ConfigurationDataUtils loadConf strategy

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -80,7 +80,7 @@ public class ClientBuilderImpl implements ClientBuilder {
     @Override
     public ClientBuilder loadConf(Map<String, Object> config) {
         conf = ConfigurationDataUtils.loadData(
-            config, conf, ClientConfigurationData.class);
+            config, conf);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -85,7 +85,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> loadConf(Map<String, Object> config) {
-        this.conf = ConfigurationDataUtils.loadData(config, conf, ConsumerConfigurationData.class);
+        this.conf = ConfigurationDataUtils.loadData(config, conf);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -116,7 +116,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public ProducerBuilder<T> loadConf(Map<String, Object> config) {
         conf = ConfigurationDataUtils.loadData(
-            config, conf, ProducerConfigurationData.class);
+            config, conf);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -102,7 +102,7 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     @Override
     public ReaderBuilder<T> loadConf(Map<String, Object> config) {
         MessageId startMessageId = conf.getStartMessageId();
-        conf = ConfigurationDataUtils.loadData(config, conf, ReaderConfigurationData.class);
+        conf = ConfigurationDataUtils.loadData(config, conf);
         conf.setStartMessageId(startMessageId);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -51,20 +51,17 @@ public final class ConfigurationDataUtils {
         return mapper.get();
     }
 
-    private ConfigurationDataUtils() {}
+    private ConfigurationDataUtils() {
+    }
 
     public static <T> T loadData(Map<String, Object> config,
-                                 T existingData,
-                                 Class<T> dataCls) {
+                                 T existingData) {
         ObjectMapper mapper = getThreadLocal();
         try {
-            String existingConfigJson = mapper.writeValueAsString(existingData);
-            Map<String, Object> existingConfig = mapper.readValue(existingConfigJson, Map.class);
             Map<String, Object> newConfig = new HashMap<>();
-            newConfig.putAll(existingConfig);
             newConfig.putAll(config);
             String configJson = mapper.writeValueAsString(newConfig);
-            return mapper.readValue(configJson, dataCls);
+            return mapper.readerForUpdating(existingData).readValue(configJson);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load config into existing configuration data", e);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -19,10 +19,8 @@
 package org.apache.pulsar.client.impl.conf;
 
 import static com.google.common.base.Preconditions.checkArgument;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Sets;
-
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +29,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -134,6 +131,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private RegexSubscriptionMode regexSubscriptionMode = RegexSubscriptionMode.PersistentOnly;
 
+    @JsonIgnore
     private transient DeadLetterPolicy deadLetterPolicy;
 
     private boolean retryEnable = false;
@@ -149,12 +147,13 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private boolean resetIncludeHead = false;
 
+    @JsonIgnore
     private transient KeySharedPolicy keySharedPolicy;
 
     private boolean batchIndexAckEnabled = false;
 
     private boolean ackReceiptEnabled = false;
-    
+
     private boolean poolMessages = false;
 
     @JsonIgnore


### PR DESCRIPTION
### Motivation

When using `loadConf`, ConfigurationDataUtils was loading existing values
in a Map using Jackson mapper. If there is a `@JsonIgnore`, Jackson
ignores theses fields, but there will be forgotten in the new instance.


### Modifications
Using `readerForUpdating(existingData).readValue(configJson)` will
refresh only overriden values in config map.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *org.apache.pulsar.client.impl.conf.ConfigurationDataUtilsTest*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no (at least, it will no longer fails silently on `@JsonIgnore` properties)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
This was a bug in `loadConf` code, it is intended to work as follow (I think)  




- [x] `doc-not-needed`
