### PR TITLE
[Doc] Fix doc for chunked message related stats.

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -40,7 +40,7 @@ public interface ConsumerStats {
     /** Total rate of messages redelivered by this consumer (msg/s). */
     double getMsgRateRedeliver();
 
-    /** Total chunked messages dispatched. */
+    /** The total rate of chunked messages delivered to this consumer. */
     double getChunkedMessageRate();
 
     /** Name of the consumer. */

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
@@ -37,7 +37,7 @@ public interface PublisherStats {
     /** Average message size published by this publisher. */
     double getAverageMsgSize();
 
-    /** total chunked message count received. **/
+    /** The total rate of chunked messages published by this publisher. **/
     double getChunkedMessageRate();
 
     /** Id of this publisher. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -45,7 +45,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
     /** Total rate of messages redelivered by this consumer (msg/s). */
     public double msgRateRedeliver;
 
-    /** Total chunked messages dispatched. */
+    /** The total rate of chunked messages delivered to this consumer. */
     public double chunkedMessageRate;
 
     /** Name of the consumer. */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/PublisherStatsImpl.java
@@ -43,7 +43,7 @@ public class PublisherStatsImpl implements PublisherStats {
     /** Average message size published by this publisher. */
     public double averageMsgSize;
 
-    /** total chunked message count received. **/
+    /** The total rate of chunked messages published by this publisher. **/
     public double chunkedMessageRate;
 
     /** Id of this publisher. */

--- a/site2/docs/admin-api-topics.md
+++ b/site2/docs/admin-api-topics.md
@@ -233,7 +233,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher.
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -339,7 +339,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 

--- a/site2/website-next/docs/admin-api-topics.md
+++ b/site2/website-next/docs/admin-api-topics.md
@@ -321,7 +321,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher. The totoal rate of 
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -425,7 +425,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 

--- a/site2/website-next/versioned_docs/version-2.9.0/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.9.0/admin-api-topics.md
@@ -322,7 +322,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher.
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -426,7 +426,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 

--- a/site2/website-next/versioned_docs/version-2.9.1/admin-api-topics.md
+++ b/site2/website-next/versioned_docs/version-2.9.1/admin-api-topics.md
@@ -322,7 +322,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher.
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -426,7 +426,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 

--- a/site2/website/versioned_docs/version-2.9.0/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.0/admin-api-topics.md
@@ -232,7 +232,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher.
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -336,7 +336,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 

--- a/site2/website/versioned_docs/version-2.9.1/admin-api-topics.md
+++ b/site2/website/versioned_docs/version-2.9.1/admin-api-topics.md
@@ -232,7 +232,7 @@ You can check the following statistics of a given non-partitioned topic.
 
       -   **averageMsgSize**: The average message size in bytes from this publisher within the last interval.
 
-      -   **chunkedMessageRate**: Total chunked message count received for this producer on this topic.
+      -   **chunkedMessageRate**: The total rate of chunked messages published by this publisher.
 
       -   **producerId**: The internal identifier for this producer on this topic.
 
@@ -336,7 +336,7 @@ You can check the following statistics of a given non-partitioned topic.
 
                 -   **msgRateRedeliver**: Total rate of messages redelivered by this consumer (msg/s).
 
-                -   **chunkedMessageRate**: Total chunked messages dispatched.
+                -   **chunkedMessageRate**: The total rate of chunked messages delivered to this consumer.
 
                 -   **avgMessagesPerEntry**: Number of average messages per entry for the consumer consumed.
 


### PR DESCRIPTION

### Motivation

The current documentation has some incorrect statements in the description of the stats related to chunked messages.

### Modifications

* Fix doc for chunked message related stats.

### Documentation
  
- [x] `doc` 
  


