### PR TITLE
[Security] Upgrade Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire.version>3.0.0-M3</surefire.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
     <testng.version>7.3.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -385,11 +385,11 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.17.0.jar
-    - org.apache.logging.log4j-log4j-core-2.17.0.jar
-    - org.apache.logging.log4j-log4j-slf4j-impl-2.17.0.jar
-    - org.apache.logging.log4j-log4j-web-2.17.0.jar
-    - org.apache.logging.log4j-log4j-1.2-api-2.17.0.jar
+    - org.apache.logging.log4j-log4j-api-2.17.1.jar
+    - org.apache.logging.log4j-log4j-core-2.17.1.jar
+    - org.apache.logging.log4j-log4j-slf4j-impl-2.17.1.jar
+    - org.apache.logging.log4j-log4j-web-2.17.1.jar
+    - org.apache.logging.log4j-log4j-1.2-api-2.17.1.jar
  * Java Native Access JNA -- net.java.dev.jna-jna-4.2.0.jar
  * BookKeeper
     - org.apache.bookkeeper-bookkeeper-common-4.14.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>6.10.2</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.12.3</jackson.version>


### PR DESCRIPTION
### Motivation

- fixes CVE-2021-44832
- see https://logging.apache.org/log4j/2.x/security.html for more details

### Modifications

- upgrade Log4j to 2.17.1