### PR TITLE
PIP-120 : Enable client memory limit controller by default

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -172,7 +172,7 @@ public interface ProducerBuilder<T> extends Cloneable {
      * the client application. Until, the producer gets a successful acknowledgment back from the broker,
      * it will keep in memory (direct memory pool) all the messages in the pending queue.
      *
-     * <p>Default is 1000.
+     * <p>Default is 0, disable the pending messages check.
      *
      * @param maxPendingMessages
      *            the max size of the pending messages queue for the producer

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -188,7 +188,7 @@ public interface ProducerBuilder<T> extends Cloneable {
      * The purpose of this setting is to have an upper-limit on the number
      * of pending messages when publishing on a partitioned topic.
      *
-     * <p>Default is 50000.
+     * <p>Default is 0, disable the pending messages across partitions check.
      *
      * <p>If publishing at high rate over a topic with many partitions (especially when publishing messages without a
      * partitioning key), it might be beneficial to increase this parameter to allow for more pipelining within the
@@ -198,6 +198,7 @@ public interface ProducerBuilder<T> extends Cloneable {
      *            max pending messages across all the partitions
      * @return the producer builder instance
      */
+    @Deprecated
     ProducerBuilder<T> maxPendingMessagesAcrossPartitions(int maxPendingMessagesAcrossPartitions);
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -145,6 +145,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         return this;
     }
 
+    @Deprecated
     @Override
     public ProducerBuilder<T> maxPendingMessagesAcrossPartitions(int maxPendingMessagesAcrossPartitions) {
         conf.setMaxPendingMessagesAcrossPartitions(maxPendingMessagesAcrossPartitions);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -270,9 +270,9 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "memoryLimitBytes",
-            value = "Limit of client memory usage (in byte)."
+            value = "Limit of client memory usage (in byte). The 64M default can guarantee a high producer throughput."
     )
-    private long memoryLimitBytes = 0;
+    private long memoryLimitBytes = 64 * 1024 * 1024;
 
     @ApiModelProperty(
             name = "proxyServiceUrl",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -53,7 +53,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
     public static final int DEFAULT_BATCHING_MAX_MESSAGES = 1000;
-    public static final int DEFAULT_MAX_PENDING_MESSAGES = 1000;
+    public static final int DEFAULT_MAX_PENDING_MESSAGES = 0;
     public static final int DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS = 50000;
 
     private String topicName = null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -54,7 +54,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
 
     public static final int DEFAULT_BATCHING_MAX_MESSAGES = 1000;
     public static final int DEFAULT_MAX_PENDING_MESSAGES = 0;
-    public static final int DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS = 50000;
+    public static final int DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS = 0;
 
     private String topicName = null;
     private String producerName = null;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -346,12 +346,12 @@ public class ProducerBuilderImplTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalid() {
-        producerBuilderImpl.maxPendingMessagesAcrossPartitions(999);
+        producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "maxPendingMessagesAcrossPartitions needs to be >= maxPendingMessages")
     public void testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalidErrorMessages() {
-        producerBuilderImpl.maxPendingMessagesAcrossPartitions(999);
+        producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
     @Test


### PR DESCRIPTION
Fixes #13306  
### Motivation
See #13306 

### Modifications
Enable the `MemeoryLimitController`. The `memoryLimitBytes` default is 64M which is easier to control than the `maxPendingMessages`. 

The default 64M has a good performance in produce throughput in our perf test. I am going to post the performance result here.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

  
- [x] `doc` 
  
  (There is description in the configuration modification)
  

