### PR TITLE
[pulsar-client-admin]: reduce code duplication in TopicsImpl

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -297,6 +297,8 @@ public abstract class BaseResource {
           throw new PulsarAdminException(e);
         } catch (TimeoutException e) {
           throw new PulsarAdminException.TimeoutException(e);
+        } catch (Exception e) {
+            throw getApiException(e);
         }
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -31,9 +31,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.client.Entity;
@@ -143,16 +140,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getList(String namespace, TopicDomain topicDomain) throws PulsarAdminException {
-        try {
-            return getListAsync(namespace, topicDomain).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getListAsync(namespace, topicDomain));
     }
 
     @Override
@@ -207,16 +195,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getPartitionedTopicList(String namespace) throws PulsarAdminException {
-        try {
-            return getPartitionedTopicListAsync(namespace).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPartitionedTopicListAsync(namespace));
     }
 
     @Override
@@ -258,16 +237,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getListInBundle(String namespace, String bundleRange) throws PulsarAdminException {
-        try {
-            return getListInBundleAsync(namespace, bundleRange).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getListInBundleAsync(namespace, bundleRange));
     }
 
     @Override
@@ -293,16 +263,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Map<String, Set<AuthAction>> getPermissions(String topic) throws PulsarAdminException {
-        try {
-            return getPermissionsAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPermissionsAsync(topic));
     }
 
     @Override
@@ -327,16 +288,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void grantPermission(String topic, String role, Set<AuthAction> actions) throws PulsarAdminException {
-        try {
-            grantPermissionAsync(topic, role, actions).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> grantPermissionAsync(topic, role, actions));
     }
 
     @Override
@@ -348,16 +300,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void revokePermissions(String topic, String role) throws PulsarAdminException {
-        try {
-            revokePermissionsAsync(topic, role).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> revokePermissionsAsync(topic, role));
     }
 
     @Override
@@ -369,48 +312,21 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void createPartitionedTopic(String topic, int numPartitions) throws PulsarAdminException {
-        try {
-            createPartitionedTopicAsync(topic, numPartitions).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> createPartitionedTopicAsync(topic, numPartitions));
     }
 
     @Override
     public void createNonPartitionedTopic(String topic) throws PulsarAdminException {
-        try {
-            createNonPartitionedTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> createNonPartitionedTopicAsync(topic));
     }
 
     @Override
     public void createMissedPartitions(String topic) throws PulsarAdminException {
-        try {
-            createMissedPartitionsAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> createMissedPartitionsAsync(topic));
     }
 
     @Override
-    public CompletableFuture<Void> createNonPartitionedTopicAsync(String topic){
+    public CompletableFuture<Void> createNonPartitionedTopicAsync(String topic) {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn);
         return asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
@@ -440,17 +356,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void updatePartitionedTopic(String topic, int numPartitions)
             throws PulsarAdminException {
-        try {
-            updatePartitionedTopicAsync(topic, numPartitions).get(this.readTimeoutMs,
-                    TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> updatePartitionedTopicAsync(topic, numPartitions));
     }
 
     @Override
@@ -467,17 +373,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void updatePartitionedTopic(String topic, int numPartitions, boolean updateLocalTopicOnly, boolean force)
             throws PulsarAdminException {
-        try {
-            updatePartitionedTopicAsync(topic, numPartitions, updateLocalTopicOnly, force)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> updatePartitionedTopicAsync(topic, numPartitions, updateLocalTopicOnly, force));
     }
 
     @Override
@@ -499,16 +395,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PartitionedTopicMetadata getPartitionedTopicMetadata(String topic) throws PulsarAdminException {
-        try {
-            return getPartitionedTopicMetadataAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPartitionedTopicMetadataAsync(topic));
     }
 
     @Override
@@ -544,16 +431,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void deletePartitionedTopic(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
-        try {
-            deletePartitionedTopicAsync(topic, force, deleteSchema).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> deletePartitionedTopicAsync(topic, force, deleteSchema));
     }
 
     @Override
@@ -577,16 +455,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void delete(String topic, boolean force, boolean deleteSchema) throws PulsarAdminException {
-        try {
-            deleteAsync(topic, force, deleteSchema).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> deleteAsync(topic, force, deleteSchema));
     }
 
     @Override
@@ -600,16 +469,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void unload(String topic) throws PulsarAdminException {
-        try {
-            unloadAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> unloadAsync(topic));
     }
 
     @Override
@@ -621,16 +481,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public MessageId terminateTopic(String topic) throws PulsarAdminException {
-        try {
-            return terminateTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> terminateTopicAsync(topic));
     }
 
     @Override
@@ -665,16 +516,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public List<String> getSubscriptions(String topic) throws PulsarAdminException {
-        try {
-            return getSubscriptionsAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getSubscriptionsAsync(topic));
     }
 
     @Override
@@ -703,17 +545,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         boolean getPreciseBacklog = getStatsOptions.isGetPreciseBacklog();
         boolean subscriptionBacklogSize = getStatsOptions.isSubscriptionBacklogSize();
         boolean getEarliestTimeInBacklog = getStatsOptions.isGetEarliestTimeInBacklog();
-        try {
-            return getStatsAsync(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getStatsAsync(topic, getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog));
     }
 
     @Override
@@ -768,16 +600,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PersistentTopicInternalStats getInternalStats(String topic, boolean metadata) throws PulsarAdminException {
-        try {
-            return getInternalStatsAsync(topic, metadata).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getInternalStatsAsync(topic, metadata));
     }
 
     @Override
@@ -809,16 +632,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public String getInternalInfo(String topic) throws PulsarAdminException {
-        try {
-            return getInternalInfoAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getInternalInfoAsync(topic));
     }
 
     @Override
@@ -845,17 +659,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public PartitionedTopicStats getPartitionedStats(String topic, boolean perPartition, boolean getPreciseBacklog,
                                                      boolean subscriptionBacklogSize)
             throws PulsarAdminException {
-        try {
-            return getPartitionedStatsAsync(topic, perPartition, getPreciseBacklog, subscriptionBacklogSize)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPartitionedStatsAsync(topic, perPartition, getPreciseBacklog, subscriptionBacklogSize));
     }
 
     @Override
@@ -912,16 +716,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public PartitionedTopicInternalStats getPartitionedInternalStats(String topic)
             throws PulsarAdminException {
-        try {
-            return getPartitionedInternalStatsAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPartitionedInternalStatsAsync(topic));
     }
 
     @Override
@@ -947,30 +742,12 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void deleteSubscription(String topic, String subName) throws PulsarAdminException {
-        try {
-            deleteSubscriptionAsync(topic, subName).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> deleteSubscriptionAsync(topic, subName));
     }
 
     @Override
     public void deleteSubscription(String topic, String subName, boolean force) throws PulsarAdminException {
-        try {
-            deleteSubscriptionAsync(topic, subName, force).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> deleteSubscriptionAsync(topic, subName, force));
     }
 
     @Override
@@ -989,16 +766,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void skipAllMessages(String topic, String subName) throws PulsarAdminException {
-        try {
-            skipAllMessagesAsync(topic, subName).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> skipAllMessagesAsync(topic, subName));
     }
 
     @Override
@@ -1011,16 +779,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void skipMessages(String topic, String subName, long numMessages) throws PulsarAdminException {
-        try {
-            skipMessagesAsync(topic, subName, numMessages).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> skipMessagesAsync(topic, subName, numMessages));
     }
 
     @Override
@@ -1033,16 +792,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void expireMessages(String topic, String subName, long expireTimeInSeconds) throws PulsarAdminException {
-        try {
-            expireMessagesAsync(topic, subName, expireTimeInSeconds).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> expireMessagesAsync(topic, subName, expireTimeInSeconds));
     }
 
     @Override
@@ -1057,17 +807,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void expireMessages(String topic, String subscriptionName, MessageId messageId, boolean isExcluded)
             throws PulsarAdminException {
-        try {
-            expireMessagesAsync(topic, subscriptionName, messageId, isExcluded)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> expireMessagesAsync(topic, subscriptionName, messageId, isExcluded));
     }
 
     @Override
@@ -1083,17 +823,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void expireMessagesForAllSubscriptions(String topic, long expireTimeInSeconds) throws PulsarAdminException {
-        try {
-            expireMessagesForAllSubscriptionsAsync(topic, expireTimeInSeconds)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> expireMessagesForAllSubscriptionsAsync(topic, expireTimeInSeconds));
     }
 
     @Override
@@ -1133,16 +863,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        try {
-            return peekMessagesAsync(topic, subName, numMessages).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> peekMessagesAsync(topic, subName, numMessages));
     }
 
     @Override
@@ -1184,17 +905,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public Message<byte[]> examineMessage(String topic, String initialPosition, long messagePosition)
             throws PulsarAdminException {
-        try {
-            return examineMessageAsync(topic, initialPosition, messagePosition)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> examineMessageAsync(topic, initialPosition, messagePosition));
     }
 
     @Override
@@ -1231,16 +942,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void truncate(String topic) throws PulsarAdminException {
-        try {
-            truncateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> truncateAsync(topic));
     }
 
     @Override
@@ -1295,16 +997,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public Message<byte[]> getMessageById(String topic, long ledgerId, long entryId)
             throws PulsarAdminException {
-        try {
-            return getMessageByIdAsync(topic, ledgerId, entryId).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMessageByIdAsync(topic, ledgerId, entryId));
     }
 
     @Override
@@ -1331,18 +1024,8 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public MessageId getMessageIdByTimestamp(String topic, long timestamp)
             throws PulsarAdminException {
-        try {
-            return getMessageIdByTimestampAsync(topic, timestamp).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMessageIdByTimestampAsync(topic, timestamp));
     }
-
 
 
     @Override
@@ -1391,35 +1074,13 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void resetCursor(String topic, String subName, MessageId messageId) throws PulsarAdminException {
-        try {
-            resetCursorAsync(topic, subName, messageId).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        } catch (Exception e) {
-            throw getApiException(e);
-        }
+        sync(() -> resetCursorAsync(topic, subName, messageId));
     }
 
     @Override
     public void resetCursor(String topic, String subName, MessageId messageId
             , boolean isExcluded) throws PulsarAdminException {
-        try {
-            resetCursorAsync(topic, subName, messageId, isExcluded).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        } catch (Exception e) {
-            throw getApiException(e);
-        }
+        sync(() -> resetCursorAsync(topic, subName, messageId, isExcluded));
     }
 
     @Override
@@ -1440,16 +1101,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void triggerCompaction(String topic) throws PulsarAdminException {
-        try {
-            triggerCompactionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> triggerCompactionAsync(topic));
     }
 
     @Override
@@ -1462,16 +1114,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public LongRunningProcessStatus compactionStatus(String topic)
             throws PulsarAdminException {
-        try {
-            return compactionStatusAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> compactionStatusAsync(topic));
     }
 
     @Override
@@ -1496,16 +1139,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void triggerOffload(String topic, MessageId messageId) throws PulsarAdminException {
-        try {
-            triggerOffloadAsync(topic, messageId).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> triggerOffloadAsync(topic, messageId));
     }
 
     @Override
@@ -1535,16 +1169,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public OffloadProcessStatus offloadStatus(String topic)
             throws PulsarAdminException {
-        try {
-            return offloadStatusAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> offloadStatusAsync(topic));
     }
 
     @Override
@@ -1809,16 +1434,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public MessageId getLastMessageId(String topic) throws PulsarAdminException {
-        try {
-            return getLastMessageIdAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getLastMessageIdAsync(topic));
     }
 
     @Override
@@ -1868,16 +1484,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public Long getBacklogSizeByMessageId(String topic, MessageId messageId)
             throws PulsarAdminException {
-        try {
-            return getBacklogSizeByMessageIdAsync(topic, messageId).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getBacklogSizeByMessageIdAsync(topic, messageId));
     }
 
     @Override
@@ -1944,17 +1551,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxUnackedMessagesOnConsumer(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getMaxUnackedMessagesOnConsumerAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxUnackedMessagesOnConsumerAsync(topic, applied));
     }
 
     @Override
@@ -1986,17 +1583,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxUnackedMessagesOnConsumer(String topic, int maxNum) throws PulsarAdminException {
-        try {
-            setMaxUnackedMessagesOnConsumerAsync(topic, maxNum)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxUnackedMessagesOnConsumerAsync(topic, maxNum));
     }
 
     @Override
@@ -2008,31 +1595,12 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxUnackedMessagesOnConsumer(String topic) throws PulsarAdminException {
-        try {
-            removeMaxUnackedMessagesOnConsumerAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxUnackedMessagesOnConsumerAsync(topic));
     }
 
     @Override
     public InactiveTopicPolicies getInactiveTopicPolicies(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getInactiveTopicPoliciesAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getInactiveTopicPoliciesAsync(topic, applied));
     }
 
     @Override
@@ -2076,17 +1644,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void setInactiveTopicPolicies(String topic
             , InactiveTopicPolicies inactiveTopicPolicies) throws PulsarAdminException {
-        try {
-            setInactiveTopicPoliciesAsync(topic, inactiveTopicPolicies)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setInactiveTopicPoliciesAsync(topic, inactiveTopicPolicies));
     }
 
     @Override
@@ -2098,32 +1656,13 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeInactiveTopicPolicies(String topic) throws PulsarAdminException {
-        try {
-            removeInactiveTopicPoliciesAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeInactiveTopicPoliciesAsync(topic));
     }
 
     @Override
     public DelayedDeliveryPolicies getDelayedDeliveryPolicy(String topic
             , boolean applied) throws PulsarAdminException {
-        try {
-            return getDelayedDeliveryPolicyAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getDelayedDeliveryPolicyAsync(topic, applied));
     }
 
     @Override
@@ -2166,16 +1705,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeDelayedDeliveryPolicy(String topic) throws PulsarAdminException {
-        try {
-            removeDelayedDeliveryPolicyAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeDelayedDeliveryPolicyAsync(topic));
     }
 
     @Override
@@ -2189,32 +1719,12 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void setDelayedDeliveryPolicy(String topic
             , DelayedDeliveryPolicies delayedDeliveryPolicies) throws PulsarAdminException {
-        try {
-            setDelayedDeliveryPolicyAsync(topic, delayedDeliveryPolicies)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setDelayedDeliveryPolicyAsync(topic, delayedDeliveryPolicies));
     }
 
     @Override
     public Boolean getDeduplicationEnabled(String topic) throws PulsarAdminException {
-        try {
-            return getDeduplicationEnabledAsync(topic).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getDeduplicationEnabledAsync(topic));
     }
 
     @Override
@@ -2248,17 +1758,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Boolean getDeduplicationStatus(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getDeduplicationStatusAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getDeduplicationStatusAsync(topic, applied));
     }
 
     @Override
@@ -2283,17 +1783,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void enableDeduplication(String topic, boolean enabled) throws PulsarAdminException {
-        try {
-            enableDeduplicationAsync(topic, enabled).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> enableDeduplicationAsync(topic, enabled));
     }
 
     @Override
@@ -2305,17 +1795,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setDeduplicationStatus(String topic, boolean enabled) throws PulsarAdminException {
-        try {
-            enableDeduplicationAsync(topic, enabled).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> enableDeduplicationAsync(topic, enabled));
     }
 
     @Override
@@ -2327,17 +1807,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void disableDeduplication(String topic) throws PulsarAdminException {
-        try {
-            disableDeduplicationAsync(topic).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> disableDeduplicationAsync(topic));
     }
 
     @Override
@@ -2349,16 +1819,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeDeduplicationStatus(String topic) throws PulsarAdminException {
-        try {
-            removeDeduplicationStatusAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeDeduplicationStatusAsync(topic));
     }
 
     @Override
@@ -2380,17 +1841,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public OffloadPolicies getOffloadPolicies(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getOffloadPoliciesAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getOffloadPoliciesAsync(topic, applied));
     }
 
     @Override
@@ -2415,17 +1866,8 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setOffloadPolicies(String topic, OffloadPolicies offloadPolicies) throws PulsarAdminException {
-        try {
-            setOffloadPoliciesAsync(topic, offloadPolicies).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+
+        sync(() -> setOffloadPoliciesAsync(topic, offloadPolicies));
     }
 
     @Override
@@ -2437,17 +1879,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeOffloadPolicies(String topic) throws PulsarAdminException {
-        try {
-            removeOffloadPoliciesAsync(topic).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeOffloadPoliciesAsync(topic));
     }
 
     @Override
@@ -2469,17 +1901,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxUnackedMessagesOnSubscription(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getMaxUnackedMessagesOnSubscriptionAsync(topic, applied).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxUnackedMessagesOnSubscriptionAsync(topic, applied));
     }
 
     @Override
@@ -2504,17 +1926,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxUnackedMessagesOnSubscription(String topic, int maxNum) throws PulsarAdminException {
-        try {
-            setMaxUnackedMessagesOnSubscriptionAsync(topic, maxNum).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxUnackedMessagesOnSubscriptionAsync(topic, maxNum));
     }
 
     @Override
@@ -2526,17 +1938,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxUnackedMessagesOnSubscription(String topic) throws PulsarAdminException {
-        try {
-            removeMaxUnackedMessagesOnSubscriptionAsync(topic).
-                    get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxUnackedMessagesOnSubscriptionAsync(topic));
     }
 
     @Override
@@ -2588,16 +1990,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setRetention(String topic, RetentionPolicies retention) throws PulsarAdminException {
-        try {
-            setRetentionAsync(topic, retention).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setRetentionAsync(topic, retention));
     }
 
     @Override
@@ -2619,16 +2012,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public RetentionPolicies getRetention(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getRetentionAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getRetentionAsync(topic, applied));
     }
 
     @Override
@@ -2654,16 +2038,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeRetention(String topic) throws PulsarAdminException {
-        try {
-            removeRetentionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeRetentionAsync(topic));
     }
 
     @Override
@@ -2675,16 +2050,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setPersistence(String topic, PersistencePolicies persistencePolicies) throws PulsarAdminException {
-        try {
-            setPersistenceAsync(topic, persistencePolicies).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setPersistenceAsync(topic, persistencePolicies));
     }
 
     @Override
@@ -2706,16 +2072,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PersistencePolicies getPersistence(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getPersistenceAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPersistenceAsync(topic, applied));
     }
 
     @Override
@@ -2741,16 +2098,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removePersistence(String topic) throws PulsarAdminException {
-        try {
-            removePersistenceAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removePersistenceAsync(topic));
     }
 
     @Override
@@ -2762,16 +2110,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public DispatchRate getDispatchRate(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getDispatchRateAsync(topic, applied));
     }
 
     @Override
@@ -2807,16 +2146,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        try {
-            setDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setDispatchRateAsync(topic, dispatchRate));
     }
 
     @Override
@@ -2828,16 +2158,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeDispatchRate(String topic) throws PulsarAdminException {
-        try {
-            removeDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeDispatchRateAsync(topic));
     }
 
     @Override
@@ -2849,16 +2170,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public DispatchRate getSubscriptionDispatchRate(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getSubscriptionDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getSubscriptionDispatchRateAsync(topic, applied));
     }
 
     @Override
@@ -2894,16 +2206,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscriptionDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        try {
-            setSubscriptionDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setSubscriptionDispatchRateAsync(topic, dispatchRate));
     }
 
     @Override
@@ -2915,16 +2218,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeSubscriptionDispatchRate(String topic) throws PulsarAdminException {
-        try {
-            removeSubscriptionDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeSubscriptionDispatchRateAsync(topic));
     }
 
     @Override
@@ -2946,16 +2240,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Long getCompactionThreshold(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getCompactionThresholdAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getCompactionThresholdAsync(topic, applied));
     }
 
     @Override
@@ -2981,16 +2266,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setCompactionThreshold(String topic, long compactionThreshold) throws PulsarAdminException {
-        try {
-            setCompactionThresholdAsync(topic, compactionThreshold).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setCompactionThresholdAsync(topic, compactionThreshold));
     }
 
     @Override
@@ -3002,16 +2278,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeCompactionThreshold(String topic) throws PulsarAdminException {
-        try {
-            removeCompactionThresholdAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeCompactionThresholdAsync(topic));
     }
 
     @Override
@@ -3023,16 +2290,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public PublishRate getPublishRate(String topic) throws PulsarAdminException {
-        try {
-            return getPublishRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getPublishRateAsync(topic));
     }
 
     @Override
@@ -3057,16 +2315,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setPublishRate(String topic, PublishRate publishRate) throws PulsarAdminException {
-        try {
-            setPublishRateAsync(topic, publishRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setPublishRateAsync(topic, publishRate));
     }
 
     @Override
@@ -3078,16 +2327,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removePublishRate(String topic) throws PulsarAdminException {
-        try {
-            removePublishRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removePublishRateAsync(topic));
     }
 
     @Override
@@ -3099,16 +2339,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxConsumersPerSubscription(String topic) throws PulsarAdminException {
-        try {
-            return getMaxConsumersPerSubscriptionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxConsumersPerSubscriptionAsync(topic));
     }
 
     @Override
@@ -3133,18 +2364,8 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxConsumersPerSubscription(String topic, int maxConsumersPerSubscription)
-        throws PulsarAdminException {
-        try {
-            setMaxConsumersPerSubscriptionAsync(topic, maxConsumersPerSubscription)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+            throws PulsarAdminException {
+        sync(() -> setMaxConsumersPerSubscriptionAsync(topic, maxConsumersPerSubscription));
     }
 
     @Override
@@ -3156,16 +2377,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxConsumersPerSubscription(String topic) throws PulsarAdminException {
-        try {
-            removeMaxConsumersPerSubscriptionAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxConsumersPerSubscriptionAsync(topic));
     }
 
     @Override
@@ -3187,16 +2399,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxProducers(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getMaxProducersAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxProducersAsync(topic, applied));
     }
 
     @Override
@@ -3222,16 +2425,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxProducers(String topic, int maxProducers) throws PulsarAdminException {
-        try {
-            setMaxProducersAsync(topic, maxProducers).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxProducersAsync(topic, maxProducers));
     }
 
     @Override
@@ -3243,16 +2437,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxProducers(String topic) throws PulsarAdminException {
-        try {
-            removeMaxProducersAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxProducersAsync(topic));
     }
 
     @Override
@@ -3264,16 +2449,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException {
-        try {
-            return getMaxSubscriptionsPerTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxSubscriptionsPerTopicAsync(topic));
     }
 
     @Override
@@ -3298,17 +2474,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxSubscriptionsPerTopic(String topic, int maxSubscriptionsPerTopic) throws PulsarAdminException {
-        try {
-            setMaxSubscriptionsPerTopicAsync(topic, maxSubscriptionsPerTopic)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxSubscriptionsPerTopicAsync(topic, maxSubscriptionsPerTopic));
     }
 
     @Override
@@ -3320,16 +2486,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxSubscriptionsPerTopic(String topic) throws PulsarAdminException {
-        try {
-            removeMaxSubscriptionsPerTopicAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxSubscriptionsPerTopicAsync(topic));
     }
 
     @Override
@@ -3341,16 +2498,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxMessageSize(String topic) throws PulsarAdminException {
-        try {
-            return getMaxMessageSizeAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxMessageSizeAsync(topic));
     }
 
     @Override
@@ -3375,16 +2523,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxMessageSize(String topic, int maxMessageSize) throws PulsarAdminException {
-        try {
-            setMaxMessageSizeAsync(topic, maxMessageSize).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxMessageSizeAsync(topic, maxMessageSize));
     }
 
     @Override
@@ -3396,16 +2535,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxMessageSize(String topic) throws PulsarAdminException {
-        try {
-            removeMaxMessageSizeAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxMessageSizeAsync(topic));
     }
 
     @Override
@@ -3427,16 +2557,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getMaxConsumers(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getMaxConsumersAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getMaxConsumersAsync(topic, applied));
     }
 
     @Override
@@ -3462,16 +2583,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setMaxConsumers(String topic, int maxConsumers) throws PulsarAdminException {
-        try {
-            setMaxConsumersAsync(topic, maxConsumers).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setMaxConsumersAsync(topic, maxConsumers));
     }
 
     @Override
@@ -3483,16 +2595,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeMaxConsumers(String topic) throws PulsarAdminException {
-        try {
-            removeMaxConsumersAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeMaxConsumersAsync(topic));
     }
 
     @Override
@@ -3505,16 +2608,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Integer getDeduplicationSnapshotInterval(String topic) throws PulsarAdminException {
-        try {
-            return getDeduplicationSnapshotIntervalAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getDeduplicationSnapshotIntervalAsync(topic));
     }
 
     @Override
@@ -3539,16 +2633,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setDeduplicationSnapshotInterval(String topic, int interval) throws PulsarAdminException {
-        try {
-            setDeduplicationSnapshotIntervalAsync(topic, interval).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setDeduplicationSnapshotIntervalAsync(topic, interval));
     }
 
     @Override
@@ -3560,16 +2645,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeDeduplicationSnapshotInterval(String topic) throws PulsarAdminException {
-        try {
-            removeDeduplicationSnapshotIntervalAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeDeduplicationSnapshotIntervalAsync(topic));
     }
 
     @Override
@@ -3583,17 +2659,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     public void setSubscriptionTypesEnabled(
             String topic, Set<SubscriptionType>
             subscriptionTypesEnabled) throws PulsarAdminException {
-        try {
-            setSubscriptionTypesEnabledAsync(topic, subscriptionTypesEnabled)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setSubscriptionTypesEnabledAsync(topic, subscriptionTypesEnabled));
     }
 
     @Override
@@ -3606,16 +2672,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Set<SubscriptionType> getSubscriptionTypesEnabled(String topic) throws PulsarAdminException {
-        try {
-            return getSubscriptionTypesEnabledAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getSubscriptionTypesEnabledAsync(topic));
     }
 
     @Override
@@ -3640,17 +2697,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeSubscriptionTypesEnabled(String topic) throws PulsarAdminException {
-        try {
-            removeSubscriptionTypesEnabledAsync(topic)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeSubscriptionTypesEnabledAsync(topic));
     }
 
     @Override
@@ -3672,16 +2719,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public DispatchRate getReplicatorDispatchRate(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getReplicatorDispatchRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getReplicatorDispatchRateAsync(topic, applied));
     }
 
     @Override
@@ -3707,16 +2745,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException {
-        try {
-            setReplicatorDispatchRateAsync(topic, dispatchRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setReplicatorDispatchRateAsync(topic, dispatchRate));
     }
 
     @Override
@@ -3728,16 +2757,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeReplicatorDispatchRate(String topic) throws PulsarAdminException {
-        try {
-            removeReplicatorDispatchRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeReplicatorDispatchRateAsync(topic));
     }
 
     @Override
@@ -3759,16 +2779,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public SubscribeRate getSubscribeRate(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getSubscribeRateAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getSubscribeRateAsync(topic, applied));
     }
 
     @Override
@@ -3794,16 +2805,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setSubscribeRate(String topic, SubscribeRate subscribeRate) throws PulsarAdminException {
-        try {
-            setSubscribeRateAsync(topic, subscribeRate).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setSubscribeRateAsync(topic, subscribeRate));
     }
 
     @Override
@@ -3815,16 +2817,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeSubscribeRate(String topic) throws PulsarAdminException {
-        try {
-            removeSubscribeRateAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeSubscribeRateAsync(topic));
     }
 
     @Override
@@ -3837,17 +2830,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public void setReplicatedSubscriptionStatus(String topic, String subName, boolean enabled)
             throws PulsarAdminException {
-        try {
-            setReplicatedSubscriptionStatusAsync(topic, subName, enabled).get(this.readTimeoutMs,
-                    TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setReplicatedSubscriptionStatusAsync(topic, subName, enabled));
     }
 
     @Override
@@ -3860,17 +2843,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     public Map<String, Boolean> getReplicatedSubscriptionStatus(String topic,
                                                                 String subName) throws PulsarAdminException {
-        try {
-            return getReplicatedSubscriptionStatusAsync(topic, subName)
-                    .get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getReplicatedSubscriptionStatusAsync(topic, subName));
     }
 
     public CompletableFuture<Map<String, Boolean>> getReplicatedSubscriptionStatusAsync(String topic, String subName) {
@@ -3895,16 +2868,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public Set<String> getReplicationClusters(String topic, boolean applied) throws PulsarAdminException {
-        try {
-            return getReplicationClustersAsync(topic, applied).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        return sync(() -> getReplicationClustersAsync(topic, applied));
     }
 
     @Override
@@ -3930,16 +2894,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void setReplicationClusters(String topic, List<String> clusterIds) throws PulsarAdminException {
-        try {
-            setReplicationClustersAsync(topic, clusterIds).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> setReplicationClustersAsync(topic, clusterIds));
     }
 
     @Override
@@ -3951,16 +2906,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public void removeReplicationClusters(String topic) throws PulsarAdminException {
-        try {
-            removeReplicationClustersAsync(topic).get(this.readTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            throw (PulsarAdminException) e.getCause();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarAdminException(e);
-        } catch (TimeoutException e) {
-            throw new PulsarAdminException.TimeoutException(e);
-        }
+        sync(() -> removeReplicationClustersAsync(topic));
     }
 
     @Override


### PR DESCRIPTION
### Motivation
`TopicsImpl` contains lots of code duplication. So do a clean up.

### Modifications
Refer: #13086 @eolivelli 
use `sync()` to reduce code duplication.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation
Check the box below and label this PR (if you have committer privilege).

Need to update docs?
- [x] `no-need-doc` 
(Just code clean up)
