### PR TITLE
[WIP]Support IP as advertisedAddress if not set

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -187,9 +187,19 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Hostname or IP address the service advertises to the outside world."
-            + " If not set, the value of `InetAddress.getLocalHost().getHostname()` is used."
+            + " If `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostname()` is "
+            + "used by default."
+            + " If `advertisedAddress` is not set and `ipAsAdvertisedAddress` is set to true, the value of "
+            + "`InetAddress.getLocalHost().getHostAddress()` is used"
     )
     private String advertisedAddress;
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "If `ipAsAdvertisedAddress` is set to true and `advertisedAddress` is not set,"
+            + " the value of `InetAddress.getLocalHost().getHostAddress()` is used to set the advertised address."
+    )
+    private boolean ipAsAdvertisedAddress = false;
 
     @FieldContext(category=CATEGORY_SERVER,
             doc = "Used to specify multiple advertised listeners for the broker."

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -53,9 +53,15 @@ public class MultipleListenerValidatorTest {
 
         config.setAdvertisedAddress(null);
         assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, false),
-                ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null));
+                ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null, false));
         assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
-                ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null));
+                ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null, false));
+
+        config.setIpAsAdvertisedAddress(true);
+        assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, false),
+                InetAddress.getLocalHost().getHostAddress());
+        assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
+                InetAddress.getLocalHost().getHostAddress());
     }
 
     @Test

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
@@ -108,7 +108,9 @@ public final class PulsarStandaloneBuilder {
             zkServers = pulsarStandalone.getAdvertisedAddress();
         } else if (isBlank(pulsarStandalone.getConfig().getAdvertisedAddress())) {
             // Use advertised address as local hostname
-            pulsarStandalone.getConfig().setAdvertisedAddress(ServiceConfigurationUtils.unsafeLocalhostResolve());
+            pulsarStandalone.getConfig().setAdvertisedAddress(
+                    ServiceConfigurationUtils.unsafeLocalhostResolve(
+                            pulsarStandalone.getConfig().isIpAsAdvertisedAddress()));
         } else {
             // Use advertised address from config file
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -291,10 +291,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         this.advertisedListeners = MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
 
         // the advertised address is defined as the host component of the broker's canonical name.
-        this.advertisedAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        this.advertisedAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
+                config.getAdvertisedAddress(),
+                config.isIpAsAdvertisedAddress());
 
         // use `internalListenerName` listener as `advertisedAddress`
-        this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getBindAddress());
+        this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
+                config.getAdvertisedAddress(),
+                config.isIpAsAdvertisedAddress());
         this.brokerVersion = PulsarVersion.getVersion();
         this.config = config;
         this.processTerminator = processTerminator;
@@ -1562,7 +1566,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
         // worker talks to local broker
         String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
-                brokerConfig.getAdvertisedAddress());
+                brokerConfig.getAdvertisedAddress(),
+                brokerConfig.isIpAsAdvertisedAddress());
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setPulsarFunctionsCluster(brokerConfig.getClusterName());
         // inherit broker authorization setting

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -251,7 +251,7 @@ public class PulsarFunctionE2ESecurityTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -326,7 +326,7 @@ public class PulsarFunctionLocalRunTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
@@ -245,7 +245,7 @@ public class PulsarFunctionPublishTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -166,7 +166,9 @@ public class PulsarWorkerAssignmentTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        final String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        final String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
+                config.getAdvertisedAddress(),
+                false);
         workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
@@ -273,7 +273,7 @@ public abstract class AbstractPulsarE2ETest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
@@ -192,7 +192,7 @@ public class PulsarFunctionAdminTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         workerConfig.setWorkerHostname(hostname);
         workerConfig
                 .setWorkerId("c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
@@ -203,7 +203,7 @@ public class PulsarFunctionTlsTest {
         workerConfig.setInstanceLivenessCheckFreqMs(100);
         workerConfig.setWorkerPort(0);
         workerConfig.setPulsarFunctionsCluster(config.getClusterName());
-        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress(), false);
         this.workerId = "c-" + config.getClusterName() + "-fw-" + hostname + "-" + workerConfig.getWorkerPort();
         workerConfig.setWorkerHostname(hostname);
         workerConfig.setWorkerId(workerId);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -144,9 +144,19 @@ public class ProxyConfiguration implements PulsarConfiguration {
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Hostname or IP address the service advertises to the outside world."
-            + " If not set, the value of `InetAddress.getLocalHost().getCanonicalHostName()` is used."
+            + " If `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostname()` is "
+            + "used by default."
+            + " If `advertisedAddress` is not set and `ipAsAdvertisedAddress` is set to true, the value of "
+            + "`InetAddress.getLocalHost().getHostAddress()` is used"
     )
     private String advertisedAddress;
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "If `ipAsAdvertisedAddress` is set to true and `advertisedAddress` is not set,"
+            + " the value of `InetAddress.getLocalHost().getHostAddress()` is used to set the advertised address."
+    )
+    private boolean ipAsAdvertisedAddress = false;
 
     @FieldContext(category = CATEGORY_SERVER,
             doc = "Enable or disable the proxy protocol.")

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -226,7 +226,9 @@ public class ProxyService implements Closeable {
         }
 
         final String hostname =
-            ServiceConfigurationUtils.getDefaultOrConfiguredAddress(proxyConfig.getAdvertisedAddress());
+            ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
+                    proxyConfig.getAdvertisedAddress(),
+                    proxyConfig.isIpAsAdvertisedAddress());
 
         if (proxyConfig.getServicePort().isPresent()) {
             this.serviceUrl = String.format("pulsar://%s:%d/", hostname, getListenPort().get());

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -162,7 +162,8 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |jvmGCMetricsLoggerClassName|Classname of Pluggable JVM GC metrics logger that can log GC specific metrics.|N/A|
 |bindAddress| Hostname or IP address the service binds on, default is 0.0.0.0.  |0.0.0.0|
 |bindAddresses| Additional Hostname or IP addresses the service binds on: `listener_name:scheme://host:port,...`.  ||
-|advertisedAddress| Hostname or IP address the service advertises to the outside world. If not set, the value of `InetAddress.getLocalHost().getHostName()` is used.  ||
+|advertisedAddress| Hostname or IP address the service advertises to the outside world. If `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostName()` is used by default. If `advertisedAddress` is not set and `ipAsAdvertisedAddress` is set to true, the value of `InetAddress.getLocalHost().getHostAddress()` is used ||
+|ipAsAdvertisedAddress| If `ipAsAdvertisedAddress` is set to true and `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostAddress()` is used to set the advertised address.|false|
 |clusterName| Name of the cluster to which this broker belongs to ||
 |brokerDeduplicationEnabled|  Sets the default behavior for message deduplication in the broker. If enabled, the broker will reject messages that were already stored in the topic. This setting can be overridden on a per-namespace basis.  |false|
 |brokerDeduplicationMaxNumberOfProducers| The maximum number of producers for which information will be stored for deduplication purposes.  |10000|
@@ -437,7 +438,8 @@ You can set the log level and configuration in the  [log4j2.yaml](https://github
 |webServicePort|  The port used by the standalone broker for HTTP requests  |8080|
 |bindAddress| The hostname or IP address on which the standalone service binds  |0.0.0.0|
 |bindAddresses| Additional Hostname or IP addresses the service binds on: `listener_name:scheme://host:port,...`.  ||
-|advertisedAddress| The hostname or IP address that the standalone service advertises to the outside world. If not set, the value of `InetAddress.getLocalHost().getHostName()` is used.  ||
+|advertisedAddress| Hostname or IP address the service advertises to the outside world. If `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostName()` is used by default. If `advertisedAddress` is not set and `ipAsAdvertisedAddress` is set to true, the value of `InetAddress.getLocalHost().getHostAddress()` is used ||
+|ipAsAdvertisedAddress| If `ipAsAdvertisedAddress` is set to true and `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostAddress()` is used to set the advertised address.|false|
 | numAcceptorThreads | Number of threads to use for Netty Acceptor | 1 |
 | numIOThreads | Number of threads to use for Netty IO | 2 * Runtime.getRuntime().availableProcessors() |
 | numHttpServerThreads | Number of threads to use for HTTP requests processing | 2 * Runtime.getRuntime().availableProcessors()|
@@ -705,7 +707,8 @@ The [Pulsar proxy](concepts-architecture-overview.md#pulsar-proxy) can be config
 | functionWorkerWebServiceURLTLS | The TLS Web service URL pointing to the function worker cluster. It is only configured when you setup function workers in a separate cluster. | |
 |zookeeperSessionTimeoutMs| ZooKeeper session timeout (in milliseconds) |30000|
 |zooKeeperCacheExpirySeconds|ZooKeeper cache expiry time in seconds|300|
-|advertisedAddress|Hostname or IP address the service advertises to the outside world. If not set, the value of `InetAddress.getLocalHost().getHostname()` is used.|N/A|
+|advertisedAddress| Hostname or IP address the service advertises to the outside world. If `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostName()` is used by default. If `advertisedAddress` is not set and `ipAsAdvertisedAddress` is set to true, the value of `InetAddress.getLocalHost().getHostAddress()` is used ||
+|ipAsAdvertisedAddress| If `ipAsAdvertisedAddress` is set to true and `advertisedAddress` is not set, the value of `InetAddress.getLocalHost().getHostAddress()` is used to set the advertised address.|false|
 |servicePort| The port to use for server binary Protobuf requests |6650|
 |servicePortTls|  The port to use to server binary Protobuf TLS requests  |6651|
 |statusFilePath|  Path for the file used to determine the rotation status for the proxy instance when responding to service discovery health checks ||


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation

Sometimes we need use IP as advertisedAddress  when  executing automatic deployment

### Modifications

* Add the field `ipAsAdvertisedAddress` in `ProxyConfiguration` and `ServiceConfiguration`
* Most changes are concentrated on `org.apache.pulsar.broker.ServiceConfigurationUtils#getDefaultOrConfiguredAddress` and  `org.apache.pulsar.broker.ServiceConfigurationUtils#unsafeLocalhostResolve`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Extended case `MultipleListenerValidatorTest#testGetAppliedAdvertised`*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

- [x] `doc` 
  


