### PR TITLE
[security] Allow config client dns bind addr and port

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -98,9 +98,14 @@ public class ConnectionPool implements Closeable {
             log.error("Failed to create channel initializer");
             throw new PulsarClientException(e);
         }
-
-        this.dnsResolver = new DnsNameResolverBuilder(eventLoopGroup.next()).traceEnabled(true)
-                .channelType(EventLoopUtil.getDatagramChannelClass(eventLoopGroup)).build();
+        DnsNameResolverBuilder dnsNameResolverBuilder = new DnsNameResolverBuilder(eventLoopGroup.next())
+                .traceEnabled(true).channelType(EventLoopUtil.getDatagramChannelClass(eventLoopGroup));
+        if (conf.getDnsLookupBindAddress() != null) {
+            InetSocketAddress addr = new InetSocketAddress(conf.getDnsLookupBindAddress(),
+                    conf.getDnsLookupBindPort());
+            dnsNameResolverBuilder.localAddress(addr);
+        }
+        this.dnsResolver = dnsNameResolverBuilder.build();
     }
 
     private static final Random random = new Random();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -297,13 +297,13 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "dnsLookupBindAddress",
-            value = "The Pulsar client dns lookup bind address."
+            value = "The Pulsar client dns lookup bind address, default behavior is bind on 0.0.0.0"
     )
     private String dnsLookupBindAddress = null;
 
     @ApiModelProperty(
             name = "dnsLookupBindPort",
-            value = "The Pulsar client dns lookup bind port, takes effect when dnsLookupBindAddress is configured." +
+            value = "The Pulsar client dns lookup bind port, takes effect when dnsLookupBindAddress is configured," +
                     " default value is 0."
     )
     private int dnsLookupBindPort = 0;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -295,6 +295,19 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     @JsonIgnore
     private Clock clock = Clock.systemDefaultZone();
 
+    @ApiModelProperty(
+            name = "dnsLookupBindAddress",
+            value = "The Pulsar client dns lookup bind address."
+    )
+    private String dnsLookupBindAddress = null;
+
+    @ApiModelProperty(
+            name = "dnsLookupBindPort",
+            value = "The Pulsar client dns lookup bind port, takes effect when dnsLookupBindAddress is configured." +
+                    " default value is 0."
+    )
+    private int dnsLookupBindPort = 0;
+
     // socks5
     @ApiModelProperty(
             name = "socks5ProxyAddress",

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -60,6 +60,8 @@ public class ConfigurationDataUtilsTest {
         config.put("maxLookupRedirects", 50);
         config.put("authParams", "testAuthParams");
         config.put("authParamMap", authParamMap);
+        config.put("dnsLookupBindAddress", "0.0.0.0");
+        config.put("dnsLookupBindPort", 0);
 
         confData = ConfigurationDataUtils.loadData(config, confData, ClientConfigurationData.class);
         assertEquals("pulsar://localhost:6650", confData.getServiceUrl());
@@ -69,6 +71,8 @@ public class ConfigurationDataUtilsTest {
         assertEquals("testAuthParams", confData.getAuthParams());
         assertEquals("v1", confData.getAuthParamMap().get("k1"));
         assertEquals("v2", confData.getAuthParamMap().get("k2"));
+        assertEquals("0.0.0.0", confData.getDnsLookupBindAddress());
+        assertEquals(0, confData.getDnsLookupBindPort());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

By default, the pulsar client dns start listen on `0.0.0.0`, which could be a security risk

### Modifications

- Allow config client dns bind addr and port
- And default behavior is not changed

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `doc` 
  
  IMO, this change to code will generated doc automatically.


