### PR TITLE
[owasp] add suppression for pulsar-package-bookkeeper-storage

### DIFF
--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -33,6 +33,11 @@
     <cpe>cpe:/a:apache:zookeeper</cpe>
   </suppress>
   <suppress>
+    <notes>pulsar-package-bookkeeper-storage gets mixed with bookkeeper.</notes>
+    <gav regex="true">org\.apache\.pulsar:.*</gav>
+    <cpe>cpe:/a:apache:bookkeeper</cpe>
+  </suppress>
+  <suppress>
     <notes>kubernetes client doesn't contain CVE-2020-8554</notes>
     <gav regex="true">io\.kubernetes:.*</gav>
     <cve>CVE-2020-8554</cve>


### PR DESCRIPTION
### Motivation

OWASP job is failing again claming this vulnerability

`pulsar-package-bookkeeper-storage-2.10.0-SNAPSHOT.jar (pkg:maven/org.apache.pulsar/pulsar-package-bookkeeper-storage@2.10.0-SNAPSHOT, cpe:2.3:a:apache:bookkeeper:2.10.0:snapshot:*:*:*:*:*:*, cpe:2.3:a:apache:pulsar:2.10.0:snapshot:*:*:*:*:*:*) : CVE-2019-17571`
see [here](https://github.com/apache/pulsar/runs/4601587548?check_suite_focus=true)


### Modifications

Add suppression because it is a false positive

### Documentation

- [x] `no-need-doc` 
