### PR TITLE
Upgrade Gson version 2.8.6 to 2.8.9

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -325,7 +325,7 @@ The Apache Software License, Version 2.0
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-1.17.0.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.7.6.jar
  * Gson
-    - com.google.code.gson-gson-2.8.6.jar
+    - com.google.code.gson-gson-2.8.9.jar
     - io.gsonfire-gson-fire-1.8.5.jar
  * Guava
     - com.google.guava-guava-30.1-jre.jar

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ flexible messaging model and an intuitive client API.</description>
     <grpc.version>1.33.0</grpc.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
-    <gson.version>2.8.6</gson.version>
+    <gson.version>2.8.9</gson.version>
     <sketches.version>0.8.3</sketches.version>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.6.0</cassandra-driver-core.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -437,7 +437,7 @@ The Apache Software License, Version 2.0
     - commons-lang-2.6.jar
     - commons-logging-1.2.jar
   * GSON
-    - gson-2.8.6.jar
+    - gson-2.8.9.jar
   * Snappy
     - snappy-java-1.1.7.jar
   * Jackson


### PR DESCRIPTION
Fixes #13607

Master Issue: #13607

### Motivation

see #13607

### Modifications

- Upgrade Gson version 2.8.6 to 2.8.9

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: ( no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 
 
- [x] `no-need-doc` 

