### PR TITLE
Issue 13379: Metrics: noise stacktrace if Prometheus closes the connection due to a timeout

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
@@ -85,8 +85,8 @@ public class PrometheusMetricsServlet extends HttpServlet {
                 if (e instanceof EOFException) {
                     // NO STACKTRACE
                     log.error("Failed to send metrics, "
-                            + "likely the client or this server closed the connection due to a timeout ({} ms elapsed): {}",
-                             time, e + "");
+                            + "likely the client or this server closed "
+                            + "the connection due to a timeout ({} ms elapsed): {}", time, e + "");
                 } else {
                     log.error("Failed to generate prometheus stats, {} ms elapsed", time, e);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.stats.prometheus;
 
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -70,6 +71,7 @@ public class PrometheusMetricsServlet extends HttpServlet {
         AsyncContext context = request.startAsync();
         context.setTimeout(metricsServletTimeoutMs);
         executor.execute(safeRun(() -> {
+            long start = System.currentTimeMillis();
             HttpServletResponse res = (HttpServletResponse) context.getResponse();
             try {
                 res.setStatus(HttpStatus.OK_200);
@@ -77,11 +79,19 @@ public class PrometheusMetricsServlet extends HttpServlet {
                 PrometheusMetricsGenerator.generate(pulsar, shouldExportTopicMetrics, shouldExportConsumerMetrics,
                         shouldExportProducerMetrics, splitTopicAndPartitionLabel, res.getOutputStream(),
                         metricsProviders);
-                context.complete();
-
             } catch (Exception e) {
-                log.error("Failed to generate prometheus stats", e);
+                long end = System.currentTimeMillis();
+                long time = end - start;
+                if (e instanceof EOFException) {
+                    // NO STACKTRACE
+                    log.error("Failed to send metrics, " +
+                            "likely the client closed the connection due to a timeout ({} ms elapsed): {}",
+                             time, e + "");
+                } else {
+                    log.error("Failed to generate prometheus stats, {} ms elapsed", time, e);
+                }
                 res.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+            } finally {
                 context.complete();
             }
         }));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
@@ -84,8 +84,8 @@ public class PrometheusMetricsServlet extends HttpServlet {
                 long time = end - start;
                 if (e instanceof EOFException) {
                     // NO STACKTRACE
-                    log.error("Failed to send metrics, " +
-                            "likely the client closed the connection due to a timeout ({} ms elapsed): {}",
+                    log.error("Failed to send metrics, "
+                            + "likely the client closed the connection due to a timeout ({} ms elapsed): {}",
                              time, e + "");
                 } else {
                     log.error("Failed to generate prometheus stats, {} ms elapsed", time, e);


### PR DESCRIPTION
Fixes #13379 

### Motivation

When there is a timeout in serving the metrics Pulsar will print a long stacktrace that is scary and meaningless to the users.

### Modifications

1. Provide a better log message: no stack trace, include the processing time
2. ensure that context.complete() is always executed, in a finally block
3. Handle gracefully the case of "AsyncContext completed and/or Request lifecycle recycled" in case of  server side timeout (metricsServletTimeoutMs)

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
