### PR TITLE
[C++] Fix in Apple Silicon macOS the clang-format cannot find

### DIFF
--- a/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
+++ b/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
@@ -30,7 +30,7 @@
 #  CLANG_FORMAT_BIN, The path to the clang format binary
 #  CLANG_TIDY_FOUND, Whether clang format was found
 
-list(APPEND CLANG_SEARCH_PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin)
+list(APPEND CLANG_SEARCH_PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin /opt/homebrew/bin)
 if (WIN32)
        list(APPEND CLANG_SEARCH_PATHS "C:/Program Files/LLVM/bin" "C:/Program Files (x86)/LLVM/bin")
 endif()


### PR DESCRIPTION
### Motivation

When we install `clang-format` in Apple Silicon's macOS with brew, the install path is `/opt/homebrew/bin` not `/usr/local/bin`.

### Modifications

Add `/opt/homebrew/bin` to `CLANG_SEARCH_PATHS`

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
  


