### PR TITLE
Enable CheckStyle Plugin in Pulsar Test Mocks

### DIFF
--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -65,4 +65,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -75,8 +75,8 @@ public class PulsarMockBookKeeper extends BookKeeper {
         return super.getConf();
     }
 
-    Map<Long, PulsarMockLedgerHandle> ledgers = new ConcurrentHashMap<>();
-    AtomicLong sequence = new AtomicLong(3);
+    final Map<Long, PulsarMockLedgerHandle> ledgers = new ConcurrentHashMap<>();
+    final AtomicLong sequence = new AtomicLong(3);
 
     CompletableFuture<Void> defaultResponse = CompletableFuture.completedFuture(null);
     private static final List<BookieId> ensemble = Collections.unmodifiableList(Lists.newArrayList(
@@ -88,8 +88,8 @@ public class PulsarMockBookKeeper extends BookKeeper {
         return ensemble;
     }
 
-    Queue<Long> addEntryDelaysMillis = new ConcurrentLinkedQueue<>();
-    List<CompletableFuture<Void>> failures = new ArrayList<>();
+    final Queue<Long> addEntryDelaysMillis = new ConcurrentLinkedQueue<>();
+    final List<CompletableFuture<Void>> failures = new ArrayList<>();
 
     public PulsarMockBookKeeper(OrderedExecutor orderedExecutor) throws Exception {
         this.orderedExecutor = orderedExecutor;
@@ -120,7 +120,8 @@ public class PulsarMockBookKeeper extends BookKeeper {
                 try {
                     long id = sequence.getAndIncrement();
                     log.info("Creating ledger {}", id);
-                    PulsarMockLedgerHandle lh = new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd);
+                    PulsarMockLedgerHandle lh =
+                            new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd);
                     ledgers.put(id, lh);
                     return FutureUtils.value(lh);
                 } catch (Throwable t) {
@@ -303,7 +304,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
             getProgrammedFailure().get();
         } catch (ExecutionException ee) {
             if (ee.getCause() instanceof BKException) {
-                throw (BKException)ee.getCause();
+                throw (BKException) ee.getCause();
             } else {
                 throw new BKException.BKUnexpectedConditionException();
             }
@@ -331,7 +332,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
     private int emptyLedgerAfter = -1;
 
     /**
-     * After N times, make a ledger to appear to be empty
+     * After N times, make a ledger to appear to be empty.
      */
     public synchronized void returnEmptyLedgerAfter(int steps) {
         emptyLedgerAfter = steps;
@@ -373,12 +374,12 @@ public class PulsarMockBookKeeper extends BookKeeper {
 
         @Override
         public CompletableFuture<Versioned<Set<BookieId>>> getAllBookies() {
-            return CompletableFuture.completedFuture(new Versioned<Set<BookieId>>(new HashSet<>(ensemble), new LongVersion(0)));
+            return CompletableFuture.completedFuture(new Versioned<>(new HashSet<>(ensemble), new LongVersion(0)));
         }
 
         @Override
         public CompletableFuture<Versioned<Set<BookieId>>> getReadOnlyBookies() {
-            return CompletableFuture.completedFuture(new Versioned<Set<BookieId>>(new HashSet<>(), new LongVersion(0)));
+            return CompletableFuture.completedFuture(new Versioned<>(new HashSet<>(), new LongVersion(0)));
         }
 
         @Override
@@ -404,7 +405,8 @@ public class PulsarMockBookKeeper extends BookKeeper {
 
     private final MetadataClientDriver metadataClientDriver = new MetadataClientDriver() {
         @Override
-        public MetadataClientDriver initialize(ClientConfiguration conf, ScheduledExecutorService scheduler, StatsLogger statsLogger, Optional<Object> ctx) throws MetadataException {
+        public MetadataClientDriver initialize(ClientConfiguration conf, ScheduledExecutorService scheduler,
+                                               StatsLogger statsLogger, Optional<Object> ctx) throws MetadataException {
             return this;
         }
 

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -19,10 +19,8 @@
 package org.apache.bookkeeper.client;
 
 import com.google.common.collect.Lists;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
 import java.security.GeneralSecurityException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -31,7 +29,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.ReadCallback;
@@ -78,23 +75,23 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
     @Override
     public void asyncClose(CloseCallback cb, Object ctx) {
         bk.getProgrammedFailure().thenComposeAsync((res) -> {
-                fenced = true;
+            fenced = true;
 
-                Versioned<LedgerMetadata> current = getVersionedLedgerMetadata();
-                Versioned<LedgerMetadata> newMetadata = new Versioned<>(
-                        LedgerMetadataBuilder.from(current.getValue())
-                        .withClosedState().withLastEntryId(getLastAddConfirmed())
-                        .withLength(getLength()).build(),
-                        new LongVersion(((LongVersion)current.getVersion()).getLongVersion() + 1));
-                setLedgerMetadata(current, newMetadata);
-                return FutureUtils.value(null);
-            }, bk.executor).whenCompleteAsync((res, exception) -> {
-                    if (exception != null) {
-                        cb.closeComplete(PulsarMockBookKeeper.getExceptionCode(exception), null, ctx);
-                    } else {
-                        cb.closeComplete(BKException.Code.OK, this, ctx);
-                    }
-                }, bk.executor);
+            Versioned<LedgerMetadata> current = getVersionedLedgerMetadata();
+            Versioned<LedgerMetadata> newMetadata = new Versioned<>(
+                    LedgerMetadataBuilder.from(current.getValue())
+                            .withClosedState().withLastEntryId(getLastAddConfirmed())
+                            .withLength(getLength()).build(),
+                    new LongVersion(((LongVersion) current.getVersion()).getLongVersion() + 1));
+            setLedgerMetadata(current, newMetadata);
+            return FutureUtils.value(null);
+        }, bk.executor).whenCompleteAsync((res, exception) -> {
+            if (exception != null) {
+                cb.closeComplete(PulsarMockBookKeeper.getExceptionCode(exception), null, ctx);
+            } else {
+                cb.closeComplete(BKException.Code.OK, this, ctx);
+            }
+        }, bk.executor);
     }
 
     @Override
@@ -128,7 +125,8 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
                 return FutureUtils.value(entries);
             }).whenCompleteAsync((res, exception) -> {
                     if (exception != null) {
-                        cb.readComplete(PulsarMockBookKeeper.getExceptionCode(exception), PulsarMockLedgerHandle.this, null, ctx);
+                        cb.readComplete(PulsarMockBookKeeper.getExceptionCode(exception),
+                                PulsarMockLedgerHandle.this, null, ctx);
                     } else {
                         cb.readComplete(BKException.Code.OK, PulsarMockLedgerHandle.this, res, ctx);
                     }

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
@@ -41,7 +41,8 @@ class PulsarMockReadHandle implements ReadHandle {
     private final LedgerMetadata metadata;
     private final List<LedgerEntryImpl> entries;
 
-    PulsarMockReadHandle(PulsarMockBookKeeper bk, long ledgerId, LedgerMetadata metadata, List<LedgerEntryImpl> entries) {
+    PulsarMockReadHandle(PulsarMockBookKeeper bk, long ledgerId, LedgerMetadata metadata,
+                         List<LedgerEntryImpl> entries) {
         this.bk = bk;
         this.ledgerId = ledgerId;
         this.metadata = metadata;

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/package-info.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.client;

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -34,7 +34,7 @@ import org.objenesis.ObjenesisStd;
 import org.objenesis.instantiator.ObjectInstantiator;
 
 /**
- * mock zookeeper with different session based on {@link MockZooKeeper}
+ * mock zookeeper with different session based on {@link MockZooKeeper}.
  */
 public class MockZooKeeperSession extends ZooKeeper {
 
@@ -250,8 +250,6 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public String toString() {
-        return "MockZooKeeperSession{" +
-                "sessionId=" + sessionId +
-                '}';
+        return "MockZooKeeperSession{" + "sessionId=" + sessionId + '}';
     }
 }

--- a/testmocks/src/main/java/org/apache/zookeeper/package-info.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.zookeeper;


### PR DESCRIPTION
### Motivation
currently, the `testmocks` module is not protected by the `checkstyle-plugin`.
### Modifications
- Enable CheckStyle Plugin
- Fix checkstyle violations
### Documentation
Check the box below and label this PR (if you have committer privilege).
Need to update docs?
- [x] `no-need-doc`
java checkstyle changes, no need doc.