### PR TITLE
[broker] Fix compatibility issue with other metadata store implementations in resources

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -152,6 +152,20 @@ public class BaseResources<T> {
         return cache.delete(path);
     }
 
+    protected CompletableFuture<Void> deleteIgnoreNotFoundAsync(String path) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        cache.delete(path).whenComplete((ignore, ex) -> {
+            if (ex instanceof MetadataStoreException.NotFoundException) {
+                future.complete(null);
+            } else if (ex != null) {
+                future.completeExceptionally(ex);
+            } else {
+                future.complete(null);
+            }
+        });
+        return future;
+    }
+
     protected boolean exists(String path) throws MetadataStoreException {
         try {
             return cache.exists(path).get(operationTimeoutSec, TimeUnit.SECONDS);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -152,7 +152,7 @@ public class BaseResources<T> {
         return cache.delete(path);
     }
 
-    protected CompletableFuture<Void> deleteIgnoreNotFoundAsync(String path) {
+    protected CompletableFuture<Void> deleteIfExistsAsync(String path) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         cache.delete(path).whenComplete((ignore, ex) -> {
             if (ex != null && ex.getCause() instanceof MetadataStoreException.NotFoundException) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -155,7 +155,7 @@ public class BaseResources<T> {
     protected CompletableFuture<Void> deleteIgnoreNotFoundAsync(String path) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         cache.delete(path).whenComplete((ignore, ex) -> {
-            if (ex instanceof MetadataStoreException.NotFoundException) {
+            if (ex != null && ex.getCause() instanceof MetadataStoreException.NotFoundException) {
                 future.complete(null);
             } else if (ex != null) {
                 future.completeExceptionally(ex);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
@@ -29,7 +29,6 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.CacheGetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.zookeeper.KeeperException;
 
 public class LocalPoliciesResources extends BaseResources<LocalPolicies> {
 
@@ -85,17 +84,7 @@ public class LocalPoliciesResources extends BaseResources<LocalPolicies> {
 
     public CompletableFuture<Void> deleteLocalPoliciesTenantAsync(String tenant) {
         final String localPoliciesPath = joinPath(LOCAL_POLICIES_ROOT, tenant);
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteAsync(localPoliciesPath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause().getCause() instanceof KeeperException) {
-                future.complete(null);
-            } else if (ex != null) {
-                future.completeExceptionally(ex);
-            } else {
-                future.complete(null);
-            }
-        });
-        return future;
+        return deleteIgnoreNotFoundAsync(localPoliciesPath);
     }
 
     public static boolean isLocalPoliciesPath(String path) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -38,7 +38,6 @@ import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,35 +134,13 @@ public class NamespaceResources extends BaseResources<Policies> {
     // clear resource of `/namespace/{namespaceName}` for zk-node
     public CompletableFuture<Void> deleteNamespaceAsync(NamespaceName ns) {
         final String namespacePath = joinPath(NAMESPACE_BASE_PATH, ns.toString());
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteAsync(namespacePath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
-                future.complete(null);
-            } else if (ex != null) {
-                future.completeExceptionally(ex);
-            } else {
-                future.complete(null);
-            }
-        });
-
-        return future;
+        return deleteIgnoreNotFoundAsync(namespacePath);
     }
 
     // clear resource of `/namespace/{tenant}` for zk-node
     public CompletableFuture<Void> deleteTenantAsync(String tenant) {
         final String tenantPath = joinPath(NAMESPACE_BASE_PATH, tenant);
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteAsync(tenantPath).whenComplete((ignore, ex) -> {
-            if (ex != null && ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
-                future.complete(null);
-            } else if (ex != null) {
-                future.completeExceptionally(ex);
-            } else {
-                future.complete(null);
-            }
-        });
-
-        return future;
+        return deleteIgnoreNotFoundAsync(tenantPath);
     }
 
     public static NamespaceName namespaceFromPath(String path) {
@@ -266,17 +243,7 @@ public class NamespaceResources extends BaseResources<Policies> {
 
         public CompletableFuture<Void> clearPartitionedTopicTenantAsync(String tenant) {
             final String partitionedTopicPath = joinPath(PARTITIONED_TOPIC_PATH, tenant);
-            CompletableFuture<Void> future = new CompletableFuture<Void>();
-            deleteAsync(partitionedTopicPath).whenComplete((ignore, ex) -> {
-                if (ex != null && ex.getCause().getCause() instanceof KeeperException.NoNodeException) {
-                    future.complete(null);
-                } else if (ex != null) {
-                    future.completeExceptionally(ex);
-                } else {
-                    future.complete(null);
-                }
-            });
-            return future;
+            return deleteIgnoreNotFoundAsync(partitionedTopicPath);
         }
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -134,13 +134,13 @@ public class NamespaceResources extends BaseResources<Policies> {
     // clear resource of `/namespace/{namespaceName}` for zk-node
     public CompletableFuture<Void> deleteNamespaceAsync(NamespaceName ns) {
         final String namespacePath = joinPath(NAMESPACE_BASE_PATH, ns.toString());
-        return deleteIgnoreNotFoundAsync(namespacePath);
+        return deleteIfExistsAsync(namespacePath);
     }
 
     // clear resource of `/namespace/{tenant}` for zk-node
     public CompletableFuture<Void> deleteTenantAsync(String tenant) {
         final String tenantPath = joinPath(NAMESPACE_BASE_PATH, tenant);
-        return deleteIgnoreNotFoundAsync(tenantPath);
+        return deleteIfExistsAsync(tenantPath);
     }
 
     public static NamespaceName namespaceFromPath(String path) {
@@ -243,7 +243,7 @@ public class NamespaceResources extends BaseResources<Policies> {
 
         public CompletableFuture<Void> clearPartitionedTopicTenantAsync(String tenant) {
             final String partitionedTopicPath = joinPath(PARTITIONED_TOPIC_PATH, tenant);
-            return deleteIgnoreNotFoundAsync(partitionedTopicPath);
+            return deleteIfExistsAsync(partitionedTopicPath);
         }
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

There are some direct usages of zookeeper in brokers, these should be fixed as we supports multi metadata store implementations now.

### Modifications

Add a common `deleteIgnoreNotFoundAsync` in `BaseResources` which will not throw exception while deleting a non-exists path.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:
- org.apache.pulsar.broker.admin.AdminTest#properties
- org.apache.pulsar.websocket.proxy.ProxyAuthorizationTest#test
- org.apache.pulsar.client.api.AuthenticatedProducerConsumerTest#testDeleteAuthenticationPoliciesOfTopic
- ...

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
Bug fix.