### PR TITLE
Optimize transaction FieldUpdater to static final

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -66,7 +66,7 @@ public class TransactionImpl implements Transaction , TimerTask {
     private final ArrayList<CompletableFuture<MessageId>> sendFutureList;
     private final ArrayList<CompletableFuture<Void>> ackFutureList;
     private volatile State state;
-    private final AtomicReferenceFieldUpdater<TransactionImpl, State> STATE_UPDATE =
+    private static final AtomicReferenceFieldUpdater<TransactionImpl, State> STATE_UPDATE =
         AtomicReferenceFieldUpdater.newUpdater(TransactionImpl.class, State.class, "state");
 
     @Override


### PR DESCRIPTION
### Modifications
Optimize transaction FieldUpdater to static final, to reduce memory cost.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  code optimize
 


