### PR TITLE
[broker]loadBalancerMemoryResourceWeight config  default value optimiz…

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1145,7 +1145,7 @@ loadBalancerCPUResourceWeight=1.0
 
 # The heap memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerMemoryResourceWeight=1.0
+loadBalancerMemoryResourceWeight=0.0
 
 # The direct memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.


### PR DESCRIPTION
### Motivation


*memory.percentUsage() value is depends on the gc trigger moment, this value has a random affect on ThresholdShedder loadBalancer strategy. it is a meaningless dimension*


###  the usage data from one broker

![企业微信截图_16403104135773](https://user-images.githubusercontent.com/5210343/147305803-45f42c19-ec9c-489d-9f98-b44205a43f8c.png)

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*
  - The default values of configurations: (yes)


  



