### PR TITLE
[doc] add notes on worker threads

### DIFF
--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -291,6 +291,13 @@ const consumer = await client.subscribe({
 });
 ```
 
+> #### Note
+> Pulsar Node.js client uses [AsyncWorker](https://github.com/nodejs/node-addon-api/blob/main/doc/async_worker.md); asynchronous operations such as creating consumers/producers and receiving/sending messages are performed in worker threads.
+> Until completion of these operations, worker threads are blocked.
+> Since there are only 4 worker threads by default, a called method may never complete.
+>
+> To avoid this situation, you can set `UV_THREADPOOL_SIZE` to increase the number of worker threads, or define `listener` instead of calling `receive()` many times.
+
 ## Readers
 
 Pulsar readers process messages from Pulsar topics. Readers are different from consumers because with readers you need to explicitly specify which message in the stream you want to begin with (consumers, on the other hand, automatically begin with the most recently unacked message). You can [configure](#reader-configuration) Node.js readers using a reader configuration object.

--- a/site2/docs/client-libraries-node.md
+++ b/site2/docs/client-libraries-node.md
@@ -292,7 +292,7 @@ const consumer = await client.subscribe({
 ```
 
 > #### Note
-> Pulsar Node.js client uses [AsyncWorker](https://github.com/nodejs/node-addon-api/blob/main/doc/async_worker.md); asynchronous operations such as creating consumers/producers and receiving/sending messages are performed in worker threads.
+> Pulsar Node.js client uses [AsyncWorker](https://github.com/nodejs/node-addon-api/blob/main/doc/async_worker.md). Asynchronous operations such as creating consumers/producers and receiving/sending messages are performed in worker threads.
 > Until completion of these operations, worker threads are blocked.
 > Since there are only 4 worker threads by default, a called method may never complete.
 >


### PR DESCRIPTION
### Motivation

The document of Node.js client lacks information on worker threads.

### Modifications

Add notes on worker threads to the document.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc`