### PR TITLE
Revert "[Authorization] Converge authz of ns policies from super-user to tenant-administrator (#13157)"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1178,7 +1178,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetPublishRate(PublishRate maxPublishMessageRate) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Set namespace publish-rate {}/{}", clientAppId(), namespaceName, maxPublishMessageRate);
         updatePolicies(namespaceName, policies -> {
             policies.publishMaxMessageRate.put(pulsar().getConfiguration().getClusterName(), maxPublishMessageRate);
@@ -1189,7 +1189,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalRemovePublishRate() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Remove namespace publish-rate {}/{}", clientAppId(), namespaceName, topicName);
         try {
             updatePolicies(namespaceName, policies -> {
@@ -1216,7 +1216,7 @@ public abstract class NamespacesBase extends AdminResource {
 
     @SuppressWarnings("deprecation")
     protected void internalSetTopicDispatchRate(DispatchRateImpl dispatchRate) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Set namespace dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
 
         try {
@@ -1235,7 +1235,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalDeleteTopicDispatchRate() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         try {
             updatePolicies(namespaceName, policies -> {
                 policies.topicDispatchRate.remove(pulsar().getConfiguration().getClusterName());
@@ -1260,7 +1260,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetSubscriptionDispatchRate(DispatchRateImpl dispatchRate) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Set namespace subscription dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
 
         try {
@@ -1278,7 +1278,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalDeleteSubscriptionDispatchRate() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
 
         try {
             updatePolicies(namespaceName, policies -> {
@@ -1302,7 +1302,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetSubscribeRate(SubscribeRate subscribeRate) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Set namespace subscribe-rate {}/{}", clientAppId(), namespaceName, subscribeRate);
         try {
             updatePolicies(namespaceName, policies -> {
@@ -1319,7 +1319,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalDeleteSubscribeRate() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         try {
             updatePolicies(namespaceName, policies -> {
                 policies.clusterSubscribeRate.remove(pulsar().getConfiguration().getClusterName());
@@ -1341,7 +1341,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalRemoveReplicatorDispatchRate() {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         try {
             updatePolicies(namespaceName, policies -> {
                 policies.replicatorDispatchRate.remove(pulsar().getConfiguration().getClusterName());
@@ -1357,7 +1357,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetReplicatorDispatchRate(DispatchRateImpl dispatchRate) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         log.info("[{}] Set namespace replicator dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
         try {
             updatePolicies(namespaceName, policies -> {
@@ -1758,7 +1758,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetInactiveTopic(InactiveTopicPolicies inactiveTopicPolicies) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.INACTIVE_TOPIC, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
         internalSetPolicies("inactive_topic_policies", inactiveTopicPolicies);
     }
@@ -1785,7 +1785,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetDelayedDelivery(DelayedDeliveryPolicies delayedDeliveryPolicies) {
-        validateNamespacePolicyOperation(namespaceName, PolicyName.DELAYED_DELIVERY, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
         internalSetPolicies("delayed_delivery_policies", delayedDeliveryPolicies);
     }
@@ -2179,7 +2179,7 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected void internalSetMaxSubscriptionsPerTopic(Integer maxSubscriptionsPerTopic){
-        validateNamespacePolicyOperation(namespaceName, PolicyName.MAX_SUBSCRIPTIONS, PolicyOperation.WRITE);
+        validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
         if (maxSubscriptionsPerTopic != null && maxSubscriptionsPerTopic < 0) {
             throw new RestException(Status.PRECONDITION_FAILED,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -122,8 +122,7 @@ public class Namespaces extends NamespacesBase {
     @Path("/{property}/{cluster}/{namespace}/destinations")
     @ApiOperation(hidden = true, value = "Get the list of all the topics under a certain namespace.",
             response = String.class, responseContainer = "Set")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist")})
     public void getTopics(@PathParam("property") String property,
                                   @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
@@ -901,8 +900,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{property}/{cluster}/{namespace}/clearBacklog")
     @ApiOperation(hidden = true, value = "Clear backlog for all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBacklog(@Suspended final AsyncResponse asyncResponse,
             @PathParam("property") String property, @PathParam("cluster") String cluster,
@@ -923,7 +921,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(hidden = true, value = "Clear backlog for all topics on a namespace bundle.")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBundleBacklog(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
@@ -936,8 +934,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{property}/{cluster}/{namespace}/clearBacklog/{subscription}")
     @ApiOperation(hidden = true, value = "Clear backlog for a given subscription on all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBacklogForSubscription(@Suspended final AsyncResponse asyncResponse,
             @PathParam("property") String property, @PathParam("cluster") String cluster,
@@ -958,7 +955,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(hidden = true, value = "Clear backlog for a given subscription on all topics on a namespace bundle.")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBundleBacklogForSubscription(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
@@ -971,8 +968,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{property}/{cluster}/{namespace}/unsubscribe/{subscription}")
     @ApiOperation(hidden = true, value = "Unsubscribes the given subscription on all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void unsubscribeNamespace(@Suspended final AsyncResponse asyncResponse,
             @PathParam("property") String property, @PathParam("cluster") String cluster,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/PersistentTopics.java
@@ -69,8 +69,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     @Path("/{property}/{cluster}/{namespace}")
     @ApiOperation(hidden = true, value = "Get the list of topics under a namespace.",
             response = String.class, responseContainer = "List")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin or consume permission on namespace"),
             @ApiResponse(code = 404, message = "Namespace doesn't exist")})
     public void getList(@Suspended final AsyncResponse asyncResponse, @PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) {
@@ -88,8 +87,7 @@ public class PersistentTopics extends PersistentTopicsBase {
     @Path("/{property}/{cluster}/{namespace}/partitioned")
     @ApiOperation(hidden = true, value = "Get the list of partitioned topics under a namespace.",
             response = String.class, responseContainer = "List")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin or consume permission on namespace"),
             @ApiResponse(code = 404, message = "Namespace doesn't exist")})
     public List<String> getPartitionedTopicList(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -93,8 +93,7 @@ public class Namespaces extends NamespacesBase {
     @Path("/{tenant}/{namespace}/topics")
     @ApiOperation(value = "Get the list of all the topics under a certain namespace.",
             response = String.class, responseContainer = "Set")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist")})
     public void getTopics(@PathParam("tenant") String tenant,
                                   @PathParam("namespace") String namespace,
@@ -907,8 +906,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{tenant}/{namespace}/clearBacklog")
     @ApiOperation(value = "Clear backlog for all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBacklog(@Suspended final AsyncResponse asyncResponse, @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
@@ -928,7 +926,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Clear backlog for all topics on a namespace bundle.")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBundleBacklog(@PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange,
@@ -940,8 +938,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{tenant}/{namespace}/clearBacklog/{subscription}")
     @ApiOperation(value = "Clear backlog for a given subscription on all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBacklogForSubscription(@Suspended final AsyncResponse asyncResponse,
             @PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
@@ -962,7 +959,7 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Clear backlog for a given subscription on all topics on a namespace bundle.")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void clearNamespaceBundleBacklogForSubscription(@PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace, @PathParam("subscription") String subscription,
@@ -975,8 +972,7 @@ public class Namespaces extends NamespacesBase {
     @POST
     @Path("/{tenant}/{namespace}/unsubscribe/{subscription}")
     @ApiOperation(value = "Unsubscribes the given subscription on all topics on a namespace.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace does not exist") })
     public void unsubscribeNamespace(@Suspended final AsyncResponse asyncResponse, @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -85,7 +85,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             response = String.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin or consume permission on namespace"),
             @ApiResponse(code = 404, message = "tenant/namespace/topic doesn't exit"),
             @ApiResponse(code = 412, message = "Namespace name is not valid"),
             @ApiResponse(code = 500, message = "Internal server error")})
@@ -111,7 +111,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             response = String.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
-            @ApiResponse(code = 403, message = "Don't have admin or operate permission on the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin or consume permission on namespace"),
             @ApiResponse(code = 404, message = "tenant/namespace/topic doesn't exit"),
             @ApiResponse(code = 412, message = "Namespace name is not valid"),
             @ApiResponse(code = 500, message = "Internal server error")})

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -55,14 +55,8 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
-import org.apache.pulsar.common.policies.data.DispatchRate;
-import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
-import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
-import org.apache.pulsar.common.policies.data.PublishRate;
-import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TenantOperation;
@@ -173,128 +167,6 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         } catch (PulsarClientException.AuthorizationException pa) {
             // Ok
         }
-
-        log.info("-- Exiting {} test --", methodName);
-    }
-
-    @Test
-    public void testNamespacePoliciesPermission() throws Exception {
-        log.info("-- Starting {} test --", methodName);
-
-        conf.setAuthorizationProvider(PulsarAuthorizationProvider.class.getName());
-        setup();
-
-        final String tenantRole = "tenant-role";
-        final String namespace = "my-property/my-ns-sub-auth";
-        Authentication adminAuthentication = new ClientAuthentication("superUser");
-
-        @Cleanup
-        PulsarAdmin superAdmin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
-                .authentication(adminAuthentication).build());
-
-        Authentication tenantAdminAuthentication = new ClientAuthentication(tenantRole);
-        @Cleanup
-        PulsarAdmin tenantAdmin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
-                .authentication(tenantAdminAuthentication).build());
-
-        superAdmin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
-        superAdmin.tenants().createTenant("my-property",
-                new TenantInfoImpl(Sets.newHashSet(tenantRole), Sets.newHashSet("test")));
-        superAdmin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
-
-        // verify super-user and tenant-administrator are able to perform all namespace-policies admin api
-        // test for `publish-rate`
-        PublishRate publishRate = new PublishRate(10, 100);
-        superAdmin.namespaces().setPublishRate(namespace, publishRate);
-        assertEquals(superAdmin.namespaces().getPublishRate(namespace), publishRate);
-        superAdmin.namespaces().removePublishRate(namespace);
-        assertNull(superAdmin.namespaces().getPublishRate(namespace));
-        tenantAdmin.namespaces().setPublishRate(namespace, publishRate);
-        assertEquals(tenantAdmin.namespaces().getPublishRate(namespace), publishRate);
-        tenantAdmin.namespaces().removePublishRate(namespace);
-        assertNull(tenantAdmin.namespaces().getPublishRate(namespace));
-
-        // test for `topic-dispatch-rate`
-        DispatchRate dispatchRate = DispatchRate.builder()
-                .dispatchThrottlingRateInByte(4096)
-                .dispatchThrottlingRateInMsg(1000)
-                .build();
-        superAdmin.namespaces().setDispatchRate(namespace, dispatchRate);
-        assertEquals(superAdmin.namespaces().getDispatchRate(namespace), dispatchRate);
-        superAdmin.namespaces().removeDispatchRate(namespace);
-        assertNull(superAdmin.namespaces().getDispatchRate(namespace));
-        tenantAdmin.namespaces().setDispatchRate(namespace, dispatchRate);
-        assertEquals(tenantAdmin.namespaces().getDispatchRate(namespace), dispatchRate);
-        tenantAdmin.namespaces().removeDispatchRate(namespace);
-        assertNull(tenantAdmin.namespaces().getDispatchRate(namespace));
-
-        // test for `subscription-dispatch-rate`
-        superAdmin.namespaces().setSubscriptionDispatchRate(namespace, dispatchRate);
-        assertEquals(superAdmin.namespaces().getSubscriptionDispatchRate(namespace), dispatchRate);
-        superAdmin.namespaces().removeSubscriptionDispatchRate(namespace);
-        assertNull(superAdmin.namespaces().getSubscriptionDispatchRate(namespace));
-        tenantAdmin.namespaces().setSubscriptionDispatchRate(namespace, dispatchRate);
-        assertEquals(tenantAdmin.namespaces().getSubscriptionDispatchRate(namespace), dispatchRate);
-        tenantAdmin.namespaces().removeSubscriptionDispatchRate(namespace);
-        assertNull(tenantAdmin.namespaces().getSubscriptionDispatchRate(namespace));
-
-        // test for `subscribe-rate`
-        SubscribeRate subscribeRate = new SubscribeRate(10, 60);
-        superAdmin.namespaces().setSubscribeRate(namespace, subscribeRate);
-        assertEquals(superAdmin.namespaces().getSubscribeRate(namespace), subscribeRate);
-        superAdmin.namespaces().removeSubscribeRate(namespace);
-        assertNull(superAdmin.namespaces().getSubscribeRate(namespace));
-        tenantAdmin.namespaces().setSubscribeRate(namespace, subscribeRate);
-        assertEquals(tenantAdmin.namespaces().getSubscribeRate(namespace), subscribeRate);
-        tenantAdmin.namespaces().removeSubscribeRate(namespace);
-        assertNull(tenantAdmin.namespaces().getSubscribeRate(namespace));
-
-        // test for `replicator-dispatch-rate`
-        superAdmin.namespaces().setReplicatorDispatchRate(namespace, dispatchRate);
-        assertEquals(superAdmin.namespaces().getReplicatorDispatchRate(namespace), dispatchRate);
-        superAdmin.namespaces().removeReplicatorDispatchRate(namespace);
-        assertNull(superAdmin.namespaces().getReplicatorDispatchRate(namespace));
-        tenantAdmin.namespaces().setReplicatorDispatchRate(namespace, dispatchRate);
-        assertEquals(tenantAdmin.namespaces().getReplicatorDispatchRate(namespace), dispatchRate);
-        tenantAdmin.namespaces().removeReplicatorDispatchRate(namespace);
-        assertNull(tenantAdmin.namespaces().getReplicatorDispatchRate(namespace));
-
-        // test for `inactive-topic`
-        InactiveTopicPolicies inactiveTopicPolicies = new InactiveTopicPolicies(
-                InactiveTopicDeleteMode.delete_when_no_subscriptions, 30, true);
-        superAdmin.namespaces().setInactiveTopicPolicies(namespace, inactiveTopicPolicies);
-        assertEquals(superAdmin.namespaces().getInactiveTopicPolicies(namespace), inactiveTopicPolicies);
-        superAdmin.namespaces().removeInactiveTopicPolicies(namespace);
-        assertNull(superAdmin.namespaces().getInactiveTopicPolicies(namespace));
-        tenantAdmin.namespaces().setInactiveTopicPolicies(namespace, inactiveTopicPolicies);
-        assertEquals(tenantAdmin.namespaces().getInactiveTopicPolicies(namespace), inactiveTopicPolicies);
-        tenantAdmin.namespaces().removeInactiveTopicPolicies(namespace);
-        assertNull(tenantAdmin.namespaces().getInactiveTopicPolicies(namespace));
-
-        // test for `delayed-delivery`
-        DelayedDeliveryPolicies delayedDeliveryPolicies = DelayedDeliveryPolicies.builder()
-                .tickTime(60)
-                .active(true)
-                .build();
-        superAdmin.namespaces().setDelayedDeliveryMessages(namespace, delayedDeliveryPolicies);
-        assertEquals(superAdmin.namespaces().getDelayedDelivery(namespace), delayedDeliveryPolicies);
-        superAdmin.namespaces().removeDelayedDeliveryMessages(namespace);
-        assertNull(superAdmin.namespaces().getDelayedDelivery(namespace));
-        tenantAdmin.namespaces().setDelayedDeliveryMessages(namespace, delayedDeliveryPolicies);
-        assertEquals(tenantAdmin.namespaces().getDelayedDelivery(namespace), delayedDeliveryPolicies);
-        tenantAdmin.namespaces().removeDelayedDeliveryMessages(namespace);
-        assertNull(tenantAdmin.namespaces().getDelayedDelivery(namespace));
-
-        // test for `max-subscriptions-per-topic`
-        superAdmin.namespaces().setMaxSubscriptionsPerTopic(namespace, 10);
-        assertEquals(superAdmin.namespaces().getMaxSubscriptionsPerTopic(namespace).intValue(), 10);
-        superAdmin.namespaces().removeMaxSubscriptionsPerTopic(namespace);
-        assertNull(superAdmin.namespaces().getMaxSubscriptionsPerTopic(namespace));
-        tenantAdmin.namespaces().setMaxSubscriptionsPerTopic(namespace, 20);
-        assertEquals(tenantAdmin.namespaces().getMaxSubscriptionsPerTopic(namespace).intValue(), 20);
-        tenantAdmin.namespaces().removeMaxSubscriptionsPerTopic(namespace);
-        assertNull(tenantAdmin.namespaces().getMaxSubscriptionsPerTopic(namespace));
 
         log.info("-- Exiting {} test --", methodName);
     }


### PR DESCRIPTION
### Motivation

With #13157, some namespace policies can now be changed by tenant admins as well as superusers. I don't think this change is correct.

For example, I think that the publish rate limiting is to prevent a specific tenant from inconvenience to other tenants by publishing at a very high rate. It is a problem that tenant managers can raise this on their own.

Therefore, the privilege to change the publish rate limit should only be granted to the administrators of the entire Pulsar instance, i.e. the superusers. 

### Modifications

This reverts commit #13157.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc`

