### PR TITLE
[Broker] Ignore the print the log that the topic does not exist

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4554,8 +4554,9 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void handleTopicPolicyException(String methodName, Throwable thr, AsyncResponse asyncResponse) {
         Throwable cause = thr.getCause();
-        if (!(cause instanceof WebApplicationException)
-                || !(((WebApplicationException) cause).getResponse().getStatus() == 307)) {
+        if (!(cause instanceof WebApplicationException) || !(
+                ((WebApplicationException) cause).getResponse().getStatus() == 307
+                        || ((WebApplicationException) cause).getResponse().getStatus() == 404)) {
             log.error("[{}] Failed to perform {} on topic {}",
                     clientAppId(), methodName, topicName, cause);
         }


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation
 
When setting a policy for the non-exist topic, the exception thrown should not be recorded as an error log. 

### Modifications

- Dot print this log that the topic does not exist

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [x] `no-need-doc` 
Just improve the print log.

  
