### PR TITLE
Support rename the file has been processed.

### DIFF
--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
@@ -190,6 +190,7 @@ public class FileListingThread extends Thread {
                         .endsWith(processedFileSuffix)) {
                     return false;
                 }
+
                 return filePattern.matcher(file.getName()).matches();
             }
         };

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
@@ -140,7 +140,8 @@ public class FileListingThread extends Thread {
         final long minAge = Optional.ofNullable(fileConfig.getMinimumFileAge()).orElse(0);
         final Long maxAge = Optional.ofNullable(fileConfig.getMaximumFileAge()).orElse(Long.MAX_VALUE);
         final boolean ignoreHidden = Optional.ofNullable(fileConfig.getIgnoreHiddenFiles()).orElse(true);
-        final Pattern filePattern = Pattern.compile(Optional.ofNullable(fileConfig.getFileFilter()).orElse("[^\\.].*"));
+        final Pattern filePattern = Pattern.compile(Optional.ofNullable(fileConfig.getFileFilter())
+                .orElse("[^\\.].*"));
         final String indir = fileConfig.getInputDirectory();
         final String pathPatternStr = fileConfig.getPathFilter();
         final Pattern pathPattern = (!recurseDirs || pathPatternStr == null) ? null : Pattern.compile(pathPatternStr);
@@ -185,7 +186,8 @@ public class FileListingThread extends Thread {
                     return false;
                 }
 
-                if (!keepOriginal && !StringUtils.isBlank(processedFileSuffix) && file.getName().endsWith(processedFileSuffix)) {
+                if (!keepOriginal && !StringUtils.isBlank(processedFileSuffix) && file.getName()
+                        .endsWith(processedFileSuffix)) {
                     return false;
                 }
                 return filePattern.matcher(file.getName()).matches();

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileListingThread.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Worker thread that checks the configured input directory for
@@ -143,6 +144,7 @@ public class FileListingThread extends Thread {
         final String indir = fileConfig.getInputDirectory();
         final String pathPatternStr = fileConfig.getPathFilter();
         final Pattern pathPattern = (!recurseDirs || pathPatternStr == null) ? null : Pattern.compile(pathPatternStr);
+        final String processedFileSuffix = fileConfig.getProcessedFileSuffix();
 
         return new FileFilter() {
             @Override
@@ -180,6 +182,10 @@ public class FileListingThread extends Thread {
                  * permissions on the directory the file is in
                  */
                 if (!keepOriginal && !Files.isWritable(file.toPath().getParent())) {
+                    return false;
+                }
+
+                if (!keepOriginal && !StringUtils.isBlank(processedFileSuffix) && file.getName().endsWith(processedFileSuffix)) {
                     return false;
                 }
                 return filePattern.matcher(file.getName()).matches();

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
@@ -173,7 +173,8 @@ public class FileSourceConfig implements Serializable {
         }
 
         if (processedFileSuffix != null && keepFile) {
-            throw new IllegalArgumentException("The property keepFile must be false if the property processedFileSuffix is set");
+            throw new IllegalArgumentException(
+                    "The property keepFile must be false if the property processedFileSuffix is set");
         }
     }
 }

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
@@ -112,6 +112,12 @@ public class FileSourceConfig implements Serializable {
      */
     private Integer numWorkers = 1;
 
+    /**
+     * If set, do not delete but only rename file that has been processed.
+     * This config only work when 'keepFile' property is false.
+     */
+    private String processedFileSuffix;
+
     public static FileSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), FileSourceConfig.class);

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/FileSourceConfig.java
@@ -171,5 +171,9 @@ public class FileSourceConfig implements Serializable {
         if (numWorkers != null && numWorkers <= 0) {
             throw new IllegalArgumentException("The property numWorkers must be greater than zero");
         }
+
+        if (processedFileSuffix != null && keepFile) {
+            throw new IllegalArgumentException("The property keepFile must be false if the property processedFileSuffix is set");
+        }
     }
 }

--- a/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/ProcessedFileThread.java
+++ b/pulsar-io/file/src/main/java/org/apache/pulsar/io/file/ProcessedFileThread.java
@@ -21,8 +21,10 @@ package org.apache.pulsar.io.file;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Worker thread that cleans up all the files that have been processed.
@@ -31,9 +33,11 @@ public class ProcessedFileThread extends Thread {
 
     private final BlockingQueue<File> recentlyProcessed;
     private final boolean keepOriginal;
+    private final String processedFileSuffix;
 
     public ProcessedFileThread(FileSourceConfig fileConfig, BlockingQueue<File> recentlyProcessed) {
         keepOriginal = Optional.ofNullable(fileConfig.getKeepFile()).orElse(false);
+        processedFileSuffix = fileConfig.getProcessedFileSuffix();
         this.recentlyProcessed = recentlyProcessed;
     }
 
@@ -51,7 +55,12 @@ public class ProcessedFileThread extends Thread {
     private void handle(File f) {
         if (!keepOriginal) {
             try {
-                Files.deleteIfExists(f.toPath());
+                if (StringUtils.isBlank(processedFileSuffix)) {
+                    Files.deleteIfExists(f.toPath());
+                } else {
+                    File targetFile = new File(f.getParentFile(), f.getName() + processedFileSuffix);
+                    Files.move(f.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/AbstractFileTests.java
@@ -122,6 +122,12 @@ public abstract class AbstractFileTests {
         f.get();
     }
 
+    protected final void generateFiles(int numFiles, int numLines, String directory, String suffix) throws IOException, InterruptedException, ExecutionException {
+        generatorThread = new TestFileGenerator(producedFiles, numFiles, 1, numLines, directory, "prefix", suffix, getPermissions());
+        Future<?> f = executor.submit(generatorThread);
+        f.get();
+    }
+
     protected static final FileAttribute<Set<PosixFilePermission>> getPermissions() {
         Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxrwxrwx");
         return PosixFilePermissions.asFileAttribute(perms);

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/FileListingThreadTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/FileListingThreadTests.java
@@ -235,4 +235,50 @@ public class FileListingThreadTests extends AbstractFileTests {
             cleanUp();
         }
     }
+
+    @Test
+    public final void processedFileFilterTest() throws IOException {
+
+        String processedFileSuffix = ".file_process_done";
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("inputDirectory", directory.toString());
+        map.put("keepFile", Boolean.FALSE);
+        map.put("processedFileSuffix", processedFileSuffix);
+
+        try {
+            generateFiles(5, 1, directory.toString(), ".txt");
+            generateFiles(1, 1, directory.toString(), processedFileSuffix);
+            listingThread = new FileListingThread(FileSourceConfig.load(map), workQueue, inProcess, recentlyProcessed);
+            executor.execute(listingThread);
+            Thread.sleep(2000);
+            verify(workQueue, times(5)).offer(any(File.class));
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Unable to generate files" + e.getLocalizedMessage());
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test
+    public final void processedFileFilterTest2() throws IOException {
+
+        String processedFileSuffix = ".file_process_done";
+        Map<String, Object> map = new HashMap<String, Object> ();
+        map.put("inputDirectory", directory.toString());
+        map.put("keepFile", Boolean.TRUE);
+        map.put("processedFileSuffix", processedFileSuffix);
+
+        try {
+            generateFiles(5, 1, directory.toString(), ".txt");
+            generateFiles(1, 1, directory.toString(), processedFileSuffix);
+            listingThread = new FileListingThread(FileSourceConfig.load(map), workQueue, inProcess, recentlyProcessed);
+            executor.execute(listingThread);
+            Thread.sleep(2000);
+            verify(workQueue, times(6)).offer(any(File.class));
+        } catch (InterruptedException | ExecutionException e) {
+            fail("Unable to generate files" + e.getLocalizedMessage());
+        } finally {
+            cleanUp();
+        }
+    }
 }

--- a/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/ProcessedFileThreadTests.java
+++ b/pulsar-io/file/src/test/java/org/apache/pulsar/io/file/ProcessedFileThreadTests.java
@@ -83,7 +83,7 @@ public class ProcessedFileThreadTests extends AbstractFileTests {
     }
 
     @Test
-    public final void mulitpleFileTest() throws IOException {
+    public final void multipleFileTest() throws IOException {
 
         consumer = Mockito.mock(PushSource.class);
         Mockito.doNothing().when(consumer).consume((Record<byte[]>) any(Record.class));
@@ -250,6 +250,62 @@ public class ProcessedFileThreadTests extends AbstractFileTests {
                 verify(inProcess, times(1)).add(produced);
                 verify(inProcess, times(1)).remove(produced);
                 verify(recentlyProcessed, times(1)).add(produced);
+            }
+
+        } catch (InterruptedException e) {
+            fail("Unable to generate files" + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public final void renameFileTest() throws IOException {
+
+        consumer = Mockito.mock(PushSource.class);
+        Mockito.doNothing().when(consumer).consume((Record<byte[]>) any(Record.class));
+
+        String processedFileSuffix = ".file_process_done";
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("inputDirectory", directory.toString());
+        map.put("keepFile", Boolean.FALSE);
+        map.put("pollingInterval", 100);
+        map.put("processedFileSuffix", processedFileSuffix);
+        fileConfig = FileSourceConfig.load(map);
+
+        try {
+            // Start producing files, with a .1 sec delay between
+            generatorThread =
+                    new TestFileGenerator(producedFiles, 500, 100, 1, directory.toString(), "continuous", ".txt",
+                            getPermissions());
+            executor.execute(generatorThread);
+
+            listingThread = new FileListingThread(fileConfig, workQueue, inProcess, recentlyProcessed);
+            consumerThread = new FileConsumerThread(consumer, workQueue, inProcess, recentlyProcessed);
+            cleanupThread = new ProcessedFileThread(fileConfig, recentlyProcessed);
+            executor.execute(listingThread);
+            executor.execute(consumerThread);
+            executor.execute(cleanupThread);
+
+            // Run for 30 seconds
+            Thread.sleep(30000);
+
+            // Stop producing files
+            generatorThread.halt();
+
+            // Let the consumer catch up
+            while (!workQueue.isEmpty() && !inProcess.isEmpty() && !recentlyProcessed.isEmpty()) {
+                Thread.sleep(2000);
+            }
+
+
+            // Make sure every single file was processed.
+            for (File produced : producedFiles) {
+                verify(workQueue, times(1)).offer(produced);
+                verify(inProcess, times(1)).add(produced);
+                verify(inProcess, times(1)).remove(produced);
+                verify(recentlyProcessed, times(1)).add(produced);
+
+                assert(!produced.exists());
+                assert(new File(produced.getAbsolutePath() + processedFileSuffix).exists());
             }
 
         } catch (InterruptedException e) {

--- a/site2/docs/io-file-source.md
+++ b/site2/docs/io-file-source.md
@@ -26,6 +26,7 @@ The configuration of the File source connector has the following properties.
 | `ignoreHiddenFiles` |Boolean| false | true| Whether the hidden files should be ignored or not. |
 | `pollingInterval`|Long | false | 10000L | Indicates how long to wait before performing a directory listing. |
 | `numWorkers` | Integer | false | 1 | The number of worker threads that process files.<br><br> This allows you to process a larger number of files concurrently. <br><br>However, setting this to a value greater than 1 makes the data from multiple files mixed in the target topic. |
+| `processedFileSuffix` | String | false | NULL | If set, do not delete but only rename file that has been processed. <br><br>  This config only work when 'keepFile' property is false. |
 
 ### Example
 
@@ -47,7 +48,8 @@ Before using the File source connector, you need to create a configuration file 
           "maximumSize": 5000000,
           "ignoreHiddenFiles": true,
           "pollingInterval": 5000,
-          "numWorkers": 1
+          "numWorkers": 1,
+          "processedFileSuffix": ".processed_done"
        }
     }
     ```
@@ -68,6 +70,7 @@ Before using the File source connector, you need to create a configuration file 
         ignoreHiddenFiles: true
         pollingInterval: 5000
         numWorkers: 1
+        processedFileSuffix: ".processed_done"
     ```
 
 ## Usage


### PR DESCRIPTION
### Motivation

Support rename the file has been processed.
#13301 

### Modifications
Add property 'processedFileSuffix'.

If set, do not delete but only rename file that has been processed.
This config only work when 'keepFile' property is false.

### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [√] `no-need-doc`