### PR TITLE
[security] Upgrade Netty to 4.1.72 - CVE-2021-43797

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.68.Final</version>
+      <version>4.1.72.Final</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -365,11 +365,13 @@ The Apache Software License, Version 2.0
     - io.netty-netty-resolver-4.1.72.Final.jar
     - io.netty-netty-resolver-dns-4.1.72.Final.jar
     - io.netty-netty-transport-4.1.72.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.72.Final.jar
     - io.netty-netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
     - io.netty-netty-transport-native-epoll-4.1.72.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.72.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.46.Final.jar
+    - io.netty-netty-tcnative-classes-2.0.46.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -352,24 +352,24 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-compress-1.21.jar
     - org.apache.commons-commons-lang3-3.11.jar
  * Netty
-    - io.netty-netty-buffer-4.1.68.Final.jar
-    - io.netty-netty-codec-4.1.68.Final.jar
-    - io.netty-netty-codec-dns-4.1.68.Final.jar
-    - io.netty-netty-codec-http-4.1.68.Final.jar
-    - io.netty-netty-codec-http2-4.1.68.Final.jar
-    - io.netty-netty-codec-socks-4.1.68.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.68.Final.jar
-    - io.netty-netty-common-4.1.68.Final.jar
-    - io.netty-netty-handler-4.1.68.Final.jar
-    - io.netty-netty-handler-proxy-4.1.68.Final.jar
-    - io.netty-netty-resolver-4.1.68.Final.jar
-    - io.netty-netty-resolver-dns-4.1.68.Final.jar
-    - io.netty-netty-transport-4.1.68.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.68.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.68.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.68.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.68.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.42.Final.jar
+    - io.netty-netty-buffer-4.1.72.Final.jar
+    - io.netty-netty-codec-4.1.72.Final.jar
+    - io.netty-netty-codec-dns-4.1.72.Final.jar
+    - io.netty-netty-codec-http-4.1.72.Final.jar
+    - io.netty-netty-codec-http2-4.1.72.Final.jar
+    - io.netty-netty-codec-socks-4.1.72.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.72.Final.jar
+    - io.netty-netty-common-4.1.72.Final.jar
+    - io.netty-netty-handler-4.1.72.Final.jar
+    - io.netty-netty-handler-proxy-4.1.72.Final.jar
+    - io.netty-netty-resolver-4.1.72.Final.jar
+    - io.netty-netty-resolver-dns-4.1.72.Final.jar
+    - io.netty-netty-transport-4.1.72.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.72.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.72.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.46.Final.jar
  * Prometheus client
     - io.prometheus-simpleclient-0.5.0.jar
     - io.prometheus-simpleclient_common-0.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.7</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>3.2.5</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.68.Final</netty.version>
-    <netty-tc-native.version>2.0.42.Final</netty-tc-native.version>
+    <netty.version>4.1.72.Final</netty.version>
+    <netty-tc-native.version>2.0.46.Final</netty-tc-native.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -246,7 +246,9 @@ The Apache Software License, Version 2.0
     - netty-resolver-4.1.72.Final.jar
     - netty-resolver-dns-4.1.72.Final.jar
     - netty-tcnative-boringssl-static-2.0.46.Final.jar
+    - netty-tcnative-classes-2.0.46.Final.jar
     - netty-transport-4.1.72.Final.jar
+    - netty-transport-classes-epoll-4.1.72.Final.jar
     - netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.72.Final.jar
     - netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -233,23 +233,23 @@ The Apache Software License, Version 2.0
     - commons-lang3-3.11.jar
  * Netty
     - netty-3.10.6.Final.jar
-    - netty-buffer-4.1.68.Final.jar
-    - netty-codec-4.1.68.Final.jar
-    - netty-codec-dns-4.1.68.Final.jar
-    - netty-codec-http-4.1.68.Final.jar
-    - netty-codec-haproxy-4.1.68.Final.jar
-    - netty-codec-socks-4.1.68.Final.jar
-    - netty-handler-proxy-4.1.68.Final.jar
-    - netty-common-4.1.68.Final.jar
-    - netty-handler-4.1.68.Final.jar
+    - netty-buffer-4.1.72.Final.jar
+    - netty-codec-4.1.72.Final.jar
+    - netty-codec-dns-4.1.72.Final.jar
+    - netty-codec-http-4.1.72.Final.jar
+    - netty-codec-haproxy-4.1.72.Final.jar
+    - netty-codec-socks-4.1.72.Final.jar
+    - netty-handler-proxy-4.1.72.Final.jar
+    - netty-common-4.1.72.Final.jar
+    - netty-handler-4.1.72.Final.jar
     - netty-reactive-streams-2.0.4.jar
-    - netty-resolver-4.1.68.Final.jar
-    - netty-resolver-dns-4.1.68.Final.jar
-    - netty-tcnative-boringssl-static-2.0.42.Final.jar
-    - netty-transport-4.1.68.Final.jar
-    - netty-transport-native-epoll-4.1.68.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.68.Final.jar
-    - netty-transport-native-unix-common-4.1.68.Final-linux-x86_64.jar
+    - netty-resolver-4.1.72.Final.jar
+    - netty-resolver-dns-4.1.72.Final.jar
+    - netty-tcnative-boringssl-static-2.0.46.Final.jar
+    - netty-transport-4.1.72.Final.jar
+    - netty-transport-native-epoll-4.1.72.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.72.Final.jar
+    - netty-transport-native-unix-common-4.1.72.Final-linux-x86_64.jar
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty


### PR DESCRIPTION
### Motivation

Netty versions prior to 4.1.71 are vulnerable to CVE-2021-43797
https://nvd.nist.gov/vuln/detail/CVE-2021-43797


Netty release notes:
- https://netty.io/news/2021/10/11/4-1-69-Final.html
- https://netty.io/news/2021/10/11/4-1-70-Final.html
- https://netty.io/news/2021/12/09/4-1-71-Final.html
- https://netty.io/news/2021/12/13/4-1-72-Final.html


### Modifications
- Upgraded Netty libraries to 4.1.72.Final
- Upgraded netty-tcnative-boringssl-static to 2.0.46.Final which is compatible with Netty 4.1.72.Final

### Documentation

- [x] no-need-doc