### PR TITLE
[broker] Deliver messages immediately when use Key_Shared subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -829,8 +829,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     @Override
     public boolean trackDelayedDelivery(long ledgerId, long entryId, MessageMetadata msgMetadata) {
-        if (!topic.isDelayedDeliveryEnabled()) {
-            // If broker has the feature disabled, always deliver messages immediately
+        if (!topic.isDelayedDeliveryEnabled() || SubType.Key_Shared.equals(this.getType())) {
+            // If broker has the feature disabled, or the subscription type is Key_Shared,
+            // always deliver messages immediately
             return false;
         }
 


### PR DESCRIPTION
### Motivation

We should avoid delayed message work with the `Key_Shared` subscription, it is contrary to the `Key_Shared` semantics.

### Modifications

Deliver messages immediately if it is a `Key_Shared` subscription.

### Documentation

- [x] `no-need-doc` 
  
 This is a bug fix, no need doc.

