### PR TITLE
[#13416] Test independent of config change

### DIFF
--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -27,11 +27,9 @@ import java.beans.PropertyDescriptor;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 @Test(groups = "broker")
 public class ProxyConfigurationTest {
@@ -42,7 +40,6 @@ public class ProxyConfigurationTest {
             final ProxyConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), ProxyConfiguration.class);
             final ProxyConfiguration fileConfig = PulsarConfigurationLoader.create(stream, ProxyConfiguration.class);
             List<String> toSkip = Arrays.asList("properties", "class");
-            int counter = 0;
             for (PropertyDescriptor pd : Introspector.getBeanInfo(ProxyConfiguration.class).getPropertyDescriptors()) {
                 if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
                     continue;
@@ -50,11 +47,9 @@ public class ProxyConfigurationTest {
                 final String key = pd.getName();
                 final Object javaValue = pd.getReadMethod().invoke(javaConfig);
                 final Object fileValue = pd.getReadMethod().invoke(fileConfig);
-                assertTrue(Objects.equals(javaValue, fileValue), "property '"
-                        + key + "' conf/proxy.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
-                counter++;
+                assertEquals(fileValue, javaValue, "property '"
+                        + key + "' conf/proxy.conf default value doesn't match java default value\nConf: " + fileValue + "\nJava: " + javaValue);
             }
-            assertEquals(79, counter);
         }
     }
 

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/service/WebSocketProxyConfigurationTest.java
@@ -26,11 +26,9 @@ import java.beans.PropertyDescriptor;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 @Test(groups = "broker")
 public class WebSocketProxyConfigurationTest {
@@ -41,7 +39,6 @@ public class WebSocketProxyConfigurationTest {
             final WebSocketProxyConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), WebSocketProxyConfiguration.class);
             final WebSocketProxyConfiguration fileConfig = PulsarConfigurationLoader.create(stream, WebSocketProxyConfiguration.class);
             List<String> toSkip = Arrays.asList("properties", "class");
-            int counter = 0;
             for (PropertyDescriptor pd : Introspector.getBeanInfo(WebSocketProxyConfiguration.class).getPropertyDescriptors()) {
                 if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
                     continue;
@@ -49,11 +46,9 @@ public class WebSocketProxyConfigurationTest {
                 final String key = pd.getName();
                 final Object javaValue = pd.getReadMethod().invoke(javaConfig);
                 final Object fileValue = pd.getReadMethod().invoke(fileConfig);
-                assertTrue(Objects.equals(javaValue, fileValue), "property '"
-                        + key + "' conf/websocket.conf default value doesn't match java default value\nConf: "+ fileValue + "\nJava: " + javaValue);
-                counter++;
+                assertEquals(fileValue, javaValue, "property '"
+                        + key + "' conf/websocket.conf default value doesn't match java default value\nConf: " + fileValue + "\nJava: " + javaValue);
             }
-            assertEquals(36, counter);
         }
     }
 


### PR DESCRIPTION
### Motivation
Related to #13416, we should also change the test of `proxy` and `websocket`

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  simple unit test changes, no need doc


