### PR TITLE
Fix bug :Infinity value for CPU or Bandwidth usage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/GenericBrokerHostUsageImpl.java
@@ -54,9 +54,9 @@ public class GenericBrokerHostUsageImpl implements BrokerHostUsage {
         this.totalCpuLimit = getTotalCpuLimit();
         // Call now to initialize values before the constructor returns
         calculateBrokerHostUsage();
-        executorService.scheduleAtFixedRate(catchingAndLoggingThrowables(this::checkCpuLoad), CPU_CHECK_MILLIS,
+        executorService.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::checkCpuLoad), CPU_CHECK_MILLIS,
                 CPU_CHECK_MILLIS, TimeUnit.MILLISECONDS);
-        executorService.scheduleAtFixedRate(catchingAndLoggingThrowables(this::doCalculateBrokerHostUsage),
+        executorService.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::doCalculateBrokerHostUsage),
                 hostUsageCheckIntervalMin,
                 hostUsageCheckIntervalMin, TimeUnit.MINUTES);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -108,9 +108,9 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         SystemResourceUsage usage = new SystemResourceUsage();
         long now = System.currentTimeMillis();
         double elapsedSeconds = (now - lastCollection) / 1000d;
-        double cpuUsage = getTotalCpuUsage(elapsedSeconds);
+        double cpuUsage = (elapsedSeconds <= 0) ? 0 : getTotalCpuUsage(elapsedSeconds);
 
-        if (lastCollection == 0L) {
+        if (lastCollection == 0L || elapsedSeconds <= 0) {
             usage.setMemory(getMemUsage());
             usage.setBandwidthIn(new ResourceUsage(0d, totalNicLimit));
             usage.setBandwidthOut(new ResourceUsage(0d, totalNicLimit));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -105,15 +105,16 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         double totalNicUsageRx = getTotalNicUsageRxKb(nics);
         double totalCpuLimit = getTotalCpuLimit();
 
-        SystemResourceUsage usage = new SystemResourceUsage();
         long now = System.currentTimeMillis();
         double elapsedSeconds = (now - lastCollection) / 1000d;
-        double cpuUsage = getTotalCpuUsage(elapsedSeconds);
-
         if (elapsedSeconds <= 0) {
             log.warn("elapsedSeconds {} is not expected,skip this round of calculateBrokerHostUsage", elapsedSeconds);
             return;
         }
+
+        SystemResourceUsage usage = new SystemResourceUsage();
+        double cpuUsage = getTotalCpuUsage(elapsedSeconds);
+
         if (lastCollection == 0L) {
             usage.setMemory(getMemUsage());
             usage.setBandwidthIn(new ResourceUsage(0d, totalNicLimit));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -108,7 +108,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         long now = System.currentTimeMillis();
         double elapsedSeconds = (now - lastCollection) / 1000d;
         if (elapsedSeconds <= 0) {
-            log.warn("elapsedSeconds {} is not expected,skip this round of calculateBrokerHostUsage", elapsedSeconds);
+            log.warn("elapsedSeconds {} is not expected, skip this round of calculateBrokerHostUsage", elapsedSeconds);
             return;
         }
 


### PR DESCRIPTION
### Motivation
In the pulsar cluster, there are some errors:
![image](https://user-images.githubusercontent.com/19296967/148105483-a14d1dd4-f5c2-45d1-9864-9eca23b3d8bb.png)


Check grafana monitoring and I found ：
![image](https://user-images.githubusercontent.com/19296967/148102683-551df50b-0fe2-4c21-b61c-c4fd594cd276.png)
![image](https://user-images.githubusercontent.com/19296967/148102858-973b100f-7307-4744-94f0-ac5631904016.png)

At this point in time, I found that the GC pause time exceeds 1 minute, and the execution cycle of the method calculateBrokerHostUsage is 1 minute, which may cause the interval between two executions to be very short, even less than 1ms，so elapsedSeconds==0 is possible :
![image](https://user-images.githubusercontent.com/19296967/148105636-e41762c4-344e-4007-9b2d-6469fd9ededf.png)

By checking the code, I found that only elapsedSeconds==0 can cause this to happen。

So the correct way we should judge whether elapsedSeconds is not 0 and use the following method to strictly ensure that the interval between two method calculateBrokerHostUsage  executions is 1 minute:
   
 public ScheduledFuture<?> schedule(Runnable command,long delay, TimeUnit unit);

### The impact of the bug：
When a node appears Infinity, it will cause all the bundles of the node to be unloaded. When the balance strategy uses ThresholdShedder and loadBalancerHistoryResourcePercentage>0, then the node is unrecoverable and will keep trying to unload, even if all the bundles on the node have been unloaded。

### Documentation

- [x] `no-need-doc` 
  
