### PR TITLE
Fix a bug with MutliRoleTokenAuth and chained auth

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -105,7 +105,15 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
         if (token == null)
             return Collections.emptyList();
 
+        // we assume this is a JWT, however, it may not necessarily be
+        // instead, if a user is using chained authentication, they might have different types
+        // of tokens
+        // We handle this and just assume it an empty list
         String[] splitToken = token.split("\\.");
+        if (splitToken.length < 2) {
+            log.warn("Unable to extract additional roles from JWT token");
+            return Collections.emptyList();
+        }
         String unsignedToken = splitToken[0] + "." + splitToken[1] + ".";
 
         Jwt<?, Claims> jwt = parser.parseClaimsJwt(unsignedToken);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -96,4 +96,31 @@ public class MultiRolesTokenAuthorizationProviderTest {
 
         Assert.assertFalse(provider.authorize(ads, role -> CompletableFuture.completedFuture(false)).get());
     }
+
+    @Test
+    public void testMultiRolesNotFailNonJWT() throws Exception {
+        String token = "a-static-token";
+
+        MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
+
+        AuthenticationDataSource ads = new AuthenticationDataSource() {
+            @Override
+            public boolean hasDataFromHttp() {
+                return true;
+            }
+
+            @Override
+            public String getHttpHeader(String name) {
+                if (name.equals("Authorization")) {
+                    return "Bearer " + token;
+                } else {
+                    throw new IllegalArgumentException("Wrong HTTP header");
+                }
+            }
+        };
+
+        Assert.assertFalse(provider.authorize(ads, role -> {
+            return CompletableFuture.completedFuture(false);
+        }).get());
+    }
 }


### PR DESCRIPTION

### Motivation

If a user has configured chained authentication with
MultiRolesTokenAuthorizationProvider, it is possible that a token
could be passed that is not a JWT.


### Modifications

In this case, we just want to return an empty list of roles and let the
default role pass through

### Verifying this change

- [X] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

- Adds a simple test for the failing case of a token that is not a JWT to ensure it doesn't fail

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

NO to all
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
Minor bug fix
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


