### PR TITLE
bundle metrics would overwrite loadbalance metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -189,6 +189,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     private AtomicReference<List<Metrics>> bundleUnloadMetrics = new AtomicReference<>();
     // record bundle split metrics
     private AtomicReference<List<Metrics>> bundleSplitMetrics = new AtomicReference<>();
+    // record bundle metrics
+    private AtomicReference<List<Metrics>> bundleMetrics = new AtomicReference<>();
 
     private long bundleSplitCount = 0;
     private long unloadBrokerCount = 0;
@@ -944,7 +946,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             Map<String, String> dimensions = new HashMap<>();
             dimensions.put("broker", pulsar.getAdvertisedAddress());
             dimensions.put("bundle", bundle);
-            dimensions.put("metric", "loadBalancing");
+            dimensions.put("metric", "bundle");
             Metrics m = Metrics.create(dimensions);
             m.put("brk_bundle_msg_rate_in", stats.msgRateIn);
             m.put("brk_bundle_msg_rate_out", stats.msgRateOut);
@@ -955,7 +957,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             m.put("brk_bundle_msg_throughput_out", stats.msgThroughputOut);
             metrics.add(m);
         }
-        this.loadBalancingMetrics.set(metrics);
+        this.bundleMetrics.set(metrics);
     }
 
     /**
@@ -1115,6 +1117,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
         if (this.bundleSplitMetrics.get() != null) {
             metricsCollection.addAll(this.bundleSplitMetrics.get());
+        }
+
+        if (this.bundleMetrics.get() != null) {
+            metricsCollection.addAll(this.bundleMetrics.get());
         }
 
         return metricsCollection;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -177,6 +177,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         this.conf.setWebServicePort(Optional.of(0));
         this.conf.setWebServicePortTls(Optional.of(0));
         this.conf.setNumExecutorThreadPoolSize(5);
+        this.conf.setExposeBundlesMetricsInPrometheus(true);
     }
 
     protected final void init() throws Exception {

--- a/site2/docs/reference-metrics.md
+++ b/site2/docs/reference-metrics.md
@@ -350,7 +350,7 @@ All the bundle metrics are labelled with the following labels:
 - cluster: cluster=${pulsar_cluster}. ${pulsar_cluster} is the cluster name that you have configured in the `broker.conf` file.
 - broker: broker=${broker}. ${broker} is the IP address of the broker
 - bundle: bundle=${bundle}. ${bundle} is the bundle range on this broker
-- metric: metric="loadBalancing".
+- metric: metric="bundle".
 
 | Name | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION


### Motivation
#12366  added bundle metrics, But, If we enabled expose these metrics, It would overwrite previous load balancing metrics.

### Modifications

seperate bundle metrics and load balance metrics


### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


