### PR TITLE
Enable CheckStyle Plugin in Pulsar Build Tools

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -182,6 +182,24 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.37</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>${project.basedir}/src/main/resources/pulsar/checkstyle.xml</configLocation>
+          <suppressionsLocation>${project.basedir}/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <encoding>UTF-8</encoding>
+          <excludes>**/proto/*</excludes>
+        </configuration>
+      </plugin>
     </plugins>
     <extensions>
       <extension>

--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.tests;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
-
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.IConfigurationAnnotation;
 import org.testng.annotations.ITestAnnotation;

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.tests;
 
-import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.LockInfo;
@@ -33,14 +31,14 @@ import java.util.Date;
 import java.util.Map;
 import javax.management.JMException;
 import javax.management.ObjectName;
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 
 /**
- * Adapted from Hadoop TimedOutTestsListener
+ * Adapted from Hadoop TimedOutTestsListener.
  *
  * https://raw.githubusercontent.com/apache/hadoop/master/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TimedOutTestsListener.java
  */
 public class ThreadDumpUtil {
-    static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
 
     private static final String INDENT = "    ";
 

--- a/buildtools/src/main/java/org/apache/pulsar/tests/package-info.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;


### PR DESCRIPTION
### Motivation
currently, the `buildTools` module is not protected by the `checkstyle-plugin`.

### Modifications
- Enable CheckStyle Plugin
- Fix checkstyle violations

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
java checkstyle changes, no need doc.