### PR TITLE
[Build] fix python client build failure on apline

### DIFF
--- a/pulsar-client-cpp/docker/alpine/Dockerfile
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile
@@ -91,7 +91,9 @@ RUN curl -L https://github.com/google/snappy/archive/1.1.8.tar.gz --output snapp
     rm -rf /snappy-1.1.8 /snappy-1.1.8.tar.gz
 
 
-RUN pip3 install wheel twine
+RUN pip3 install --upgrade pip && pip3 install wheel twine
 
 RUN adduser pulsar -D && \
     addgroup pulsar abuild
+
+WORKDIR /pulsar

--- a/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
+++ b/pulsar-client-cpp/docker/alpine/Dockerfile-alpine-3.8
@@ -91,7 +91,9 @@ RUN curl -L https://github.com/google/snappy/archive/1.1.8.tar.gz --output snapp
     rm -rf /snappy-1.1.8 /snappy-1.1.8.tar.gz
 
 
-RUN pip3 install wheel twine
+RUN pip3 install --upgrade pip && pip3 install wheel twine
 
 RUN adduser pulsar -D && \
     addgroup pulsar abuild
+
+WORKDIR /pulsar

--- a/pulsar-client-cpp/docker/alpine/build-wheel-file-within-docker.sh
+++ b/pulsar-client-cpp/docker/alpine/build-wheel-file-within-docker.sh
@@ -25,14 +25,15 @@ cd $ROOT_DIR/pulsar-client-cpp
 PYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR:-/usr/include/python3.8}
 PYTHON_LIBRARY=${PYTHON_LIBRARY:-/usr/lib/python3.8}
 
-cmake .  -DBUILD_TESTS=OFF \
-          -DBUILD_PYTHON_WRAPPER=ON \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DLINK_STATIC=ON  \
-          -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
-          -DPYTHON_LIBRARY=${PYTHON_LIBRARY}
+cmake . -DBUILD_TESTS=OFF \
+        -DBUILD_PYTHON_WRAPPER=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLINK_STATIC=ON  \
+        -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
+        -DPYTHON_LIBRARY=${PYTHON_LIBRARY} \
+        -DCMAKE_CXX_FLAGS="-Wno-error=array-bounds"
 
-make -j2 _pulsar
+make -j$(grep -c ^processor /proc/cpuinfo) _pulsar
 
 cd python
 python3 setup.py bdist_wheel

--- a/pulsar-client-cpp/docker/alpine/build-wheel.sh
+++ b/pulsar-client-cpp/docker/alpine/build-wheel.sh
@@ -24,11 +24,12 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 PROJECT_VERSION=$(python $ROOT_DIR/src/get-project-version.py)
 IMAGE_NAME=${IMAGE_NAME:-apachepulsar/pulsar-build:alpine-3.11}
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
-cd $ROOT_DIR
-
+pushd $ROOT_DIR
 echo "Using image: $IMAGE_NAME"
 VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
 COMMAND="/pulsar/pulsar-client-cpp/docker/alpine/build-wheel-file-within-docker.sh"
-DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE_NAME}"
+DOCKER_CMD="docker run -i ${VOLUME_OPTION} -e USE_FULL_POM_NAME -e NAME_POSTFIX ${IMAGE_NAME}"
+
+echo "Using command: $DOCKER_CMD"
 $DOCKER_CMD bash -c "${COMMAND}"
+popd


### PR DESCRIPTION

Master Issue: #12623 

### Motivation

We need to enable the release of apline python client

### Modifications

* Disable build warnings and fix errors in the build process
* Add the environment variables such as `NAME_POSTFIX` for custom building.

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


