### PR TITLE
[Docs] Issue Form Remove "free rider"

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_request.yml
+++ b/.github/ISSUE_TEMPLATE/doc_request.yml
@@ -34,7 +34,7 @@ body:
   - type: checkboxes
     attributes:
       label: Note
-      description: Please make some research on your question before submitting a doc issue. **Free rider is not welcomed**. Thanks!
+      description: Please research your question prior to submitting doc issues.
       options:
-        - label: I have made some research on my question and I need help on docs.
+        - label: I have researched my question.
           required: true


### PR DESCRIPTION
### Motivation

The "free rider" statement is inappropriate. It will discourage contribution by those who see a problem, but have no idea what to do to fix it. It is not always the case that a user can understand how to even submit a PR.

For example this page - https://pulsar.apache.org/docs/en/client-libraries/#third-party-clients suggests that users submit a PR, but does not provide an easy way to do so.

### Modifications

Rewrote the section including improving the English

### Verifying this change

This change is a trivial change outside of the code base.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [X] `no-need-doc` 
  
  It changes the docs issue form
  

