### PR TITLE
Remove deprecated Mockito api use

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.common.util.netty;
 
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
@@ -30,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
@@ -62,7 +62,7 @@ public class ChannelFuturesTest {
 
     @BeforeMethod
     public void setup() {
-        initMocks(this);
+        MockitoAnnotations.openMocks(this);
         when(channel.eventLoop()).thenReturn(eventLoop);
 
         channelFuture = new DefaultChannelPromise(channel);

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
@@ -73,7 +73,7 @@ public class WebSocketWebResourceTest {
 
     @BeforeMethod
     public void setup(Method method) throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         ServiceConfiguration config = new ServiceConfiguration();
         config.setSuperUserRoles(Sets.newHashSet(SUPER_USER));


### PR DESCRIPTION
### Modifications
Remove deprecated Mockito api use

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  trival changes, no need doc