### PR TITLE
[issue #13439][backlogQuota] Allow both limit and limitsize be null

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
@@ -35,7 +35,7 @@ public class BacklogQuotaImpl implements BacklogQuota {
      * @since 2.9.1
      */
     @Deprecated
-    private Long limit;
+    private long limit;
 
     /**
      * backlog quota by size in byte.
@@ -57,7 +57,6 @@ public class BacklogQuotaImpl implements BacklogQuota {
     @Deprecated
     public long getLimit() {
         if (limitSize == null) {
-            // the limitSize and limit can't be both null
             return limit;
         }
         return limitSize;
@@ -71,7 +70,6 @@ public class BacklogQuotaImpl implements BacklogQuota {
 
     public long getLimitSize() {
         if (limitSize == null) {
-            // the limitSize and limit can't be both null
             return limit;
         }
         return limitSize;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -105,4 +105,24 @@ public class BacklogQuotaCompatibilityTest {
                 BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
     }
 
+    @Test
+    public void testBackwardCompatibilityNullLimitAndLimitSize() throws IOException {
+        String oldPolicyStr = "{\"auth_policies\":{\"namespace_auth\":{},\"destination_auth\":{},"
+                + "\"subscription_auth_roles\":{}},\"replication_clusters\":[],\"backlog_quota_map\":"
+                + "{\"destination_storage\":{\"policy\":\"consumer_backlog_eviction\"}},"
+                + "\"clusterDispatchRate\":{},\"topicDispatchRate\":{},\"subscriptionDispatchRate\":{},"
+                + "\"replicatorDispatchRate\":{},\"clusterSubscribeRate\":{},\"publishMaxMessageRate\":{},"
+                + "\"latency_stats_sample_rate\":{},\"subscription_expiration_time_minutes\":0,\"deleted\":false,"
+                + "\"encryption_required\":false,\"subscription_auth_mode\":\"None\","
+                + "\"max_consumers_per_subscription\":0,\"offload_threshold\":-1,"
+                + "\"schema_auto_update_compatibility_strategy\":\"Full\",\"schema_compatibility_strategy\":"
+                + "\"UNDEFINED\",\"is_allow_auto_update_schema\":true,\"schema_validation_enforced\":false,"
+                + "\"subscription_types_enabled\":[]}\n";
+        Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
+                0);
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
+                0);
+    }
+
 }


### PR DESCRIPTION
Fixes #13439 
### Motivation
Now we only constraint `limit` or `limitSize` be set on pulsar-admin, we don't limit it on rest endpoint. So there are situtations that both `limit` and `limitSize` be null

### Verifying this change

This change added tests and can be verified as follows:
  - *Added test method in `BacklogQuotaCompatibilityTest`

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  bug fix, no need doc


