### PR TITLE
[owasp] Suppress false positive check for netty-tcnative-classes

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -42,4 +42,11 @@
     <gav regex="true">org\.apache\.avro:.*</gav>
     <cve>CVE-2019-17195</cve>
   </suppress>
+  <suppress base="true">
+    <notes><![CDATA[
+        FP per #3889
+        ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+    <cpe>cpe:/a:netty:netty</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation
OWASP dependency check is failing after https://github.com/apache/pulsar/pull/13328 because of
```
netty-tcnative-classes-2.0.46.Final.jar (pkg:maven/io.netty/netty-tcnative-classes@2.0.46.Final, cpe:2.3:a:netty:netty:2.0.46:*:*:*:*:*:*:*) : CVE-2014-3488, CVE-2015-2156, CVE-2019-16869, CVE-2019-20444, CVE-2019-20445, CVE-2021-21290, CVE-2021-21295, CVE-2021-21409, CVE-2021-37136, CVE-2021-37137, CVE-2021-43797
```

see: https://github.com/apache/pulsar/runs/4541586789?check_suite_focus=true

It is a false positive and there's a [PR](https://github.com/jeremylong/DependencyCheck/pull/3890/files) in the owasp plugin repository to suppress this warning.


### Modifications

* Added the suppression for this jar as in the owasp plugin repository

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
 

