### PR TITLE
[kafka-connect-adaptor] Map headers to properties when converting a record

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -213,9 +214,19 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
         KafkaSchemaWrappedSchema valueSchema;
 
+        Map<String, String> properties;
+
         AbstractKafkaSourceRecord(SourceRecord srcRecord) {
             this.destinationTopic = Optional.of("persistent://"+topicNamespace + "/" + srcRecord.topic());
             this.partitionIndex = Optional.ofNullable(srcRecord.kafkaPartition());
+            properties = new HashMap<>();
+            if (srcRecord.headers() != null) {
+                for (Header header : srcRecord.headers()) {
+                    if (header.value() != null) {
+                        properties.put(header.key(), header.value().toString());
+                    }
+                }
+            }
         }
 
         @Override
@@ -230,7 +241,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
         @Override
         public Map<String, String> getProperties() {
-            return PROPERTIES;
+            return properties;
         }
 
         public boolean isEmpty() {

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectHeadersTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectHeadersTest.java
@@ -1,0 +1,236 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.kafka.connect;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.connect.file.FileStreamSourceConnector;
+import org.apache.kafka.connect.runtime.TaskConfig;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.source.PulsarRecord;
+import org.apache.pulsar.io.core.SinkContext;
+import org.apache.pulsar.io.core.SourceContext;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+
+@Slf4j
+public class KafkaConnectHeadersTest extends ProducerConsumerBase {
+    private Map<String, Object> config = new HashMap<>();
+    private String sourceOffsetTopicName;
+    // The topic to publish data to, for kafkaSource
+    private String topicName;
+    private KafkaConnectSource kafkaConnectSource;
+    private File tempFile;
+    private SourceContext sourceContext;
+    private PulsarClient client;
+
+    private String sinkOffsetTopicName = "persistent://my-property/my-ns/kafka-connect-sink-offset";
+
+    private Path file;
+    private Map<String, Object> props;
+    private SinkContext sinkContext;
+
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+        config.put(TaskConfig.TASK_CLASS_CONFIG,
+                "org.apache.kafka.connect.file.FileStreamSourceTask");
+        config.put(PulsarKafkaWorkerConfig.KEY_CONVERTER_CLASS_CONFIG,
+                "org.apache.kafka.connect.storage.StringConverter");
+        config.put(PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG,
+                "org.apache.pulsar.io.kafka.connect.StringConverterWithHeaders");
+
+        this.sourceOffsetTopicName = "persistent://my-property/my-ns/kafka-connect-source-offset";
+        config.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, sourceOffsetTopicName);
+
+        this.topicName = "persistent://my-property/my-ns/kafka-connect-source";
+        config.put(FileStreamSourceConnector.TOPIC_CONFIG, topicName);
+        tempFile = File.createTempFile("some-file-name", null);
+        config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsoluteFile().toString());
+        config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG,
+                String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE));
+
+        this.sourceContext = mock(SourceContext.class);
+
+        file = Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+
+        props = Maps.newHashMap();
+        props.put("topic", "test-topic");
+        props.put("offsetStorageTopic", sinkOffsetTopicName);
+        props.put("kafkaConnectorSinkClass",
+                "org.apache.kafka.connect.file.FileStreamSinkConnector");
+
+        Map<String, String> kafkaConnectorProps = Maps.newHashMap();
+        kafkaConnectorProps.put("file", file.toString());
+        props.put("kafkaConnectorConfigProperties", kafkaConnectorProps);
+
+        this.sinkContext = mock(SinkContext.class);
+
+        this.client = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .build();
+        when(sinkContext.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
+        when(sinkContext.getPulsarClient()).thenReturn(this.client);
+        when(sourceContext.getPulsarClient()).thenReturn(this.client);
+
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        if (this.client != null) {
+            this.client.close();
+        }
+        tempFile.delete();
+
+        if (file != null && Files.exists(file)) {
+            Files.delete(file);
+        }
+
+        super.internalCleanup();
+    }
+
+    protected void completedFlush(Throwable error, Void result) {
+        if (error != null) {
+            log.error("Failed to flush {} offsets to storage: ", this, error);
+        } else {
+            log.info("Finished flushing {} offsets to storage", this);
+        }
+    }
+
+    @Test
+    public void testSourceOpenAndRead() throws Exception {
+        kafkaConnectSource = new KafkaConnectSource();
+        kafkaConnectSource.open(config, sourceContext);
+
+        // use FileStreamSourceConnector, each line is a record, need "\n" and end of each record.
+        OutputStream os = Files.newOutputStream(tempFile.toPath());
+
+        String line1 = "This is the first line\n";
+        os.write(line1.getBytes());
+        os.flush();
+
+        // Note: FileStreamSourceTask read the whole line as Value, and set Key as null.
+        Record<KeyValue<byte[], byte[]>> record = kafkaConnectSource.read();
+        String readBack1 = new String(record.getValue().getValue());
+        assertTrue(line1.contains(readBack1));
+        assertNull(record.getValue().getKey());
+        log.info("read line1: {}", readBack1);
+        record.ack();
+
+        assertTrue(record.getProperties().get("test-header").contains("test-header-value"));
+    }
+
+    private GenericRecord getGenericRecord(Object value, Schema schema) {
+        final GenericRecord rec;
+        if (value instanceof GenericRecord) {
+            rec = (GenericRecord) value;
+        } else {
+            rec = MockGenericObjectWrapper.builder()
+                    .nativeObject(value)
+                    .schemaType(schema != null ? schema.getSchemaInfo().getType() : null)
+                    .schemaVersion(new byte[]{1}).build();
+        }
+        return rec;
+    }
+
+    @Test
+    public void testSink() throws Exception {
+        KafkaConnectSink sink = new KafkaConnectSink();
+        sink.open(props, sinkContext);SinkTask task = spy(sink.task);
+        ArgumentCaptor<Collection<SinkRecord>> recordsCapture =
+                ArgumentCaptor.forClass(Collection.class);
+        doCallRealMethod().when(task).put(recordsCapture.capture());
+        sink.task = task;
+        Schema schema = Schema.STRING;
+
+        final GenericRecord rec = getGenericRecord("This is a test", schema);
+        Message msg = mock(MessageImpl.class);
+        when(msg.getValue()).thenReturn(rec);
+        when(msg.getKey()).thenReturn("key");
+        when(msg.hasKey()).thenReturn(true);
+        when(msg.getProperties()).thenReturn(ImmutableMap.of("test-header", "test-value"));
+        when(msg.getMessageId()).thenReturn(new MessageIdImpl(1, 0, 0));
+
+
+        final AtomicInteger status = new AtomicInteger(0);
+        Record<GenericObject> record = PulsarRecord.<String>builder()
+                .topicName("fake-topic")
+                .message(msg)
+                .schema(schema)
+                .ackFunction(status::incrementAndGet)
+                .failFunction(status::decrementAndGet)
+                .build();
+
+        sink.write(record);
+        sink.flush();
+
+        assertEquals(status.get(), 1);
+        assertTrue(recordsCapture.getValue() != null);
+        assertTrue(!recordsCapture.getValue().isEmpty());
+        assertTrue("test-value".equals(recordsCapture
+                .getValue()
+                .iterator()
+                .next()
+                .headers()
+                .lastWithName("test-header")
+                .value()));
+        sink.close();
+    }
+}

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/SchemaedFileStreamSinkTask.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/SchemaedFileStreamSinkTask.java
@@ -77,7 +77,9 @@ public class SchemaedFileStreamSinkTask extends FileStreamSinkTask {
                         om.writeValueAsString(recOut),
                         record.kafkaOffset(),
                         record.timestamp(),
-                        record.timestampType());
+                        record.timestampType(),
+                        record.headers()
+                        );
                 out.add(toSink);
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/StringConverterWithHeaders.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/StringConverterWithHeaders.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.kafka.connect;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.storage.StringConverter;
+
+public class StringConverterWithHeaders extends StringConverter {
+    @Override
+    public byte[] fromConnectData(String topic, Headers headers, Schema schema, Object value) {
+        headers.add("test-header", "test-header-value".getBytes());
+        return super.fromConnectData(topic, headers, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
+        return super.toConnectData(topic, headers, value);
+    }
+
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

This PR maps the properties to source record headers back and forth to support connectors/converters using the headers to store information like the schema id.

### Modifications

- Change the task to be visible for test
- Updates the sink and source classes to map the headers to pulsar properties 

### Verifying this change

This change added tests and can be verified as follows:

  -  Add a new test to verify the headers are used from the source and sinks

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no)
  - The public API: no
  - The schema:  no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


