### PR TITLE
Github Workflow: websuite build - increase job timeout

### DIFF
--- a/.github/workflows/ci-pulsar-website-build.yaml
+++ b/.github/workflows/ci-pulsar-website-build.yaml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.repository == 'apache/pulsar' }}
     name: Build and publish pulsar website
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Motivation

The job times out after 2h 
https://github.com/apache/pulsar/runs/4601374159?check_suite_focus=true#logs

When the job completes it takes almost 2h, so it looks like a matter of time
https://github.com/apache/pulsar/actions/workflows/ci-pulsar-website-build.yaml

### Modifications

Raised the timeout to 3h

### Documentation

  
- [x] `no-need-doc` 
  

