### PR TITLE
[C++] PIP 37: Support large message size

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -437,6 +437,50 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      */
     int getPriorityLevel() const;
 
+    /**
+     * Consumer buffers chunk messages into memory until it receives all the chunks of the original message.
+     * While consuming chunk-messages, chunks from same message might not be contiguous in the stream and they
+     * might be mixed with other messages' chunks. so, consumer has to maintain multiple buffers to manage
+     * chunks coming from different messages. This mainly happens when multiple publishers are publishing
+     * messages on the topic concurrently or publisher failed to publish all chunks of the messages.
+     *
+     * eg: M1-C1, M2-C1, M1-C2, M2-C2
+     * Here, Messages M1-C1 and M1-C2 belong to original message M1, M2-C1 and M2-C2 belong to M2 message.
+     *
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it
+     * can be guarded by providing this maxPendingChunkedMessage threshold. Once, consumer reaches this
+     * threshold, it drops the outstanding unchunked-messages by silently acking or asking broker to redeliver
+     * later by marking it unacked. See setAutoOldestChunkedMessageOnQueueFull.
+     *
+     * Default: 100
+     *
+     * @param maxPendingChunkedMessage the number of max pending chunked messages
+     */
+    ConsumerConfiguration& setMaxPendingChunkedMessage(size_t maxPendingChunkedMessage);
+
+    /**
+     * The associated getter of setMaxPendingChunkedMessage
+     */
+    size_t getMaxPendingChunkedMessage() const;
+
+    /**
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it
+     * can be guarded by providing the maxPendingChunkedMessage threshold. See setMaxPendingChunkedMessage.
+     * Once, consumer reaches this threshold, it drops the outstanding unchunked-messages by silently acking
+     * if autoAckOldestChunkedMessageOnQueueFull is true else it marks them for redelivery.
+     *
+     * Default: false
+     *
+     * @param autoAckOldestChunkedMessageOnQueueFull whether to ack the discarded chunked message
+     */
+    ConsumerConfiguration& setAutoOldestChunkedMessageOnQueueFull(
+        bool autoAckOldestChunkedMessageOnQueueFull);
+
+    /**
+     * The associated getter of setAutoOldestChunkedMessageOnQueueFull
+     */
+    bool isAutoOldestChunkedMessageOnQueueFull() const;
+
     friend class PulsarWrapper;
 
    private:

--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -452,6 +452,8 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      * threshold, it drops the outstanding unchunked-messages by silently acking or asking broker to redeliver
      * later by marking it unacked. See setAutoOldestChunkedMessageOnQueueFull.
      *
+     * If it's zero, the pending chunked messages will not be limited.
+     *
      * Default: 100
      *
      * @param maxPendingChunkedMessage the number of max pending chunked messages

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -478,10 +478,20 @@ class PULSAR_PUBLIC ProducerConfiguration {
      * producer to split message into multiple chunks and publish them to broker separately in order. So, it
      * allows client to successfully publish large size of messages in pulsar.
      *
-     * Set it true to enable this feature.
+     * Set it true to enable this feature. If so, you must disable batching (see setBatchingEnabled),
+     * otherwise the producer creation will fail.
+     *
+     * There are some other recommendations when it's enabled:
+     * 1. This features is right now only supported for non-shared subscription and persistent-topic.
+     * 2. It's better to reduce setMaxPendingMessages to avoid producer accupying large amount of memory by
+     * buffered messages.
+     * 3. Set message-ttl on the namespace to cleanup chunked messages. Sometimes due to broker-restart or
+     * publish time, producer might fail to publish entire large message. So, consumer will not be able to
+     * consume and ack those messages.
      *
      * Default: false
      *
+     * @param chunkingEnabled whether chunking is enabled
      * @return the ProducerConfiguration self
      */
     ProducerConfiguration& setChunkingEnabled(bool chunkingEnabled);

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -473,6 +473,24 @@ class PULSAR_PUBLIC ProducerConfiguration {
      */
     ProducerConfiguration& setProperties(const std::map<std::string, std::string>& properties);
 
+    /**
+     * If message size is higher than allowed max publish-payload size by broker then enableChunking helps
+     * producer to split message into multiple chunks and publish them to broker separately in order. So, it
+     * allows client to successfully publish large size of messages in pulsar.
+     *
+     * Set it true to enable this feature.
+     *
+     * Default: false
+     *
+     * @return the ProducerConfiguration self
+     */
+    ProducerConfiguration& setChunkingEnabled(bool chunkingEnabled);
+
+    /**
+     * The getter associated with setChunkingEnabled().
+     */
+    bool isChunkingEnabled() const;
+
     friend class PulsarWrapper;
 
    private:

--- a/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
+++ b/pulsar-client-cpp/lib/BatchMessageContainerBase.cc
@@ -74,7 +74,8 @@ Result BatchMessageContainerBase::createOpSendMsgHelper(OpSendMsg& opSendMsg,
         return ResultMessageTooBig;
     }
 
-    opSendMsg.msg_.impl_ = impl;
+    opSendMsg.metadata_ = impl->metadata;
+    opSendMsg.payload_ = impl->payload;
     opSendMsg.sequenceId_ = impl->metadata.sequence_id();
     opSendMsg.producerId_ = producerId_;
     opSendMsg.timeout_ = TimeUtils::now() + milliseconds(producerConfig_.getSendTimeout());

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1366,8 +1366,9 @@ void ClientConnection::sendMessage(const OpSendMsg& opSend) {
 }
 
 void ClientConnection::sendMessageInternal(const OpSendMsg& opSend) {
-    PairSharedBuffer buffer = Commands::newSend(outgoingBuffer_, outgoingCmd_, opSend.producerId_,
-                                                opSend.sequenceId_, getChecksumType(), opSend.msg_);
+    PairSharedBuffer buffer =
+        Commands::newSend(outgoingBuffer_, outgoingCmd_, opSend.producerId_, opSend.sequenceId_,
+                          getChecksumType(), opSend.metadata_, opSend.payload_);
 
     asyncWrite(buffer, customAllocWriteHandler(std::bind(&ClientConnection::handleSendPair,
                                                          shared_from_this(), std::placeholders::_1)));
@@ -1408,8 +1409,9 @@ void ClientConnection::sendPendingCommands() {
             assert(any.type() == typeid(OpSendMsg));
 
             const OpSendMsg& op = boost::any_cast<const OpSendMsg&>(any);
-            PairSharedBuffer buffer = Commands::newSend(outgoingBuffer_, outgoingCmd_, op.producerId_,
-                                                        op.sequenceId_, getChecksumType(), op.msg_);
+            PairSharedBuffer buffer =
+                Commands::newSend(outgoingBuffer_, outgoingCmd_, op.producerId_, op.sequenceId_,
+                                  getChecksumType(), op.metadata_, op.payload_);
 
             asyncWrite(buffer, customAllocWriteHandler(std::bind(&ClientConnection::handleSendPair,
                                                                  shared_from_this(), std::placeholders::_1)));

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -29,6 +29,7 @@
 #include <pulsar/ConsoleLoggerFactory.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <sstream>
+#include <stdexcept>
 #include <lib/HTTPLookupService.h>
 #include <lib/TopicName.h>
 #include <algorithm>
@@ -147,6 +148,9 @@ LookupServicePtr ClientImpl::getLookup() { return lookupServicePtr_; }
 
 void ClientImpl::createProducerAsync(const std::string& topic, ProducerConfiguration conf,
                                      CreateProducerCallback callback) {
+    if (conf.isChunkingEnabled() && conf.getBatchingEnabled()) {
+        throw std::invalid_argument("Batching and chunking of messages can't be enabled together");
+    }
     TopicNamePtr topicName;
     {
         Lock lock(mutex_);

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -178,7 +178,7 @@ void ClientImpl::handleCreateProducer(const Result result, const LookupDataResul
             producer = std::make_shared<PartitionedProducerImpl>(shared_from_this(), topicName,
                                                                  partitionMetadata->getPartitions(), conf);
         } else {
-            producer = std::make_shared<ProducerImpl>(shared_from_this(), topicName->toString(), conf);
+            producer = std::make_shared<ProducerImpl>(shared_from_this(), *topicName, conf);
         }
         producer->getProducerCreatedFuture().addListener(
             std::bind(&ClientImpl::handleProducerCreated, shared_from_this(), std::placeholders::_1,

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -80,7 +80,8 @@ class Commands {
                                   const std::string& listenerName);
 
     static PairSharedBuffer newSend(SharedBuffer& headers, proto::BaseCommand& cmd, uint64_t producerId,
-                                    uint64_t sequenceId, ChecksumType checksumType, const Message& msg);
+                                    uint64_t sequenceId, ChecksumType checksumType,
+                                    const proto::MessageMetadata& metadata, const SharedBuffer& payload);
 
     static SharedBuffer newSubscribe(const std::string& topic, const std::string& subscription,
                                      uint64_t consumerId, uint64_t requestId,

--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -231,4 +231,21 @@ ConsumerConfiguration& ConsumerConfiguration::setKeySharedPolicy(KeySharedPolicy
 
 KeySharedPolicy ConsumerConfiguration::getKeySharedPolicy() const { return impl_->keySharedPolicy; }
 
+ConsumerConfiguration& ConsumerConfiguration::setMaxPendingChunkedMessage(size_t maxPendingChunkedMessage) {
+    impl_->maxPendingChunkedMessage = maxPendingChunkedMessage;
+    return *this;
+}
+
+size_t ConsumerConfiguration::getMaxPendingChunkedMessage() const { return impl_->maxPendingChunkedMessage; }
+
+ConsumerConfiguration& ConsumerConfiguration::setAutoOldestChunkedMessageOnQueueFull(
+    bool autoAckOldestChunkedMessageOnQueueFull) {
+    impl_->autoAckOldestChunkedMessageOnQueueFull = autoAckOldestChunkedMessageOnQueueFull;
+    return *this;
+}
+
+bool ConsumerConfiguration::isAutoOldestChunkedMessageOnQueueFull() const {
+    return impl_->autoAckOldestChunkedMessageOnQueueFull;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
@@ -50,6 +50,8 @@ struct ConsumerConfigurationImpl {
     std::map<std::string, std::string> properties;
     int priorityLevel{0};
     KeySharedPolicy keySharedPolicy;
+    size_t maxPendingChunkedMessage{100};
+    bool autoAckOldestChunkedMessageOnQueueFull{false};
 };
 }  // namespace pulsar
 #endif /* LIB_CONSUMERCONFIGURATIONIMPL_H_ */

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -344,6 +344,8 @@ Optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuffer& pay
                         trackMessage(messageId);
                     }
                 });
+            it = chunkedMessageCache_.putIfAbsent(
+                uuid, ChunkedMessageCtx{metadata.num_chunks_from_msg(), metadata.total_chunk_msg_size()});
         }
     }
 
@@ -355,6 +357,7 @@ Optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuffer& pay
         } else {
             LOG_ERROR("Received a chunk whose chunk id is invalid (uuid: "
                       << uuid << " chunkId: " << chunkId << ", messageId: " << messageId << ")");
+            chunkedMessageCache_.remove(uuid);
         }
         lock.unlock();
         increaseAvailablePermits(cnx);

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -158,7 +158,8 @@ class ConsumerImpl : public ConsumerImplBase,
    private:
     bool waitingForZeroQueueSizeMessage;
     bool uncompressMessageIfNeeded(const ClientConnectionPtr& cnx, const proto::MessageIdData& messageIdData,
-                                   const proto::MessageMetadata& metadata, SharedBuffer& payload);
+                                   const proto::MessageMetadata& metadata, SharedBuffer& payload,
+                                   bool checkMaxMessageSize);
     void discardCorruptedMessage(const ClientConnectionPtr& cnx, const proto::MessageIdData& messageId,
                                  proto::CommandAck::ValidationError validationError);
     void increaseAvailablePermits(const ClientConnectionPtr& currentCnx, int delta = 1);

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -272,9 +272,11 @@ class ConsumerImpl : public ConsumerImplBase,
     const bool autoAckOldestChunkedMessageOnQueueFull_;
 
     mutable std::mutex chunkProcessMutex_;
+    // The key is UUID, value is the associated ChunkedMessageCtx of the chunked message.
     std::unordered_map<std::string, ChunkedMessageCtx> chunkedMessagesMap_;
-    // This list contains all the keys of `chunkedMessagesMap_`.
-    // Here we use list for removing uuid of expired chunks quickly
+    // This list contains all the keys of `chunkedMessagesMap_`, each key is an UUID that identifies a pending
+    // chunked message. Once the number of pending chunked messages exceeds the limit, the oldest UUIDs and
+    // the associated ChunkedMessageCtx will be removed.
     std::list<std::string> pendingChunkedMessageUuidQueue_;
 
     /**

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -238,7 +238,11 @@ class ConsumerImpl : public ConsumerImplBase,
         }
 
         ChunkedMessageCtx(const ChunkedMessageCtx&) = delete;
-        ChunkedMessageCtx(ChunkedMessageCtx&& rhs) noexcept = default;
+        // Here we don't use =default to be compatible with GCC 4.8
+        ChunkedMessageCtx(ChunkedMessageCtx&& rhs) noexcept
+            : totalChunks_(rhs.totalChunks_),
+              chunkedMsgBuffer_(std::move(rhs.chunkedMsgBuffer_)),
+              chunkedMessageIds_(std::move(rhs.chunkedMessageIds_)) {}
 
         bool validateChunkId(int chunkId) const noexcept { return chunkId == numChunks(); }
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -278,20 +278,22 @@ class ConsumerImpl : public ConsumerImplBase,
 
     /**
      * Process a chunk. If the chunk is the last chunk of a message, concatenate all buffered chunks into the
-     * payload. In this case, `payload` will point to the completed payload. Otherwise, the chunk will be
-     * buffered.
+     * payload and return it.
      *
-     * @param payload the original payload, which could be modified if this method returns true
+     * @param payload the payload of a chunk
      * @param metadata the message metadata
      * @param messageId
      * @param messageIdData
      * @param cnx
      *
-     * @return true if chunks are concatenated into a completed message payload successfully
+     * @return the concatenated payload if chunks are concatenated into a completed message payload
+     *   successfully, else Optional::empty()
      */
-    bool processMessageChunk(SharedBuffer& payload, const proto::MessageMetadata& metadata,
-                             const MessageId& messageId, const proto::MessageIdData& messageIdData,
-                             const ClientConnectionPtr& cnx);
+    Optional<SharedBuffer> processMessageChunk(const SharedBuffer& payload,
+                                               const proto::MessageMetadata& metadata,
+                                               const MessageId& messageId,
+                                               const proto::MessageIdData& messageIdData,
+                                               const ClientConnectionPtr& cnx);
 
     void removeOldestPendingChunkedMessage();
 

--- a/pulsar-client-cpp/lib/MapCache.h
+++ b/pulsar-client-cpp/lib/MapCache.h
@@ -37,7 +37,8 @@ class MapCache {
     using iterator = typename decltype(map_)::iterator;
 
     MapCache() = default;
-    MapCache(MapCache&&) noexcept = default;
+    // Here we don't use =default to be compatible with GCC 4.8
+    MapCache(MapCache&& rhs) noexcept : map_(std::move(rhs.map_)), keys_(std::move(rhs.keys_)) {}
 
     size_t size() const noexcept { return map_.size(); }
 
@@ -91,7 +92,7 @@ class MapCache {
 
    private:
     void removeKeyFromKeys(const Key& key) {
-        for (auto it = keys_.cbegin(); it != keys_.end(); ++it) {
+        for (auto it = keys_.begin(); it != keys_.end(); ++it) {
             if (*it == key) {
                 keys_.erase(it);
             }

--- a/pulsar-client-cpp/lib/MapCache.h
+++ b/pulsar-client-cpp/lib/MapCache.h
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace pulsar {
+
+// A thread safe map cache that supports removing the first N oldest entries from the map.
+// Value must be moveable and have the default constructor.
+template <typename Key, typename Value>
+class MapCache {
+    using Lock = std::lock_guard<std::mutex>;
+
+    mutable std::mutex mutex_;
+    std::unordered_map<Key, Value> map_;
+    std::deque<Key> keys_;
+
+   public:
+    using const_iterator = typename decltype(map_)::const_iterator;
+
+    MapCache() = default;
+    MapCache(MapCache&&) noexcept = default;
+
+    const_iterator find(const Key& key) const {
+        Lock lock(mutex_);
+        return map_.find(key);
+    }
+
+    const_iterator end() const {
+        Lock lock(mutex_);
+        return map_.end();
+    }
+
+    bool putIfAbsent(const Key& key, Value&& value) {
+        Lock lock(mutex_);
+        auto it = map_.find(key);
+        if (it == map_.end()) {
+            map_.emplace(key, std::move(value));
+            keys_.push_back(key);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    std::vector<Value> removeOldestValues(size_t numToRemove) {
+        std::vector<Value> values;
+        values.reserve(numToRemove);
+
+        Lock lock(mutex_);
+        for (size_t i = 0; !keys_.empty() && i < numToRemove; i++) {
+            const auto key = keys_.front();
+            auto it = map_.find(key);
+            if (it != map_.end()) {
+                values.emplace_back(std::move(it->second));
+                map_.erase(it);
+            }
+            keys_.pop_front();
+        }
+        return values;
+    }
+
+    void remove(const Key& key) {
+        Lock lock(mutex_);
+        auto it = map_.find(key);
+        if (it != map_.end()) {
+            removeKeyFromKeys(key);
+            map_.erase(it);
+        }
+    }
+
+    // Following methods are only used for tests
+    std::vector<Key> getKeys() const {
+        Lock lock(mutex_);
+        std::vector<Key> keys;
+        for (auto key : keys_) {
+            keys.emplace_back(key);
+        }
+        return keys;
+    }
+
+    size_t size() const {
+        Lock lock(mutex_);
+        return map_.size();
+    }
+
+   private:
+    void removeKeyFromKeys(const Key& key) {
+        for (auto it = keys_.cbegin(); it != keys_.end(); ++it) {
+            if (*it == key) {
+                keys_.erase(it);
+            }
+        }
+    }
+};
+
+}  // namespace pulsar

--- a/pulsar-client-cpp/lib/MapCache.h
+++ b/pulsar-client-cpp/lib/MapCache.h
@@ -95,6 +95,7 @@ class MapCache {
         for (auto it = keys_.begin(); it != keys_.end(); ++it) {
             if (*it == key) {
                 keys_.erase(it);
+                break;
             }
         }
     }

--- a/pulsar-client-cpp/lib/MemoryLimitController.cc
+++ b/pulsar-client-cpp/lib/MemoryLimitController.cc
@@ -25,6 +25,10 @@ MemoryLimitController::MemoryLimitController(uint64_t memoryLimit)
     : memoryLimit_(memoryLimit), currentUsage_(0), mutex_(), condition_() {}
 
 bool MemoryLimitController::tryReserveMemory(uint64_t size) {
+    // Avoid CAS operation when size is 0
+    if (size == 0) {
+        return true;
+    }
     while (true) {
         uint64_t current = currentUsage_;
         uint64_t newUsage = current + size;

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -36,8 +36,6 @@ struct OpSendMsg {
     boost::posix_time::ptime timeout_;
     uint32_t messagesCount_;
     uint64_t messagesSize_;
-    int totalChunks_ = 0;
-    int chunkId_ = -1;
 
     OpSendMsg() = default;
 
@@ -50,16 +48,6 @@ struct OpSendMsg {
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)),
           messagesCount_(messagesCount),
           messagesSize_(messagesSize) {}
-
-    OpSendMsg& setTotalChunks(int totalChunks) {
-        totalChunks_ = totalChunks;
-        return *this;
-    }
-
-    OpSendMsg& setChunkId(int chunkId) {
-        chunkId_ = chunkId;
-        return *this;
-    }
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/OpSendMsg.h
+++ b/pulsar-client-cpp/lib/OpSendMsg.h
@@ -36,6 +36,8 @@ struct OpSendMsg {
     boost::posix_time::ptime timeout_;
     uint32_t messagesCount_;
     uint64_t messagesSize_;
+    int totalChunks_ = 0;
+    int chunkId_ = -1;
 
     OpSendMsg() = default;
 
@@ -48,6 +50,16 @@ struct OpSendMsg {
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)),
           messagesCount_(messagesCount),
           messagesSize_(messagesSize) {}
+
+    OpSendMsg& setTotalChunks(int totalChunks) {
+        totalChunks_ = totalChunks;
+        return *this;
+    }
+
+    OpSendMsg& setChunkId(int chunkId) {
+        chunkId_ = chunkId;
+        return *this;
+    }
 };
 
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -86,8 +86,7 @@ unsigned int PartitionedProducerImpl::getNumPartitionsWithLock() const {
 
 ProducerImplPtr PartitionedProducerImpl::newInternalProducer(unsigned int partition, bool lazy) {
     using namespace std::placeholders;
-    std::string topicPartitionName = topicName_->getTopicPartitionName(partition);
-    auto producer = std::make_shared<ProducerImpl>(client_, topicPartitionName, conf_, partition);
+    auto producer = std::make_shared<ProducerImpl>(client_, *topicName_, conf_, partition);
 
     if (lazy) {
         createLazyPartitionProducer(partition);
@@ -97,7 +96,7 @@ ProducerImplPtr PartitionedProducerImpl::newInternalProducer(unsigned int partit
                       const_cast<PartitionedProducerImpl*>(this)->shared_from_this(), _1, _2, partition));
     }
 
-    LOG_DEBUG("Creating Producer for single Partition - " << topicPartitionName);
+    LOG_DEBUG("Creating Producer for single Partition - " << topicName_ << "-partition-" << partition);
     return producer;
 }
 

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -251,4 +251,11 @@ ProducerConfiguration& ProducerConfiguration::setProperties(
     return *this;
 }
 
+ProducerConfiguration& ProducerConfiguration::setChunkingEnabled(bool chunkingEnabled) {
+    impl_->chunkingEnabled = chunkingEnabled;
+    return *this;
+}
+
+bool ProducerConfiguration::isChunkingEnabled() const { return impl_->chunkingEnabled; }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -48,6 +48,7 @@ struct ProducerConfigurationImpl {
     std::set<std::string> encryptionKeys;
     ProducerCryptoFailureAction cryptoFailureAction{ProducerCryptoFailureAction::FAIL};
     std::map<std::string, std::string> properties;
+    bool chunkingEnabled{false};
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -360,7 +360,8 @@ bool ProducerImpl::isValidProducerState(const SendCallback& callback) const {
             // OK
         case HandlerBase::Pending:
             // We are OK to queue the messages on the client, it will be sent to the broker once we get the
-            // connectionPL
+            // connection
+            return true;
         case HandlerBase::Closing:
         case HandlerBase::Closed:
             callback(ResultAlreadyClosed, {});

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -391,7 +391,9 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
     auto self = shared_from_this();
     sendAsyncWithStatsUpdate(msg, [this, self, now, callback](Result result, const MessageId& messageId) {
         producerStatsBasePtr_->messageReceived(result, now);
-        callback(result, messageId);
+        if (callback) {
+            callback(result, messageId);
+        }
     });
 }
 
@@ -430,7 +432,7 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, const SendCallba
     const auto compressedSize = static_cast<uint32_t>(payload.readableBytes());
     const auto maxMessageSize = static_cast<uint32_t>(ClientConnection::getMaxMessageSize());
 
-    if (compressedSize > ClientConnection::getMaxMessageSize() && !chunkingEnabled_) {
+    if (compressed && compressedSize > ClientConnection::getMaxMessageSize() && !chunkingEnabled_) {
         LOG_WARN(getName() << " - compressed Message payload size " << payload.readableBytes()
                            << " cannot exceed " << ClientConnection::getMaxMessageSize()
                            << " bytes unless chunking is enabled");

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -426,7 +426,7 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, const SendCallba
 
     const bool compressed = !canAddToBatch(msg);
     const auto payload =
-        compressed ? uncompressedPayload : applyCompression(uncompressedPayload, conf_.getCompressionType());
+        compressed ? applyCompression(uncompressedPayload, conf_.getCompressionType()) : uncompressedPayload;
     const auto compressedSize = static_cast<uint32_t>(payload.readableBytes());
     const auto maxMessageSize = static_cast<uint32_t>(ClientConnection::getMaxMessageSize());
 
@@ -445,7 +445,7 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, const SendCallba
     }
 
     const int totalChunks =
-        canAddToBatch(msg) ? 1 : getNumOfChunks(uncompressedSize, ClientConnection::getMaxMessageSize());
+        canAddToBatch(msg) ? 1 : getNumOfChunks(compressedSize, ClientConnection::getMaxMessageSize());
     // Each chunk should be sent individually, so try to acquire extra permits for chunks.
     for (int i = 0; i < (totalChunks - 1); i++) {
         const auto result = canEnqueueRequest(0);  // size is 0 because the memory has already reserved

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -42,10 +42,10 @@ struct ProducerImpl::PendingCallbacks {
     }
 };
 
-ProducerImpl::ProducerImpl(ClientImplPtr client, const std::string& topic, const ProducerConfiguration& conf,
-                           int32_t partition)
+ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
+                           const ProducerConfiguration& conf, int32_t partition)
     : HandlerBase(
-          client, topic,
+          client, (partition < 0) ? topicName.toString() : topicName.getTopicPartitionName(partition),
           Backoff(milliseconds(100), seconds(60), milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
       conf_(conf),
       semaphore_(),

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -47,12 +47,13 @@ class PulsarFriend;
 
 class Producer;
 class MemoryLimitController;
+class TopicName;
 
 class ProducerImpl : public HandlerBase,
                      public std::enable_shared_from_this<ProducerImpl>,
                      public ProducerImplBase {
    public:
-    ProducerImpl(ClientImplPtr client, const std::string& topic,
+    ProducerImpl(ClientImplPtr client, const TopicName& topic,
                  const ProducerConfiguration& producerConfiguration, int32_t partition = -1);
     ~ProducerImpl();
 

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -136,13 +136,6 @@ class ProducerImpl : public HandlerBase,
      */
     Result canEnqueueRequest(uint32_t payloadSize);
 
-    /**
-     * It calls the previous overloaded method. If the result is not ResultOk, `batchMessageAndSend` will be
-     * called to send all pending messages. Then `callback` will be completed with `result` and a default
-     * MessageId.
-     */
-    bool canEnqueueRequest(const SendCallback& callback, uint32_t size);
-
     void releaseSemaphore(uint32_t payloadSize);
     void releaseSemaphoreForSendOp(const OpSendMsg& op);
 

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -126,6 +126,8 @@ class ProducerImpl : public HandlerBase,
     bool encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
                         SharedBuffer& encryptedPayload);
 
+    void sendAsyncWithStatsUpdate(const Message& msg, const SendCallback& callback);
+
     /**
      * Reserve a spot in the messages queue before acquiring the ProducerImpl mutex. When the queue is full,
      * this call will block until a spot is available if blockIfQueueIsFull is true. Otherwise, it will return
@@ -141,7 +143,7 @@ class ProducerImpl : public HandlerBase,
 
     void cancelTimers();
 
-    bool isValidProducerState(const SendCallback& callback);
+    bool isValidProducerState(const SendCallback& callback) const;
     bool canAddToBatch(const Message& msg) const;
 
     typedef std::unique_lock<std::mutex> Lock;

--- a/pulsar-client-cpp/lib/SharedBuffer.h
+++ b/pulsar-client-cpp/lib/SharedBuffer.h
@@ -165,7 +165,7 @@ class SharedBuffer {
     }
 
     // Return current writer index
-    uint32_t writerIndex() { return writeIdx_; }
+    uint32_t writerIndex() const noexcept { return writeIdx_; }
 
     // skip writerIndex
     void skipBytes(uint32_t size) {
@@ -180,7 +180,7 @@ class SharedBuffer {
     }
 
     // Return current reader index
-    uint32_t readerIndex() { return readIdx_; }
+    uint32_t readerIndex() const noexcept { return readIdx_; }
 
     // set readerIndex
     void setReaderIndex(uint32_t index) {

--- a/pulsar-client-cpp/lib/SharedBuffer.h
+++ b/pulsar-client-cpp/lib/SharedBuffer.h
@@ -94,13 +94,13 @@ class SharedBuffer {
     /**
      * Return a shared buffer that include a portion of current buffer. No memory is copied
      */
-    SharedBuffer slice(uint32_t offset) {
+    SharedBuffer slice(uint32_t offset) const {
         SharedBuffer buf(*this);
         buf.consume(offset);
         return buf;
     }
 
-    SharedBuffer slice(uint32_t offset, uint32_t length) {
+    SharedBuffer slice(uint32_t offset, uint32_t length) const {
         SharedBuffer buf(*this);
         buf.consume(offset);
         assert(buf.readableBytes() >= length);

--- a/pulsar-client-cpp/lib/TopicName.cc
+++ b/pulsar-client-cpp/lib/TopicName.cc
@@ -216,7 +216,7 @@ std::string TopicName::getLookupName() {
     return ss.str();
 }
 
-std::string TopicName::toString() {
+std::string TopicName::toString() const {
     std::stringstream ss;
     std::string seperator("/");
     if (isV2Topic_ && cluster_.empty()) {
@@ -230,7 +230,7 @@ std::string TopicName::toString() {
 
 bool TopicName::isPersistent() const { return this->domain_ == TopicDomain::Persistent; }
 
-const std::string TopicName::getTopicPartitionName(unsigned int partition) {
+std::string TopicName::getTopicPartitionName(unsigned int partition) const {
     std::stringstream topicPartitionName;
     // make this topic name as well
     topicPartitionName << toString() << PartitionedProducerImpl::PARTITION_NAME_SUFFIX << partition;

--- a/pulsar-client-cpp/lib/TopicName.h
+++ b/pulsar-client-cpp/lib/TopicName.h
@@ -55,14 +55,14 @@ class PULSAR_PUBLIC TopicName : public ServiceUnitId {
     std::string getNamespacePortion();
     std::string getLocalName();
     std::string getEncodedLocalName();
-    std::string toString();
+    std::string toString() const;
     bool isPersistent() const;
     NamespaceNamePtr getNamespaceName();
     int getPartitionIndex() const noexcept { return partition_; }
     static std::shared_ptr<TopicName> get(const std::string& topicName);
     bool operator==(const TopicName& other);
     static std::string getEncodedName(const std::string& nameBeforeEncoding);
-    const std::string getTopicPartitionName(unsigned int partition);
+    std::string getTopicPartitionName(unsigned int partition) const;
     static int getPartitionIndex(const std::string& topic);
 
    private:

--- a/pulsar-client-cpp/lib/stats/ProducerStatsBase.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsBase.h
@@ -27,7 +27,7 @@ namespace pulsar {
 class ProducerStatsBase {
    public:
     virtual void messageSent(const Message& msg) = 0;
-    virtual void messageReceived(Result&, boost::posix_time::ptime&) = 0;
+    virtual void messageReceived(Result, const boost::posix_time::ptime&) = 0;
     virtual ~ProducerStatsBase(){};
 };
 

--- a/pulsar-client-cpp/lib/stats/ProducerStatsDisabled.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsDisabled.h
@@ -25,7 +25,7 @@ namespace pulsar {
 class ProducerStatsDisabled : public ProducerStatsBase {
    public:
     virtual void messageSent(const Message& msg){};
-    virtual void messageReceived(Result&, boost::posix_time::ptime&){};
+    virtual void messageReceived(Result, const boost::posix_time::ptime&){};
 };
 }  // namespace pulsar
 #endif  // PULSAR_PRODUCER_STATS_DISABLED_HEADER

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.cc
@@ -93,7 +93,7 @@ void ProducerStatsImpl::messageSent(const Message& msg) {
     totalBytesSent_ += msg.getLength();
 }
 
-void ProducerStatsImpl::messageReceived(Result& res, boost::posix_time::ptime& publishTime) {
+void ProducerStatsImpl::messageReceived(Result res, const boost::posix_time::ptime& publishTime) {
     boost::posix_time::ptime currentTime = boost::posix_time::microsec_clock::universal_time();
     double diffInMicros = (currentTime - publishTime).total_microseconds();
     Lock lock(mutex_);

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -82,7 +82,7 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
 
     void messageSent(const Message&);
 
-    void messageReceived(Result&, boost::posix_time::ptime&);
+    void messageReceived(Result, const boost::posix_time::ptime&);
 
     ~ProducerStatsImpl();
 

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -303,4 +303,4 @@ globalZookeeperServers={{ zookeeper_servers }}
 brokerServicePurgeInactiveFrequencyInSeconds=60
 
 # Given a specific limit of the max message size
-maxMessageSize=10240
+maxMessageSize=1024000

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -301,3 +301,6 @@ globalZookeeperServers={{ zookeeper_servers }}
 
 # Deprecated. Use brokerDeleteInactiveTopicsFrequencySeconds
 brokerServicePurgeInactiveFrequencyInSeconds=60
+
+# Given a specific limit of the max message size
+maxMessageSize=10240

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -602,7 +602,7 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     Result result = client.createProducer(topicName, conf, producer);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
+    int size = ClientConnection::getMaxMessageSize() + 1000 * 100;
     char *content = new char[size];
     memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
@@ -610,7 +610,7 @@ TEST(BasicEndToEndTest, testMessageTooBig) {
     ASSERT_EQ(ResultMessageTooBig, result);
 
     // Anything up to MaxMessageSize should be allowed
-    size = Commands::DefaultMaxMessageSize;
+    size = ClientConnection::getMaxMessageSize();
     msg = MessageBuilder().setAllocatedContent(content, size).build();
     result = producer.send(msg);
     ASSERT_EQ(ResultOk, result);
@@ -1156,7 +1156,7 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = producerFuture.get(producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
+    int size = ClientConnection::getMaxMessageSize() + 1000 * 100;
     char *content = new char[size];
     memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();
@@ -1208,7 +1208,7 @@ TEST(BasicEndToEndTest, testBigMessageSizeBatching) {
     result = client.createProducer(topicName, conf2, producer2);
     ASSERT_EQ(ResultOk, result);
 
-    int size = Commands::DefaultMaxMessageSize + 1000 * 100;
+    int size = ClientConnection::getMaxMessageSize() + 1000 * 100;
     char *content = new char[size];
     memset(content, 0, size);
     Message msg = MessageBuilder().setAllocatedContent(content, size).build();

--- a/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ConsumerConfigurationTest.cc
@@ -59,6 +59,8 @@ TEST(ConsumerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.isReplicateSubscriptionStateEnabled(), false);
     ASSERT_EQ(conf.getProperties().empty(), true);
     ASSERT_EQ(conf.getPriorityLevel(), 0);
+    ASSERT_EQ(conf.getMaxPendingChunkedMessage(), 100);
+    ASSERT_EQ(conf.isAutoOldestChunkedMessageOnQueueFull(), false);
 }
 
 TEST(ConsumerConfigurationTest, testCustomConfig) {
@@ -139,6 +141,12 @@ TEST(ConsumerConfigurationTest, testCustomConfig) {
 
     conf.setPriorityLevel(1);
     ASSERT_EQ(conf.getPriorityLevel(), 1);
+
+    conf.setMaxPendingChunkedMessage(500);
+    ASSERT_EQ(conf.getMaxPendingChunkedMessage(), 500);
+
+    conf.setAutoOldestChunkedMessageOnQueueFull(true);
+    ASSERT_TRUE(conf.isAutoOldestChunkedMessageOnQueueFull());
 }
 
 TEST(ConsumerConfigurationTest, testReadCompactPersistentExclusive) {

--- a/pulsar-client-cpp/tests/MapCacheTest.cc
+++ b/pulsar-client-cpp/tests/MapCacheTest.cc
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <lib/MapCache.h>
+
+using namespace pulsar;
+
+struct MoveOnlyInt {
+    int x = 0;
+
+    MoveOnlyInt() = default;
+    MoveOnlyInt(int xx) : x(xx) {}
+    MoveOnlyInt(const MoveOnlyInt&) = delete;
+    MoveOnlyInt(MoveOnlyInt&& rhs) noexcept : x(rhs.x) {}
+
+    bool operator=(const MoveOnlyInt& rhs) const { return x == rhs.x; }
+};
+
+using VecInt = std::vector<int>;
+
+inline VecInt toIntVec(const std::vector<MoveOnlyInt>& v) {
+    VecInt result;
+    for (const auto& i : v) {
+        result.emplace_back(i.x);
+    }
+    return result;
+}
+
+TEST(MapCacheTest, testPutIfAbsent) {
+    MapCache<int, MoveOnlyInt> cache;
+
+    ASSERT_TRUE(cache.putIfAbsent(1, {100}));
+    ASSERT_FALSE(cache.putIfAbsent(1, {200}));
+    auto it = cache.find(1);
+    ASSERT_NE(it, cache.end());
+    ASSERT_EQ(it->second.x, 100);
+
+    cache.remove(1);
+    ASSERT_EQ(cache.find(1), cache.end());
+}
+
+TEST(MapCacheTest, testRemoveOldestValues) {
+    MapCache<int, MoveOnlyInt> cache;
+    ASSERT_TRUE(cache.putIfAbsent(1, {200}));
+    ASSERT_TRUE(cache.putIfAbsent(2, {210}));
+    ASSERT_TRUE(cache.putIfAbsent(3, {220}));
+    ASSERT_EQ(cache.getKeys(), (VecInt{1, 2, 3}));
+
+    ASSERT_EQ(toIntVec(cache.removeOldestValues(2)), (VecInt{200, 210}));
+
+    ASSERT_EQ(cache.getKeys(), (VecInt{3}));
+    ASSERT_EQ(cache.size(), 1);
+    auto it = cache.find(3);
+    ASSERT_NE(it, cache.end());
+    ASSERT_EQ(it->second.x, 220);
+}
+
+TEST(MapCacheTest, testRemoveAllValues) {
+    MapCache<int, MoveOnlyInt> cache;
+    ASSERT_TRUE(cache.putIfAbsent(1, {300}));
+    ASSERT_TRUE(cache.putIfAbsent(2, {310}));
+    ASSERT_TRUE(cache.putIfAbsent(3, {320}));
+
+    // removeOldestValues works well even if the argument is greater than the size of keys
+    ASSERT_EQ(toIntVec(cache.removeOldestValues(10000)), (VecInt{300, 310, 320}));
+    ASSERT_TRUE(cache.getKeys().empty());
+    ASSERT_EQ(cache.size(), 0);
+}

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -131,9 +131,10 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
     ASSERT_EQ(chunkedMessageCache.size(), 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(Pulsar, MessageChunkingTest,
-                         ::testing::Values(CompressionNone, CompressionLZ4, CompressionZLib, CompressionZSTD,
-                                           CompressionSNAPPY),
-                         [](const ::testing::TestParamInfo<MessageChunkingTest::ParamType>& info) {
-                             return toString(info.param);
-                         });
+// The CI env is Ubuntu 16.04, the gtest-dev version is 1.8.0 that doesn't have INSTANTIATE_TEST_SUITE_P
+INSTANTIATE_TEST_CASE_P(Pulsar, MessageChunkingTest,
+                        ::testing::Values(CompressionNone, CompressionLZ4, CompressionZLib, CompressionZSTD,
+                                          CompressionSNAPPY),
+                        [](const ::testing::TestParamInfo<MessageChunkingTest::ParamType>& info) {
+                            return toString(info.param);
+                        });

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <ctime>
+#include <random>
+
+#include <pulsar/Client.h>
+#include <gtest/gtest.h>
+#include "lib/LogUtils.h"
+
+DECLARE_LOG_OBJECT()
+
+using namespace pulsar;
+
+static const std::string lookupUrl = "pulsar://localhost:6650";
+
+// See the `maxMessageSize` config in test-conf/standalone-ssl.conf
+static constexpr size_t maxMessageSize = 10240;
+
+static std::string toString(CompressionType compressionType) {
+    switch (compressionType) {
+        case CompressionType::CompressionNone:
+            return "None";
+        case CompressionType::CompressionLZ4:
+            return "LZ4";
+        case CompressionType::CompressionZLib:
+            return "ZLib";
+        case CompressionType::CompressionZSTD:
+            return "ZSTD";
+        case CompressionType::CompressionSNAPPY:
+            return "SNAPPY";
+        default:
+            return "Unknown (" + std::to_string(compressionType) + ")";
+    }
+}
+
+class MessageChunkingTest : public ::testing::TestWithParam<CompressionType> {
+   public:
+    void TearDown() override { client_.close(); }
+
+    void createProducer(const std::string& topic, Producer& producer) {
+        ProducerConfiguration conf;
+        conf.setBatchingEnabled(false);
+        conf.setChunkingEnabled(true);
+        conf.setCompressionType(GetParam());
+        LOG_INFO("Create producer to topic: " << topic
+                                              << ", compression: " << toString(conf.getCompressionType()));
+        ASSERT_EQ(ResultOk, client_.createProducer(topic, conf, producer));
+    }
+
+    void createConsumer(const std::string& topic, Consumer& consumer) {
+        ASSERT_EQ(ResultOk, client_.subscribe(topic, "my-sub", consumer));
+    }
+
+   private:
+    Client client_{lookupUrl};
+};
+
+TEST_F(MessageChunkingTest, testInvalidConfig) {
+    Client client(lookupUrl);
+    ProducerConfiguration conf;
+    conf.setBatchingEnabled(true);
+    conf.setChunkingEnabled(true);
+    Producer producer;
+    ASSERT_THROW(client.createProducer("xxx", conf, producer), std::invalid_argument);
+    client.close();
+}
+
+TEST_P(MessageChunkingTest, testEndToEnd) {
+    const std::string topic =
+        "MessageChunkingTest-EndToEnd-" + toString(GetParam()) + std::to_string(time(nullptr));
+    Consumer consumer;
+    createConsumer(topic, consumer);
+    Producer producer;
+    createProducer(topic, producer);
+
+    std::string largeMessage(maxMessageSize * 3, 'a');
+    std::default_random_engine e(time(nullptr));
+    std::uniform_int_distribution<unsigned> u(0, 25);
+    for (auto& ch : largeMessage) {
+        ch = 'a' + u(e);
+    }
+
+    MessageId sendMessageId;
+    ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent(largeMessage).build(), sendMessageId));
+    LOG_INFO("Send to " << sendMessageId);
+
+    Message msg;
+    ASSERT_EQ(ResultOk, consumer.receive(msg, 3000));
+    LOG_INFO("Receive " << msg.getLength() << " bytes from " << msg.getMessageId());
+    ASSERT_EQ(msg.getDataAsString(), largeMessage);
+    ASSERT_EQ(msg.getMessageId(), sendMessageId);
+}
+
+INSTANTIATE_TEST_SUITE_P(Pulsar, MessageChunkingTest, ::testing::Values(CompressionNone),
+                         [](const ::testing::TestParamInfo<MessageChunkingTest::ParamType>& info) {
+                             return toString(info.param);
+                         });

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -22,6 +22,7 @@
 #include <pulsar/Client.h>
 #include <gtest/gtest.h>
 #include "lib/LogUtils.h"
+#include "PulsarFriend.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -124,6 +125,10 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
     ASSERT_EQ(receivedMessageIds, sendMessageIds);
     ASSERT_EQ(receivedMessageIds.front().ledgerId(), receivedMessageIds.front().ledgerId());
     ASSERT_GT(receivedMessageIds.back().entryId(), numMessages);
+
+    // Verify the cache has been cleared
+    auto& chunkedMessageCache = PulsarFriend::getChunkedMessageCache(consumer);
+    ASSERT_EQ(chunkedMessageCache.size(), 0);
 }
 
 INSTANTIATE_TEST_SUITE_P(Pulsar, MessageChunkingTest,

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -134,7 +134,4 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
 // The CI env is Ubuntu 16.04, the gtest-dev version is 1.8.0 that doesn't have INSTANTIATE_TEST_SUITE_P
 INSTANTIATE_TEST_CASE_P(Pulsar, MessageChunkingTest,
                         ::testing::Values(CompressionNone, CompressionLZ4, CompressionZLib, CompressionZSTD,
-                                          CompressionSNAPPY),
-                        [](const ::testing::TestParamInfo<MessageChunkingTest::ParamType>& info) {
-                            return toString(info.param);
-                        });
+                                          CompressionSNAPPY));

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -107,7 +107,9 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
     ASSERT_EQ(msg.getMessageId(), sendMessageId);
 }
 
-INSTANTIATE_TEST_SUITE_P(Pulsar, MessageChunkingTest, ::testing::Values(CompressionNone),
+INSTANTIATE_TEST_SUITE_P(Pulsar, MessageChunkingTest,
+                         ::testing::Values(CompressionNone, CompressionLZ4, CompressionZLib, CompressionZSTD,
+                                           CompressionSNAPPY),
                          [](const ::testing::TestParamInfo<MessageChunkingTest::ParamType>& info) {
                              return toString(info.param);
                          });

--- a/pulsar-client-cpp/tests/MessageChunkingTest.cc
+++ b/pulsar-client-cpp/tests/MessageChunkingTest.cc
@@ -31,7 +31,7 @@ using namespace pulsar;
 static const std::string lookupUrl = "pulsar://localhost:6650";
 
 // See the `maxMessageSize` config in test-conf/standalone-ssl.conf
-static constexpr size_t maxMessageSize = 10240;
+static constexpr size_t maxMessageSize = 1024000;
 
 static std::string toString(CompressionType compressionType) {
     switch (compressionType) {

--- a/pulsar-client-cpp/tests/ProducerConfigurationTest.cc
+++ b/pulsar-client-cpp/tests/ProducerConfigurationTest.cc
@@ -46,6 +46,7 @@ TEST(ProducerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.isEncryptionEnabled(), false);
     ASSERT_EQ(conf.getEncryptionKeys(), std::set<std::string>{});
     ASSERT_EQ(conf.getProperties().empty(), true);
+    ASSERT_EQ(conf.isChunkingEnabled(), false);
 }
 
 class MockMessageRoutingPolicy : public MessageRoutingPolicy {
@@ -129,4 +130,7 @@ TEST(ProducerConfigurationTest, testCustomConfig) {
     conf.setProperty("k1", "v1");
     ASSERT_EQ(conf.getProperties()["k1"], "v1");
     ASSERT_EQ(conf.hasProperty("k1"), true);
+
+    conf.setChunkingEnabled(true);
+    ASSERT_EQ(conf.isChunkingEnabled(), true);
 }

--- a/pulsar-client-cpp/tests/ProducerTest.cc
+++ b/pulsar-client-cpp/tests/ProducerTest.cc
@@ -26,6 +26,7 @@
 #include "lib/Utils.h"
 #include "lib/Latch.h"
 #include "lib/LogUtils.h"
+#include "lib/ProducerImpl.h"
 DECLARE_LOG_OBJECT()
 
 using namespace pulsar;
@@ -240,4 +241,12 @@ TEST(ProducerTest, testSendAsyncCloseAsyncConcurrentlyWithLazyProducers) {
         client.close();
         LOG_INFO("End of run " << run);
     }
+}
+
+TEST(ProducerTest, testGetNumOfChunks) {
+    ASSERT_EQ(ProducerImpl::getNumOfChunks(11, 5), 3);
+    ASSERT_EQ(ProducerImpl::getNumOfChunks(10, 5), 2);
+    ASSERT_EQ(ProducerImpl::getNumOfChunks(8, 5), 2);
+    ASSERT_EQ(ProducerImpl::getNumOfChunks(4, 5), 1);
+    ASSERT_EQ(ProducerImpl::getNumOfChunks(1, 0), 1);
 }

--- a/pulsar-client-cpp/tests/PulsarFriend.h
+++ b/pulsar-client-cpp/tests/PulsarFriend.h
@@ -79,6 +79,12 @@ class PulsarFriend {
         return std::static_pointer_cast<ConsumerImpl>(consumer.impl_);
     }
 
+    static decltype(ConsumerImpl::chunkedMessageCache_) & getChunkedMessageCache(Consumer consumer) {
+        auto consumerImpl = getConsumerImplPtr(consumer);
+        ConsumerImpl::Lock lock(consumerImpl->chunkProcessMutex_);
+        return consumerImpl->chunkedMessageCache_;
+    }
+
     static std::shared_ptr<PartitionedConsumerImpl> getPartitionedConsumerImplPtr(Consumer consumer) {
         return std::static_pointer_cast<PartitionedConsumerImpl>(consumer.impl_);
     }


### PR DESCRIPTION
### Motivation

This PR is a C++ catch up of https://github.com/apache/pulsar/pull/4400, which implements [PIP 37](https://github.com/apache/pulsar/wiki/PIP-37%3A-Large-message-size-handling-in-Pulsar).

### Modifications

Changes of the interfaces:
- Add the `chunkingEnabled` config to producer so that producer can enable chunking messages by enabling `chunkingEnabled` and disabling `batchingEnabled`.
- Add the `maxPendingChunkedMessage` and `autoOldestChunkedMessageOnQueueFull` configs to consumer to control the behavior to handle chunks.

Implementations of producer side:
- Refactor the `sendAsync` method to follow the similar logic of Java client. If `canAddToBatch` returns false and the message size exceeds the limit, split the large message into chunks and send them one by one.
- Fix the bug of `Commands::newSend` that it didn't use `readableBytes()` as the buffer's size, which could lead to a wrong check sum result when sending chunks because each chunk is a reference of the original large buffer and only the reader index is different.

Implementations of consumer side:
- Add a `MapCache` class to wrap a hash map with a double ended queue that records the UUIDs in order of time. Because when we removes an UUID, we need to remove the related cache from both the map and the queue. This class only exposes the necessary methods to avoid one of the two data structures is not cleaned. In addition, it makes test easier to verify the cache is cleared after chunks are merged.
- For chunks, call `processMessageChunk` to cache these chunks and merge the chunks with the same UUID into the completed message once the last chunks arrived.

Tests:
- Configure `maxMessageSize=10240` in `test-conf/standalone-ssl.conf` so that we don't need to create a too large message in tests.
- Add `MapCacheTest` to verify the public methods of `MapCache`.
- Add `MessageChunkingTest` to verify the basic end to end case with all compression types.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (**yes**)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)