### PR TITLE
[Issue 12726] [broker] Fix deadlock in metadata-store callback thread for branch 2.9

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1185,7 +1185,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                         log.info("[{}][{}] Creating producer. producerId={}", remoteAddress, topicName, producerId);
 
-                        service.getOrCreateTopic(topicName.toString()).thenAccept((Topic topic) -> {
+                        service.getOrCreateTopic(topicName.toString()).thenAcceptAsync((Topic topic) -> {
                             // Before creating producer, check if backlog quota exceeded
                             // on topic for size based limit and time based limit
                             for (BacklogQuota.BacklogQuotaType backlogQuotaType :
@@ -1250,7 +1250,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     return null;
                                 });
                             });
-                        }).exceptionally(exception -> {
+                        }, getBrokerService().getPulsar().getExecutor()).exceptionally(exception -> {
                             Throwable cause = exception.getCause();
                             if (cause instanceof NoSuchElementException) {
                                 cause = new TopicNotFoundException("Topic Not Found.");


### PR DESCRIPTION
Fixes #12726 for branch 2.9

### Motivation

See #12726

#12753 fixed this in master, but can not merged into branch 2.9.

### Modifications

Use thenAcceptAsync instead to avoid  dead lock on metadata thread.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as org.apache.pulsar.broker.admin.PersistentTopicsTest
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
Bug fix.