### PR TITLE
[security] Allow Client Builder set Dnslookup params

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -539,6 +539,20 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder enableTransaction(boolean enableTransaction);
 
     /**
+     *  Set dns lookup bind address.
+     * @param dnsLookupBindAddress
+     * @return
+     */
+    ClientBuilder dnsLookupBindAddress(String dnsLookupBindAddress);
+
+    /**
+     *  Set dns lookup bind port.
+     * @param dnsLookupBindPort
+     * @return
+     */
+    ClientBuilder dnsLookupBindPort(int dnsLookupBindPort);
+
+    /**
      *  Set socks5 proxy address.
      * @param socks5ProxyAddress
      * @return

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -539,18 +539,12 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder enableTransaction(boolean enableTransaction);
 
     /**
-     *  Set dns lookup bind address.
-     * @param dnsLookupBindAddress
+     * Set dns lookup bind address and port.
+     * @param address dnsBindAddress
+     * @param port dnsBindPort
      * @return
      */
-    ClientBuilder dnsLookupBindAddress(String dnsLookupBindAddress);
-
-    /**
-     *  Set dns lookup bind port.
-     * @param dnsLookupBindPort
-     * @return
-     */
-    ClientBuilder dnsLookupBindPort(int dnsLookupBindPort);
+    ClientBuilder dnsLookupBind(String address, int port);
 
     /**
      *  Set socks5 proxy address.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -339,6 +339,21 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder dnsLookupBindAddress(String dnsLookupBindAddress) {
+        conf.setDnsLookupBindAddress(dnsLookupBindAddress);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder dnsLookupBindPort(int dnsLookupBindPort) {
+        if (dnsLookupBindPort < 0 || dnsLookupBindPort > 65535) {
+            throw new IllegalArgumentException("DnsLookBindPort need to be within the range of 0 and 65535");
+        }
+        conf.setDnsLookupBindPort(dnsLookupBindPort);
+        return this;
+    }
+
+    @Override
     public ClientBuilder socks5ProxyAddress(InetSocketAddress socks5ProxyAddress) {
         conf.setSocks5ProxyAddress(socks5ProxyAddress);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -343,7 +343,7 @@ public class ClientBuilderImpl implements ClientBuilder {
         checkArgument(port >= 0 && port <= 65535, "DnsLookBindPort need to be within the range of 0 and 65535");
         conf.setDnsLookupBindAddress(address);
         conf.setDnsLookupBindPort(port);
-        return null;
+        return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -339,16 +339,11 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
-    public ClientBuilder dnsLookupBindAddress(String dnsLookupBindAddress) {
-        conf.setDnsLookupBindAddress(dnsLookupBindAddress);
-        return this;
-    }
-
-    @Override
-    public ClientBuilder dnsLookupBindPort(int dnsLookupBindPort) {
-       checkArgument(dnsLookupBindPort >= 0 && dnsLookupBindPort <= 65535, "DnsLookBindPort need to be within the range of 0 and 65535");
-        conf.setDnsLookupBindPort(dnsLookupBindPort);
-        return this;
+    public ClientBuilder dnsLookupBind(String address, int port) {
+        checkArgument(port >= 0 && port <= 65535, "DnsLookBindPort need to be within the range of 0 and 65535");
+        conf.setDnsLookupBindAddress(address);
+        conf.setDnsLookupBindPort(port);
+        return null;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -346,9 +346,7 @@ public class ClientBuilderImpl implements ClientBuilder {
 
     @Override
     public ClientBuilder dnsLookupBindPort(int dnsLookupBindPort) {
-        if (dnsLookupBindPort < 0 || dnsLookupBindPort > 65535) {
-            throw new IllegalArgumentException("DnsLookBindPort need to be within the range of 0 and 65535");
-        }
+       checkArgument(dnsLookupBindPort >= 0 && dnsLookupBindPort <= 65535, "DnsLookBindPort need to be within the range of 0 and 65535");
         conf.setDnsLookupBindPort(dnsLookupBindPort);
         return this;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -71,8 +71,13 @@ public class ClientBuilderImplTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testClientBuilderWithIllegalPort() throws PulsarClientException {
-        PulsarClient.builder().dnsLookupBindPort(-1).build();
+    public void testClientBuilderWithIllegalMinusPort() throws PulsarClientException {
+        PulsarClient.builder().dnsLookupBind("localhost", -1).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClientBuilderWithIllegalLargePort() throws PulsarClientException {
+        PulsarClient.builder().dnsLookupBind("localhost", 65536).build();
     }
 
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -70,4 +70,10 @@ public class ClientBuilderImplTest {
         }).build();
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClientBuilderWithIllegalPort() throws PulsarClientException {
+        PulsarClient.builder().dnsLookupBindPort(-1).build();
+    }
+
+
 }


### PR DESCRIPTION
### Motivation

related to #13390 

### Modifications

- Allow config client dns bind addr and port through client builder.

### Verify
- add `testClientBuilderWithIllegalPort` check for illegal param

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `doc` 
  
  IMO, this change to code will generated doc automatically.