### PR TITLE
[feature] Pluggable consumer selector for key shared subscription type

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1430,3 +1430,6 @@ tlsEnabled=false
 # Enable Key_Shared subscription (default is enabled)
 # @deprecated since 2.8.0 subscriptionTypesEnabled is preferred over subscriptionKeySharedEnable.
 subscriptionKeySharedEnable=true
+
+#consumer selector strategy for Key shared subscription
+keySharedConsumerSelectorStrategy=org.apache.pulsar.broker.service.ConsistentHashingStickyKeyConsumerSelector

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2595,6 +2595,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private Set<String> additionalServlets = new TreeSet<>();
 
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "consumer selector strategy for Key shared subscription"
+    )
+    private String keySharedConsumerSelectorStrategy = "org.apache.pulsar.broker.service."
+            + "ConsistentHashingStickyKeyConsumerSelector";
+
     public String getMetadataStoreUrl() {
         if (StringUtils.isNotBlank(metadataStoreUrl)) {
             return metadataStoreUrl;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -239,5 +239,24 @@ public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDi
 
     private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);
 
+    public StickyKeyConsumerSelector createConsumerSelectorInstance(ServiceConfiguration conf) {
+        try {
+            Class<?> consumerSelectorClass = Class.forName(conf.getKeySharedConsumerSelectorStrategy());
+            Object consumerSelectorClassInstance = consumerSelectorClass.getDeclaredConstructor().newInstance();
+            if (consumerSelectorClassInstance instanceof StickyKeyConsumerSelector) {
+                return (StickyKeyConsumerSelector) consumerSelectorClassInstance;
+            } else {
+                log.error("create key shared consumer selector strategy failed."
+                        + "using ConsistentHashingStickyKeyConsumerSelector instead.");
+                return new ConsistentHashingStickyKeyConsumerSelector(
+                        conf.getSubscriptionKeySharedConsistentHashingReplicaPoints());
+            }
+        } catch (Exception e) {
+            log.error("Error when trying to create key shared consumer selector strategy: ", e);
+        }
+        return new ConsistentHashingStickyKeyConsumerSelector(
+                conf.getSubscriptionKeySharedConsistentHashingReplicaPoints());
+    }
+
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherMultipleConsumers.java
@@ -246,16 +246,14 @@ public abstract class AbstractDispatcherMultipleConsumers extends AbstractBaseDi
             if (consumerSelectorClassInstance instanceof StickyKeyConsumerSelector) {
                 return (StickyKeyConsumerSelector) consumerSelectorClassInstance;
             } else {
-                log.error("create key shared consumer selector strategy failed."
-                        + "using ConsistentHashingStickyKeyConsumerSelector instead.");
-                return new ConsistentHashingStickyKeyConsumerSelector(
-                        conf.getSubscriptionKeySharedConsistentHashingReplicaPoints());
+                throw new RuntimeException(String.format("Failed create KeySharedConsumerSelectorStrategy: %s."
+                        + "Class should be implemented StickyKeyConsumerSelector interface",
+                        conf.getKeySharedConsumerSelectorStrategy()));
             }
         } catch (Exception e) {
-            log.error("Error when trying to create key shared consumer selector strategy: ", e);
+            throw new RuntimeException(String.format("Failed create KeySharedConsumerSelectorStrategy: %s.",
+                    conf.getKeySharedConsumerSelectorStrategy()), e);
         }
-        return new ConsistentHashingStickyKeyConsumerSelector(
-                conf.getSubscriptionKeySharedConsistentHashingReplicaPoints());
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -47,6 +47,10 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
 
     private final int numberOfPoints;
 
+    public ConsistentHashingStickyKeyConsumerSelector() {
+        this(DEFAULT_REPLICE_POINTS);
+    }
+
     public ConsistentHashingStickyKeyConsumerSelector(int numberOfPoints) {
         this.hashRing = new TreeMap<>();
         this.numberOfPoints = numberOfPoints;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -198,8 +198,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private PulsarCommandSender commandSender;
     private final ConnectionController connectionController;
 
-    private static final KeySharedMeta emptyKeySharedMeta = new KeySharedMeta()
-            .setKeySharedMode(KeySharedMode.AUTO_SPLIT);
+    private static final KeySharedMeta customKeySharedMeta = new KeySharedMeta()
+            .setKeySharedMode(KeySharedMode.CUSTOM);
 
     // Flag to manage throttling-publish-buffer by atomically enable/disable read-channel.
     private boolean autoReadDisabledPublishBufferLimiting = false;
@@ -948,7 +948,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final boolean forceTopicCreation = subscribe.isForceTopicCreation();
         final KeySharedMeta keySharedMeta = subscribe.hasKeySharedMeta()
               ? new KeySharedMeta().copyFrom(subscribe.getKeySharedMeta())
-              : emptyKeySharedMeta;
+              : customKeySharedMeta;
 
         CompletableFuture<Boolean> isAuthorizedFuture = isTopicOperationAllowed(
                 topicName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.common.util.Murmur3_32Hash;
 public interface StickyKeyConsumerSelector {
 
     int DEFAULT_RANGE_SIZE =  2 << 15;
+    int DEFAULT_REPLICE_POINTS = 100;
 
     /**
      * Add a new consumer.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
@@ -53,7 +53,9 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
             case STICKY:
                 this.selector = new HashRangeExclusiveStickyKeyConsumerSelector();
                 break;
-
+            case CUSTOM:
+                this.selector = createConsumerSelectorInstance(topic.getBrokerService().getPulsar().getConfiguration());
+                break;
             case AUTO_SPLIT:
             default:
                 ServiceConfiguration conf = topic.getBrokerService().getPulsar().getConfiguration();
@@ -77,7 +79,7 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
                 || selector instanceof HashRangeAutoSplitStickyKeyConsumerSelector) {
             keySharedMode = KeySharedMode.AUTO_SPLIT;
         } else {
-            keySharedMode = null;
+            keySharedMode = KeySharedMode.CUSTOM;
         }
         this.selector = selector;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -94,6 +94,10 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             this.selector = new HashRangeExclusiveStickyKeyConsumerSelector();
             break;
 
+        case CUSTOM:
+            this.selector = createConsumerSelectorInstance(conf);
+            break;
+
         default:
             throw new IllegalArgumentException("Invalid key-shared mode: " + keySharedMode);
         }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedMode.java
@@ -37,5 +37,10 @@ public enum KeySharedMode {
      * New consumer with fixed hash range to attach the topic, if new consumer use conflict hash range with
      * exits consumers, new consumer will be rejected.
      */
-    STICKY
+    STICKY,
+
+    /**
+     * Custom consumer selector strategy through service configuration keySharedConsumerSelectorStrategy.
+     */
+    CUSTOM
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -45,6 +45,10 @@ public abstract class KeySharedPolicy {
         return new KeySharedPolicySticky();
     }
 
+    public static KeySharedPolicyCustom customHashRange() {
+        return new KeySharedPolicyCustom();
+    }
+
     public abstract void validate();
 
     /**
@@ -132,6 +136,21 @@ public abstract class KeySharedPolicy {
 
         KeySharedPolicyAutoSplit() {
             this.keySharedMode = KeySharedMode.AUTO_SPLIT;
+        }
+
+        @Override
+        public void validate() {
+            // do nothing here
+        }
+    }
+
+    /**
+     * Auto split hash range key shared policy.
+     */
+    public static class KeySharedPolicyCustom extends KeySharedPolicy {
+
+        KeySharedPolicyCustom() {
+            this.keySharedMode = KeySharedMode.CUSTOM;
         }
 
         @Override

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -322,6 +322,7 @@ message AuthData {
 enum KeySharedMode {
     AUTO_SPLIT = 0;
     STICKY = 1;
+    CUSTOM = 2;
 }
 
 message KeySharedMeta {


### PR DESCRIPTION
Fix  #13473

Support user defined and pluggable consumer selector by adding a broker configuration `keySharedConsumerSelectorStrategy` which default value is `org.apache.pulsar.broker.service.ConsistentHashingStickyKeyConsumerSelector`



### Modification
Currently, client can specify keySharedPolicy like this, but only support pre-defined `autoSplitHashRange` and `stickyHashRange`.
https://github.com/apache/pulsar/blob/6c7dcc0cf877cfcb8bcea18cde7662ebacb01d4c/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java#L1034-L1041

Now, custom keySharedPolicy `KeySharedPolicyCustome` is supported, and the pre configured `keySharedConsumerSelectorStrategy` will be used.

If  client  doesn't have a keySharedPolicy, `KeySharedMode.CUSTOME` will be used.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


