### PR TITLE
[broker-test] make test independent of serviceConf change

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -224,7 +224,6 @@ public class ServiceConfigurationTest {
             final ServiceConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), ServiceConfiguration.class);
             final ServiceConfiguration fileConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
             List<String> toSkip = Arrays.asList("properties", "class");
-            int counter = 0;
             for (PropertyDescriptor pd : Introspector.getBeanInfo(ServiceConfiguration.class).getPropertyDescriptors()) {
                 if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
                     continue;
@@ -234,9 +233,7 @@ public class ServiceConfigurationTest {
                 final Object fileValue = pd.getReadMethod().invoke(fileConfig);
                 assertTrue(Objects.equals(javaValue, fileValue), "property '"
                         + key + "' conf/broker.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
-                counter++;
             }
-            assertEquals(counter, 378);
         }
 
     }


### PR DESCRIPTION
### Motivation
#13272 added a test to validate value of the service config and along with it has added constant value to check number of config param in the ServiceConfiguration.java which is incorrect because for every new config we need to modify that test and have to increment the counter which is not feasible and also not required. so, remove the constant config-number change and make test independent of number of config in Conf file.