### PR TITLE
Bump slf4j from 1.7.25 to 1.7.32

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -40,7 +40,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire.version>3.0.0-M3</surefire.version>
     <log4j2.version>2.17.1</log4j2.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.32</slf4j.version>
     <testng.version>7.3.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -540,9 +540,9 @@ BSD 2-Clause License
 MIT License
  * Java SemVer -- com.github.zafarkhaja-java-semver-0.9.0.jar -- licenses/LICENSE-SemVer.txt
  * SLF4J -- licenses/LICENSE-SLF4J.txt
-    - org.slf4j-jul-to-slf4j-1.7.25.jar
-    - org.slf4j-slf4j-api-1.7.25.jar
-    - org.slf4j-jcl-over-slf4j-1.7.25.jar
+    - org.slf4j-jul-to-slf4j-1.7.32.jar
+    - org.slf4j-slf4j-api-1.7.32.jar
+    - org.slf4j-jcl-over-slf4j-1.7.32.jar
  * The Checker Framework
     - org.checkerframework-checker-qual-3.5.0.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ flexible messaging model and an intuitive client API.</description>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
     <rocksdb.version>6.10.2</rocksdb.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.32</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.17.1</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -485,12 +485,12 @@ MIT License
    - pcollections-2.1.2.jar
  * SLF4J
    - slf4j-jdk14-1.7.29.jar
-   - slf4j-api-1.7.25.jar
+   - slf4j-api-1.7.32.jar
    - slf4j-jdk14-1.7.30.jar
  * JCL 1.2 Implemented Over SLF4J
-   - jcl-over-slf4j-1.7.25.jar
+   - jcl-over-slf4j-1.7.32.jar
  * JUL to SLF4J Bridge
-   - jul-to-slf4j-1.7.25.jar
+   - jul-to-slf4j-1.7.32.jar
  * Checker Qual
    - checker-qual-3.5.0.jar
 


### PR DESCRIPTION
### Motivation
Bump slf4j to 1.7.32 solve CVE-2018-8088

### Modifications
Bump slf4j from 1.7.25 to 1.7.32

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc` 
  
  bump dependencies, no need doc


