### PR TITLE
bump grpc version to 1.42.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.11.4</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.33.0</grpc.version>
+    <grpc.version>1.42.1</grpc.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.6</gson.version>


### PR DESCRIPTION
bump pulsar GRPC version to 1.42.1 since bookkeeper had.
Compile error：

```
 Could not resolve dependencies for project org.apache.pulsar:pulsar-functions-instance:jar:2.10.0-SNAPSHOT: Failed to collect dependencies for org.apache.pulsar:pulsar-functions-instance:jar:2.10.0-SNAPSHOT: Could not resolve version conflict among [org.apache.bookkeeper:stream-storage-java-client:jar:4.14.3 -> io.grpc:grpc-api:jar:1.42.1, org.apache.bookkeeper:stream-storage-java-client:jar:4.14.3 -> io.grpc:grpc-auth:jar:1.42.1 -> io.grpc:grpc-api:jar:[1.42.1,1.42.1], org.apache.bookkeeper:stream-storage-java-client:jar:4.14.3 -> io.grpc:grpc-core:jar:1.33.0 -> io.grpc:grpc-api:jar:[1.33.0,1.33.0], org.apache.bookkeeper:stream-storage-java-client:jar:4.14.3 -> io.grpc:grpc-protobuf:jar:1.42.1 -> io.grpc:grpc-api:jar:1.42.1, org.apache.bookkeeper:stream-storage-java-client:jar:4.14.3 -> io.grpc:grpc-protobuf-lite:jar:1.33.0 -> io.grpc:grpc-api:jar:1.33.0, io.grpc:grpc-stub:jar:1.33.0 -> io.grpc:grpc-api:jar:1.33.0, io.grpc:grpc-all:jar:1.33.0 -> io.grpc:grpc-api:jar:[1.33.0,1.33.0]]
```

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


