### PR TITLE
Remove the unused junit4 dependency in managed ledger

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -94,15 +94,6 @@
        <artifactId>snappy-java</artifactId>
        <scope>test</scope>
     </dependency>
-    <!--
-        junit is a runtime dependency of zookeeper tests, so only
-        add this dependency here.
-    -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.awaitility</groupId>


### PR DESCRIPTION
### Motivation
Remove the unused junit depency in managed ledger

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
 dependency change, no need doc


