### PR TITLE
[Broker] Modify return result of NamespacesBase#internalGetBookieAffinityGroup

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -999,12 +999,9 @@ public abstract class NamespacesBase extends AdminResource {
             final BookieAffinityGroupData bookkeeperAffinityGroup = getLocalPolicies().getLocalPolicies(namespaceName)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND,
                             "Namespace local-policies does not exist")).bookieAffinityGroup;
-            if (bookkeeperAffinityGroup == null) {
-                throw new RestException(Status.NOT_FOUND, "bookie-affinity group does not exist");
-            }
             return bookkeeperAffinityGroup;
         } catch (NotFoundException e) {
-            log.warn("[{}] Failed to update local-policy configuration for namespace {}: does not exist",
+            log.warn("[{}] Failed to get local-policy configuration for namespace {}: does not exist",
                     clientAppId(), namespaceName);
             throw new RestException(Status.NOT_FOUND, "Namespace policies does not exist");
         } catch (RestException re) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +55,6 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -494,12 +494,7 @@ public class BrokerBookieIsolationTest {
         // (3) delete affinity-group
         admin.namespaces().deleteBookieAffinityGroup(ns2);
 
-        try {
-            admin.namespaces().getBookieAffinityGroup(ns2);
-            fail("should have fail due to affinity-group not present");
-        } catch (NotFoundException e) {
-            // Ok
-        }
+        assertNull(admin.namespaces().getBookieAffinityGroup(ns2));
 
         assertEquals(admin.namespaces().getBookieAffinityGroup(ns3),
                 BookieAffinityGroupData.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -214,6 +214,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(tenantAdmin.namespaces().getPublishRate(namespace), publishRate);
         tenantAdmin.namespaces().removePublishRate(namespace);
         assertNull(tenantAdmin.namespaces().getPublishRate(namespace));
+        assertNull(superAdmin.namespaces().getBookieAffinityGroup(namespace));
 
         // test for `topic-dispatch-rate`
         DispatchRate dispatchRate = DispatchRate.builder()


### PR DESCRIPTION
### Motivation
~~Currently, there are some namespace operations that only `superUser` can access. In fact, `tenantAdmin` of this namespace should also be able to access.~~
~~The namespace operations involved includes:~~
- ~~set-bookie-affinity-group~~
- ~~get-bookie-affinity-group~~
- ~~split-namespace-bundle~~
- ~~unload-namespace-bundle~~

It is similar to this [PR](https://github.com/apache/pulsar/pull/13237#issue-1077409702), we should return `null` instead of `RestException`.

### Documentation  
- [x] `no-need-doc` 
