### PR TITLE
Apply modernizer plugin to pulsar-client-autn pulsar-websocket and pu…

### DIFF
--- a/pulsar-broker-auth-athenz/pom.xml
+++ b/pulsar-broker-auth-athenz/pom.xml
@@ -58,6 +58,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-broker-auth-sasl/pom.xml
+++ b/pulsar-broker-auth-sasl/pom.xml
@@ -111,4 +111,27 @@
       </dependencies>
     </profile>
   </profiles>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -37,6 +37,7 @@ import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER_CHEC
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,7 +50,6 @@ import javax.security.auth.login.LoginException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.AuthData;
@@ -75,7 +75,7 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
 
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {
-        this.configuration = Maps.newHashMap();
+        this.configuration = new HashMap<>();
         final String allowedIdsPatternRegExp = config.getSaslJaasClientAllowedIds();
         configuration.put(JAAS_CLIENT_ALLOWED_IDS, allowedIdsPatternRegExp);
         configuration.put(JAAS_SERVER_SECTION_NAME, config.getSaslJaasServerSectionName());

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleToken.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleToken.java
@@ -113,7 +113,7 @@ public class SaslRoleToken implements Principal {
      * Generates the token.
      */
     private void generateToken() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(USER_ROLE).append("=").append(getUserRole()).append(ATTR_SEPARATOR);
         sb.append(SESSION).append("=").append(getSession()).append(ATTR_SEPARATOR);
         sb.append(EXPIRES).append("=").append(getExpires());

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/ProxySaslAuthenticationTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/ProxySaslAuthenticationTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.authentication;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -267,7 +266,7 @@ public class ProxySaslAuthenticationTest extends ProducerConsumerBase {
 		}
 
 		Message<byte[]> msg = null;
-		Set<String> messageSet = Sets.newHashSet();
+		Set<String> messageSet = new HashSet<>();
 		for (int i = 0; i < 10; i++) {
 			msg = consumer.receive(5, TimeUnit.SECONDS);
 			String receivedMessage = new String(msg.getData());

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import javax.security.auth.login.Configuration;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.shaded.com.google.common.collect.Maps;
@@ -228,7 +227,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         }
 
         Message<byte[]> msg = null;
-        Set<String> messageSet = Sets.newHashSet();
+        Set<String> messageSet = new HashSet<>();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -61,6 +61,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -68,4 +68,26 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
+++ b/pulsar-client-auth-sasl/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationSasl.java
@@ -41,6 +41,7 @@ import static org.apache.pulsar.common.sasl.SaslConstants.SASL_TYPE_VALUE;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -55,7 +56,6 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import com.google.common.collect.Maps;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Authentication;
@@ -212,7 +212,7 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
                                                        AuthenticationDataProvider authData,
                                                        Map<String, String> previousRespHeaders) throws Exception {
 
-        Map<String, String> headers = Maps.newHashMap();
+        Map<String, String> headers = new HashMap<>();
 
         if (authData.hasDataForHttp()) {
             authData.getHttpHeaders().forEach(header ->
@@ -281,7 +281,7 @@ public class AuthenticationSasl implements Authentication, EncodedAuthentication
     }
 
     private Map<String, String> getHeaders(Response response) {
-        Map<String, String> headers = Maps.newHashMap();
+        Map<String, String> headers = new HashMap<>();
         String saslHeader = response.getHeaderString(SASL_HEADER_TYPE);
         String headerState = response.getHeaderString(SASL_HEADER_STATE);
         String authToken = response.getHeaderString(SASL_AUTH_TOKEN);

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -116,4 +116,26 @@
 			</dependencies>
 		</profile>
 	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.gaul</groupId>
+				<artifactId>modernizer-maven-plugin</artifactId>
+				<configuration>
+					<failOnViolations>true</failOnViolations>
+					<javaVersion>8</javaVersion>
+				</configuration>
+				<executions>
+					<execution>
+						<id>modernizer</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>modernizer</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
@@ -219,7 +219,7 @@ public class PerformanceClient {
         // Read payload data from file if needed
         final byte[] payloadBytes = new byte[arguments.msgSize];
         Random random = new Random(0);
-        List<byte[]> payloadByteList = Lists.newArrayList();
+        List<byte[]> payloadByteList = new ArrayList<>();
         if (arguments.payloadFilename != null) {
             Path payloadFilePath = Paths.get(arguments.payloadFilename);
             if (Files.notExists(payloadFilePath) || Files.size(payloadFilePath) == 0)  {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -30,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -59,7 +60,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 
 public class PerformanceConsumer {
@@ -258,7 +258,7 @@ public class PerformanceConsumer {
             // keep compatibility with the previous version
             if (arguments.topic.size() == 1) {
                 String prefixTopicName = TopicName.get(arguments.topic.get(0)).toString().trim();
-                List<String> defaultTopics = Lists.newArrayList();
+                List<String> defaultTopics = new ArrayList<>();
                 for (int i = 0; i < arguments.numTopics; i++) {
                     defaultTopics.add(String.format("%s-%d", prefixTopicName, i));
                 }
@@ -282,7 +282,7 @@ public class PerformanceConsumer {
                 if (arguments.subscriberName == null) {
                     arguments.subscriberName = arguments.subscriptions.get(0);
                 }
-                List<String> defaultSubscriptions = Lists.newArrayList();
+                List<String> defaultSubscriptions = new ArrayList<>();
                 for (int i = 0; i < arguments.numSubscriptions; i++) {
                     defaultSubscriptions.add(String.format("%s-%d", arguments.subscriberName, i));
                 }
@@ -477,7 +477,7 @@ public class PerformanceConsumer {
 
         };
 
-        List<Future<Consumer<ByteBuffer>>> futures = Lists.newArrayList();
+        List<Future<Consumer<ByteBuffer>>> futures = new ArrayList<>();
         ConsumerBuilder<ByteBuffer> consumerBuilder = pulsarClient.newConsumer(Schema.BYTEBUFFER) //
                 .messageListener(listener) //
                 .receiverQueueSize(arguments.receiverQueueSize) //

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -28,7 +28,6 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -41,6 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -312,7 +312,7 @@ public class PerformanceProducer {
             // keep compatibility with the previous version
             if (arguments.topics.size() == 1) {
                 String prefixTopicName = arguments.topics.get(0);
-                List<String> defaultTopics = Lists.newArrayList();
+                List<String> defaultTopics = new ArrayList<>();
                 for (int i = 0; i < arguments.numTopics; i++) {
                     defaultTopics.add(String.format("%s%s%d", prefixTopicName, arguments.separator, i));
                 }
@@ -377,7 +377,7 @@ public class PerformanceProducer {
         // Read payload data from file if needed
         final byte[] payloadBytes = new byte[arguments.msgSize];
         Random random = new Random(0);
-        List<byte[]> payloadByteList = Lists.newArrayList();
+        List<byte[]> payloadByteList = new ArrayList<>();
         if (arguments.payloadFilename != null) {
             Path payloadFilePath = Paths.get(arguments.payloadFilename);
             if (Files.notExists(payloadFilePath) || Files.size(payloadFilePath) == 0)  {
@@ -557,7 +557,7 @@ public class PerformanceProducer {
         PulsarClient client = null;
         try {
             // Now processing command line arguments
-            List<Future<Producer<byte[]>>> futures = Lists.newArrayList();
+            List<Future<Producer<byte[]>>> futures = new ArrayList<>();
 
             ClientBuilder clientBuilder = PulsarClient.builder() //
                     .enableTransaction(arguments.isEnableTransaction)//
@@ -641,7 +641,7 @@ public class PerformanceProducer {
                 }
             }
 
-            final List<Producer<byte[]>> producers = Lists.newArrayListWithCapacity(futures.size());
+            final List<Producer<byte[]>> producers = new ArrayList<>(futures.size());
             for (Future<Producer<byte[]>> future : futures) {
                 producers.add(future.get());
             }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -28,10 +28,10 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.RateLimiter;
 import java.io.FileInputStream;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -162,7 +162,7 @@ public class PerformanceReader {
             // keep compatibility with the previous version
             if (arguments.topic.size() == 1) {
                 String prefixTopicName = arguments.topic.get(0);
-                List<String> defaultTopics = Lists.newArrayList();
+                List<String> defaultTopics = new ArrayList<>();
                 for (int i = 0; i < arguments.numTopics; i++) {
                     defaultTopics.add(String.format("%s-%d", prefixTopicName, i));
                 }
@@ -273,7 +273,7 @@ public class PerformanceReader {
 
         PulsarClient pulsarClient = clientBuilder.build();
 
-        List<CompletableFuture<Reader<byte[]>>> futures = Lists.newArrayList();
+        List<CompletableFuture<Reader<byte[]>>> futures = new ArrayList<>();
 
         MessageId startMessageId;
         if ("earliest".equals(arguments.startMessageId)) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -26,12 +26,12 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.collect.Lists;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -667,12 +667,12 @@ public class PerformanceTransaction {
                 .subscriptionInitialPosition(arguments.subscriptionInitialPosition);
 
         Iterator<String> consumerTopicsIterator = arguments.consumerTopic.iterator();
-        List<List<Consumer<byte[]>>> consumers = Lists.newArrayListWithCapacity(arguments.consumerTopic.size());
+        List<List<Consumer<byte[]>>> consumers = new ArrayList<>(arguments.consumerTopic.size());
         while(consumerTopicsIterator.hasNext()){
             String topic = consumerTopicsIterator.next();
-            final List<Consumer<byte[]>> subscriptions = Lists.newArrayListWithCapacity(arguments.numSubscriptions);
+            final List<Consumer<byte[]>> subscriptions = new ArrayList<>(arguments.numSubscriptions);
             final List<Future<Consumer<byte[]>>> subscriptionFutures =
-                    Lists.newArrayListWithCapacity(arguments.numSubscriptions);
+                    new ArrayList<>(arguments.numSubscriptions);
             log.info("Create subscriptions for topic {}", topic);
             for (int j = 0; j < arguments.numSubscriptions; j++) {
                 String subscriberName = arguments.subscriptions.get(j);
@@ -694,12 +694,12 @@ public class PerformanceTransaction {
         ProducerBuilder<byte[]> producerBuilder = client.newProducer(Schema.BYTES)
                 .sendTimeout(0, TimeUnit.SECONDS);
 
-        final List<Future<Producer<byte[]>>> producerFutures = Lists.newArrayList();
+        final List<Future<Producer<byte[]>>> producerFutures = new ArrayList<>();
         for (String topic : arguments.producerTopic) {
             log.info("Create producer for topic {}", topic);
             producerFutures.add(producerBuilder.clone().topic(topic).createAsync());
         }
-        final List<Producer<byte[]>> producers = Lists.newArrayListWithCapacity(producerFutures.size());
+        final List<Producer<byte[]>> producers = new ArrayList<>(producerFutures.size());
 
         for (Future<Producer<byte[]>> future : producerFutures) {
             producers.add(future.get());

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/utils/PaddingDecimalFormat.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/utils/PaddingDecimalFormat.java
@@ -61,7 +61,7 @@ public class PaddingDecimalFormat extends DecimalFormat {
         int numLength = toAppendTo.length() - initLength;
         int padLength = minimumLength - numLength;
         if (padLength > 0) {
-            StringBuffer pad = new StringBuffer(padLength);
+            StringBuilder pad = new StringBuilder(padLength);
             for (int i = 0; i < padLength; i++) {
                 pad.append(' ');
             }

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -127,6 +127,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <failOnViolations>true</failOnViolations>
+          <javaVersion>8</javaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketProxyStatsBase.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketProxyStatsBase.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.websocket.admin;
 
-import com.google.common.collect.Maps;
-
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.ws.rs.core.Response.Status;
@@ -94,7 +93,7 @@ public class WebSocketProxyStatsBase extends WebSocketWebResource {
 
     public Map<String, ProxyTopicStat> getStat() {
 
-        Map<String, ProxyTopicStat> statMap = Maps.newHashMap();
+        Map<String, ProxyTopicStat> statMap = new HashMap<>();
 
         service().getProducers().forEach((topicName, handlers) -> {
             ProxyTopicStat topicStat = statMap.computeIfAbsent(topicName, t -> new ProxyTopicStat());

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.websocket.service;
 
-import com.google.common.collect.Lists;
-
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +52,7 @@ import org.slf4j.LoggerFactory;
 
 public class ProxyServer {
     private final Server server;
-    private final List<Handler> handlers = Lists.newArrayList();
+    private final List<Handler> handlers = new ArrayList<>();
     private final WebSocketProxyConfiguration conf;
     private final WebExecutorThreadPool executorService;
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -21,12 +21,11 @@ package org.apache.pulsar.websocket.service;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
-
-import com.google.common.collect.Sets;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -93,7 +92,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private boolean authenticationEnabled;
 
     @FieldContext(doc = "Authentication provider name list, which is a list of class names")
-    private Set<String> authenticationProviders = Sets.newTreeSet();
+    private Set<String> authenticationProviders = new TreeSet<>();
 
     @FieldContext(doc = "Enforce authorization")
     private boolean authorizationEnabled;
@@ -103,7 +102,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(doc = "Role names that are treated as \"super-user\", "
             + "which means they can do all admin operations and publish to or consume from all topics")
-    private Set<String> superUserRoles = Sets.newTreeSet();
+    private Set<String> superUserRoles = new TreeSet<>();
 
     @FieldContext(doc = "Allow wildcard matching in authorization "
             + "(wildcard matching only applicable if wildcard-char: "

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/JvmMetrics.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/JvmMetrics.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.common.stats.Metrics.create;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 
 import java.lang.management.ManagementFactory;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +59,7 @@ public class JvmMetrics {
     }
 
     public Metrics generate() {
-        Map<String, String> dimensionMap = Maps.newHashMap();
+        Map<String, String> dimensionMap = new HashMap<>();
         dimensionMap.put("system", "jvm");
         Metrics m = create(dimensionMap);
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyStats.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.websocket.stats;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import static org.apache.pulsar.websocket.ProducerHandler.ENTRY_LATENCY_BUCKETS_USEC;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -29,9 +31,6 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.websocket.WebSocketService;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,8 +52,8 @@ public class ProxyStats {
         this.service = service;
         this.jvmMetrics = new JvmMetrics(service);
         this.topicStats = new ConcurrentOpenHashMap<>();
-        this.metricsCollection = Lists.newArrayList();
-        this.tempMetricsCollection = Lists.newArrayList();
+        this.metricsCollection = new ArrayList<>();
+        this.tempMetricsCollection = new ArrayList<>();
         // schedule stat generation task every 1 minute
         service.getExecutor()
                 .scheduleAtFixedRate(catchingAndLoggingThrowables(this::generate), 120, 60, TimeUnit.SECONDS);
@@ -147,7 +146,7 @@ public class ProxyStats {
             publishMsgLatency.refresh();
             long[] latencyBuckets = publishMsgLatency.getBuckets();
 
-            Map<String, String> dimensionMap = Maps.newHashMap();
+            Map<String, String> dimensionMap = new HashMap<>();
             dimensionMap.put("namespace", namespace);
             Metrics dMetrics = Metrics.create(dimensionMap);
             dMetrics.put("ns_msg_publish_rate", numberOfMsgPublished);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyTopicStat.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/stats/ProxyTopicStat.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.websocket.stats;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.pulsar.client.api.SubscriptionMode;
@@ -25,8 +26,6 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.websocket.ConsumerHandler;
 import org.apache.pulsar.websocket.ProducerHandler;
 import org.apache.pulsar.websocket.ReaderHandler;
-
-import com.google.common.collect.Sets;
 
 /**
  * Stats of topic served by web-socket proxy. It shows current stats of producers and consumers connected to proxy for a
@@ -38,8 +37,8 @@ public class ProxyTopicStat {
     public final Set<ConsumerStats> consumerStats;
 
     public ProxyTopicStat() {
-        this.producerStats = Sets.newHashSet();
-        this.consumerStats = Sets.newHashSet();
+        this.producerStats = new HashSet<>();
+        this.consumerStats = new HashSet<>();
     }
 
     public static class ProducerStats {


### PR DESCRIPTION
Master Issue: #12271

### Motivation

Apply Maven Modernizer plugin to enforce we move away from legacy APIs for pulsar-client-auth pulsar-websocket and pulsar-broker-auth modules.
### Modifications

Add Maven Modernizer plugin in pom and fix violation.

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
