### PR TITLE
[Doc] add an important notice for 2.9.0

### DIFF
--- a/site2/website/release-notes.md
+++ b/site2/website/release-notes.md
@@ -38,6 +38,10 @@ It also includes fixes for some breaking changes introduced in 2.9.0.
 ### 2.9.0
 #### 2021-11-25
 
+**IMPORTANT NOTICE**
+
+**IT IS NOT RECOMMENDED TO USE PULSAR 2.9.0 ON PRODUCT ENVIRONMENT** since it does not include the fixes for [Log4j2 vulnerability (CVE-2021-44228)](https://pulsar.apache.org/blog/2021/12/11/Log4j-CVE/) and the [bundle unloading timeout issue](https://github.com/apache/pulsar/pull/12993).
+
 ### News and noteworthy
 - PIP-45 Pluggable metadata interface introduced many changes about ZooKeeper metadata management: consistency, resilience, stability, tech debt reduction (less code duplication)
 - Pulsar IO: Oracle Debezium connector, new Schema aware Elasticsearch sink connector


### PR DESCRIPTION
- 2.9.0 will not be announced because it is not a stable version for users to use. 

    Users need to be informed about this important info, or else they might encounter some severe problems.

- I'm considering adding this important notice to the 2.9.0 doc page (e.g., add it to the beginning of the `Run Pulsar locally` chapter) after the 2.9.0 doc set is generated.

![image](https://user-images.githubusercontent.com/50226895/146735562-fc0a49f5-a389-4324-90f4-bb09064b9193.png)

  After upgrading Docusaurus, if we can implement the "floating window" feature on the website, it is better to add the important notice as a "floating window" on the 2.9.0 doc pages. I've documented this requirement [here](https://docs.google.com/document/d/1IV35SI_F8G8cL-Vuzknc6RTGLK9_edRMpZpnrHvAWNs/edit#bookmark=id.qh7ccf1e4wfe).
![image](https://user-images.githubusercontent.com/50226895/146735978-1a5abc51-452c-420c-82df-e3291002a756.png)
