### PR TITLE
[C++] Fix Version.h not found when CMake binary directory is customized

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -337,6 +337,7 @@ file(MAKE_DIRECTORY ${AUTOGEN_DIR})
 include_directories(
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_BINARY_DIR}/include
   ${AUTOGEN_DIR}
   ${Boost_INCLUDE_DIR}
   ${OPENSSL_INCLUDE_DIR}


### PR DESCRIPTION
### Motivation

When I build C++ tests on my local env, the following error happened.

```
tests/VersionTest.cc:19:10: fatal error: 'pulsar/Version.h' file not found
#include <pulsar/Version.h>
```

It's because I specified another directory as CMake directory.

```bash
mkdir _builds && cd _builds && cmake ..
```

After https://github.com/apache/pulsar/pull/12769, the `Version.h` is generated under `${CMAKE_BINARY_DIR}/include/pulsar` directory but it's not included in `CMakeLists.txt`. CI works well because it's built in the default CMake directory so that `CMAKE_BINARY_DIR` is the same with `CMAKE_SOURCE_DIR`, which is included.

### Modifications

Add the `${CMAKE_BINARY_DIR}/include` to `included_directories`.