### PR TITLE
Improve clarity of the Log4Shell CVE blog post

### DIFF
--- a/site2/website/blog/2021-12-11-Log4j-CVE.md
+++ b/site2/website/blog/2021-12-11-Log4j-CVE.md
@@ -8,9 +8,10 @@ allow remote execution for attackers.
 
 The vulnerability issue is described and tracked under [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228).
 
-Current releases of Apache Pulsar are bundling Log4j2 versions that are
-affected by this vulnerability. We strongly recommend to follow the advisory of the
-Apache Log4j community and patch your systems as soon as possible.
+Current releases of Apache Pulsar are bundling Log4j2 versions that are affected by this vulnerability.
+Default configuration, combined with JVM version and other factors, can render it exploitable.
+We strongly recommend to follow the advisory of the Apache Log4j community and patch your systems 
+as soon as possible, as well as looking for unexpected behavior in your Pulsar logs.
 
 There are 2 workarounds to patch a Pulsar deployments. You can set either of:
 


### PR DESCRIPTION
### Motivation

- There was feedback from Senior Security Engineer [Gabriel Marquet](https://twitter.com/gbysec) that the message about Pulsar being impacted isn't clearly communicated [in the Log4Shell CVE blog post](https://pulsar.apache.org/blog/2021/12/11/Log4j-CVE/). He proposed making the change in this PR.

- It also seems that the users@pulsar.apache.org mailing list wasn't notified about the blog post. Perhaps a second round of communications would need to go out to reach more members in the Apache Pulsar community.

### Modifications

- add a sentence that clarifies that Pulsar is also impacted