### PR TITLE
[C++] Adjust clang-format search names

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -277,3 +277,23 @@ ${PULSAR_PATH}/pulsar-test-service-stop.sh
 It's recommended to install [LLVM](https://llvm.org/builds/) for `clang-tidy` and `clang-format`. Pulsar C++ client use `clang-format` 5.0 to format files, which is a little different with latest `clang-format`.
 
 We welcome contributions from the open source community, kindly make sure your changes are backward compatible with GCC 4.8 and Boost 1.53.
+
+### Install `clang-format` on macOS
+
+Since the homebrew-core doesn't have `clang-format@5`, here is a tap to install `clang-format@5` in your macOS.
+```shell
+# Step 1: Add tap
+brew tap demogorgon314/clang-format
+
+# Step 2: Install clang-format@5
+brew install clang-format@5
+```
+### Install `clang-format` on Ubuntu 18.04
+You can find pre-built binaries on the LLVM website: https://releases.llvm.org/download.html#5.0.2
+
+Or you want to use apt install clang-format-5.0.
+```shell
+sudo apt update
+sudo apt install clang-format-5.0
+```
+

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -280,7 +280,7 @@ We welcome contributions from the open source community, kindly make sure your c
 
 ### Install `clang-format` on macOS
 
-Since the homebrew-core doesn't have `clang-format@5`, here is a tap to install `clang-format@5` in your macOS.
+`homebrew-core` does not have `clang-format@5`. You can install `clang-format@5` on your macOS using the tap below.
 ```shell
 # Step 1: Add tap
 brew tap demogorgon314/clang-format

--- a/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
+++ b/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
@@ -82,11 +82,8 @@ if (CLANG_FORMAT_VERSION)
     endif()
 else()
     find_program(CLANG_FORMAT_BIN
-            NAMES clang-format-4.0
-            clang-format-3.9
-            clang-format-3.8
-            clang-format-3.7
-            clang-format-3.6
+            NAMES clang-format-5
+            clang-format-5.0
             clang-format
             PATHS ${CLANG_SEARCH_PATHS}
             NO_DEFAULT_PATH


### PR DESCRIPTION
### Motivation

The Pulsar C++ client use `clang-format` 5.0 to format files, we don't need to search for a version lower than 5.0.

Additionally, the old version of clang-format might be hard to install in the normal way, for example, in macOS,  users can't use brew to install clang-format@5, because brew doesn't maintain the old version software with very few users. In this PR, it introduced a solution to install `clang-format@5` in macOS.

### Modifications

* Make CMake don't search clang-format for a version lower than 5.0.
* Introduce solution to install clang-format 5.0

### Documentation

Need to update docs? 

- [x] `doc` 
  


