### PR TITLE
[Client]Allow to override PULSAR_MEM settings via PULSAR_EXTRA_OPS

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
 PULSAR_GC=" -client "
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_EXTRA_OPTS} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled"
+PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
 PULSAR_GC=" -client "
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} ${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled"
+PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_EXTRA_OPTS} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=


### PR DESCRIPTION
### Motivation

`pulsar-client` runs `conf/pulsar_tools_env.sh` to set `PULSAR_EXTRA_OPTS`. If `PULSAR_EXTRA_OPTS` are given in the command line and contain `-Xmx`, it will be overridden by `PULSAR_MEM`.

### Modifications

Exchange the order of applying env variables. First go the hardcoded PULSAR_MEM settings, then potentially the user settings.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
 
- [ x] `no-need-doc` 
  
 Change in a shell script, which is not documented.
  


