### PR TITLE
[branch 2.8] [owasp] port suppressions files from master and make the check pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>6.1.5</dependency-check-maven.version>
+    <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -2169,6 +2169,10 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>dependency-check-maven</artifactId>
             <version>${dependency-check-maven.version}</version>
             <configuration>
+              <suppressionFiles>
+                <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-false-positives.xml</suppressionFile>
+                <suppressionFile>${pulsar.basedir}/src/owasp-dependency-check-suppressions.xml</suppressionFile>
+              </suppressionFiles>
               <msbuildAnalyzerEnabled>false</msbuildAnalyzerEnabled>
               <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
               <yarnAuditAnalyzerEnabled>false</yarnAuditAnalyzerEnabled>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- add supressions for false-positives detected by OWASP Dependency Check -->
+  <suppress>
+    <notes>
+      apache:http_server is not used.
+    </notes>
+    <cpe>cpe:/a:apache:http_server</cpe>
+  </suppress>
+  <suppress>
+    <notes>pulsar-zookeeper-utils gets mixed with zookeeper.</notes>
+    <gav regex="true">org\.apache\.pulsar:.*</gav>
+    <cpe>cpe:/a:apache:zookeeper</cpe>
+  </suppress>
+  <suppress>
+    <notes>pulsar-package-bookkeeper-storage gets mixed with bookkeeper.</notes>
+    <gav regex="true">org\.apache\.pulsar:.*</gav>
+    <cpe>cpe:/a:apache:bookkeeper</cpe>
+  </suppress>
+  <suppress>
+    <notes>kubernetes client doesn't contain CVE-2020-8554</notes>
+    <gav regex="true">io\.kubernetes:.*</gav>
+    <cve>CVE-2020-8554</cve>
+  </suppress>
+  <suppress>
+    <notes>avro doesn't contain CVE-2019-17195</notes>
+    <gav regex="true">org\.apache\.avro:.*</gav>
+    <cve>CVE-2019-17195</cve>
+  </suppress>
+  <suppress base="true">
+    <notes><![CDATA[
+        FP per #3889
+        ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+    <cpe>cpe:/a:netty:netty</cpe>
+  </suppress>
+</suppressions>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- add supressions for known vulnerabilities detected by OWASP Dependency Check -->
+  <suppress>
+    <notes>Ignore netty CVEs in GRPC shaded Netty.</notes>
+    <filePath regex="true">.*grpc-netty-shaded.*</filePath>
+    <cpe>cpe:/a:netty:netty</cpe>
+  </suppress>
+  <suppress>
+    <notes>Suppress all pulsar-presto-distribution vulnerabilities</notes>
+    <filePath regex="true">.*pulsar-presto-distribution-.*</filePath>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress libthrift-0.12.0.jar vulnerabilities</notes>
+    <gav>org.apache.thrift:libthrift:0.12.0</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress vert.x 3.5.4 vulnerabilities</notes>
+    <gav regex="true">io\.vertx:.*:3\.5\.4</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+  <suppress>
+    <notes>Suppress Zookeeper 3.6.2 vulnerabilities</notes>
+    <gav regex="true">org\.apache\.zookeeper:.*:3\.6\.2</gav>
+    <vulnerabilityName regex="true">.*</vulnerabilityName>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
### Motivation

The owasp dependency check fails because the suppressions we have in the master branch are missing

### Modifications

* Aligned the plugin version to the master branch one (6.1.5 -> 6.1.6)
* Added the suppressions (copied from the master branch)

Now the owasp check passes  

### Documentation

- [x] `no-need-doc` 
  