### PR TITLE
[Schema] Display null fields in SchemaInfo

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -207,6 +207,7 @@ public final class SchemaUtils {
     public static String jsonifySchemaInfo(SchemaInfo schemaInfo) {
         GsonBuilder gsonBuilder = new GsonBuilder()
             .setPrettyPrinting()
+            .serializeNulls()
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToStringAdapter(schemaInfo))
             .registerTypeHierarchyAdapter(Map.class, SCHEMA_PROPERTIES_SERIALIZER);
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -211,7 +211,7 @@ public final class SchemaUtils {
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToStringAdapter(schemaInfo))
             .registerTypeHierarchyAdapter(Map.class, SCHEMA_PROPERTIES_SERIALIZER);
 
-        return gsonBuilder.create().toJson(schemaInfo);
+        return gsonBuilder.create().toJson(JsonParser.parseString(new String(schemaInfo.getSchema())));
     }
 
     /**


### PR DESCRIPTION
### Motivation
The null field may also be important in some scenarios, so we should include the null field when getting the json string.
Such as:
* we excepted
> {
  "type": "record",
  "name": "Student",
  "namespace": "org.apache.pulsar.broker.transaction.TestConsumer",
  "fields": [
    {
      "name": "name",
      "type": [
        "null",
        "string"
      ],
      "default": null
    }
  ]
}
>
* Instead of 
> {
  "type": "record",
  "name": "Student",
  "namespace": "org.apache.pulsar.broker.transaction.TestConsumer",
  "fields": [
    {
      "name": "name",
      "type": [
        "null",
        "string"
      ],
    }
  ]
}
>
* The  schema
>  @NoArgsConstructor
    public static class Student {
        @Nullable
        private String name;
    }
>    
### Modification
Add `.serializeNulls()` when build a `gsonBuilder`
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


