### PR TITLE
[Issue 10816][Proxy] Refresh client auth token

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyClientCnx.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyClientCnx.java
@@ -20,10 +20,16 @@ package org.apache.pulsar.proxy.server;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.apache.pulsar.PulsarVersion;
+import org.apache.pulsar.client.api.PulsarClientException.TimeoutException;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
 import org.apache.pulsar.common.protocol.Commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,32 +37,112 @@ import org.slf4j.LoggerFactory;
 public class ProxyClientCnx extends ClientCnx {
 
     String clientAuthRole;
-    AuthData clientAuthData;
     String clientAuthMethod;
     int protocolVersion;
+    private final boolean forwardAuthorizationCredentials;
+    private final Supplier<CompletableFuture<AuthData>> clientAuthDataSupplier;
 
     public ProxyClientCnx(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, String clientAuthRole,
-                          AuthData clientAuthData, String clientAuthMethod, int protocolVersion) {
+                          Supplier<CompletableFuture<AuthData>> clientAuthDataSupplier,
+                          String clientAuthMethod, int protocolVersion, boolean forwardAuthorizationCredentials) {
         super(conf, eventLoopGroup);
         this.clientAuthRole = clientAuthRole;
-        this.clientAuthData = clientAuthData;
         this.clientAuthMethod = clientAuthMethod;
         this.protocolVersion = protocolVersion;
+        this.forwardAuthorizationCredentials = forwardAuthorizationCredentials;
+        this.clientAuthDataSupplier = clientAuthDataSupplier;
     }
 
     @Override
-    protected ByteBuf newConnectCommand() throws Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("New Connection opened via ProxyClientCnx with params clientAuthRole = {},"
-                            + " clientAuthData = {}, clientAuthMethod = {}",
-                    clientAuthRole, clientAuthData, clientAuthMethod);
+    protected void sendConnectCommand() throws Exception {
+        CompletableFuture<ByteBuf> connectCommandFuture = newConnectCommand();
+        if (!connectCommandFuture.isDone()) {
+            eventLoopGroup.schedule(() -> {
+                connectCommandFuture.completeExceptionally(
+                    new TimeoutException("New connect command timeout after ms " + operationTimeoutMs)
+                );
+            }, operationTimeoutMs, TimeUnit.MILLISECONDS);
         }
 
+        connectCommandFuture.whenComplete((data, th) -> {
+            if (th == null) {
+                // Send CONNECT command
+                ctx.writeAndFlush(data).addListener(future -> {
+                    if (future.isSuccess()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Complete: {}", future.isSuccess());
+                        }
+                        state = State.SentConnectFrame;
+                    } else {
+                        log.warn("Error during handshake", future.cause());
+                        ctx.close();
+                    }
+                });
+            } else {
+                log.warn("Error during handshake", th);
+                ctx.close();
+            }
+        });
+    }
+
+    private CompletableFuture<ByteBuf> newConnectCommand() throws Exception {
         authenticationDataProvider = authentication.getAuthData(remoteHostName);
         AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
-        return Commands.newConnect(authentication.getAuthMethodName(), authData, this.protocolVersion,
-            PulsarVersion.getVersion(), proxyToTargetBrokerAddress, clientAuthRole, clientAuthData,
-            clientAuthMethod);
+
+        return clientAuthDataSupplier.get().thenApply(clientAuthData -> {
+            if (log.isDebugEnabled()) {
+                log.debug("New Connection opened via ProxyClientCnx with params clientAuthRole = {},"
+                        + " clientAuthData = {}, clientAuthMethod = {}",
+                    clientAuthRole, clientAuthData, clientAuthMethod);
+            }
+
+            return Commands.newConnect(authentication.getAuthMethodName(), authData, this.protocolVersion,
+                PulsarVersion.getVersion(), proxyToTargetBrokerAddress, clientAuthRole, clientAuthData,
+                clientAuthMethod);
+        });
+    }
+
+    @Override
+    protected void handleAuthChallenge(CommandAuthChallenge authChallenge) {
+        boolean isRefresh = Arrays.equals(
+            AuthData.REFRESH_AUTH_DATA_BYTES,
+            authChallenge.getChallenge().getAuthData()
+        );
+
+        if (!forwardAuthorizationCredentials || !isRefresh) {
+            super.handleAuthChallenge(authChallenge);
+            return;
+        }
+
+        clientAuthDataSupplier.get()
+            .thenAccept(authData -> sendAuthResponse(authData, clientAuthMethod))
+            .exceptionally(ex -> {
+                log.error("{} Error refresh auth data: {}", ctx.channel(), ex);
+                connectionFuture.completeExceptionally(ex);
+                close();
+                return null;
+            });
+    }
+
+    private void sendAuthResponse(AuthData authData, String authMethod) {
+        ByteBuf response = Commands.newAuthResponse(
+            authMethod,
+            authData,
+            protocolVersion,
+            PulsarVersion.getVersion()
+        );
+
+        if (log.isDebugEnabled()) {
+            log.debug("{} Mutual auth {}", ctx.channel(), authentication.getAuthMethodName());
+        }
+
+        ctx.writeAndFlush(response).addListener(writeFuture -> {
+            if (!writeFuture.isSuccess()) {
+                log.warn("{} Failed to send response for mutual auth to broker: {}", ctx.channel(),
+                    writeFuture.cause().getMessage());
+                connectionFuture.completeExceptionally(writeFuture.cause());
+            }
+        });
     }
 
     private static final Logger log = LoggerFactory.getLogger(ProxyClientCnx.class);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyClientCnxTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyClientCnxTest.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import org.apache.pulsar.PulsarVersion;
+import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.util.netty.EventLoopUtil;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProxyClientCnxTest {
+
+    private EventLoopGroup eventLoop;
+
+    @BeforeTest
+    public void setup() {
+        eventLoop = EventLoopUtil.newEventLoopGroup(1, false, new DefaultThreadFactory("ProxyClientCnxTest"));
+    }
+
+    @AfterTest
+    public void cleanup() {
+        eventLoop.shutdownGracefully();
+    }
+
+    @Test
+    public void shouldCloseConnection() throws Exception {
+        Supplier<CompletableFuture<AuthData>> authDataSupplier = () -> failed(new RuntimeException("Error"));
+        ProxyClientCnx proxyClientCnx = createProxyCnx(authDataSupplier);
+        ChannelHandlerContext ctx = createCtx();
+
+        proxyClientCnx.channelActive(ctx);
+
+        verify(ctx).close();
+    }
+
+    @Test
+    public void shouldSendConnectCommand() throws Exception {
+        AuthData clientAuthData = generateAuthData();
+        Supplier<CompletableFuture<AuthData>> authDataSupplier = () -> CompletableFuture.completedFuture(clientAuthData);
+        ProxyClientCnx proxyClientCnx = createProxyCnx(authDataSupplier);
+        ChannelHandlerContext ctx = createCtx();
+
+        proxyClientCnx.channelActive(ctx);
+
+        String authMethodName = AuthenticationDisabled.INSTANCE.getAuthMethodName();
+        final ByteBuf command = Commands.newConnect(authMethodName, AuthData.of(new byte[0]),
+            proxyClientCnx.protocolVersion,
+            PulsarVersion.getVersion(), null, proxyClientCnx.clientAuthRole, clientAuthData,
+            proxyClientCnx.clientAuthMethod);
+
+        verify(ctx).writeAndFlush(Mockito.eq(command));
+    }
+
+    @Test
+    public void shouldCloseConnectionIfRefreshTokenError() throws Exception {
+        @SuppressWarnings("unchecked")
+        Supplier<CompletableFuture<AuthData>> authDataSupplier = mock(Supplier.class);
+        ProxyClientCnx proxyClientCnx = createProxyCnx(authDataSupplier);
+        ChannelHandlerContext ctx = createCtx();
+
+        AuthData authData = generateAuthData();
+        when(authDataSupplier.get()).thenReturn(CompletableFuture.completedFuture(authData));
+
+        proxyClientCnx.channelActive(ctx);
+        verify(ctx, never()).close();
+
+        clearInvocations(ctx);
+
+        CommandAuthChallenge command = new CommandAuthChallenge()
+            .setProtocolVersion(Commands.getCurrentProtocolVersion());
+        command.setChallenge()
+            .setAuthData(AuthData.REFRESH_AUTH_DATA.getBytes())
+            .setAuthMethodName("token");
+
+        when(authDataSupplier.get()).thenReturn(failed(new RuntimeException("Client auth data error")));
+        proxyClientCnx.handleAuthChallenge(command);
+
+        verify(ctx).close();
+    }
+
+    @Test
+    public void shouldSendRefreshedToken() throws Exception {
+        @SuppressWarnings("unchecked")
+        Supplier<CompletableFuture<AuthData>> authDataSupplier = mock(Supplier.class);
+        ProxyClientCnx proxyClientCnx = createProxyCnx(authDataSupplier);
+        ChannelHandlerContext ctx = createCtx();
+
+        AuthData authData = generateAuthData();
+        when(authDataSupplier.get()).thenReturn(CompletableFuture.completedFuture(authData));
+
+        proxyClientCnx.channelActive(ctx);
+        verify(ctx, never()).close();
+
+        CommandAuthChallenge command = new CommandAuthChallenge()
+            .setProtocolVersion(Commands.getCurrentProtocolVersion());
+        command.setChallenge()
+            .setAuthData(AuthData.REFRESH_AUTH_DATA.getBytes())
+            .setAuthMethodName("token");
+
+        clearInvocations(ctx);
+
+        authData = generateAuthData();
+        when(authDataSupplier.get()).thenReturn(CompletableFuture.completedFuture(authData));
+        proxyClientCnx.handleAuthChallenge(command);
+
+        ByteBuf response = Commands.newAuthResponse(
+            proxyClientCnx.clientAuthMethod,
+            authData,
+            proxyClientCnx.protocolVersion,
+            PulsarVersion.getVersion()
+        );
+        verify(ctx).writeAndFlush(Mockito.eq(response));
+    }
+
+    private ChannelHandlerContext createCtx() {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        when(ctx.channel()).thenReturn(channel);
+        ChannelFuture listenerFuture = mock(ChannelFuture.class);
+        when(listenerFuture.addListener(any())).thenReturn(listenerFuture);
+        when(ctx.writeAndFlush(any())).thenReturn(listenerFuture);
+        return ctx;
+    }
+
+    private ProxyClientCnx createProxyCnx(Supplier<CompletableFuture<AuthData>> authDataSupplier) {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setKeepAliveIntervalSeconds(0);
+
+        return new ProxyClientCnx(conf, eventLoop, "client-role", authDataSupplier,
+            "auth-method", Commands.getCurrentProtocolVersion(), true
+        );
+    }
+
+    public AuthData generateAuthData() {
+        byte[] bytes = new byte[10];
+        new Random().nextBytes(bytes);
+        return AuthData.of(bytes);
+    }
+
+    public <R> CompletableFuture<R> failed(Throwable error) {
+        CompletableFuture<R> future = new CompletableFuture<>();
+        future.completeExceptionally(error);
+        return future;
+    }
+}


### PR DESCRIPTION
Fixes #10816

### Motivation

See #10816

### Modifications

Refresh client token on proxy (to lookup) in case when refresh token command have been received from broker.

### Verifying this change

- [x] Make sure that the change passes the CI checks. 

This change added tests and can be verified as follows:
- org.apache.pulsar.proxy.server.ProxyWithJwtAuthorizationTest#testRefreshClientToken

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
Bug fix
  