### PR TITLE
[Security] Upgrade to Log4J 2.17.0 to mitigate CVE-2021-45105

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire.version>3.0.0-M3</surefire.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
     <testng.version>7.3.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -385,11 +385,11 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.16.0.jar
-    - org.apache.logging.log4j-log4j-core-2.16.0.jar
-    - org.apache.logging.log4j-log4j-slf4j-impl-2.16.0.jar
-    - org.apache.logging.log4j-log4j-web-2.16.0.jar
-    - org.apache.logging.log4j-log4j-1.2-api-2.16.0.jar
+    - org.apache.logging.log4j-log4j-api-2.17.0.jar
+    - org.apache.logging.log4j-log4j-core-2.17.0.jar
+    - org.apache.logging.log4j-log4j-slf4j-impl-2.17.0.jar
+    - org.apache.logging.log4j-log4j-web-2.17.0.jar
+    - org.apache.logging.log4j-log4j-1.2-api-2.17.0.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.14.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.12.3</jackson.version>


### PR DESCRIPTION
### Motivation

- more details at https://logging.apache.org/log4j/2.x/security.html
description of CVE-2021-45105
> Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.
- default Pulsar configurations aren't impacted

### Modifications

- upgrade Log4J version from 2.16.0 to 2.17.0

### Additional context

Analysis on the mailing list https://lists.apache.org/thread/0hn40hcmxo8nbbkgsyfgl6gb8lg74o5o