### PR TITLE
support dynamic config for replicationProducerQueueSize

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2028,7 +2028,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_REPLICATION,
             doc = "Duration to check replication policy to avoid replicator "
-                    + "inconsistency due to missing ZooKeeper watch (disable with value 0)"
+                    + "inconsistency due to missing ZooKeeper watch (disable with value 0)."
+                    + "When dynamically modified, it only takes effect for the newly added replicators"
         )
     private int replicationPolicyCheckDurationSeconds = 600;
     @Deprecated

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2021,6 +2021,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String replicatorPrefix = "pulsar.repl";
     @FieldContext(
         category = CATEGORY_REPLICATION,
+        dynamic = true,
         doc = "Replicator producer queue size"
     )
     private int replicationProducerQueueSize = 1000;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2022,14 +2022,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_REPLICATION,
         dynamic = true,
-        doc = "Replicator producer queue size"
+        doc = "Replicator producer queue size. "
+                + "When dynamically modified, it only takes effect for the newly added replicators"
     )
     private int replicationProducerQueueSize = 1000;
     @FieldContext(
             category = CATEGORY_REPLICATION,
             doc = "Duration to check replication policy to avoid replicator "
-                    + "inconsistency due to missing ZooKeeper watch (disable with value 0)."
-                    + "When dynamically modified, it only takes effect for the newly added replicators"
+                    + "inconsistency due to missing ZooKeeper watch (disable with value 0)"
         )
     private int replicationPolicyCheckDurationSeconds = 600;
     @Deprecated


### PR DESCRIPTION
### Motivation
support dynamic config for replicationProducerQueueSize.

When the size of replicationProducerQueueSize is dynamically adjusted, it is effective for newly added replicate tasks. For existing replicate tasks, you can also delete and rebuild to make them effective.

### Documentation

- [x] `no-need-doc` 
  
