### PR TITLE
[CI] Create unique OWASP dependency check reports for each branch

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: owasp-dependency-check-reports
+          name: owasp-dependency-check-reports-${{ matrix.checkout_branch }}
           path: |
             distribution/server/target/dependency-check-report.html
             distribution/offloaders/target/dependency-check-report.html


### PR DESCRIPTION
### Motivation

- currently the uploaded reports for different branches get overwritten since a common name is used

### Modifications

- use branch name as part of uploaded filename