### PR TITLE
[configuration]exposeBunlesMetricsInPrometheus

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1233,7 +1233,7 @@ exposeManagedCursorMetricsInPrometheus=false
 metricsServletTimeoutMs=30000
 
 # Enable or disable broker bundles metrics. The default value is false.
-exposeBunlesMetricsInPrometheus
+exposeBunlesMetricsInPrometheus=false
 
 ### --- Functions --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1233,7 +1233,7 @@ exposeManagedCursorMetricsInPrometheus=false
 metricsServletTimeoutMs=30000
 
 # Enable or disable broker bundles metrics. The default value is false.
-exposeBunlesMetricsInPrometheus=false
+exposeBundlesMetricsInPrometheus=false
 
 ### --- Functions --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1232,6 +1232,9 @@ exposeManagedCursorMetricsInPrometheus=false
 # Set it to 0 to disable timeout.
 metricsServletTimeoutMs=30000
 
+#Enable or disable the broker bundles metrics. default is false
+exposeBunlesMetricsInPrometheus
+
 ### --- Functions --- ###
 
 # Enable Functions Worker Service in Broker

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1232,7 +1232,7 @@ exposeManagedCursorMetricsInPrometheus=false
 # Set it to 0 to disable timeout.
 metricsServletTimeoutMs=30000
 
-#Enable or disable the broker bundles metrics. default is false
+# Enable or disable broker bundles metrics. The default value is false.
 exposeBunlesMetricsInPrometheus
 
 ### --- Functions --- ###

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2230,7 +2230,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_METRICS,
             doc = "Enable expose the broker bundles metrics."
     )
-    private boolean exposeBunlesMetricsInPrometheus = false;
+    private boolean exposeBundlesMetricsInPrometheus = false;
 
     /**** --- Functions --- ****/
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -916,7 +916,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             final SystemResourceUsage systemResourceUsage = LoadManagerShared.getSystemResourceUsage(brokerHostUsage);
             localData.update(systemResourceUsage, getBundleStats());
             updateLoadBalancingMetrics(systemResourceUsage);
-            if (conf.isExposeBunlesMetricsInPrometheus()) {
+            if (conf.isExposeBundlesMetricsInPrometheus()) {
                 updateLoadBalancingBundlesMetrics(getBundleStats());
             }
         } catch (Exception e) {


### PR DESCRIPTION
Issue #12366  support expose bundles metrics to prometheus, but forget add configuration `exposeBunlesMetricsInPrometheus` to broker.conf.



### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
doc already added in #12825  
- [ ] `doc` 
  
  (If this PR contains doc changes)


