### PR TITLE
[Tests] Upgrade Mockito to latest stable 3.x version, 3.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ flexible messaging model and an intuitive client API.</description>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.3.0</testng.version>
     <junit4.version>4.13.1</junit4.version>
-    <mockito.version>3.8.0</mockito.version>
+    <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>
     <javassist.version>3.25.0-GA</javassist.version>
     <failsafe.version>2.3.1</failsafe.version>


### PR DESCRIPTION
### Motivation

Mockito version 3.8.0 is outdated. Upgrade to latest stable 3.x version.

### Modifications

Upgrade Mockito to 3.12.4