### PR TITLE
update log content 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -608,7 +608,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         return;
                     }
 
-                    log.info("[{}] Unloading bundle: {} from broker {}", strategy.getClass().getSimpleName(), bundle, broker);
+                    log.info("[{}] Unloading bundle: {} from broker {}",
+                            strategy.getClass().getSimpleName(), bundle, broker);
                     try {
                         pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange);
                         loadData.getRecentlyUnloadedBundles().put(bundle, System.currentTimeMillis());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -608,7 +608,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         return;
                     }
 
-                    log.info("[%s] Unloading bundle: {} from broker {}", strategy.getClass().getSimpleName(), bundle, broker);
+                    log.info("[{}] Unloading bundle: {} from broker {}", strategy.getClass().getSimpleName(), bundle, broker);
                     try {
                         pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange);
                         loadData.getRecentlyUnloadedBundles().put(bundle, System.currentTimeMillis());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -608,7 +608,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         return;
                     }
 
-                    log.info("[Overload shedder] Unloading bundle: {} from broker {}", bundle, broker);
+                    log.info("[%s] Unloading bundle: {} from broker {}", strategy.getClass().getSimpleName(), bundle, broker);
                     try {
                         pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange);
                         loadData.getRecentlyUnloadedBundles().put(bundle, System.currentTimeMillis());


### PR DESCRIPTION
### Modifications
When we do not use OverloadShedder, the following log description is incorrect:
log.info("[Overload shedder] Unloading bundle: {} from broker {}", bundle, broker);




### Documentation

- [x] `no-need-doc` 
  
 
