### PR TITLE
Return message ID from compacted ledger while the compaction cursor reach the end of the topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.compaction;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -34,4 +35,5 @@ public interface CompactedTopic {
                                 ReadEntriesCallback callback,
                                 Consumer consumer);
     CompletableFuture<Entry> readLastEntryOfCompactedLedger();
+    Optional<Position> getCompactionHorizon();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -311,9 +311,8 @@ public class CompactedTopicImpl implements CompactedTopic {
             .compare(p.getEntryId(), m.getEntryId()).result();
     }
 
-    @VisibleForTesting
-    PositionImpl getCompactionHorizon() {
-        return this.compactionHorizon;
+    public synchronized Optional<Position> getCompactionHorizon() {
+        return Optional.ofNullable(this.compactionHorizon);
     }
     private static final Logger log = LoggerFactory.getLogger(CompactedTopicImpl.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.compaction;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;


### PR DESCRIPTION
### Motivation

The problem happens when the compaction cursor reaches the end of the topic but the tail messages
of the topic have been removed by producer writes null value messages during the topic compaction.

For example:

- 5 messages in the original topic with key: 0,1,2,3,4
- the corresponding message IDs are: 1:0, 1:1, 1:2, 1:3, 1:4
- producer send null value messages for key 3 and 4
- trigger the topic compaction task

After the compaction task complete,

- 5 messages in the original topic: 1:0, 1:1, 1:2, 1:3, 1:4
- 3 messages in the compacted ledger: 1:0, 1:1, 1:2

At this moment, if the reader tries to get the last message ID of the topic,
we should return `1:2` not `1:4`, because the reader is not able to read the message
with keys `3` and `4` from the compacted topic, otherwise, the `reader.readNext()` method
will be blocked until a new message written to the topic.

### Modifications

The fix is straightforward, when the broker receives a get last message ID request,
the broker will check if the compaction cursor reaches the end of the original topic.
If yes, respond last message ID from the compacted ledger.

### Verifying this change

New test added `testHasMessageAvailableWithNullValueMessage` which ensure the `hasMessageAvailable()`
return false no more messages from the compacted topic if the compaction cursor reaches the end of the topic.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


