### PR TITLE
[owasp] Periodic jobs on active branches

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -30,10 +30,22 @@ jobs:
     name: Run OWASP Dependency Check
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: master
+            checkout_branch: 'master'
+          - name: branch-2.9
+            checkout_branch: 'branch-2.9'
+          - name: branch-2.8
+            checkout_branch: 'branch-2.8'
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.checkout_branch }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm


### PR DESCRIPTION
### Motivation

OWASP dependency check is never run against active release branches, so we are not aware to have a fixable vulnerability on an active branches. 

### Modifications

* Added matrix axis in the periodic OWASP job to run against master, branch-2.8 and branch-2.9.
 
### Documentation

- [x] `no-need-doc` 
 