### PR TITLE
Fix invalid setting of enabled ciphers to fix warning from BoringSSL

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -185,9 +185,7 @@ public class KeyStoreSSLContext {
 
     private SSLEngine configureSSLEngine(SSLEngine sslEngine) {
         sslEngine.setEnabledProtocols(protocols.toArray(new String[0]));
-        if (this.ciphers == null) {
-            sslEngine.setEnabledCipherSuites(sslEngine.getSupportedCipherSuites());
-        } else {
+        if (this.ciphers != null) {
             sslEngine.setEnabledCipherSuites(this.ciphers.toArray(new String[0]));
         }
 


### PR DESCRIPTION
### Motivation

When running pulsar-admin and connecting to a broker with TLS, the first two lines of output in standard output are warnings from Netty / BoringSSL:
```
17:15:47.460 [main] INFO  io.netty.handler.ssl.ReferenceCountedOpenSslContext - BoringSSL doesn't allow to enable or disable TLSv1.3 ciphers explicitly. Provided TLSv1.3 ciphers: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384', default TLSv1.3 ciphers that will be used: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'.
17:15:47.814 [main] INFO  io.netty.handler.ssl.ReferenceCountedOpenSslContext - BoringSSL doesn't allow to enable or disable TLSv1.3 ciphers explicitly. Provided TLSv1.3 ciphers: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384', default TLSv1.3 ciphers that will be used: 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'.
```
This is annoying since it garbles the output.

### Modifications

Don't call `sslEngine.setEnabledCipherSuites(sslEngine.getSupportedCipherSuites())` at all since it is useless. That's what causes the issue.

