### PR TITLE
[Build] Fix warning about missing maven-checkstyle-plugin version in buildtools/pom.xml

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -44,6 +44,8 @@
     <testng.version>7.3.0</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -185,11 +187,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.37</version>
+            <version>${puppycrawl.checkstyle.version}</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
### Motivation

Running the maven build produces this warning
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:buildtools:jar:2.10.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-checkstyle-plugin is missing. @ line 185, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
This problem started appearing after changes made by PR #13530.

### Modifications

- specify plugin version for maven-checkstyle-plugin in buildtools/pom.xml