### PR TITLE
[Broker] Return null instead of RestException when get bookieAffinityGroup

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -999,12 +999,9 @@ public abstract class NamespacesBase extends AdminResource {
             final BookieAffinityGroupData bookkeeperAffinityGroup = getLocalPolicies().getLocalPolicies(namespaceName)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND,
                             "Namespace local-policies does not exist")).bookieAffinityGroup;
-            if (bookkeeperAffinityGroup == null) {
-                throw new RestException(Status.NOT_FOUND, "bookie-affinity group does not exist");
-            }
             return bookkeeperAffinityGroup;
         } catch (NotFoundException e) {
-            log.warn("[{}] Failed to update local-policy configuration for namespace {}: does not exist",
+            log.warn("[{}] Failed to get local-policy configuration for namespace {}: does not exist",
                     clientAppId(), namespaceName);
             throw new RestException(Status.NOT_FOUND, "Namespace policies does not exist");
         } catch (RestException re) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +55,6 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -494,12 +494,7 @@ public class BrokerBookieIsolationTest {
         // (3) delete affinity-group
         admin.namespaces().deleteBookieAffinityGroup(ns2);
 
-        try {
-            admin.namespaces().getBookieAffinityGroup(ns2);
-            fail("should have fail due to affinity-group not present");
-        } catch (NotFoundException e) {
-            // Ok
-        }
+        assertNull(admin.namespaces().getBookieAffinityGroup(ns2));
 
         assertEquals(admin.namespaces().getBookieAffinityGroup(ns3),
                 BookieAffinityGroupData.builder()


### PR DESCRIPTION
### Motivation
It should return `null` instead of `RestException` in `NamespacesBase#internalGetBookieAffinityGroup` method, because `null` means that the `bookieAffinityGroup` is not configured on namespace-persistent policy.

It is the same as `internalGetNamespaceAntiAffinityGroup` method as below:
https://github.com/apache/pulsar/blob/f97d6e5a50355e1de628569c6de68cd7210094f0/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L1821-L1827

### Documentation
- [x] `no-need-doc` 
