### PR TITLE
[Replication] Fix race condition in stopping replicator while it is starting

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -194,15 +194,13 @@ public abstract class AbstractReplicator {
             return CompletableFuture.completedFuture(null);
         }
 
-        if (producer != null && (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopping)
-                || STATE_UPDATER.compareAndSet(this, State.Started, State.Stopping))) {
+        if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopping)
+                || STATE_UPDATER.compareAndSet(this, State.Started, State.Stopping)) {
             log.info("[{}][{} -> {}] Disconnect replicator at position {} with backlog {}", topicName, localCluster,
                     remoteCluster, getReplicatorReadPosition(), getNumberOfEntriesInBacklog());
-            return closeProducerAsync();
         }
 
-        STATE_UPDATER.set(this, State.Stopped);
-        return CompletableFuture.completedFuture(null);
+        return closeProducerAsync();
     }
 
     public CompletableFuture<Void> remove() {


### PR DESCRIPTION
### Motivation

- similar motivation as #12724

- there was a chance for a race condition that resulted in the replicator not disconnecting if disconnect was called when the replicator was starting.

### Modifications

Modify the logic to move the chance for the race condition that leaves the replicator producer running