### PR TITLE
Fix - Cancel connect task when replicator disconnect after connect failed.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -58,10 +58,10 @@ public abstract class AbstractReplicator {
 
     protected static final AtomicReferenceFieldUpdater<AbstractReplicator, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(AbstractReplicator.class, State.class, "state");
-    private volatile State state = State.Stopped;
+    private volatile State state = State.Init;
 
     protected enum State {
-        Stopped, Starting, Started, Stopping
+        Init, Starting, Started, Stopping, Stopped
     }
 
     public AbstractReplicator(String topicName, String replicatorPrefix, String localCluster, String remoteCluster,
@@ -85,7 +85,7 @@ public abstract class AbstractReplicator {
                 .maxPendingMessages(producerQueueSize) //
                 .producerName(String.format("%s%s%s", getReplicatorName(replicatorPrefix, localCluster),
                         REPL_PRODUCER_NAME_DELIMITER, remoteCluster));
-        STATE_UPDATER.set(this, State.Stopped);
+        STATE_UPDATER.set(this, State.Init);
     }
 
     protected abstract void readEntries(org.apache.pulsar.client.api.Producer<byte[]> producer);
@@ -115,7 +115,7 @@ public abstract class AbstractReplicator {
             return;
         }
         State state = STATE_UPDATER.get(this);
-        if (!STATE_UPDATER.compareAndSet(this, State.Stopped, State.Starting)) {
+        if (!STATE_UPDATER.compareAndSet(this, State.Init, State.Starting)) {
             if (state == State.Started) {
                 // Already running
                 if (log.isDebugEnabled()) {
@@ -133,7 +133,7 @@ public abstract class AbstractReplicator {
         producerBuilder.createAsync().thenAccept(producer -> {
             readEntries(producer);
         }).exceptionally(ex -> {
-            if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopped)) {
+            if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Init)) {
                 long waitTimeMs = backOff.next();
                 log.warn("[{}][{} -> {}] Failed to create remote producer ({}), retrying in {} s", topicName,
                         localCluster, remoteCluster, ex.getMessage(), waitTimeMs / 1000.0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1369,7 +1369,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }
     }
 
-    @Test
+    @Test(timeOut = 30000)
     private void testCloseReplicatorBeforeConnected() throws Exception {
         String cluster = "tmp-cluster";
         String tenant = "tmp-tenant";
@@ -1395,14 +1395,13 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // 3.Disconnect replicator.
         Field field = AbstractReplicator.class.getDeclaredField("backOff");
         Backoff backOff = (Backoff) field.get(replicator);
-        while (backOff.getNext() == 100) {
-            Thread.sleep(10);
-        }
+
+        Awaitility.await().until(() -> backOff.getNext() > 100);
         replicator.disconnect();
 
         // 4.Check if start task canceled.
         long lastNum = backOff.getNext();
-        Thread.sleep(10000);
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).until(() -> backOff.getNext() != lastNum);
         long curNum = backOff.getNext();
         assert(lastNum == curNum);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -74,7 +74,6 @@ import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
-import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
@@ -86,7 +85,6 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.schema.Schemas;
@@ -1367,44 +1365,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
         for (String expectTopic : expectedTopicList) {
             Assert.assertTrue(list.contains(expectTopic));
         }
-    }
-
-    @Test
-    private void testCloseReplicatorBeforeConnected() throws Exception {
-        String cluster = "tmp-cluster";
-        String tenant = "tmp-tenant";
-        String namespace = "vv-ns";
-        TopicName topicName = TopicName.get("persistent", tenant, namespace, "testCloseReplicatorBeforeConnected");
-
-        // 1.Remote cluster is not available.
-        admin1.clusters().createCluster(cluster, ClusterData.builder()
-                .serviceUrl("http://localhost:18787")
-                .brokerServiceUrl("pulsar://localhost:18787")
-                .build());
-        admin1.tenants().createTenant("tmp-tenant",
-                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("r1", cluster)));
-        admin1.namespaces().createNamespace(topicName.getNamespace());
-        admin1.namespaces().setNamespaceReplicationClusters(topicName.getNamespace(), Sets.newHashSet("r1", cluster));
-
-        // 2.Start replicator.
-        @Cleanup
-        MessageProducer producer = new MessageProducer(url1, topicName);
-        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(topicName.toString()).get();
-        Replicator replicator = topic.getPersistentReplicator(cluster);
-
-        // 3.Disconnect replicator.
-        Field field = AbstractReplicator.class.getDeclaredField("backOff");
-        Backoff backOff = (Backoff) field.get(replicator);
-        while (backOff.getNext() == 100) {
-            Thread.sleep(10);
-        }
-        replicator.disconnect();
-
-        // 4.Check if start task canceled.
-        long lastNum = backOff.getNext();
-        Thread.sleep(10000);
-        long curNum = backOff.getNext();
-        assert(lastNum == curNum);
     }
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorTest.class);


### PR DESCRIPTION
### Motivation

If remote cluster is unvalid when replication create, replicator would try reconnect even if topic deleted.

### Modifications


### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`